### PR TITLE
added dockerd to wait_for_process loop

### DIFF
--- a/run_marqo.sh
+++ b/run_marqo.sh
@@ -14,10 +14,10 @@ function wait_for_process () {
     local max_time_wait=30
     local process_name="$1"
     local waited_sec=0
-#    while ! pgrep "$process_name" >/dev/null && ((waited_sec < max_time_wait)); do
     while ! [[ $(docker ps -a | grep CONTAINER) ]] >/dev/null && ((waited_sec < max_time_wait)); do
         echo "Process $process_name is not running yet. Retrying in 1 seconds"
         echo "Waited $waited_sec seconds of $max_time_wait seconds"
+        dockerd &
         sleep 1
         ((waited_sec=waited_sec+1))
         if ((waited_sec >= max_time_wait)); then


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
- Marqo running DIND won't restart again after one successful restart

* **What is the new behavior (if this is a feature change)?**
- Marqo can restart after a successful restart

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
- No

* **Other information**:
- Added a NUMBER_OF_RESTARTS=5 to the api-tests start_stop test. This ensures that Marqo is tested for 5 restarts
- Ran marqo-api-tests on amd64
