### PR TITLE
Useful error propagated to user when Marqo receives 429

### DIFF
--- a/src/marqo/_httprequests.py
+++ b/src/marqo/_httprequests.py
@@ -15,7 +15,7 @@ from marqo.errors import (
     IndexAlreadyExistsError,
     InvalidIndexNameError,
     HardwareCompatabilityError,
-    IndexMaxFieldsError
+    IndexMaxFieldsError, TooManyRequestsError
 )
 from urllib3.exceptions import InsecureRequestWarning
 import warnings
@@ -150,6 +150,10 @@ def convert_to_marqo_web_error_and_raise(response: requests.Response, err: reque
         response_dict = response.json()
     except JSONDecodeError:
         raise_catchall_http_as_marqo_error(response=response, err=err)
+    if response.status_code == 429:
+        raise TooManyRequestsError(
+            message="Marqo-OS received too many requests! "
+                    "Please try reducing the frequency of add_documents and update_documents calls.")
 
     try:
         open_search_error_type = response_dict["error"]["type"]

--- a/src/marqo/errors.py
+++ b/src/marqo/errors.py
@@ -93,6 +93,11 @@ class __InvalidRequestError(MarqoWebError):
     error_type = "invalid_request"
 
 
+class TooManyRequestsError(__InvalidRequestError):
+    code = "too_many_requests"
+    status_code = HTTPStatus.TOO_MANY_REQUESTS
+
+
 class IndexAlreadyExistsError(__InvalidRequestError):
     code = "index_already_exists"
     status_code = HTTPStatus.CONFLICT

--- a/tests/tensor_search/test__httprequests.py
+++ b/tests/tensor_search/test__httprequests.py
@@ -1,0 +1,42 @@
+import requests
+from tests.marqo_test import MarqoTestCase
+from marqo import _httprequests
+from unittest import mock
+from marqo.tensor_search import tensor_search
+from marqo.errors import (
+    IndexNotFoundError, TooManyRequestsError
+)
+
+class Test_HttpRequests(MarqoTestCase):
+
+    def setUp(self) -> None:
+        self.endpoint = self.authorized_url
+        self.generic_header = {"Content-type": "application/json"}
+        self.index_name_1 = "my-test-index-1"
+        try:
+            tensor_search.delete_index(config=self.config, index_name=self.index_name_1)
+        except IndexNotFoundError as s:
+            pass
+
+    def test_too_many_reqs_error(self):
+        mock_post = mock.MagicMock()
+        mock_response = requests.Response()
+        mock_response.status_code = 429
+        mock_response.json = lambda: '{"a":"b"}'
+        mock_post.return_value = mock_response
+        tensor_search.create_vector_index(config=self.config, index_name=self.index_name_1)
+
+        @mock.patch('requests.post', mock_post)
+        @mock.patch('marqo._httprequests.ALLOWED_OPERATIONS', {mock_post, requests.get, requests.put})
+        def run():
+            try:
+                res = tensor_search.add_documents(
+                    config=self.config, index_name=self.index_name_1,
+                    docs=[{"some ": "doc"}], auto_refresh=True
+                )
+                raise AssertionError
+            except TooManyRequestsError:
+                pass
+            return True
+        assert run()
+


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
429 would be converted into 5xx errors without any helpful message before being sent to users

* **What is the new behavior (if this is a feature change)?**
429 errors are propagated to user with more helpful error message.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
Ran tox
