### PR TITLE
Resilient indexing

### DIFF
--- a/src/marqo/README.md
+++ b/src/marqo/README.md
@@ -1,22 +1,31 @@
+# Developer guide
+Thank you for contributing to Marqo! Contributions from the open source community help make Marqo be the tensor engine
+you want. 
 
 ### A. Run the Marqo application locally (outside of docker):
 
-1. `cd` into `src/marqo/tensor_search`
-2. Run the following command:
+1. Have a running Marqo-OS instance available to use. You can spin up a local instance with the following command
+(if you are using an arm64 machine, replace `marqoai/marqo-os:0.0.2` with `marqoai/marqo-os:0.0.2-arm`):
 ```bash
-# if you are running OpenSearch locally. 
+docker run --name marqo-os -id -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" marqoai/marqo-os:0.0.2
+```
+
+2. `cd` into `src/marqo/tensor_search`
+3. Run the following command:
+```bash
+# if you are running Marqo-OS locally: 
 export OPENSEARCH_URL="https://localhost:9200" && 
-    export PYTHONPATH="${PYTHONPATH}:<your path here>/marqo/src" &&
+    export PYTHONPATH="${PYTHONPATH}:<YOUR ABSOULTE PATH TO>/marqo/src" &&
     uvicorn api:app --host 0.0.0.0 --port 8882 --reload
 ```
 __Notes__:
 
 - This is for marqo-os (Marqo OpenSearch) running locally. You can alternatively set
 `OPENSEARCH_URL` to  a remote Marqo OpenSearch cluster 
-- 
+- To find the absolute path to the `marqo/src` directory, `cd` into the `marqo/src` directory and run `pwd` in your terminal
 
 
-### B. Build and run the Marqo as a Docker container, that creates and manages its own internal OpenSearch 
+### B. Build and run the Marqo as a Docker container, that creates and manages its own internal Marqo-OS 
 1. `cd` into the marqo root directory
 2. Run the following command:
 ```bash
@@ -25,9 +34,14 @@ docker rm -f marqo &&
      docker run --name marqo --privileged -p 8882:8882 --add-host host.docker.internal:host-gateway marqo_docker_0
 ```
 
-### C. Build and run the Marqo as a Docker container, connecting to OpenSearch which is running on the host:
-1. `cd` into the marqo root directory
-2. Run the following command:
+### C. Build and run the Marqo as a Docker container, connecting to Marqo-OS which is running on the host:
+1. Run the following command to run Marqo-OS (if you are using an arm64 machine, replace `marqoai/marqo-os:0.0.2` with `marqoai/marqo-os:0.0.2-arm`):
+```bash
+docker run --name marqo-os -id -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" marqoai/marqo-os:0.0.2
+```
+
+2. `cd` into the marqo root directory
+3. Run the following command:
 ```bash
 docker rm -f marqo &&
      DOCKER_BUILDKIT=1 docker build . -t marqo_docker_0 && 
@@ -35,7 +49,10 @@ docker rm -f marqo &&
          -e "OPENSEARCH_URL=https://localhost:9200" marqo_docker_0
 ```
 
+__Notes__:
 
+- This is for marqo-os (Marqo OpenSearch) running locally. You can alternatively set
+`OPENSEARCH_URL` to  a remote Marqo OpenSearch cluster 
 ### D. Pull marqo from `hub.docker.com` and run it
 ```
 docker rm -f marqo &&

--- a/src/marqo/errors.py
+++ b/src/marqo/errors.py
@@ -1,22 +1,6 @@
 import json
 from requests import Response
 from http import HTTPStatus
-from typing import Optional
-
-
-class S2InferenceError(Exception):
-    def __init__(self, message: Optional[str] = None) -> None:
-        if Optional is not None:
-            self.message = message
-            super().__init__(self.message)
-
-
-class ChunkerError(S2InferenceError):
-    pass
-
-
-class VectoriseError(S2InferenceError):
-    pass
 
 
 class MarqoError(Exception):

--- a/src/marqo/errors.py
+++ b/src/marqo/errors.py
@@ -1,6 +1,22 @@
 import json
 from requests import Response
 from http import HTTPStatus
+from typing import Optional
+
+
+class S2InferenceError(Exception):
+    def __init__(self, message: Optional[str] = None) -> None:
+        if Optional is not None:
+            self.message = message
+            super().__init__(self.message)
+
+
+class ChunkerError(S2InferenceError):
+    pass
+
+
+class VectoriseError(S2InferenceError):
+    pass
 
 
 class MarqoError(Exception):
@@ -79,8 +95,6 @@ class MarqoWebError(Exception):
         return f'MarqoWebError: {self.__class__.__name__} Error message: {self.message}'
 
 # ---MARQO USER ERRORS---
-
-# --
 
 
 class __InvalidRequestError(MarqoWebError):

--- a/src/marqo/s2_inference/errors.py
+++ b/src/marqo/s2_inference/errors.py
@@ -1,0 +1,16 @@
+from typing import Optional
+
+
+class S2InferenceError(Exception):
+    def __init__(self, message: Optional[str] = None) -> None:
+        if Optional is not None:
+            self.message = message
+            super().__init__(self.message)
+
+
+class ChunkerError(S2InferenceError):
+    pass
+
+
+class VectoriseError(S2InferenceError):
+    pass

--- a/src/marqo/s2_inference/processing/image.py
+++ b/src/marqo/s2_inference/processing/image.py
@@ -1,8 +1,10 @@
 import copy
 
+import PIL
+
+from marqo.errors import ChunkerError
 from PIL import Image
 import numpy as np
-
 import torch
 from torchvision.models.detection import FasterRCNN_MobileNet_V3_Large_FPN_Weights, fasterrcnn_mobilenet_v3_large_fpn
 from torchvision.models.detection import fasterrcnn_resnet50_fpn_v2, FasterRCNN_ResNet50_FPN_V2_Weights
@@ -384,6 +386,8 @@ def chunk_image(image: Union[str, ImageType], device: str, method: str = 'simple
 
     Returns:
         Tuple[List[ImageType], ndarray]: _description_
+
+    Raises ChunkerError, if the chunker can't work for some reason
     """
 
     if method in [None, 'none', '', "None", ' ']:
@@ -399,10 +403,11 @@ def chunk_image(image: Union[str, ImageType], device: str, method: str = 'simple
         patch = PatchifyPytorch(device=device, size=get_default_size())
     else:
         raise ValueError(f"unexpected image chunking type. found {method}")
-
-    patch.infer(image)
-    patch.process()
-
+    try:
+        patch.infer(image)
+        patch.process()
+    except PIL.UnidentifiedImageError as e:
+        raise ChunkerError from e
     return patch.patches,patch.bboxes_orig
 
 

--- a/src/marqo/s2_inference/processing/image.py
+++ b/src/marqo/s2_inference/processing/image.py
@@ -1,9 +1,6 @@
 import copy
-
 import PIL
-
-from marqo.errors import ChunkerError
-from PIL import Image
+from marqo.s2_inference.errors import ChunkerError
 import numpy as np
 import torch
 from torchvision.models.detection import FasterRCNN_MobileNet_V3_Large_FPN_Weights, fasterrcnn_mobilenet_v3_large_fpn

--- a/src/marqo/s2_inference/s2_inference.py
+++ b/src/marqo/s2_inference/s2_inference.py
@@ -2,7 +2,7 @@
 The functions defined here would have endpoints, later on.
 """
 import numpy as np
-from marqo.errors import VectoriseError
+from marqo.s2_inference.errors import VectoriseError
 from PIL import UnidentifiedImageError
 from marqo.s2_inference.model_registry import load_model_properties
 from marqo.s2_inference.configs import get_default_device,get_default_normalization,get_default_seq_length

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -282,7 +282,7 @@ def add_documents(config: Config, index_name: str, docs: List[dict], auto_refres
         create_vector_index(config=config, index_name=index_name)
         index_info = backend.get_index_info(config=config, index_name=index_name)
 
-    if not docs:
+    if len(docs) == 0:
         raise errors.BadRequestError(message="Received empty add documents request")
 
     existing_fields = set(index_info.properties.keys())

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -56,8 +56,8 @@ from marqo.s2_inference import s2_inference
 # _httprequests.py is designed for the client
 from marqo._httprequests import HttpRequests
 from marqo.config import Config
-# TODO add an errors.py 
 from marqo import errors
+from marqo.s2_inference import errors as s2_inference_errors
 import threading
 import re
 
@@ -356,7 +356,7 @@ def add_documents(config: Config, index_name: str, docs: List[dict], auto_refres
                         # errors of different types generated here, too.
                         content_chunks, text_chunks = image_processor.chunk_image(
                             field_content, device=selected_device, method=image_method)
-                    except errors.S2InferenceError:
+                    except s2_inference_errors.S2InferenceError:
                         document_is_valid = False
                         image_err = errors.InvalidArgError(message=f'Could not process given image: {field_content}')
                         unsuccessful_docs.append(
@@ -373,7 +373,7 @@ def add_documents(config: Config, index_name: str, docs: List[dict], auto_refres
                     vector_chunks = s2_inference.vectorise(model_name=index_info.model_name, content=content_chunks,
                                                            device=selected_device, normalize_embeddings=normalize_embeddings,
                                                            infer=infer_if_image)
-                except errors.S2InferenceError:
+                except s2_inference_errors.S2InferenceError:
                     document_is_valid = False
                     image_err = errors.InvalidArgError(message=f'Could not process given image: {field_content}')
                     unsuccessful_docs.append(

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -38,7 +38,7 @@ import typing
 import uuid
 import asyncio
 from typing import List, Optional, Union, Callable, Iterable, Sequence, Dict, Any
-from PIL import Image
+from PIL import Image, UnidentifiedImageError
 from marqo.tensor_search.enums import MediaType, MlModel, TensorField, SearchMethod, OpenSearchDataType
 from marqo.tensor_search.enums import IndexSettingsField as NsField
 from marqo.tensor_search import utils, backend, validation, configs, parallel
@@ -273,7 +273,7 @@ def add_documents(config: Config, index_name: str, docs: List[dict], auto_refres
                   device=None):
     """
     """
-
+    t0 = datetime.datetime.now()
     bulk_parent_dicts = []
 
     try:
@@ -282,26 +282,38 @@ def add_documents(config: Config, index_name: str, docs: List[dict], auto_refres
         create_vector_index(config=config, index_name=index_name)
         index_info = backend.get_index_info(config=config, index_name=index_name)
 
+    if not docs:
+        raise errors.BadRequestError(message="Received empty add documents request")
+
     existing_fields = set(index_info.properties.keys())
     new_fields = set()
-    doc_ids_to_update = []
 
     selected_device = config.indexing_device if device is None else device
 
-    for doc in docs:
+    unsuccessful_docs = []
+
+    for i, doc in enumerate(docs):
 
         indexing_instructions = {"index": {"_index": index_name}}
         copied = doc.copy()
 
-        validation.validate_doc(doc)
-        [validation.validate_field_name(field) for field in copied]
+        document_is_valid = True
+        new_fields_from_doc = set()
 
         if "_id" in doc:
             doc_id = validation.validate_id(doc["_id"])
             del copied["_id"]
-            doc_ids_to_update.append(doc_id)
         else:
             doc_id = str(uuid.uuid4())
+
+        try:
+            validation.validate_doc(doc)
+            [validation.validate_field_name(field) for field in copied]
+        except errors.InvalidArgError as err:
+            unsuccessful_docs.append(
+                (i, {'_id': doc_id, 'error': err.message, 'status': err.status_code, 'code': err.code})
+            )
+            continue
 
         indexing_instructions["index"]["_id"] = doc_id
 
@@ -309,10 +321,18 @@ def add_documents(config: Config, index_name: str, docs: List[dict], auto_refres
 
         for field in copied:
 
-            if field not in existing_fields:
-                new_fields.add((field, _infer_opensearch_data_type(copied[field])))
+            try:
+                field_content = validation.validate_field_content(copied[field])
+            except errors.InvalidArgError as err:
+                document_is_valid = False
+                unsuccessful_docs.append(
+                    (i, {'_id': doc_id, 'error': err.message, 'status': err.status_code,
+                         'code': err.code})
+                )
+                break
 
-            field_content = validation.validate_field_content(copied[field])
+            if field not in existing_fields:
+                new_fields_from_doc.add((field, _infer_opensearch_data_type(copied[field])))
 
             # TODO put this into a function to determine routing
             if isinstance(field_content, (str, Image.Image)):
@@ -329,20 +349,29 @@ def add_documents(config: Config, index_name: str, docs: List[dict], auto_refres
                     # TODO put the logic for getting field parameters into a function and add per field options
                     image_method = index_info.index_settings[NsField.index_defaults][NsField.image_preprocessing][NsField.patch_method]
                     # the chunk_image contains the no-op logic as of now - method = None will be a no-op
-                    content_chunks, text_chunks = image_processor.chunk_image(field_content, 
-                                    device=selected_device,
-                                    method=image_method)            
+                    content_chunks, text_chunks = image_processor.chunk_image(
+                        field_content, device=selected_device, method=image_method)
                 
                 normalize_embeddings = index_info.index_settings[NsField.index_defaults][NsField.normalize_embeddings]
                 infer_if_image = index_info.index_settings[NsField.index_defaults][NsField.treat_urls_and_pointers_as_images]
-                
-                vector_chunks = s2_inference.vectorise(model_name=index_info.model_name, content=content_chunks,
-                                                       device=selected_device, normalize_embeddings=normalize_embeddings,
-                                                        infer=infer_if_image)
+                try:
+                    vector_chunks = s2_inference.vectorise(model_name=index_info.model_name, content=content_chunks,
+                                                           device=selected_device, normalize_embeddings=normalize_embeddings,
+                                                           infer=infer_if_image)
+                except UnidentifiedImageError:
+                    document_is_valid = False
+                    image_err = errors.InvalidArgError(message=f'Could not process given image: {field_content}')
+                    unsuccessful_docs.append(
+                        (i, {'_id': doc_id, 'error': image_err.message, 'status': image_err.status_code,
+                             'code': image_err.code})
+                    )
+                    break
 
                 if (len(vector_chunks) != len(text_chunks)):
-                    raise RuntimeError(f"the input content after preprocessing and its vectorized counterparts must be the same length." \
-                        f"recevied text_chunks={len(text_chunks)} and vector_chunks={len(vector_chunks)}. check the preprocessing functions and try again. ")
+                    raise RuntimeError(
+                        f"the input content after preprocessing and its vectorized counterparts must be the same length."
+                        f"recevied text_chunks={len(text_chunks)} and vector_chunks={len(vector_chunks)}. "
+                        f"check the preprocessing functions and try again. ")
 
                 for text_chunk, vector_chunk in zip(text_chunks, vector_chunks):
                     # only add chunk values which are string, boolean or numeric
@@ -358,39 +387,57 @@ def add_documents(config: Config, index_name: str, docs: List[dict], auto_refres
                         TensorField.field_name: field,
                         **chunk_values_for_filtering
                     })
-        copied[TensorField.chunks] = chunks
-        bulk_parent_dicts.append(indexing_instructions)
-        bulk_parent_dicts.append(copied)
+        if document_is_valid:
+            copied[TensorField.chunks] = chunks
+            bulk_parent_dicts.append(indexing_instructions)
+            bulk_parent_dicts.append(copied)
 
-    # the HttpRequest wrapper handles error logic
-    update_mapping_response = backend.add_customer_field_properties(
-        config=config, index_name=index_name, customer_field_names=new_fields,
-        model_properties=s2_inference.get_model_properties(model_name=index_info.model_name))
+            new_fields = new_fields.union(new_fields_from_doc)
 
-    index_parent_response = HttpRequests(config).post(
-        path="_bulk", body=utils.dicts_to_jsonl(bulk_parent_dicts))
+    if bulk_parent_dicts:
+        # the HttpRequest wrapper handles error logic
+        update_mapping_response = backend.add_customer_field_properties(
+            config=config, index_name=index_name, customer_field_names=new_fields,
+            model_properties=s2_inference.get_model_properties(model_name=index_info.model_name))
+
+        index_parent_response = HttpRequests(config).post(
+            path="_bulk", body=utils.dicts_to_jsonl(bulk_parent_dicts))
+    else:
+        index_parent_response = None
 
     if auto_refresh:
         refresh_response = HttpRequests(config).post(path=F"{index_name}/_refresh")
 
-    def translate_add_doc_response(response: dict) -> dict:
-        """translates OpenSearch response dict into Marqo dict"""
-        copied_res = copy.deepcopy(response)
-        took = copied_res["took"]
-        del copied_res["took"]
-        new_items = []
-        item_fields_to_remove = ['_index', '_primary_term', '_seq_no', '_shards', '_version']
-        for item in copied_res["items"]:
-            for to_remove in item_fields_to_remove:
-                if to_remove in item["index"]:
-                    del item["index"][to_remove]
-            new_items.append(item["index"])
-        copied_res["processingTimeMs"] = took
-        copied_res["index_name"] = index_name
-        copied_res["items"] = new_items
-        return copied_res
+    t1 = datetime.datetime.now()
 
-    return translate_add_doc_response(index_parent_response)
+    def translate_add_doc_response(response: Optional[dict], time_diff: datetime.timedelta) -> dict:
+        """translates OpenSearch response dict into Marqo dict"""
+        item_fields_to_remove = ['_index', '_primary_term', '_seq_no', '_shards', '_version']
+        result_dict = {}
+        new_items = []
+
+        if response is not None:
+            copied_res = copy.deepcopy(response)
+            result_dict['errors'] = copied_res['errors']
+
+            for item in copied_res["items"]:
+                for to_remove in item_fields_to_remove:
+                    if to_remove in item["index"]:
+                        del item["index"][to_remove]
+                new_items.append(item["index"])
+
+        if unsuccessful_docs:
+            result_dict['errors'] = True
+
+        for loc, error_info in unsuccessful_docs:
+            new_items.insert(loc, error_info)
+
+        result_dict["processingTimeMs"] = time_diff.total_seconds() * 1000
+        result_dict["index_name"] = index_name
+        result_dict["items"] = new_items
+        return result_dict
+
+    return translate_add_doc_response(response=index_parent_response, time_diff= t1 - t0)
 
 
 def get_document_by_id(config: Config, index_name:str, document_id: str):

--- a/src/marqo/tensor_search/validation.py
+++ b/src/marqo/tensor_search/validation.py
@@ -89,11 +89,13 @@ def validate_doc(doc: dict) -> dict:
         doc: a document indexed by the client
 
     Raises:
-        errors.BadRequestError
+        errors.InvalidArgError
 
     Returns
         doc if all validations pass
     """
+    if not isinstance(doc, dict):
+        raise InvalidArgError("Docs must be dicts")
     if len(doc) <= 0:
         raise InvalidArgError("Can't index an empty dict.")
     return doc


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Feature

* **What is the current behavior?** (You can also link to an open issue here)
- If a document in a large add_document calls errors, then the entire call fails (rather than just the errorful doc)

* **What is the new behavior (if this is a feature change)?**
- Add_documents continues, with errored documents being indicated in the response 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
- Perhaps: if you have a logic predicated on an error response for an add_documents call, it would no longer work
- Instead you should inspect the response of the add documents call, and see if "errors" has been set to True. You can then inspect the returned items, to see which document/s triggered created an error and why

* **Other information**:
- Ran tox
