### PR TITLE
Pagination for single field queries

### DIFF
--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -115,7 +115,8 @@ def search(search_query: SearchQuery, index_name: str, device: str = Depends(api
         index_name=index_name, highlights=search_query.showHighlights,
         searchable_attributes=search_query.searchableAttributes,
         search_method=search_query.searchMethod,
-        result_count=search_query.limit, reranker=search_query.reRanker,
+        result_count=search_query.limit, offset=search_query.offset,
+        reranker=search_query.reRanker, 
         filter=search_query.filter, device=device,
         attributes_to_retrieve=search_query.attributesToRetrieve
     )

--- a/src/marqo/tensor_search/models/api_models.py
+++ b/src/marqo/tensor_search/models/api_models.py
@@ -16,6 +16,7 @@ class SearchQuery(BaseModel):
     searchableAttributes: Union[None, List[str]] = None
     searchMethod: Union[None, str] = "TENSOR"
     limit: int = 10
+    offset: int = 0
     showHighlights: bool = True
     reRanker: str = None
     filter: str = None

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -872,8 +872,7 @@ def search(config: Config, index_name: str, text: str, result_count: int = 3, of
     
     time_taken = timer() - t0
     search_result["processingTimeMs"] = round(time_taken * 1000)
-    if verbose:
-        logger.info(f"search ({search_method.lower()}) completed with total processing time: {(time_taken):.3f}s.")
+    logger.info(f"search ({search_method.lower()}) completed with total processing time: {(time_taken):.3f}s.")
 
     return search_result
 
@@ -950,8 +949,7 @@ def _lexical_search(
     
     end_preprocess_time = timer()
     total_preprocess_time = end_preprocess_time - start_preprocess_time
-    if verbose:
-        logger.info(f"search (lexical) pre-processing: took {(total_preprocess_time):.3f}s to process query.")
+    logger.info(f"search (lexical) pre-processing: took {(total_preprocess_time):.3f}s to process query.")
     
     # SEARCH TIMER-LOGGER (roundtrip)
     start_search_http_time = timer()
@@ -961,9 +959,8 @@ def _lexical_search(
     total_search_http_time = end_search_http_time - start_search_http_time
     total_os_process_time = search_res["took"] * 0.001
     num_results = len(search_res['hits']['hits'])
-    if verbose:
-        logger.info(f"search (lexical) roundtrip: took {(total_search_http_time):.3f}s to send search query (roundtrip) to Marqo-os and received {num_results} results.")
-        logger.info(f"  search (lexical) Marqo-os processing time: took {(total_os_process_time):.3f}s for Marqo-os to execute the search.")
+    logger.info(f"search (lexical) roundtrip: took {(total_search_http_time):.3f}s to send search query (roundtrip) to Marqo-os and received {num_results} results.")
+    logger.info(f"  search (lexical) Marqo-os processing time: took {(total_os_process_time):.3f}s for Marqo-os to execute the search.")
 
     # SEARCH TIMER-LOGGER (post-processing)
     start_postprocess_time = timer()
@@ -978,8 +975,7 @@ def _lexical_search(
     
     end_postprocess_time = timer()
     total_postprocess_time = end_postprocess_time - start_postprocess_time
-    if verbose:
-        logger.info(f"search (lexical) post-processing: took {(total_postprocess_time):.3f}s to format {len(res_list)} results.")
+    logger.info(f"search (lexical) post-processing: took {(total_postprocess_time):.3f}s to format {len(res_list)} results.")
     
     return {'hits': res_list}
 
@@ -1142,8 +1138,7 @@ def _vector_text_search(
     
     end_preprocess_time = timer()
     total_preprocess_time = end_preprocess_time - start_preprocess_time
-    if verbose:
-        logger.info(f"search (tensor) pre-processing: took {(total_preprocess_time):.3f}s to vectorize and process query.")
+    logger.info(f"search (tensor) pre-processing: took {(total_preprocess_time):.3f}s to vectorize and process query.")
 
     # SEARCH TIMER-LOGGER (roundtrip)
     start_search_http_time = timer()
@@ -1153,8 +1148,7 @@ def _vector_text_search(
     total_search_http_time = end_search_http_time - start_search_http_time
     total_os_process_time = response["took"] * 0.001
     num_responses = len(response["responses"])
-    if verbose:
-        logger.info(f"search (tensor) roundtrip: took {(total_search_http_time):.3f}s to send {num_responses} search queries (roundtrip) to Marqo-os.")
+    logger.info(f"search (tensor) roundtrip: took {(total_search_http_time):.3f}s to send {num_responses} search queries (roundtrip) to Marqo-os.")
     
     try:
         responses = [r['hits']['hits'] for r in response["responses"]]
@@ -1163,8 +1157,7 @@ def _vector_text_search(
         for i in range(len(vector_properties_to_search)):
             indiv_responses = response["responses"][i]['hits']['hits']
             indiv_query_time = response["responses"][i]["took"] * 0.001
-            if verbose:
-                logger.info(f"  search (tensor) Marqo-os processing time (search field = {list(vector_properties_to_search)[i]}): took {(indiv_query_time):.3f}s and received {len(indiv_responses)} hits.")
+            logger.info(f"  search (tensor) Marqo-os processing time (search field = {list(vector_properties_to_search)[i]}): took {(indiv_query_time):.3f}s and received {len(indiv_responses)} hits.")
 
     except KeyError as e:
         # KeyError indicates we have received a non-successful result
@@ -1181,8 +1174,7 @@ def _vector_text_search(
         except (KeyError, IndexError) as e2:
             raise e
 
-    if verbose:
-        logger.info(f"  search (tensor) Marqo-os processing time: took {(total_os_process_time):.3f}s for Marqo-os to execute the search.")
+    logger.info(f"  search (tensor) Marqo-os processing time: took {(total_os_process_time):.3f}s for Marqo-os to execute the search.")
 
     # SEARCH TIMER-LOGGER (post-processing)
     start_postprocess_time = timer()
@@ -1279,8 +1271,7 @@ def _vector_text_search(
 
     end_postprocess_time = timer()
     total_postprocess_time = end_postprocess_time - start_postprocess_time
-    if verbose:
-        logger.info(f"search (tensor) post-processing: took {(total_postprocess_time):.3f}s to sort and format {len(completely_sorted)} results from Marqo-os.")
+    logger.info(f"search (tensor) post-processing: took {(total_postprocess_time):.3f}s to sort and format {len(completely_sorted)} results from Marqo-os.")
     return res
 
 def check_health(config: Config):

--- a/tests/tensor_search/test_lexical_search.py
+++ b/tests/tensor_search/test_lexical_search.py
@@ -8,7 +8,7 @@ from marqo.errors import InvalidArgError, IndexNotFoundError
 from tests.marqo_test import MarqoTestCase
 
 
-class TestlexicalSearch(MarqoTestCase):
+class TestLexicalSearch(MarqoTestCase):
 
     def setUp(self) -> None:
         self.generic_header = {"Content-type": "application/json"}
@@ -223,6 +223,7 @@ class TestlexicalSearch(MarqoTestCase):
         del res_search_entry_point_no_processing_time ['processingTimeMs']
         del res_search_entry_point_no_processing_time ['query']
         del res_search_entry_point_no_processing_time ['limit']
+        del res_search_entry_point_no_processing_time ['offset']
         assert len(res_lexical_search['hits']) > 0
         assert res_search_entry_point_no_processing_time == res_lexical_search
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,4 @@ deps =
 setenv =
   PYTHONPATH = {toxinidir}{/}src:{toxinidir}
 commands =
-  pytest {posargs}
+  pytest -s {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,4 @@ deps =
 setenv =
   PYTHONPATH = {toxinidir}{/}src:{toxinidir}
 commands =
-  pytest -s {posargs}
+  pytest {posargs}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Pagination feature

* **What is the current behavior?** (You can also link to an open issue here)
Currently, results cannot be paginated. See issue: https://github.com/marqo-ai/marqo/issues/71

* **What is the new behavior (if this is a feature change)?**
This introduces an `offset` parameter, which allows users to skip results (for pagination). This uses the `from` and `size` parameters of open search.

There are some issues with skipping/duplication of results near the edges of the first few pages (around 3% of results affected overall) in tensor search specifically. This is believed to be an issue with OpenSearch KNN, and is being observed in the issue here: https://github.com/opensearch-project/k-NN/issues/698

For now, the unit tests for pagination do not assume exact precision in results when using pagination.

Additionally, `verbose` parameter was added to _lexical_search and _vector_text_search for debugging purposes. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
Yes.

* **Related Python client changes** (link commit/PR here)
https://github.com/marqo-ai/py-marqo/pull/49

* **Related documentation changes** (link commit/PR here)
https://github.com/marqo-ai/marqodocs/pull/42

* **Other information**:


* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes/features)
- [X] Docs have been added / updated (for bug fixes / features)

