### PR TITLE
adding basic HTTPf Auth to Marqo

### DIFF
--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -1,6 +1,6 @@
 """The API entrypoint for Tensor Search"""
 from fastapi.responses import JSONResponse
-
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
 import marqo.tensor_search.utils
 from models.api_models import SearchQuery
 from fastapi import FastAPI, Request, Depends, HTTPException
@@ -45,14 +45,15 @@ OPENSEARCH_URL = replace_host_localhosts(
 
 
 on_start()
+security = HTTPBasic()
 app = FastAPI()
 
 
-async def generate_config():
+async def generate_config(creds: HTTPBasicCredentials = Depends(security)):
     authorized_url = marqo.tensor_search.utils.construct_authorized_url(
         url_base=OPENSEARCH_URL,
-        username="admin",
-        password="admin"
+        username=creds.username,
+        password=creds.password
     )
     return config.Config(url=authorized_url)
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Feature

* **What is the current behavior?** (You can also link to an open issue here)
- No way to set credentials on requests

* **What is the new behavior (if this is a feature change)?**
- Every request needs to be accompanied by basic HTTP authentication

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
- Yes, if you are hitting Marqo with no auth against a local testing environment, you need to add the default credentials of username:admin password:admin
- However, if you are using the Python client, a pull request has been made to autofill these admin credentials, making them hidden to the user. If you are using the Python Client without explicitly declaring creds you should still be able to do so, if you update to the latest client. 

* **Other information**:
- Tested example cURL commands against built docker container
- Ran tox
