### PR TITLE
stop returning metadata fields within chunks

### DIFF
--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -1005,7 +1005,7 @@ def _vector_text_search(
     response = HttpRequests(config).get(path=F"{index_name}/_msearch", body=utils.dicts_to_jsonl(body))
 
     if verbose:
-        print(f'Opensearch reported {response["took"]}ms search latency')
+        logger.info(f'Opensearch reported {response["took"]}ms search latency')
 
     try:
         responses = [r['hits']['hits'] for r in response["responses"]]


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This change reduces search latency by making it so that metadata fields are not returned in chunks when searching. 

* **What is the current behavior?** (You can also link to an open issue here)

Currently, metadata is included in each chunk when it is sent back. If a field is a long text field this creates additional of load and latency due to the fact that the long text field would get attached to each chunk. Furthermore this data is currently unused so we dont need to return it.


* **What is the new behavior (if this is a feature change)?**

We no longer return metadata fields within chunks.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)


* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

