### PR TITLE
reduce k value to result count

### DIFF
--- a/src/marqo/tensor_search/configs.py
+++ b/src/marqo/tensor_search/configs.py
@@ -32,6 +32,6 @@ def default_env_vars() -> dict:
     return {
         EnvVars.MARQO_MAX_INDEX_FIELDS: None,
         EnvVars.MARQO_MAX_DOC_BYTES: 100000,
-        EnvVars.MARQO_MAX_RETRIEVABLE_DOCS: None,
+        EnvVars.MARQO_MAX_RETRIEVABLE_DOCS: 10000,
         EnvVars.MARQO_MODELS_TO_PRELOAD: ['hf/all_datasets_v4_MiniLM-L6', "ViT-L/14"]
     }

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -963,7 +963,7 @@ def _vector_text_search(
                         "knn": {
                             f"{TensorField.chunks}.{vector_field}": {
                                 "vector": vectorised_text,
-                                "k": k
+                                "k": result_count
                             }
                         }
                     },

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -732,8 +732,8 @@ def search(config: Config, index_name: str, text: str, result_count: int = 3, hi
     """
     max_docs_limit = utils.read_env_vars_and_defaults(EnvVars.MARQO_MAX_RETRIEVABLE_DOCS)
     check_upper = True if max_docs_limit is None else result_count <= int(max_docs_limit)
-    if not(check_upper and result_count >= 0):
-        upper_bound_explanation = ("The search result limit must be between 0 and the "
+    if not(check_upper and result_count > 0):
+        upper_bound_explanation = ("The search result limit must be greater than 0 and less than or equal to the"
                                   f"MARQO_MAX_RETRIEVABLE_DOCS limit of [{max_docs_limit}]. ")
         above_zero_explanation = "The search result limit must be greater than or equal to 0."
         explanation = upper_bound_explanation if max_docs_limit is not None else above_zero_explanation

--- a/tests/tensor_search/test_search.py
+++ b/tests/tensor_search/test_search.py
@@ -227,12 +227,21 @@ class TestVectorSearch(MarqoTestCase):
             raise AssertionError
         except IllegalRequestedDocCount as e:
             pass
-        # should work with 0
+        try:
+            # should not work with 0
+            search_res = tensor_search.search(
+                config=self.config, index_name=self.index_name_1, text="Exact match hehehe",
+                searchable_attributes=["other field", "Cool Field 1"], return_doc_ids=True, result_count=0
+            )
+            raise AssertionError
+        except IllegalRequestedDocCount as e:
+            pass
+        # should work with 1:
         search_res = tensor_search.search(
             config=self.config, index_name=self.index_name_1, text="Exact match hehehe",
-            searchable_attributes=["other field", "Cool Field 1"], return_doc_ids=True, result_count=0
+            searchable_attributes=["other field", "Cool Field 1"], return_doc_ids=True, result_count=1
         )
-        assert len(search_res["hits"]) == 0
+        assert len(search_res['hits']) >= 1
 
     def test_highlights_tensor(self):
         tensor_search.add_documents(


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
we reduce k to equal the result count, which vastly improves search latency. Since we have moved to lucene we no longer see the error with inner hits not being returned

* **What is the current behavior?** (You can also link to an open issue here)
Search latency is very high due to a high k - this is a problem since we moved from NMSLIB to lucene based search.

* **What is the new behavior (if this is a feature change)?**
Reduces search lateny on large indexes by approx 20x. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no


* **Have unit tests been run against this PR?** (Has there also been any additional testing?)


* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

