### PR TITLE
added --no-cache-dir args to pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN apt-get update
 RUN apt-get install python3.8-distutils -y # python3-distutils
 RUN apt-get  install python3.8 python3-pip -y # pip is 276 MB!
 # TODO: up the RAM
-RUN pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu113 --upgrade
-RUN pip3 install onnxruntime-gpu
+RUN pip3 --no-cache-dir install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu113 --upgrade
+RUN pip3 --no-cache-dir install onnxruntime-gpu
 
 COPY requirements.txt requirements.txt
 RUN pip3 install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
- Pip3 install torch in the Dockefile caches it. This increases image size and makes building problematic on some machines

* **What is the new behavior (if this is a feature change)?**
- Adding --no-cache-dir to pip3 install torch3 ensures that it isn't cached. This keeps image size lower and reduces the resources needed to build (building can take place on lower mem machines)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
NO 

* **Other information**:

