### PR TITLE
Creds set at run

### DIFF
--- a/run_marqo.sh
+++ b/run_marqo.sh
@@ -31,20 +31,20 @@ echo starting dockerd command
 dockerd &
 echo dockerd command complete
 
-echo "Waiting for processes to be running"
-processes=(dockerd)
-for process in "${processes[@]}"; do
-    wait_for_process "$process"
-    if [ $? -ne 0 ]; then
-        echo "$process is not running after max time"
-        exit 1
-    else
-        echo "$process is running"
-    fi
-done
 OPENSEARCH_IS_INTERNAL=False
 # Start opensearch in the background
 if [[ ! $OPENSEARCH_URL ]]; then
+  echo "Waiting for processes to be running"
+  processes=(dockerd)
+  for process in "${processes[@]}"; do
+      wait_for_process "$process"
+      if [ $? -ne 0 ]; then
+          echo "$process is not running after max time"
+          exit 1
+      else
+          echo "$process is running"
+      fi
+  done
   OPENSEARCH_URL="https://localhost:9200"
   OPENSEARCH_IS_INTERNAL=True
   if [[ $(docker ps -a | grep marqo-os) ]]; then

--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -1,7 +1,5 @@
 """The API entrypoint for Tensor Search"""
 from fastapi.responses import JSONResponse
-
-import marqo.tensor_search.utils
 from models.api_models import SearchQuery
 from fastapi import FastAPI, Request, Depends, HTTPException
 from marqo.errors import MarqoWebError, MarqoError
@@ -11,7 +9,7 @@ from marqo import config
 from typing import List, Dict
 import os
 from marqo.tensor_search.web import api_validation, api_utils
-
+from marqo.tensor_search.web.api_utils import generate_config
 from marqo.tensor_search.on_start_script import on_start
 
 
@@ -46,15 +44,6 @@ OPENSEARCH_URL = replace_host_localhosts(
 
 on_start()
 app = FastAPI()
-
-
-async def generate_config():
-    authorized_url = marqo.tensor_search.utils.construct_authorized_url(
-        url_base=OPENSEARCH_URL,
-        username="admin",
-        password="admin"
-    )
-    return config.Config(url=authorized_url)
 
 
 @app.exception_handler(MarqoWebError)

--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -9,7 +9,6 @@ from marqo import config
 from typing import List, Dict
 import os
 from marqo.tensor_search.web import api_validation, api_utils
-from marqo.tensor_search.web.api_utils import generate_config
 from marqo.tensor_search.on_start_script import on_start
 
 
@@ -44,6 +43,12 @@ OPENSEARCH_URL = replace_host_localhosts(
 
 on_start()
 app = FastAPI()
+
+
+async def generate_config() -> config.Config:
+    return config.Config(api_utils.upconstruct_authorized_url(
+        opensearch_url=OPENSEARCH_URL
+    ))
 
 
 @app.exception_handler(MarqoWebError)
@@ -98,7 +103,7 @@ async def create_index(index_name: str, settings: Dict = None, marqo_config: con
 
 @app.post("/indexes/{index_name}/search")
 async def search(search_query: SearchQuery, index_name: str, device: str = None,
-                 marqo_config: config.Config = Depends(generate_config)):
+                  marqo_config: config.Config = Depends(generate_config)):
     device = api_utils.translate_api_device(api_validation.validate_api_device(device))
     return tensor_search.search(
         config=marqo_config, text=search_query.q,
@@ -111,7 +116,7 @@ async def search(search_query: SearchQuery, index_name: str, device: str = None,
 
 
 @app.post("/indexes/{index_name}/documents")
-async def add_documents(docs: List[Dict], index_name: str,  refresh: bool = True,
+async def add_documents(docs: List[Dict], index_name: str, refresh: bool = True,
                         marqo_config: config.Config = Depends(generate_config),
                         batch_size: int = 0, processes: int = 1, device: str = None):
     """add_documents endpoint"""

--- a/src/marqo/tensor_search/backend.py
+++ b/src/marqo/tensor_search/backend.py
@@ -74,6 +74,11 @@ def add_customer_field_properties(config: Config, index_name: str,
     Returns:
         HTTP Response
     """
+    if config.cluster_is_s2search:
+        engine = "nmslib"
+    else:
+        engine = "lucene"
+
     body = {
         "properties": {
             enums.TensorField.chunks: {
@@ -86,7 +91,7 @@ def add_customer_field_properties(config: Config, index_name: str,
                         "method": {
                             "name": "hnsw",
                             "space_type": "cosinesimil",
-                            "engine": "lucene",  # or try Lucene
+                            "engine": engine,
                             "parameters": {
                                 "ef_construction": 128,
                                 "m": 24

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -637,6 +637,11 @@ def _vector_text_search(
         raise errors.InvalidArgError(
             "tensor_search: vector_text_search: illegal result_count: {}".format(result_count))
 
+    if config.cluster_is_s2search and filter_string is not None:
+        raise errors.InvalidArgError(
+            "filtering not yet implemented for S2Search cloud!"
+        )
+
     try:
         index_info = get_index_info(config=config, index_name=index_name)
     except KeyError as e:

--- a/src/marqo/tensor_search/web/api_utils.py
+++ b/src/marqo/tensor_search/web/api_utils.py
@@ -5,7 +5,9 @@ from marqo.tensor_search.utils import construct_authorized_url
 from marqo import config
 
 
-def generate_config(opensearch_url) -> config.Config:
+def upconstruct_authorized_url(opensearch_url: str) -> str:
+    """Generates an authorized URL, if it is not already authorized
+    """
     http_sep = "://"
     if http_sep not in opensearch_url:
         raise InternalError(f"Could not parse backend url: {opensearch_url}")
@@ -17,7 +19,7 @@ def generate_config(opensearch_url) -> config.Config:
         )
     else:
         authorized_url = opensearch_url
-    return config.Config(url=authorized_url)
+    return authorized_url
 
 
 def translate_api_device(device: Optional[str]) -> Optional[str]:

--- a/src/marqo/tensor_search/web/api_utils.py
+++ b/src/marqo/tensor_search/web/api_utils.py
@@ -1,6 +1,23 @@
-from marqo.errors import InvalidArgError
+from marqo.errors import InvalidArgError, InternalError
 from marqo.tensor_search import enums
 from typing import Optional
+from marqo.tensor_search.utils import construct_authorized_url
+from marqo import config
+
+
+def generate_config(opensearch_url) -> config.Config:
+    http_sep = "://"
+    if http_sep not in opensearch_url:
+        raise InternalError(f"Could not parse backend url: {opensearch_url}")
+    if "@" not in opensearch_url.split("/")[2]:
+        authorized_url = construct_authorized_url(
+            url_base=opensearch_url,
+            username="admin",
+            password="admin"
+        )
+    else:
+        authorized_url = opensearch_url
+    return config.Config(url=authorized_url)
 
 
 def translate_api_device(device: Optional[str]) -> Optional[str]:

--- a/tests/tensor_search/test_api_utils.py
+++ b/tests/tensor_search/test_api_utils.py
@@ -34,13 +34,13 @@ class TestApiUtils(MarqoTestCase):
                 ("http://www.unusual.com/happy@@@@#chappy:9200", "http://admin:admin@www.unusual.com/happy@@@@#chappy:9200"),
                 ("://", "://admin:admin@")
                 ]:
-            c = api_utils.generate_config(opensearch_url=opensearch_url)
+            c = api_utils.upconstruct_authorized_url(opensearch_url=opensearch_url)
             assert authorized_url == c.url
 
     def test_generate_config_bad_url(self):
         for opensearch_url in ["www.google.com", "http:/mywebsite", "yahoo"]:
             try:
-                c = api_utils.generate_config(opensearch_url=opensearch_url)
+                c = api_utils.upconstruct_authorized_url(opensearch_url=opensearch_url)
                 raise AssertionError
             except InternalError:
                 pass

--- a/tests/tensor_search/test_api_utils.py
+++ b/tests/tensor_search/test_api_utils.py
@@ -2,7 +2,7 @@ import requests
 from marqo.tensor_search import enums, backend
 from marqo.tensor_search import tensor_search
 from marqo.tensor_search.web import api_utils
-from marqo.errors import InvalidArgError
+from marqo.errors import InvalidArgError, InternalError
 from tests.marqo_test import MarqoTestCase
 
 
@@ -21,4 +21,26 @@ class TestApiUtils(MarqoTestCase):
                 api_utils.translate_api_device(bad)
                 raise AssertionError
             except InvalidArgError:
+                pass
+
+    def test_generate_config(self):
+        for opensearch_url, authorized_url in [
+                ("http://admin:admin@localhost:9200", "http://admin:admin@localhost:9200"),
+                ("http://localhost:9200", "http://admin:admin@localhost:9200"),
+                ("https://admin:admin@localhost:9200", "https://admin:admin@localhost:9200"),
+                ("https://localhost:9200", "https://admin:admin@localhost:9200"),
+                ("http://king_user:mysecretpw@unusual.com/happy@chappy:9200", "http://king_user:mysecretpw@unusual.com/happy@chappy:9200"),
+                ("http://unusual.com/happy@chappy:9200", "http://admin:admin@unusual.com/happy@chappy:9200"),
+                ("http://www.unusual.com/happy@@@@#chappy:9200", "http://admin:admin@www.unusual.com/happy@@@@#chappy:9200"),
+                ("://", "://admin:admin@")
+                ]:
+            c = api_utils.generate_config(opensearch_url=opensearch_url)
+            assert authorized_url == c.url
+
+    def test_generate_config_bad_url(self):
+        for opensearch_url in ["www.google.com", "http:/mywebsite", "yahoo"]:
+            try:
+                c = api_utils.generate_config(opensearch_url=opensearch_url)
+                raise AssertionError
+            except InternalError:
                 pass

--- a/tests/tensor_search/test_api_utils.py
+++ b/tests/tensor_search/test_api_utils.py
@@ -35,7 +35,7 @@ class TestApiUtils(MarqoTestCase):
                 ("://", "://admin:admin@")
                 ]:
             c = api_utils.upconstruct_authorized_url(opensearch_url=opensearch_url)
-            assert authorized_url == c.url
+            assert authorized_url == c
 
     def test_generate_config_bad_url(self):
         for opensearch_url in ["www.google.com", "http:/mywebsite", "yahoo"]:

--- a/tests/tensor_search/test_backend.py
+++ b/tests/tensor_search/test_backend.py
@@ -1,9 +1,14 @@
+import copy
+import json
+import pprint
+
 import requests
-from marqo.tensor_search import enums, backend
+from marqo.tensor_search import enums, backend, utils
 from marqo.tensor_search import tensor_search
 from marqo.errors import MarqoApiError, IndexNotFoundError
 from marqo.client import Client
 from tests.marqo_test import MarqoTestCase
+from unittest import mock
 
 
 class TestBackend(MarqoTestCase):
@@ -53,3 +58,39 @@ class TestBackend(MarqoTestCase):
         assert '.opendistro_security' not in cluster_indices
         assert isinstance(cluster_indices, set)
         assert self.index_name_1 in cluster_indices
+
+    def test_add_customer_field_properties_nmslib_for_s2search(self):
+        mock_config = copy.deepcopy(self.config)
+        mock_config.cluster_is_s2search = True
+        mock__put = mock.MagicMock()
+
+        tensor_search.create_vector_index(
+            config=mock_config, index_name=self.index_name_1)
+        @mock.patch("marqo._httprequests.HttpRequests.put", mock__put)
+        def run():
+            tensor_search.add_documents(config=mock_config, docs=[{"f1": "doc"}, {"f2":"C"}],
+                                        index_name=self.index_name_1, auto_refresh=True)
+            return True
+        assert run()
+        args, kwargs0 = mock__put.call_args_list[0]
+        sent_dict = json.loads(kwargs0["body"])
+        assert "nmslib" == sent_dict["properties"][enums.TensorField.chunks
+            ]["properties"][utils.generate_vector_name(field_name="f1")]["method"]["engine"]
+
+    def test_add_customer_field_properties_defaults_lucene(self):
+        mock_config = copy.deepcopy(self.config)
+        mock_config.cluster_is_s2search = False
+        mock__put = mock.MagicMock()
+
+        tensor_search.create_vector_index(
+            config=mock_config, index_name=self.index_name_1)
+        @mock.patch("marqo._httprequests.HttpRequests.put", mock__put)
+        def run():
+            tensor_search.add_documents(config=mock_config, docs=[{"f1": "doc"}, {"f2":"C"}],
+                                        index_name=self.index_name_1, auto_refresh=True)
+            return True
+        assert run()
+        args, kwargs0 = mock__put.call_args_list[0]
+        sent_dict = json.loads(kwargs0["body"])
+        assert "lucene" == sent_dict["properties"][enums.TensorField.chunks
+            ]["properties"][utils.generate_vector_name(field_name="f1")]["method"]["engine"]


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Bug fix/feature


* **What is the current behavior?** (You can also link to an open issue here)
- Doesn't work on M1 macs without changing run_marqo.sh
- Doesn't work with s2search.io backend due to credential issue

* **What is the new behavior (if this is a feature change)?**
- Credentials removed for requests. 
- BasicHTTP auth to OpenSearch is possible if the user adds credentials to the docker run marqo command's OPENSEARCH_URL environment var. 
- If an OpenSearch URL is passed to Marqo, it won't attempt to start DIND. This allows Marqo to run on machines that have difficulty running the DIND image, as long as they set the OPENSEARH_URL environment var 
- If a remote OpenSearch environment is identified as being s2search.io, then vector filtering throws a better error
- If a remote OpenSearch environment is identified as being s2search.io, then nmslib is used as the default engine

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No 

* **Other information**:
- tox passes 
- Tested against amd64 linux with against local marqo-os, example cURL commands, start and stop, no admin creds, with and without privileged flag
- Tested against amd64 linux marqo-DIND, example cURL commands, start and stop, no admin creds
- Tested against amd64 linux marqo-S2Search, example curl, start and stop, no admin creds
