### PR TITLE
Create Github action to build `marqoai/marqo` image and deploy to DockerHub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,36 @@
+name: Release Open source Marqo artefacts.
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  docker-release:
+    name: Build and push Docker images for `marqoai/marqo`
+    runs-on: ubuntu-latest
+  
+    steps:     
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up QEMU # https://github.com/docker/setup-qemu-action
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build `marqoai/marqo`
+        run: |
+          DOCKER_BUILDKIT=1 
+          docker buildx build --platform linux/arm64,linux/amd64 --push . -t marqoai/marqo:${{ github.ref_name }}
+
+      - name: Push `marqoai/marqo` to DockerHub
+        run: docker push $marqoai/marqo:${{ github.ref_name }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build `marqoai/marqo`
         run: |
           DOCKER_BUILDKIT=1 
-          docker buildx build --platform linux/arm64,linux/amd64 --push . -t marqoai/marqo:${{ github.ref_name }}
+          docker buildx build --platform linux/arm64,linux/amd64 --push . -t marqoai/marqo:test-${{ github.ref_name }}
 
       - name: Push `marqoai/marqo` to DockerHub
-        run: docker push $marqoai/marqo:${{ github.ref_name }}
+        run: docker push $marqoai/marqo:test-${{ github.ref_name }}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [] Tests for the changes have been added (for bug fixes/features)
- [] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- CI/CD update. Docker images are currently built and deployed manually for new releases. This PR introduces a Github action to build and deploy docker image on a new release with a tag of semantic version (i.e. `v*`).

**What is the current behavior?** (You can also link to an open issue here)
- Currently, docker images are built and pushed manually by a Marqo engineer.

**What is the new behavior (if this is a feature change)?**
- When a commit is pushed to the regexed tag, the Github Action `docker.yml` will be triggered, and it will push the built images to DockerHub. 

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
* N/A. Not apart of the open source, source code.

**Other information**:
* Two Github Action secrets must be added to the repo: `DOCKER_USERNAME` &. `DOCKER_PASSWORD` before merge.

