### PR TITLE
Check HTTP status for remote image paths

### DIFF
--- a/src/marqo/s2_inference/clip_utils.py
+++ b/src/marqo/s2_inference/clip_utils.py
@@ -6,7 +6,7 @@ import requests
 import numpy as np
 import clip
 import torch
-from PIL import Image
+from PIL import Image, UnidentifiedImageError
 import open_clip
 
 from marqo.s2_inference.types import *
@@ -47,8 +47,8 @@ def load_image_from_path(image_path: str) -> ImageType:
         image_path (str): Local or remote path to image.
 
     Raises:
-        ValueError: If the local path is invalid, or getting the image from a 
-        remote server returns a non-success status code.
+        ValueError: If the local path is invalid, and is not a url
+        UnidentifiedImageError: If the image is irretrievable or unprocessable.
 
     Returns:
         ImageType: In-memory PIL image.
@@ -59,7 +59,7 @@ def load_image_from_path(image_path: str) -> ImageType:
     elif validators.url(image_path):
         resp = requests.get(image_path, stream=True)
         if not resp.ok:
-            raise ValueError(f"image url {image_path} returned a {resp.status_code}. Reason {resp.reason}")
+            raise UnidentifiedImageError(f"image url {image_path} returned a {resp.status_code}. Reason {resp.reason}")
         img = Image.open(resp.raw)
     else:
         raise ValueError(f"input str of {image_path} is not a local file or a valid url")

--- a/src/marqo/s2_inference/clip_utils.py
+++ b/src/marqo/s2_inference/clip_utils.py
@@ -40,26 +40,29 @@ def format_and_load_CLIP_images(images: List[Union[str, ndarray, ImageType]]) ->
     
     return results
 
-def _load_image_from_path(image: str) -> ImageType:
-    """loads an image into PIL from a string path that is
-    either local or a url
+def load_image_from_path(image_path: str) -> ImageType:
+    """Loads an image into PIL from a string path that is either local or a url
 
     Args:
-        image (str): _description_
+        image_path (str): Local or remote path to image.
 
     Raises:
-        ValueError: _description_
+        ValueError: If the local path is invalid, or getting the image from a 
+        remote server returns a non-success status code.
 
     Returns:
-        ImageType: _description_
+        ImageType: In-memory PIL image.
     """
     
-    if os.path.isfile(image):
-        img = Image.open(image)
-    elif validators.url(image):
-        img = Image.open(requests.get(image, stream=True).raw)
+    if os.path.isfile(image_path):
+        img = Image.open(image_path)
+    elif validators.url(image_path):
+        resp = requests.get(image_path, stream=True)
+        if not resp.ok:
+            raise ValueError(f"image url {image_path} returned a {resp.status_code}. Reason {resp.reason}")
+        img = Image.open(resp.raw)
     else:
-        raise ValueError(f"input str of {image} is not a local file or a valid url")
+        raise ValueError(f"input str of {image_path} is not a local file or a valid url")
 
     return img
 
@@ -78,7 +81,7 @@ def format_and_load_CLIP_image(image: Union[str, ndarray, ImageType]) -> ImageTy
     """
     # check for the input type
     if isinstance(image, str):
-        img = _load_image_from_path(image)
+        img = load_image_from_path(image)
     elif isinstance(image, np.ndarray):
         img = Image.fromarray(image.astype('uint8'), 'RGB')
 

--- a/src/marqo/s2_inference/processing/image.py
+++ b/src/marqo/s2_inference/processing/image.py
@@ -12,7 +12,7 @@ import torchvision
 from marqo.s2_inference.s2_inference import available_models
 from marqo.s2_inference.s2_inference import get_logger
 from marqo.s2_inference.types import Dict, List, Union, ImageType, Tuple, FloatTensor, ndarray
-from marqo.s2_inference.clip_utils import format_and_load_CLIP_image, _load_image_from_path
+from marqo.s2_inference.clip_utils import format_and_load_CLIP_image, load_image_from_path
 
 logger = get_logger('image_chunks')
 
@@ -87,7 +87,7 @@ def load_rcnn_image(image_name: str, size: Tuple = (320,320)) -> Tuple[ImageType
     if isinstance(image_name, ImageType):
         image = image_name 
     elif isinstance(image_name, str):
-        image = _load_image_from_path(image_name)
+        image = load_image_from_path(image_name)
     else:
         raise TypeError(f"received {type(image_name)} but expected a string or PIL image")
 

--- a/src/marqo/s2_inference/reranking/cross_encoders.py
+++ b/src/marqo/s2_inference/reranking/cross_encoders.py
@@ -26,7 +26,7 @@ from marqo.s2_inference.reranking.model_utils import (
     _keep_top_k
     )
 
-from marqo.s2_inference.clip_utils import _load_image_from_path
+from marqo.s2_inference.clip_utils import load_image_from_path
 from marqo.s2_inference.reranking.enums import Columns, ResultsFields
 from marqo.s2_inference.reranking.configs import get_default_text_processing_parameters
 from marqo.s2_inference.processing import text as text_processor
@@ -470,7 +470,7 @@ def _load_image(filename: str, size: Tuple = None) -> ImageType:
     Returns:
         ImageType: _description_
     """
-    im = _load_image_from_path(filename)
+    im = load_image_from_path(filename)
     original_size = im.size
     if size is not None:
         im = im.resize(size).convert('RGB')


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Introduce better error messages when downloading an image fails.

* **What is the current behavior?** (You can also link to an open issue here)
https://github.com/marqo-ai/marqo/issues/189

* **What is the new behavior (if this is a feature change)?**
Check response object `resp.ok` before parsing the payload of the image response.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
Yep

* **Other information**:
- I also updated docstrings and changed the name `_load_image_from_path` to `load_image_from_path` because it is not a private method (used out of file).

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)
