### PR TITLE
Refactor attributes to retrieve

### DIFF
--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -972,10 +972,7 @@ def _vector_text_search(
 
         field_names = list(index_info.get_text_properties().keys())
         if attributes_to_retrieve is not None:
-            field_names = list(filter(lambda x: x in attributes_to_retrieve, field_names))
-        search_query["_source"] = {
-            "include":  field_names
-        }
+            search_query["_source"] = {"include": attributes_to_retrieve} if len(attributes_to_retrieve) > 0 else False
 
         if filter_string is not None:
             search_query["query"]["nested"]["query"]["knn"][f"{TensorField.chunks}.{vector_field}"]["filter"] = {

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -974,7 +974,7 @@ def _vector_text_search(
         if attributes_to_retrieve is not None:
             field_names = list(filter(lambda x: x in attributes_to_retrieve, field_names))
         search_query["_source"] = {
-            "include": ["__chunks.__field_content", "__chunks.__field_name"] + field_names
+            "include":  field_names
         }
 
         if filter_string is not None:
@@ -1004,7 +1004,7 @@ def _vector_text_search(
     response = HttpRequests(config).get(path=F"{index_name}/_msearch", body=utils.dicts_to_jsonl(body))
 
     if verbose:
-        print(f'Opensearch reported {response["took"]}ms search latency')
+        logger.info(f'Opensearch reported {response["took"]}ms search latency')
 
     try:
         responses = [r['hits']['hits'] for r in response["responses"]]


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Refactor tensor search code to make attributes to retrieve work as intended, remove hide vectors param which is currently unused. 

* **What is the current behavior?** (You can also link to an open issue here)
We currently dont use the attributes to retireve field but currently if there is an empty list given it returns false and means we get nothing back (including necessary fields like the ones for highlights)


* **What is the new behavior (if this is a feature change)?**
Attributes to retrieve works properly and works with the related change (below) where we remove metadata from fields.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Have unit tests been run against this PR?** (Has there also been any additional testing?)


* **Related Python client changes** (link commit/PR here)
https://github.com/marqo-ai/marqo/pull/217

* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

