### PR TITLE
Returned docs limit

### DIFF
--- a/src/marqo/errors.py
+++ b/src/marqo/errors.py
@@ -123,6 +123,11 @@ class InvalidArgError(__InvalidRequestError):
     status_code = HTTPStatus.BAD_REQUEST
 
 
+class IllegalRequestedDocCount(__InvalidRequestError):
+    code = "illegal_requested_doc_count"
+    status_code = HTTPStatus.BAD_REQUEST
+
+
 class DocTooLargeError(__InvalidRequestError):
     code = "doc_too_large"
     status_code = HTTPStatus.BAD_REQUEST

--- a/src/marqo/tensor_search/on_start_script.py
+++ b/src/marqo/tensor_search/on_start_script.py
@@ -42,9 +42,13 @@ class PopulateCache:
                 message="Can't connect to Marqo-os backend. \n"  
                         "    Possible causes: \n"
                         "        - If this is an arm64 machine, ensure you are using an external Marqo-os instance \n"
-                        "        - If you are using an external Marqo-os instance, check if it is running: `curl <YOUR MARQO-OS URL>` \n"
-                        "        - Ensure that the OPENSEARCH_URL environment variable defined in the `docker run marqo` command points to Marqo-os\n",
-                link="https://github.com/marqo-ai/marqo/tree/mainline/src/marqo#c-build-and-run-the-marqo-as-a-docker-container-connecting-to-marqo-os-which-is-running-on-the-host"
+                        "        - If you are using an external Marqo-os instance, check if it is running: "
+                        "`curl <YOUR MARQO-OS URL>` \n"
+                        "        - Ensure that the OPENSEARCH_URL environment variable defined "
+                        "in the `docker run marqo` command points to Marqo-os\n",
+                link="https://github.com/marqo-ai/marqo/tree/mainline/src/marqo"
+                     "#c-build-and-run-the-marqo-as-a-docker-container-connecting-"
+                     "to-marqo-os-which-is-running-on-the-host"
             ) from e
         # the following lines turns off auto create index
         # connection = HttpRequests(c)
@@ -85,9 +89,8 @@ class CUDAAvailable:
         self.logger.info(f"found devices {device_names}")
 
 
-class NLTK: 
-
-    """predownloads the nltk stuff
+class NLTK:
+    """Pre-downloads the nltk stuff
     """
 
     logger = get_logger('NLTK setup')
@@ -108,7 +111,6 @@ class NLTK:
 
 
 class ModelsForCacheing:
-    
     """warms the in-memory model cache by preloading good defaults
     """
     logger = get_logger('ModelsForStartup')

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -461,7 +461,7 @@ def add_documents(config: Config, index_name: str, docs: List[dict], auto_refres
                 for text_chunk, vector_chunk in zip(text_chunks, vector_chunks):
                     # only add chunk values which are string, boolean or numeric
                     chunk_values_for_filtering = {}
-                    for key, value in doc.items():
+                    for key, value in copied.items():
                         if not (isinstance(value, str) or isinstance(value, float)
                                 or isinstance(value, bool) or isinstance(value, int)):
                             continue

--- a/src/marqo/tensor_search/utils.py
+++ b/src/marqo/tensor_search/utils.py
@@ -167,7 +167,11 @@ def read_env_vars_and_defaults(var: str) -> Optional[str]:
     configs.default_env_vars(). If still unsuccessful, None is returned.
     """
     try:
-        return os.environ[var]
+        var = os.environ[var]
+        if var is not None and len(var) == 0:
+            return None
+        else:
+            return var
     except KeyError:
         try:
             return configs.default_env_vars()[var]

--- a/tests/marqo_test.py
+++ b/tests/marqo_test.py
@@ -12,7 +12,6 @@ class MarqoTestCase(unittest.TestCase):
             "main_user": "admin",
             "main_password": "admin"
         }
-        s2search_settings = {}
         cls.client_settings = local_opensearch_settings
         cls.authorized_url = construct_authorized_url(
             url_base=cls.client_settings["url"],

--- a/tests/tensor_search/test_add_documents.py
+++ b/tests/tensor_search/test_add_documents.py
@@ -866,7 +866,7 @@ class TestAddDocuments(MarqoTestCase):
 
     def test_doc_too_large(self):
         max_size = 400000
-        mock_environ = {enums.EnvVars.MARQO_MAX_DOC_BYTES: max_size}
+        mock_environ = {enums.EnvVars.MARQO_MAX_DOC_BYTES: str(max_size)}
 
         @mock.patch("os.environ", mock_environ)
         def run():
@@ -888,7 +888,7 @@ class TestAddDocuments(MarqoTestCase):
 
     def test_doc_too_large_single_doc(self):
         max_size = 400000
-        mock_environ = {enums.EnvVars.MARQO_MAX_DOC_BYTES: max_size}
+        mock_environ = {enums.EnvVars.MARQO_MAX_DOC_BYTES: str(max_size)}
 
         @mock.patch("os.environ", mock_environ)
         def run():

--- a/tests/tensor_search/test_add_documents.py
+++ b/tests/tensor_search/test_add_documents.py
@@ -565,9 +565,15 @@ class TestAddDocuments(MarqoTestCase):
                 url=F"{self.endpoint}/{self.index_name_1}/_doc/{doc_id}",
                 verify=False
             )
+            check_dict_no_id = copy.deepcopy(check_dict)
+            try:
+                del check_dict_no_id['_id']
+            except KeyError:
+                pass
             # make sure that the chunks have been updated
             for ch in updated_raw_doc.json()['_source']['__chunks']:
-                for field, expected_value in check_dict.items():
+                assert '_id' not in ch
+                for field, expected_value in check_dict_no_id.items():
                     assert ch[field] == expected_value
         return True
 
@@ -598,7 +604,7 @@ class TestAddDocuments(MarqoTestCase):
         )
 
     def test_put_documents_multiple_docs(self):
-        """mutliple docs updated at once"""
+        """multiple docs updated at once"""
         docs_ = [
             {"_id": "123", "Title": "Story of Joe Blogs", "Description": "Joe was a great farmer."},
             {"_id": "789", "Title": "Story of Alice Appleseed", "Description": "Alice grew up in Houston, Texas."}
@@ -859,9 +865,15 @@ class TestAddDocuments(MarqoTestCase):
             url=F"{self.endpoint}/{self.index_name_1}/_doc/789",
             verify=False
         )
+        check_dict_no_id = copy.deepcopy(check_dict)
+        try:
+            del check_dict_no_id['_id']
+        except KeyError:
+            pass
         # make sure that the chunks have been updated
         for ch in updated_raw_doc.json()['_source']['__chunks']:
-            for field, expected_value in check_dict.items():
+            assert '_id' not in ch
+            for field, expected_value in check_dict_no_id.items():
                 assert ch[field] == expected_value
 
     def test_doc_too_large(self):

--- a/tests/tensor_search/test_create_index.py
+++ b/tests/tensor_search/test_create_index.py
@@ -158,11 +158,13 @@ class TestCreateIndex(MarqoTestCase):
             @mock.patch("os.environ", {EnvVars.MARQO_MAX_INDEX_FIELDS: str(lim)})
             def run():
                 res_1 = tensor_search.add_documents(
-                    index_name=self.index_name_1, docs=[{f"f{i}": "some content" for i in range(lim)}],
+                    index_name=self.index_name_1, docs=[
+                        {f"f{i}": "some content" for i in range(lim)},
+                        {"_id": "1234", **{f"f{i}": "new content" for i in range(lim)}},
+                    ],
                     auto_refresh=True, config=self.config
                 )
                 assert not res_1['errors']
-                # Notice the lack of resiliency:
                 res_1_2 = tensor_search.add_documents(
                     index_name=self.index_name_1, docs=[
                         {'f0': 'this is fine, but there is no resiliency.'},
@@ -188,7 +190,7 @@ class TestCreateIndex(MarqoTestCase):
         @mock.patch("os.environ", {EnvVars.MARQO_MAX_INDEX_FIELDS: "5"})
         def run():
             docs = [
-                {"f1": "fgrrvb", "f2": 1234, "f3": 1.4, "f4": "hello hello", "f5": False},
+                {"f1": "fgrrvb", "f2": 1234, "f3": 1.4, "f4": "hello hello", "f5": False, "_id": "hehehehe"},
                 {"f1": "erf1f", "f2": 934, "f3": 4.0, "f4": "my name", "f5": True},
                 {"f1": "water is healthy", "f5": True},
                 {"f2": 49, "f3": 400.4, "f4": "alien message"}
@@ -222,7 +224,7 @@ class TestCreateIndex(MarqoTestCase):
                 {"f1": "fgrrvb", "f2": 1234, "f3": 1.4, "f4": "hello hello", "f5": False},
                 {"f1": "erf1f", "f2": 934, "f3": 4.0, "f4": "my name", "f5": True},
                 {"f1": "water is healthy", "f5": True},
-                {"f2": 49, "f3": 400.4, "f4": "alien message"}
+                {"f2": 49, "f3": 400.4, "f4": "alien message", "_id": "rkjn"}
             ]
             res_1 = tensor_search.add_documents(
                 index_name=self.index_name_1, docs=docs, auto_refresh=True, config=self.config

--- a/tests/tensor_search/test_create_index.py
+++ b/tests/tensor_search/test_create_index.py
@@ -155,7 +155,7 @@ class TestCreateIndex(MarqoTestCase):
             mock_read_env_vars = mock.MagicMock()
             mock_read_env_vars.return_value = lim
 
-            @mock.patch("os.environ", {EnvVars.MARQO_MAX_INDEX_FIELDS: lim})
+            @mock.patch("os.environ", {EnvVars.MARQO_MAX_INDEX_FIELDS: str(lim)})
             def run():
                 res_1 = tensor_search.add_documents(
                     index_name=self.index_name_1, docs=[{f"f{i}": "some content" for i in range(lim)}],
@@ -185,7 +185,7 @@ class TestCreateIndex(MarqoTestCase):
             assert run()
 
     def test_field_limit_non_text_types(self):
-        @mock.patch("os.environ", {EnvVars.MARQO_MAX_INDEX_FIELDS: 5})
+        @mock.patch("os.environ", {EnvVars.MARQO_MAX_INDEX_FIELDS: "5"})
         def run():
             docs = [
                 {"f1": "fgrrvb", "f2": 1234, "f3": 1.4, "f4": "hello hello", "f5": False},

--- a/tests/tensor_search/test_get_documents_by_ids.py
+++ b/tests/tensor_search/test_get_documents_by_ids.py
@@ -138,13 +138,15 @@ class TestGetDocuments(MarqoTestCase):
                 try:
                     oversized_search = tensor_search.get_documents_by_ids(
                         config=self.config, index_name=self.index_name_1,
-                        document_ids=[docs[i]['_id'] for i in range(max_doc)])
+                        document_ids=[docs[i]['_id'] for i in range(max_doc + 1)])
+                    raise AssertionError
                 except InvalidArgError:
                     pass
                 try:
                     very_oversized_search = tensor_search.get_documents_by_ids(
                          config=self.config, index_name=self.index_name_1,
-                         document_ids=[docs[i]['_id'] for i in range(max_doc)])
+                         document_ids=[docs[i]['_id'] for i in range(max_doc * 2)])
+                    raise AssertionError
                 except InvalidArgError:
                     pass
                 return True

--- a/tests/tensor_search/test_get_documents_by_ids.py
+++ b/tests/tensor_search/test_get_documents_by_ids.py
@@ -1,12 +1,13 @@
 import functools
 import pprint
+import uuid
 from marqo.tensor_search import enums
 from marqo.errors import (
     IndexNotFoundError, InvalidDocumentIdError, InvalidArgError
 )
 from marqo.tensor_search import tensor_search
 from tests.marqo_test import MarqoTestCase
-
+from unittest import mock
 
 class TestGetDocuments(MarqoTestCase):
 
@@ -108,3 +109,66 @@ class TestGetDocuments(MarqoTestCase):
                     raise AssertionError
                 except (InvalidDocumentIdError, InvalidArgError):
                     pass
+
+    def test_get_documents_env_limit(self):
+        tensor_search.create_vector_index(
+            config=self.config, index_name=self.index_name_1,
+            index_settings={enums.IndexSettingsField.index_defaults: {
+                enums.IndexSettingsField.model: enums.MlModel.bert
+            }})
+        docs = [{"Title": "a", "_id": uuid.uuid4().__str__()} for _ in range(2000)]
+        tensor_search.add_documents_orchestrator(
+            config=self.config, index_name=self.index_name_1,
+            docs=docs, auto_refresh=False, batch_size=50, processes=4
+        )
+        tensor_search.refresh_index(config=self.config, index_name=self.index_name_1)
+        for max_doc in [0, 1, 2, 5, 10, 100, 1000]:
+            mock_environ = {enums.EnvVars.MARQO_MAX_RETRIEVABLE_DOCS: max_doc}
+
+            @mock.patch("os.environ", mock_environ)
+            def run():
+                half_search = tensor_search.get_documents_by_ids(
+                   config=self.config, index_name=self.index_name_1,
+                   document_ids=[docs[i]['_id'] for i in range(max_doc // 2)])
+                assert len(half_search['results']) == max_doc // 2
+                limit_search = tensor_search.get_documents_by_ids(
+                    config=self.config, index_name=self.index_name_1,
+                    document_ids=[docs[i]['_id'] for i in range(max_doc)])
+                assert len(limit_search['results']) == max_doc
+                try:
+                    oversized_search = tensor_search.get_documents_by_ids(
+                        config=self.config, index_name=self.index_name_1,
+                        document_ids=[docs[i]['_id'] for i in range(max_doc)])
+                except InvalidArgError:
+                    pass
+                try:
+                    very_oversized_search = tensor_search.get_documents_by_ids(
+                         config=self.config, index_name=self.index_name_1,
+                         document_ids=[docs[i]['_id'] for i in range(max_doc)])
+                except InvalidArgError:
+                    pass
+                return True
+        assert run()
+
+    def test_limit_results_none(self):
+        """if env var isn't set or is None"""
+        docs = [{"Title": "a", "_id": uuid.uuid4().__str__()} for _ in range(2000)]
+
+        tensor_search.add_documents_orchestrator(
+            config=self.config, index_name=self.index_name_1,
+            docs=docs, auto_refresh=False, batch_size=50, processes=4
+        )
+        tensor_search.refresh_index(config=self.config, index_name=self.index_name_1)
+
+        for mock_environ in [dict(), {enums.EnvVars.MARQO_MAX_RETRIEVABLE_DOCS: None},
+                             {enums.EnvVars.MARQO_MAX_RETRIEVABLE_DOCS: ''}]:
+            @mock.patch("os.environ", mock_environ)
+            def run():
+                sample_size = 500
+                limit_search = tensor_search.get_documents_by_ids(
+                    config=self.config, index_name=self.index_name_1,
+                    document_ids=[docs[i]['_id'] for i in range(sample_size)])
+                assert len(limit_search['results']) == sample_size
+                return True
+
+            assert run()

--- a/tests/tensor_search/test_get_documents_by_ids.py
+++ b/tests/tensor_search/test_get_documents_by_ids.py
@@ -3,7 +3,8 @@ import pprint
 import uuid
 from marqo.tensor_search import enums
 from marqo.errors import (
-    IndexNotFoundError, InvalidDocumentIdError, InvalidArgError
+    IndexNotFoundError, InvalidDocumentIdError, InvalidArgError,
+    IllegalRequestedDocCount
 )
 from marqo.tensor_search import tensor_search
 from tests.marqo_test import MarqoTestCase
@@ -140,14 +141,14 @@ class TestGetDocuments(MarqoTestCase):
                         config=self.config, index_name=self.index_name_1,
                         document_ids=[docs[i]['_id'] for i in range(max_doc + 1)])
                     raise AssertionError
-                except InvalidArgError:
+                except IllegalRequestedDocCount:
                     pass
                 try:
                     very_oversized_search = tensor_search.get_documents_by_ids(
                          config=self.config, index_name=self.index_name_1,
                          document_ids=[docs[i]['_id'] for i in range(max_doc * 2)])
                     raise AssertionError
-                except InvalidArgError:
+                except IllegalRequestedDocCount:
                     pass
                 return True
         assert run()

--- a/tests/tensor_search/test_get_documents_by_ids.py
+++ b/tests/tensor_search/test_get_documents_by_ids.py
@@ -123,7 +123,7 @@ class TestGetDocuments(MarqoTestCase):
         )
         tensor_search.refresh_index(config=self.config, index_name=self.index_name_1)
         for max_doc in [0, 1, 2, 5, 10, 100, 1000]:
-            mock_environ = {enums.EnvVars.MARQO_MAX_RETRIEVABLE_DOCS: max_doc}
+            mock_environ = {enums.EnvVars.MARQO_MAX_RETRIEVABLE_DOCS: str(max_doc)}
 
             @mock.patch("os.environ", mock_environ)
             def run():

--- a/tests/tensor_search/test_search.py
+++ b/tests/tensor_search/test_search.py
@@ -707,12 +707,12 @@ class TestVectorSearch(MarqoTestCase):
                     try:
                         oversized_search = tensor_search.search(search_method=search_method,
                             config=self.config, index_name=self.index_name_1, text='a', result_count=max_doc + 1)
-                    except InvalidArgError:
+                    except IllegalRequestedDocCount:
                         pass
                     try:
                         very_oversized_search = tensor_search.search(search_method=search_method,
                             config=self.config, index_name=self.index_name_1, text='a', result_count=(max_doc + 1) * 2)
-                    except InvalidArgError:
+                    except IllegalRequestedDocCount:
                         pass
                     return True
             assert run()
@@ -731,7 +731,8 @@ class TestVectorSearch(MarqoTestCase):
         tensor_search.refresh_index(config=self.config, index_name=self.index_name_1)
 
         for search_method in (SearchMethod.LEXICAL, SearchMethod.TENSOR):
-            for mock_environ in [dict(), {EnvVars.MARQO_MAX_RETRIEVABLE_DOCS: None}]:
+            for mock_environ in [dict(), {EnvVars.MARQO_MAX_RETRIEVABLE_DOCS: None},
+                                 {EnvVars.MARQO_MAX_RETRIEVABLE_DOCS: ''}]:
                 @mock.patch("os.environ", mock_environ)
                 def run():
                     lim = 500

--- a/tests/tensor_search/test_search.py
+++ b/tests/tensor_search/test_search.py
@@ -692,7 +692,7 @@ class TestVectorSearch(MarqoTestCase):
         tensor_search.refresh_index(config=self.config, index_name=self.index_name_1)
         for search_method in (SearchMethod.LEXICAL, SearchMethod.TENSOR):
             for max_doc in [0, 1, 2, 5, 10, 100, 1000]:
-                mock_environ = {EnvVars.MARQO_MAX_RETRIEVABLE_DOCS: max_doc}
+                mock_environ = {EnvVars.MARQO_MAX_RETRIEVABLE_DOCS: str(max_doc)}
 
                 @mock.patch("os.environ", mock_environ)
                 def run():

--- a/tests/tensor_search/test_search.py
+++ b/tests/tensor_search/test_search.py
@@ -1,8 +1,7 @@
 import math
 import pprint
 from unittest import mock
-
-from marqo.tensor_search.enums import TensorField, SearchMethod
+from marqo.tensor_search.enums import TensorField, SearchMethod, EnvVars
 from marqo.errors import (
     MarqoApiError, MarqoError, IndexNotFoundError, InvalidArgError,
     InvalidFieldNameError
@@ -10,7 +9,8 @@ from marqo.errors import (
 from marqo.tensor_search import tensor_search, constants, index_meta_cache
 import copy
 from tests.marqo_test import MarqoTestCase
-
+import requests
+import random
 
 class TestVectorSearch(MarqoTestCase):
 
@@ -484,7 +484,7 @@ class TestVectorSearch(MarqoTestCase):
                 },
                 {
                     "_id": "other doc", "a_float": 0.66, "bfield": "some text too", "my_int":5,
-                    "fake_int":"234", "fake_float":"1.23", "gapped field_name": "gap"
+                    "fake_int": "234", "fake_float": "1.23", "gapped field_name": "gap"
                 }
             ], auto_refresh=True)
 
@@ -692,4 +692,68 @@ class TestVectorSearch(MarqoTestCase):
                 except (InvalidArgError, InvalidFieldNameError):
                     pass
 
+    def test_limit_results(self):
+        """"""
+        vocab_source = "https://www.mit.edu/~ecprice/wordlist.10000"
 
+        vocab = requests.get(vocab_source).text.splitlines()
+
+        tensor_search.add_documents(
+            config=self.config, index_name=self.index_name_1,
+            docs=[{"Title": "a" + (" ".join(random.choices(population=vocab, k=25)))}
+                  for _ in range(2000)], auto_refresh=False
+        )
+        tensor_search.refresh_index(config=self.config, index_name=self.index_name_1)
+        for search_method in (SearchMethod.LEXICAL, SearchMethod.TENSOR):
+            for max_doc in [0, 1, 2, 5, 10, 100, 1000]:
+                mock_environ = {EnvVars.MARQO_MAX_RETRIEVABLE_DOCS: max_doc}
+
+                @mock.patch("os.environ", mock_environ)
+                def run():
+                    half_search = tensor_search.search(search_method=search_method,
+                        config=self.config, index_name=self.index_name_1, text='a', result_count=max_doc//2)
+                    assert half_search['limit'] == max_doc//2
+                    assert len(half_search['hits']) == max_doc//2
+                    limit_search = tensor_search.search(search_method=search_method,
+                        config=self.config, index_name=self.index_name_1, text='a', result_count=max_doc)
+                    assert limit_search['limit'] == max_doc
+                    assert len(limit_search['hits']) == max_doc
+                    try:
+                        oversized_search = tensor_search.search(search_method=search_method,
+                            config=self.config, index_name=self.index_name_1, text='a', result_count=max_doc + 1)
+                    except InvalidArgError:
+                        pass
+                    try:
+                        very_oversized_search = tensor_search.search(search_method=search_method,
+                            config=self.config, index_name=self.index_name_1, text='a', result_count=(max_doc + 1) * 2)
+                    except InvalidArgError:
+                        pass
+                    return True
+            assert run()
+
+    def test_limit_results_none(self):
+        """if env var isn't set or is None"""
+        vocab_source = "https://www.mit.edu/~ecprice/wordlist.10000"
+
+        vocab = requests.get(vocab_source).text.splitlines()
+
+        tensor_search.add_documents(
+            config=self.config, index_name=self.index_name_1,
+            docs=[{"Title": "a" + (" ".join(random.choices(population=vocab, k=25)))}
+                  for _ in range(2000)], auto_refresh=False
+        )
+        tensor_search.refresh_index(config=self.config, index_name=self.index_name_1)
+
+        for search_method in (SearchMethod.LEXICAL, SearchMethod.TENSOR):
+            for mock_environ in [dict(), {EnvVars.MARQO_MAX_RETRIEVABLE_DOCS: None}]:
+                @mock.patch("os.environ", mock_environ)
+                def run():
+                    lim = 500
+                    half_search = tensor_search.search(
+                        search_method=search_method,
+                        config=self.config, index_name=self.index_name_1, text='a', result_count=lim)
+                    assert half_search['limit'] == lim
+                    assert len(half_search['hits']) == lim
+                    return True
+
+                assert run()

--- a/tests/tensor_search/test_validation.py
+++ b/tests/tensor_search/test_validation.py
@@ -212,7 +212,7 @@ class TestValidation(unittest.TestCase):
 
     def test_validate_doc_max_size(self):
         max_size = 1234567
-        mock_environ = {enums.EnvVars.MARQO_MAX_DOC_BYTES: max_size}
+        mock_environ = {enums.EnvVars.MARQO_MAX_DOC_BYTES: str(max_size)}
 
         @mock.patch("os.environ", mock_environ)
         def run():


### PR DESCRIPTION

* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature: limit the number of returned docs with an env var (for search and get_documents endpoints)
Better error if Marqo can't find Marqo-OS on start 
Bug fix: _id is no longer a facet filtering field 

* **What is the current behavior?** (You can also link to an open issue here)
Limit for number of returned docs was inconsistently defined, and hardcoded
_id was appearing as a facet filtering field

* **What is the new behavior (if this is a feature change)?**
The limit of the number of returned docs is settable with an env var

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
Ran tox. 
Created [a manual api test](https://github.com/marqo-ai/marqo-api-tests/blob/mainline/manual_tests/env_var_tests.py) to ensure that the env var limits behaviour is consistent after being built into a Docker image