### PR TITLE
remove second FROM statement and remove unneeded CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,10 @@
 # export BUILDKIT_PROGRESS=plain; docker rm -f marqo; DOCKER_BUILDKIT=1 docker build --no-cache . -t marqo_docker_0 && docker run --name marqo --privileged -p 8882:8882 marqo_docker_0
 ARG CUDA_VERSION=11.4.2
 FROM nvidia/cuda:${CUDA_VERSION}-cudnn8-runtime-ubuntu20.04 as cuda_image
-CMD nvidia-smi
 
 FROM cruizba/ubuntu-dind
 # this is required for onnx to find cuda
 COPY --from=cuda_image /usr/local/cuda/ /usr/local/cuda/
-FROM cruizba/ubuntu-dind
 WORKDIR /app
 RUN apt-get update
 RUN apt-get install ca-certificates curl  gnupg lsof lsb-release jq -y


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes/features)
- [X] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Bug fix: Dockerfile had two FROM statements which negated a copy from one image to another

* **What is the current behavior?** (You can also link to an open issue here)
Docker during build does not copy CUDA across to the DIND image

* **What is the new behavior (if this is a feature change)?**
Docker can copy the CUDA across from the nvidia image

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:

