### PR TITLE
workflow not triggered for markdown file changes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       mainline
+    paths-ignore:
+      - '**.md'
 
 permissions:
   contents: read


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
CI workflow optimisation

* **What is the current behavior?** (You can also link to an open issue here)
CI workflow was getting triggered for markdown file changes

* **What is the new behavior (if this is a feature change)?**
CI workflow not triggered for markdown file changes

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
From GitHub docs- 
> When all the path names match patterns in `paths-ignore`, the workflow will not run. If any path names do not match patterns in `paths-ignore`, even if some path names match the patterns, the workflow will run.
