### PR TITLE
fix: expected behaviour for lexical search if empty list

### DIFF
--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -555,7 +555,7 @@ def _lexical_search(
             f"Query arg must be of type str! text arg is of type {type(text)}. "
             f"Query arg: {text}")
 
-    if searchable_attributes is not None:
+    if searchable_attributes is not None and searchable_attributes:
         fields_to_search = searchable_attributes
     else:
         fields_to_search = index_meta_cache.get_index_info(

--- a/tests/tensor_search/test_lexical_search.py
+++ b/tests/tensor_search/test_lexical_search.py
@@ -293,3 +293,21 @@ class TestlexicalSearch(MarqoTestCase):
         assert res["hits"][0]["_id"] == "123" or res["hits"][1]["_id"] == "123"
         assert res["hits"][0]["_id"] == "abcdef" or res["hits"][1]["_id"] == "abcdef"
 
+    def test_lexical_search_empty_searchable_attribs(self):
+        """Empty searchable attribs searches all fields"""
+        d0 = {
+            "some doc 1": "some FIELD 2", "_id": "alpha alpha",
+            "the big field": "extravagant very unlikely theory. marqo is pretty awesom, in the field"
+        }
+        d1 = {"title": "Marqo", "some doc 2": "some other thing", "_id": "abcdef"}
+        d2 = {"some doc 1": "some 2 jnkerkbj", "field abc": "extravagant robodog is not a cat", "_id": "Jupyter_12"}
+
+        tensor_search.add_documents(
+            config=self.config, index_name=self.index_name_1, auto_refresh=True,
+            docs=[d0, d1, d2])
+        res = tensor_search._lexical_search(
+            config=self.config, index_name=self.index_name_1, text="extravagant",
+            return_doc_ids=True, searchable_attributes=[], result_count=3)
+        assert len(res["hits"]) == 2
+        assert (res["hits"][0]["_id"] == "alpha alpha") or (res["hits"][0]["_id"] == "Jupyter_12")
+        assert (res["hits"][0]["_id"] != "abcdef") and (res["hits"][0]["_id"] != "abcdef")


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
- if the user does a lexical search with searchable_attributes = [], then an empty search goes to OpenSearch, resulting in unhelpful results

* **What is the new behavior (if this is a feature change)?**
-if the user does a lexical search with searchable_attributes = [], then the lexical search will proceed as if a user left searchable_attributes unset (all fields will be searched)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
- Ran unit tests, ran integration tests
