### PR TITLE
Branch aware ci tests

### DIFF
--- a/.github/workflows/arm64_local_os.yml
+++ b/.github/workflows/arm64_local_os.yml
@@ -3,6 +3,13 @@ name: arm64_local_os
 # take 2
 on:
   workflow_dispatch:
+    inputs:
+      image_to_test:
+        required: false
+        default: ""
+        description: >
+          This is optional. If left unset, the docker image built from this branch is tested.
+          If set, the docker specified docker image is tested. For example "marqoai/marqo:test"
   push:
     branches:
       mainline
@@ -83,6 +90,7 @@ jobs:
       - name: Run Integration Tests - ARM64 local_os
         run: |
           export MQ_API_TEST_BRANCH="${GITHUB_REF##*/}"
+          export MQ_API_TEST_IMG="${{ github.event.inputs.image_to_test }}"
           tox -e py3-arm64_local_os
   
   Stop-Runner:

--- a/.github/workflows/arm64_local_os.yml
+++ b/.github/workflows/arm64_local_os.yml
@@ -81,9 +81,9 @@ jobs:
           echo 'export MARQO_API_TESTS_ROOT="${{ github.workspace }}"' >> conf
           
       - name: Run Integration Tests - ARM64 local_os
-        env:
-            MQ_API_TEST_BRANCH: ${{ github.ref.split('/')[2:].join('/') }}
-        run: tox -e py3-arm64_local_os
+        run: |
+          export MQ_API_TEST_BRANCH="${GITHUB_REF##*/}"
+          tox -e py3-arm64_local_os
   
   Stop-Runner:
     name: Stop self-hosted EC2 runner

--- a/.github/workflows/arm64_local_os.yml
+++ b/.github/workflows/arm64_local_os.yml
@@ -9,7 +9,7 @@ on:
         default: ""
         description: >
           This is optional. If left unset, the docker image built from this branch is tested.
-          If set, the docker specified docker image is tested. For example "marqoai/marqo:test"
+          If set, the specified docker image is tested. For example "marqoai/marqo:test"
   push:
     branches:
       mainline

--- a/.github/workflows/arm64_local_os.yml
+++ b/.github/workflows/arm64_local_os.yml
@@ -81,6 +81,8 @@ jobs:
           echo 'export MARQO_API_TESTS_ROOT="${{ github.workspace }}"' >> conf
           
       - name: Run Integration Tests - ARM64 local_os
+        env:
+            MQ_API_TEST_BRANCH: ${{ github.ref }}
         run: tox -e py3-arm64_local_os
   
   Stop-Runner:

--- a/.github/workflows/arm64_local_os.yml
+++ b/.github/workflows/arm64_local_os.yml
@@ -82,7 +82,7 @@ jobs:
           
       - name: Run Integration Tests - ARM64 local_os
         env:
-            MQ_API_TEST_BRANCH: "${GITHUB_REF##*/}"
+            MQ_API_TEST_BRANCH: ${{ github.ref.split('/')[2:].join('/') }}
         run: tox -e py3-arm64_local_os
   
   Stop-Runner:

--- a/.github/workflows/arm64_local_os.yml
+++ b/.github/workflows/arm64_local_os.yml
@@ -8,8 +8,8 @@ on:
         # This is the name of the docker image that is built by the build script:
         default: marqo_docker_0
         description: >
-          This is optional. If left unset, the docker image built from this branch is tested.
-          If set, the specified docker image is tested. For example "marqoai/marqo:test"
+          This is optional. If left as the default value "marqo_docker_0", the docker image built from this branch is tested.
+          Otherwise, the specified docker image is tested. For example "marqoai/marqo:test"
   push:
     branches:
       mainline

--- a/.github/workflows/arm64_local_os.yml
+++ b/.github/workflows/arm64_local_os.yml
@@ -82,7 +82,7 @@ jobs:
           
       - name: Run Integration Tests - ARM64 local_os
         env:
-            MQ_API_TEST_BRANCH: ${{ github.ref }}
+            MQ_API_TEST_BRANCH: ${GITHUB_REF##*/}
         run: tox -e py3-arm64_local_os
   
   Stop-Runner:

--- a/.github/workflows/arm64_local_os.yml
+++ b/.github/workflows/arm64_local_os.yml
@@ -82,7 +82,7 @@ jobs:
           
       - name: Run Integration Tests - ARM64 local_os
         env:
-            MQ_API_TEST_BRANCH: ${GITHUB_REF##*/}
+            MQ_API_TEST_BRANCH: "${GITHUB_REF##*/}"
         run: tox -e py3-arm64_local_os
   
   Stop-Runner:

--- a/.github/workflows/arm64_local_os.yml
+++ b/.github/workflows/arm64_local_os.yml
@@ -1,12 +1,12 @@
 name: arm64_local_os
 # runs Integration Tests on Local OS on an ARM64 Machine
-# take 2
 on:
   workflow_dispatch:
     inputs:
       image_to_test:
         required: false
-        default: ""
+        # This is the name of the docker image that is built by the build script:
+        default: marqo_docker_0
         description: >
           This is optional. If left unset, the docker image built from this branch is tested.
           If set, the specified docker image is tested. For example "marqoai/marqo:test"

--- a/.github/workflows/cuda_dind_os_CI.yml
+++ b/.github/workflows/cuda_dind_os_CI.yml
@@ -81,6 +81,8 @@ jobs:
           echo 'export MARQO_API_TESTS_ROOT="${{ github.workspace }}"' >> conf
           
       - name: Run CUDA Integration Tests - dind_os
+        env:
+          MQ_API_TEST_BRANCH: ${{ github.ref }}
         run: tox -e py3-cuda_dind_os
   
   Stop-Runner:

--- a/.github/workflows/cuda_dind_os_CI.yml
+++ b/.github/workflows/cuda_dind_os_CI.yml
@@ -81,9 +81,9 @@ jobs:
           echo 'export MARQO_API_TESTS_ROOT="${{ github.workspace }}"' >> conf
           
       - name: Run CUDA Integration Tests - dind_os
-        env:
-          MQ_API_TEST_BRANCH: ${{ github.ref.split('/')[2:].join('/') }}
-        run: tox -e py3-cuda_dind_os
+        run: |
+          export MQ_API_TEST_BRANCH="${GITHUB_REF##*/}"
+          tox -e py3-cuda_dind_os
   
   Stop-Runner:
     name: Stop self-hosted EC2 runner

--- a/.github/workflows/cuda_dind_os_CI.yml
+++ b/.github/workflows/cuda_dind_os_CI.yml
@@ -6,7 +6,7 @@ on:
     inputs:
       image_to_test:
         required: false
-        default: ""
+        default: marqo_docker_0
         description: >
           This is optional. If left unset, the docker image built from this branch is tested.
           If set, the specified docker image is tested. For example "marqoai/marqo:test"

--- a/.github/workflows/cuda_dind_os_CI.yml
+++ b/.github/workflows/cuda_dind_os_CI.yml
@@ -82,7 +82,7 @@ jobs:
           
       - name: Run CUDA Integration Tests - dind_os
         env:
-          MQ_API_TEST_BRANCH: "${GITHUB_REF##*/}"
+          MQ_API_TEST_BRANCH: ${{ github.ref.split('/')[2:].join('/') }}
         run: tox -e py3-cuda_dind_os
   
   Stop-Runner:

--- a/.github/workflows/cuda_dind_os_CI.yml
+++ b/.github/workflows/cuda_dind_os_CI.yml
@@ -9,7 +9,7 @@ on:
         default: ""
         description: >
           This is optional. If left unset, the docker image built from this branch is tested.
-          If set, the docker specified docker image is tested. For example "marqoai/marqo:test"
+          If set, the specified docker image is tested. For example "marqoai/marqo:test"
   push:
     branches:
       mainline

--- a/.github/workflows/cuda_dind_os_CI.yml
+++ b/.github/workflows/cuda_dind_os_CI.yml
@@ -8,8 +8,8 @@ on:
         required: false
         default: marqo_docker_0
         description: >
-          This is optional. If left unset, the docker image built from this branch is tested.
-          If set, the specified docker image is tested. For example "marqoai/marqo:test"
+          This is optional. If left as the default value "marqo_docker_0", the docker image built from this branch is tested.
+          Otherwise, the specified docker image is tested. For example "marqoai/marqo:test"
   push:
     branches:
       mainline

--- a/.github/workflows/cuda_dind_os_CI.yml
+++ b/.github/workflows/cuda_dind_os_CI.yml
@@ -82,7 +82,7 @@ jobs:
           
       - name: Run CUDA Integration Tests - dind_os
         env:
-          MQ_API_TEST_BRANCH: ${{ github.ref }}
+          MQ_API_TEST_BRANCH: ${GITHUB_REF##*/}
         run: tox -e py3-cuda_dind_os
   
   Stop-Runner:

--- a/.github/workflows/cuda_dind_os_CI.yml
+++ b/.github/workflows/cuda_dind_os_CI.yml
@@ -82,7 +82,7 @@ jobs:
           
       - name: Run CUDA Integration Tests - dind_os
         env:
-          MQ_API_TEST_BRANCH: ${GITHUB_REF##*/}
+          MQ_API_TEST_BRANCH: "${GITHUB_REF##*/}"
         run: tox -e py3-cuda_dind_os
   
   Stop-Runner:

--- a/.github/workflows/cuda_dind_os_CI.yml
+++ b/.github/workflows/cuda_dind_os_CI.yml
@@ -3,6 +3,13 @@ name: cuda_dind_os_CI
 
 on:
   workflow_dispatch:
+    inputs:
+      image_to_test:
+        required: false
+        default: ""
+        description: >
+          This is optional. If left unset, the docker image built from this branch is tested.
+          If set, the docker specified docker image is tested. For example "marqoai/marqo:test"
   push:
     branches:
       mainline
@@ -83,6 +90,7 @@ jobs:
       - name: Run CUDA Integration Tests - dind_os
         run: |
           export MQ_API_TEST_BRANCH="${GITHUB_REF##*/}"
+          export MQ_API_TEST_IMG="${{ github.event.inputs.image_to_test }}"
           tox -e py3-cuda_dind_os
   
   Stop-Runner:

--- a/.github/workflows/dind_os_CI.yml
+++ b/.github/workflows/dind_os_CI.yml
@@ -80,7 +80,7 @@ jobs:
           
       - name: Run Integration Tests - dind_os
         env:
-          MQ_API_TEST_BRANCH: "${GITHUB_REF##*/}"
+          MQ_API_TEST_BRANCH: ${{ github.ref.split('/')[2:].join('/') }}
         run: tox -e py3-dind_os
   
   Stop-Runner:

--- a/.github/workflows/dind_os_CI.yml
+++ b/.github/workflows/dind_os_CI.yml
@@ -79,9 +79,9 @@ jobs:
           echo 'export MARQO_API_TESTS_ROOT="${{ github.workspace }}"' >> conf
           
       - name: Run Integration Tests - dind_os
-        env:
-          MQ_API_TEST_BRANCH: ${{ github.ref.split('/')[2:].join('/') }}
-        run: tox -e py3-dind_os
+        run: |
+          export MQ_API_TEST_BRANCH="${GITHUB_REF##*/}"
+          tox -e py3-dind_os
   
   Stop-Runner:
     name: Stop self-hosted EC2 runner

--- a/.github/workflows/dind_os_CI.yml
+++ b/.github/workflows/dind_os_CI.yml
@@ -80,7 +80,7 @@ jobs:
           
       - name: Run Integration Tests - dind_os
         env:
-          MQ_API_TEST_BRANCH: ""${GITHUB_REF##*/}""
+          MQ_API_TEST_BRANCH: "${GITHUB_REF##*/}"
         run: tox -e py3-dind_os
   
   Stop-Runner:

--- a/.github/workflows/dind_os_CI.yml
+++ b/.github/workflows/dind_os_CI.yml
@@ -79,6 +79,8 @@ jobs:
           echo 'export MARQO_API_TESTS_ROOT="${{ github.workspace }}"' >> conf
           
       - name: Run Integration Tests - dind_os
+        env:
+          MQ_API_TEST_BRANCH: ${{ github.ref }}
         run: tox -e py3-dind_os
   
   Stop-Runner:

--- a/.github/workflows/dind_os_CI.yml
+++ b/.github/workflows/dind_os_CI.yml
@@ -6,7 +6,7 @@ on:
     inputs:
       image_to_test:
         required: false
-        default: ""
+        default: marqo_docker_0
         description: >
           This is optional. If left unset, the docker image built from this branch is tested.
           If set, the specified docker image is tested. For example "marqoai/marqo:test"

--- a/.github/workflows/dind_os_CI.yml
+++ b/.github/workflows/dind_os_CI.yml
@@ -9,7 +9,7 @@ on:
         default: ""
         description: >
           This is optional. If left unset, the docker image built from this branch is tested.
-          If set, the docker specified docker image is tested. For example "marqoai/marqo:test"
+          If set, the specified docker image is tested. For example "marqoai/marqo:test"
   push:
     branches:
       mainline

--- a/.github/workflows/dind_os_CI.yml
+++ b/.github/workflows/dind_os_CI.yml
@@ -8,8 +8,8 @@ on:
         required: false
         default: marqo_docker_0
         description: >
-          This is optional. If left unset, the docker image built from this branch is tested.
-          If set, the specified docker image is tested. For example "marqoai/marqo:test"
+          This is optional. If left as the default value "marqo_docker_0", the docker image built from this branch is tested.
+          Otherwise, the specified docker image is tested. For example "marqoai/marqo:test"
   push:
     branches:
       mainline

--- a/.github/workflows/dind_os_CI.yml
+++ b/.github/workflows/dind_os_CI.yml
@@ -80,7 +80,7 @@ jobs:
           
       - name: Run Integration Tests - dind_os
         env:
-          MQ_API_TEST_BRANCH: ${{ github.ref }}
+          MQ_API_TEST_BRANCH: ${GITHUB_REF##*/}
         run: tox -e py3-dind_os
   
   Stop-Runner:

--- a/.github/workflows/dind_os_CI.yml
+++ b/.github/workflows/dind_os_CI.yml
@@ -80,7 +80,7 @@ jobs:
           
       - name: Run Integration Tests - dind_os
         env:
-          MQ_API_TEST_BRANCH: ${GITHUB_REF##*/}
+          MQ_API_TEST_BRANCH: ""${GITHUB_REF##*/}""
         run: tox -e py3-dind_os
   
   Stop-Runner:

--- a/.github/workflows/dind_os_CI.yml
+++ b/.github/workflows/dind_os_CI.yml
@@ -3,6 +3,13 @@ name: dind_os_CI
 
 on:
   workflow_dispatch:
+    inputs:
+      image_to_test:
+        required: false
+        default: ""
+        description: >
+          This is optional. If left unset, the docker image built from this branch is tested.
+          If set, the docker specified docker image is tested. For example "marqoai/marqo:test"
   push:
     branches:
       mainline
@@ -81,6 +88,7 @@ jobs:
       - name: Run Integration Tests - dind_os
         run: |
           export MQ_API_TEST_BRANCH="${GITHUB_REF##*/}"
+          export MQ_API_TEST_IMG="${{ github.event.inputs.image_to_test }}"
           tox -e py3-dind_os
   
   Stop-Runner:

--- a/.github/workflows/local_os_CI.yml
+++ b/.github/workflows/local_os_CI.yml
@@ -80,7 +80,7 @@ jobs:
           
       - name: Run Integration Tests - local_os
         env:
-          MQ_API_TEST_BRANCH: ${{ github.ref }}
+          MQ_API_TEST_BRANCH: ${GITHUB_REF##*/}
         run: tox -e py3-local_os
   
   Stop-Runner:

--- a/.github/workflows/local_os_CI.yml
+++ b/.github/workflows/local_os_CI.yml
@@ -6,7 +6,7 @@ on:
     inputs:
       image_to_test:
         required: false
-        default: ""
+        default: marqo_docker_0
         description: >
           This is optional. If left unset, the docker image built from this branch is tested.
           If set, the specified docker image is tested. For example "marqoai/marqo:test"

--- a/.github/workflows/local_os_CI.yml
+++ b/.github/workflows/local_os_CI.yml
@@ -79,9 +79,9 @@ jobs:
           echo 'export MARQO_API_TESTS_ROOT="${{ github.workspace }}"' >> conf
           
       - name: Run Integration Tests - local_os
-        env:
-          MQ_API_TEST_BRANCH: ${{ github.ref.split('/')[2:].join('/') }}
-        run: tox -e py3-local_os
+        run: |
+          export MQ_API_TEST_BRANCH="${GITHUB_REF##*/}"
+          tox -e py3-local_os
   
   Stop-Runner:
     name: Stop self-hosted EC2 runner

--- a/.github/workflows/local_os_CI.yml
+++ b/.github/workflows/local_os_CI.yml
@@ -9,7 +9,7 @@ on:
         default: ""
         description: >
           This is optional. If left unset, the docker image built from this branch is tested.
-          If set, the docker specified docker image is tested. For example "marqoai/marqo:test"
+          If set, the specified docker image is tested. For example "marqoai/marqo:test"
   push:
     branches:
       mainline

--- a/.github/workflows/local_os_CI.yml
+++ b/.github/workflows/local_os_CI.yml
@@ -8,8 +8,8 @@ on:
         required: false
         default: marqo_docker_0
         description: >
-          This is optional. If left unset, the docker image built from this branch is tested.
-          If set, the specified docker image is tested. For example "marqoai/marqo:test"
+          This is optional. If left as the default value "marqo_docker_0", the docker image built from this branch is tested.
+          Otherwise, the specified docker image is tested. For example "marqoai/marqo:test"
   push:
     branches:
       mainline

--- a/.github/workflows/local_os_CI.yml
+++ b/.github/workflows/local_os_CI.yml
@@ -80,7 +80,7 @@ jobs:
           
       - name: Run Integration Tests - local_os
         env:
-          MQ_API_TEST_BRANCH: ${GITHUB_REF##*/}
+          MQ_API_TEST_BRANCH: "${GITHUB_REF##*/}"
         run: tox -e py3-local_os
   
   Stop-Runner:

--- a/.github/workflows/local_os_CI.yml
+++ b/.github/workflows/local_os_CI.yml
@@ -3,6 +3,13 @@ name: local_os_CI
 
 on:
   workflow_dispatch:
+    inputs:
+      image_to_test:
+        required: false
+        default: ""
+        description: >
+          This is optional. If left unset, the docker image built from this branch is tested.
+          If set, the docker specified docker image is tested. For example "marqoai/marqo:test"
   push:
     branches:
       mainline
@@ -81,6 +88,7 @@ jobs:
       - name: Run Integration Tests - local_os
         run: |
           export MQ_API_TEST_BRANCH="${GITHUB_REF##*/}"
+          export MQ_API_TEST_IMG="${{ github.event.inputs.image_to_test }}"
           tox -e py3-local_os
   
   Stop-Runner:

--- a/.github/workflows/local_os_CI.yml
+++ b/.github/workflows/local_os_CI.yml
@@ -79,6 +79,8 @@ jobs:
           echo 'export MARQO_API_TESTS_ROOT="${{ github.workspace }}"' >> conf
           
       - name: Run Integration Tests - local_os
+        env:
+          MQ_API_TEST_BRANCH: ${{ github.ref }}
         run: tox -e py3-local_os
   
   Stop-Runner:

--- a/.github/workflows/local_os_CI.yml
+++ b/.github/workflows/local_os_CI.yml
@@ -80,7 +80,7 @@ jobs:
           
       - name: Run Integration Tests - local_os
         env:
-          MQ_API_TEST_BRANCH: "${GITHUB_REF##*/}"
+          MQ_API_TEST_BRANCH: ${{ github.ref.split('/')[2:].join('/') }}
         run: tox -e py3-local_os
   
   Stop-Runner:

--- a/.github/workflows/s2search_CI.yml
+++ b/.github/workflows/s2search_CI.yml
@@ -82,7 +82,7 @@ jobs:
           
       - name: Run Integration Tests - s2search
         env:
-          MQ_API_TEST_BRANCH: ${{ github.ref }}
+          MQ_API_TEST_BRANCH: ${GITHUB_REF##*/}
         run: tox -e py3-s2search
   
   Stop-Runner:

--- a/.github/workflows/s2search_CI.yml
+++ b/.github/workflows/s2search_CI.yml
@@ -82,7 +82,7 @@ jobs:
           
       - name: Run Integration Tests - s2search
         env:
-          MQ_API_TEST_BRANCH: "${GITHUB_REF##*/}"
+          MQ_API_TEST_BRANCH: ${{ github.ref.split('/')[2:].join('/') }}
         run: tox -e py3-s2search
   
   Stop-Runner:

--- a/.github/workflows/s2search_CI.yml
+++ b/.github/workflows/s2search_CI.yml
@@ -81,6 +81,8 @@ jobs:
           echo 'export S2SEARCH_URL="${{ secrets.S2SEARCH_URL }}"' >> conf
           
       - name: Run Integration Tests - s2search
+        env:
+          MQ_API_TEST_BRANCH: ${{ github.ref }}
         run: tox -e py3-s2search
   
   Stop-Runner:

--- a/.github/workflows/s2search_CI.yml
+++ b/.github/workflows/s2search_CI.yml
@@ -81,9 +81,9 @@ jobs:
           echo 'export S2SEARCH_URL="${{ secrets.S2SEARCH_URL }}"' >> conf
           
       - name: Run Integration Tests - s2search
-        env:
-          MQ_API_TEST_BRANCH: ${{ github.ref.split('/')[2:].join('/') }}
-        run: tox -e py3-s2search
+        run: |
+          export MQ_API_TEST_BRANCH="${GITHUB_REF##*/}"
+          tox -e py3-s2search
   
   Stop-Runner:
     name: Stop self-hosted EC2 runner

--- a/.github/workflows/s2search_CI.yml
+++ b/.github/workflows/s2search_CI.yml
@@ -6,7 +6,7 @@ on:
     inputs:
       image_to_test:
         required: false
-        default: ""
+        default: marqo_docker_0
         description: >
           This is optional. If left unset, the docker image built from this branch is tested.
           If set, the specified docker image is tested. For example "marqoai/marqo:test"

--- a/.github/workflows/s2search_CI.yml
+++ b/.github/workflows/s2search_CI.yml
@@ -82,7 +82,7 @@ jobs:
           
       - name: Run Integration Tests - s2search
         env:
-          MQ_API_TEST_BRANCH: ${GITHUB_REF##*/}
+          MQ_API_TEST_BRANCH: "${GITHUB_REF##*/}"
         run: tox -e py3-s2search
   
   Stop-Runner:

--- a/.github/workflows/s2search_CI.yml
+++ b/.github/workflows/s2search_CI.yml
@@ -9,7 +9,7 @@ on:
         default: ""
         description: >
           This is optional. If left unset, the docker image built from this branch is tested.
-          If set, the docker specified docker image is tested. For example "marqoai/marqo:test"
+          If set, the specified docker image is tested. For example "marqoai/marqo:test"
   push:
     branches:
       mainline

--- a/.github/workflows/s2search_CI.yml
+++ b/.github/workflows/s2search_CI.yml
@@ -3,6 +3,13 @@ name: s2search_CI
 
 on:
   workflow_dispatch:
+    inputs:
+      image_to_test:
+        required: false
+        default: ""
+        description: >
+          This is optional. If left unset, the docker image built from this branch is tested.
+          If set, the docker specified docker image is tested. For example "marqoai/marqo:test"
   push:
     branches:
       mainline
@@ -83,6 +90,7 @@ jobs:
       - name: Run Integration Tests - s2search
         run: |
           export MQ_API_TEST_BRANCH="${GITHUB_REF##*/}"
+          export MQ_API_TEST_IMG="${{ github.event.inputs.image_to_test }}"
           tox -e py3-s2search
   
   Stop-Runner:

--- a/.github/workflows/s2search_CI.yml
+++ b/.github/workflows/s2search_CI.yml
@@ -8,8 +8,8 @@ on:
         required: false
         default: marqo_docker_0
         description: >
-          This is optional. If left unset, the docker image built from this branch is tested.
-          If set, the specified docker image is tested. For example "marqoai/marqo:test"
+          This is optional. If left as the default value "marqo_docker_0", the docker image built from this branch is tested.
+          Otherwise, the specified docker image is tested. For example "marqoai/marqo:test"
   push:
     branches:
       mainline

--- a/.github/workflows/unit_test_CI.yml
+++ b/.github/workflows/unit_test_CI.yml
@@ -97,9 +97,9 @@ jobs:
           echo 'export MARQO_API_TESTS_ROOT="${{ github.workspace }}"' >> conf
           
       - name: Run Unit Tests
-        env:
-          MQ_API_TEST_BRANCH: ${{ github.ref.split('/')[2:].join('/') }}
-        run: tox -e py3-local_os_unit_tests_w_requirements
+        run: |
+          export MQ_API_TEST_BRANCH="${GITHUB_REF##*/}"
+          tox -e py3-local_os_unit_tests_w_requirements
   
   Stop-Runner:
     name: Stop self-hosted EC2 runner

--- a/.github/workflows/unit_test_CI.yml
+++ b/.github/workflows/unit_test_CI.yml
@@ -98,7 +98,7 @@ jobs:
           
       - name: Run Unit Tests
         env:
-          MQ_API_TEST_BRANCH: ${GITHUB_REF##*/}
+          MQ_API_TEST_BRANCH: "${GITHUB_REF##*/}"
         run: tox -e py3-local_os_unit_tests_w_requirements
   
   Stop-Runner:

--- a/.github/workflows/unit_test_CI.yml
+++ b/.github/workflows/unit_test_CI.yml
@@ -6,7 +6,7 @@ on:
     inputs:
       image_to_test:
         required: false
-        default: ""
+        default: marqo_docker_0
         description: >
           This is optional. If left unset, the docker image built from this branch is tested.
           If set, the specified docker image is tested. For example "marqoai/marqo:test"

--- a/.github/workflows/unit_test_CI.yml
+++ b/.github/workflows/unit_test_CI.yml
@@ -3,6 +3,13 @@ name: unit_test_CI
 
 on:
   workflow_dispatch:
+    inputs:
+      image_to_test:
+        required: false
+        default: ""
+        description: >
+          This is optional. If left unset, the docker image built from this branch is tested.
+          If set, the docker specified docker image is tested. For example "marqoai/marqo:test"
   push:
     branches:
       mainline
@@ -99,6 +106,7 @@ jobs:
       - name: Run Unit Tests
         run: |
           export MQ_API_TEST_BRANCH="${GITHUB_REF##*/}"
+          export MQ_API_TEST_IMG="${{ github.event.inputs.image_to_test }}"
           tox -e py3-local_os_unit_tests_w_requirements
   
   Stop-Runner:

--- a/.github/workflows/unit_test_CI.yml
+++ b/.github/workflows/unit_test_CI.yml
@@ -9,7 +9,7 @@ on:
         default: ""
         description: >
           This is optional. If left unset, the docker image built from this branch is tested.
-          If set, the docker specified docker image is tested. For example "marqoai/marqo:test"
+          If set, the specified docker image is tested. For example "marqoai/marqo:test"
   push:
     branches:
       mainline

--- a/.github/workflows/unit_test_CI.yml
+++ b/.github/workflows/unit_test_CI.yml
@@ -98,7 +98,7 @@ jobs:
           
       - name: Run Unit Tests
         env:
-          MQ_API_TEST_BRANCH: "${GITHUB_REF##*/}"
+          MQ_API_TEST_BRANCH: ${{ github.ref.split('/')[2:].join('/') }}
         run: tox -e py3-local_os_unit_tests_w_requirements
   
   Stop-Runner:

--- a/.github/workflows/unit_test_CI.yml
+++ b/.github/workflows/unit_test_CI.yml
@@ -97,6 +97,8 @@ jobs:
           echo 'export MARQO_API_TESTS_ROOT="${{ github.workspace }}"' >> conf
           
       - name: Run Unit Tests
+        env:
+          MQ_API_TEST_BRANCH: ${{ github.ref }}
         run: tox -e py3-local_os_unit_tests_w_requirements
   
   Stop-Runner:

--- a/.github/workflows/unit_test_CI.yml
+++ b/.github/workflows/unit_test_CI.yml
@@ -8,8 +8,8 @@ on:
         required: false
         default: marqo_docker_0
         description: >
-          This is optional. If left unset, the docker image built from this branch is tested.
-          If set, the specified docker image is tested. For example "marqoai/marqo:test"
+          This is optional. If left as the default value "marqo_docker_0", the docker image built from this branch is tested.
+          Otherwise, the specified docker image is tested. For example "marqoai/marqo:test"
   push:
     branches:
       mainline

--- a/.github/workflows/unit_test_CI.yml
+++ b/.github/workflows/unit_test_CI.yml
@@ -3,13 +3,6 @@ name: unit_test_CI
 
 on:
   workflow_dispatch:
-    inputs:
-      image_to_test:
-        required: false
-        default: marqo_docker_0
-        description: >
-          This is optional. If left as the default value "marqo_docker_0", the docker image built from this branch is tested.
-          Otherwise, the specified docker image is tested. For example "marqoai/marqo:test"
   push:
     branches:
       mainline
@@ -106,7 +99,6 @@ jobs:
       - name: Run Unit Tests
         run: |
           export MQ_API_TEST_BRANCH="${GITHUB_REF##*/}"
-          export MQ_API_TEST_IMG="${{ github.event.inputs.image_to_test }}"
           tox -e py3-local_os_unit_tests_w_requirements
   
   Stop-Runner:

--- a/.github/workflows/unit_test_CI.yml
+++ b/.github/workflows/unit_test_CI.yml
@@ -98,7 +98,7 @@ jobs:
           
       - name: Run Unit Tests
         env:
-          MQ_API_TEST_BRANCH: ${{ github.ref }}
+          MQ_API_TEST_BRANCH: ${GITHUB_REF##*/}
         run: tox -e py3-local_os_unit_tests_w_requirements
   
   Stop-Runner:


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
CI update

* **What is the current behavior?** (You can also link to an open issue here)
The tests alway target mainline. There is no way to test against an image on Docker hub

* **What is the new behavior (if this is a feature change)?**
The tests are now against the current branch. There is an optional input is also available to specify the image name - this can be used to test against images on Docker hub

 **Have unit tests been run against this PR?** (Has there also been any additional testing?)
* The entire test suite has been run on this branch. All passed. Confirmed (via reading the log output) that the current branch, rather than mainline, was used to build the test image

* The entire test suite was also run with the optional image input set to `marqo:0.0.4`. For all tests besides the unit tests, the suite starts but never completes. This is expected because the current API test suite can't read the outdated root endpoint, preventing it from starting. This confirms that manually setting the image runs the test suite against that image (rather than the image built by test suite). 

 **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

 **Other information**:
* This change only becomes available on branches that use the CI pipeline files updated by this PR.
* To take advantage of this pipeline update, checkout the files from this PR into your feature branch. 

 **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

