### PR TITLE
Make marqo-os credentials default to admin

### DIFF
--- a/src/marqo/neural_search/api.py
+++ b/src/marqo/neural_search/api.py
@@ -4,7 +4,6 @@ from fastapi.responses import JSONResponse
 import marqo.neural_search.utils
 from models.api_models import SearchQuery
 from fastapi import FastAPI, Request, Depends, HTTPException
-from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from marqo.errors import MarqoWebError, MarqoError
 from fastapi import FastAPI
 from marqo.neural_search import neural_search
@@ -49,7 +48,7 @@ on_start()
 app = FastAPI()
 
 
-async def generate_config(creds: HTTPBasicCredentials = Depends(security)):
+async def generate_config():
     authorized_url = marqo.neural_search.utils.construct_authorized_url(
         url_base=OPENSEARCH_URL,
         username="admin",


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ x] The commit message follows our guidelines
- [ x] Tests for the changes have been added (for bug fixes/features)
- [ x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
since marqo-os should be run in a VPC or docker container with marqo itself, we can default the password to admin. This means that the user no longer needs to supply admin credentials when using the client or curl interface.

We will look to add token based authentication in the next release.

* **What is the current behavior?** (You can also link to an open issue here)
The current behaviour is that marqo requires main user and main password credentials.

* **What is the new behavior (if this is a feature change)?**
no http auth required

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Other information**:

