### PR TITLE
Onnx refactor: adding open_clip onnx support, decouple image preprocess

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ Pillow==9.3.0
 numpy==1.23.4
 validators==0.20.0
 sentence-transformers==2.2.2
-open_clip_torch==2.0.2
+open_clip_torch==2.8.2
 clip-marqo==1.0.2
 protobuf==3.20.1
 onnx==1.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ Pillow==9.3.0
 numpy==1.23.4
 validators==0.20.0
 sentence-transformers==2.2.2
-open_clip_torch==2.8.2
+open_clip_torch==2.9.1
 clip-marqo==1.0.2
 protobuf==3.20.1
 onnx==1.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ Pillow==9.3.0
 numpy==1.23.4
 validators==0.20.0
 sentence-transformers==2.2.2
-open_clip_torch==2.9.1
+open_clip_torch==2.9.2
 clip-marqo==1.0.2
 protobuf==3.20.1
 onnx==1.12.0

--- a/src/marqo/s2_inference/clip_utils.py
+++ b/src/marqo/s2_inference/clip_utils.py
@@ -246,7 +246,7 @@ class OPEN_CLIP(CLIP):
     def load(self) -> None:
         # https://github.com/mlfoundations/open_clip
         self.model, _, self.preprocess = open_clip.create_model_and_transforms(self.model_name, pretrained = self.pretrained, device=self.device, jit=False)
-        self.tokenizer = open_clip.tokenize
+        self.tokenizer = open_clip.get_tokenizer(self.model_name)
         self.model.eval()
 
     def encode_text(self, sentence: Union[str, List[str]], normalize=True) -> FloatTensor:

--- a/src/marqo/s2_inference/errors.py
+++ b/src/marqo/s2_inference/errors.py
@@ -32,6 +32,10 @@ class ModelLoadError(S2InferenceError):
     pass
 
 
+class ModelDownloadError(S2InferenceError):
+    pass
+
+
 class RerankerError(S2InferenceError):
     pass
 

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -625,7 +625,6 @@ def _get_onnx_clip_properties() -> Dict:
                 "pretrained": "openai",
                 "image_mean": None,
                 "image_std": None,
-
             },
 
 

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -1007,6 +1007,10 @@ def _get_onnx_clip_properties() -> Dict:
                 'image_std': None
             },
 
+
+
+
+
         'onnx16/open_clip/ViT-H-14/laion2b_s32b_b79k':
             {
                 'name': 'onnx16/open_clip/ViT-H-14/laion2b_s32b_b79k',
@@ -1014,8 +1018,8 @@ def _get_onnx_clip_properties() -> Dict:
                 'type': 'clip_onnx',
                 'note': 'the onnx float16 version of open_clip ViT-H-14/laion2b_s32b_b79k',
                 'repo_id': 'Marqo/onnx-open_clip-ViT-H-14',
-                'visual_file': 'onnx16-open_clip-ViT-H-14-visual.onnx',
-                'textual_file': 'onnx16-open_clip-ViT-H-14-textual.onnx',
+                'visual_file': 'onnx16-open_clip-ViT-H-14-laion2b_s32b_b79k-visual.onnx',
+                'textual_file': 'onnx16-open_clip-ViT-H-14-laion2b_s32b_b79k-textual.onnx',
                 'token': None,
                 'resolution': 224,
                 'pretrained': 'laion2b_s32b_b79k',
@@ -1030,8 +1034,8 @@ def _get_onnx_clip_properties() -> Dict:
                 'type': 'clip_onnx',
                 'note': 'the onnx float32 version of open_clip ViT-H-14/laion2b_s32b_b79k',
                 'repo_id': 'Marqo/onnx-open_clip-ViT-H-14',
-                'visual_file': 'onnx32-open_clip-ViT-H-14-visual.zip',
-                'textual_file': 'onnx32-open_clip-ViT-H-14-textual.onnx',
+                'visual_file': 'onnx32-open_clip-ViT-H-14-laion2b_s32b_b79k-visual.zip',
+                'textual_file': 'onnx32-open_clip-ViT-H-14-laion2b_s32b_b79k-textual.onnx',
                 'token': None,
                 'resolution': 224,
                 'pretrained': 'laion2b_s32b_b79k',
@@ -1040,41 +1044,451 @@ def _get_onnx_clip_properties() -> Dict:
             },
 
         'onnx16/open_clip/ViT-g-14/laion2b_s12b_b42k':
-            {'name': 'onnx16/open_clip/ViT-g-14/laion2b_s12b_b42k',
-             'dimensions': 1024,
+            {
+                'name': 'onnx16/open_clip/ViT-g-14/laion2b_s12b_b42k',
+                'dimensions': 1024,
+                'type': 'clip_onnx',
+                'note': 'the onnx float16 version of open_clip ViT-g-14/laion2b_s12b_b42k',
+                'repo_id': 'Marqo/onnx-open_clip-ViT-g-14',
+                'visual_file': 'onnx16-open_clip-ViT-g-14-laion2b_s12b_b42k-visual.onnx',
+                'textual_file': 'onnx16-open_clip-ViT-g-14-laion2b_s12b_b42k-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'laion2b_s12b_b42k',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx32/open_clip/ViT-g-14/laion2b_s12b_b42k':
+            {
+                'name': 'onnx32/open_clip/ViT-g-14/laion2b_s12b_b42k',
+                'dimensions': 1024,
+                'type': 'clip_onnx',
+                'note': 'the onnx float32 version of open_clip ViT-g-14/laion2b_s12b_b42k',
+                'repo_id': 'Marqo/onnx-open_clip-ViT-g-14',
+                'visual_file': 'onnx32-open_clip-ViT-g-14-laion2b_s12b_b42k-visual.zip',
+                'textual_file': 'onnx32-open_clip-ViT-g-14-laion2b_s12b_b42k-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'laion2b_s12b_b42k',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx16/open_clip/RN50/openai':
+            {
+                'name': 'onnx16/open_clip/RN50/openai',
+                'dimensions': 1024,
+                'type': 'clip_onnx',
+                'note': 'the onnx float16 version of open_clip RN50/openai',
+                'repo_id': 'Marqo/onnx-open_clip-RN50',
+                'visual_file': 'onnx16-open_clip-RN50-openai-visual.onnx',
+                'textual_file': 'onnx16-open_clip-RN50-openai-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'openai',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx32/open_clip/RN50/openai':
+            {
+                'name': 'onnx32/open_clip/RN50/openai',
+                'dimensions': 1024,
+                'type': 'clip_onnx',
+                'note': 'the onnx float32 version of open_clip RN50/openai',
+                'repo_id': 'Marqo/onnx-open_clip-RN50',
+                'visual_file': 'onnx32-open_clip-RN50-openai-visual.onnx',
+                'textual_file': 'onnx32-open_clip-RN50-openai-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'openai',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx16/open_clip/RN50/yfcc15m':
+            {
+                'name': 'onnx16/open_clip/RN50/yfcc15m',
+                'dimensions': 1024,
+                'type': 'clip_onnx',
+                'note': 'the onnx float16 version of open_clip RN50/yfcc15m',
+                'repo_id': 'Marqo/onnx-open_clip-RN50',
+                'visual_file': 'onnx16-open_clip-RN50-yfcc15m-visual.onnx',
+                'textual_file': 'onnx16-open_clip-RN50-yfcc15m-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'yfcc15m',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx32/open_clip/RN50/yfcc15m':
+            {
+                'name': 'onnx32/open_clip/RN50/yfcc15m',
+                'dimensions': 1024,
+                'type': 'clip_onnx',
+                'note': 'the onnx float32 version of open_clip RN50/yfcc15m',
+                'repo_id': 'Marqo/onnx-open_clip-RN50',
+                'visual_file': 'onnx32-open_clip-RN50-yfcc15m-visual.onnx',
+                'textual_file': 'onnx32-open_clip-RN50-yfcc15m-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'yfcc15m',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx16/open_clip/RN50/cc12m':
+            {
+                'name': 'onnx16/open_clip/RN50/cc12m',
+                'dimensions': 1024,
+                'type': 'clip_onnx',
+                'note': 'the onnx float16 version of open_clip RN50/cc12m',
+                'repo_id': 'Marqo/onnx-open_clip-RN50',
+                'visual_file': 'onnx16-open_clip-RN50-cc12m-visual.onnx',
+                'textual_file': 'onnx16-open_clip-RN50-cc12m-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'cc12m',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx32/open_clip/RN50/cc12m':
+            {
+                'name': 'onnx32/open_clip/RN50/cc12m',
+                'dimensions': 1024,
+                'type': 'clip_onnx',
+                'note': 'the onnx float32 version of open_clip RN50/cc12m',
+                'repo_id': 'Marqo/onnx-open_clip-RN50',
+                'visual_file': 'onnx32-open_clip-RN50-cc12m-visual.onnx',
+                'textual_file': 'onnx32-open_clip-RN50-cc12m-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'cc12m',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx16/open_clip/RN50-quickgelu/openai':
+            {
+                'name': 'onnx16/open_clip/RN50-quickgelu/openai',
+                'dimensions': 1024,
+                'type': 'clip_onnx',
+                'note': 'the onnx float16 version of open_clip RN50-quickgelu/openai',
+                'repo_id': 'Marqo/onnx-open_clip-RN50-quickgelu',
+                'visual_file': 'onnx16-open_clip-RN50-quickgelu-openai-visual.onnx',
+                'textual_file': 'onnx16-open_clip-RN50-quickgelu-openai-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'openai',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx32/open_clip/RN50-quickgelu/openai':
+            {
+                'name': 'onnx32/open_clip/RN50-quickgelu/openai',
+                'dimensions': 1024,
+                'type': 'clip_onnx',
+                'note': 'the onnx float32 version of open_clip RN50-quickgelu/openai',
+                'repo_id': 'Marqo/onnx-open_clip-RN50-quickgelu',
+                'visual_file': 'onnx32-open_clip-RN50-quickgelu-openai-visual.onnx',
+                'textual_file': 'onnx32-open_clip-RN50-quickgelu-openai-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'openai',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx16/open_clip/RN50-quickgelu/yfcc15m':
+            {
+                'name': 'onnx16/open_clip/RN50-quickgelu/yfcc15m',
+                'dimensions': 1024,
+                'type': 'clip_onnx',
+                'note': 'the onnx float16 version of open_clip RN50-quickgelu/yfcc15m',
+                'repo_id': 'Marqo/onnx-open_clip-RN50-quickgelu',
+                'visual_file': 'onnx16-open_clip-RN50-quickgelu-yfcc15m-visual.onnx',
+                'textual_file': 'onnx16-open_clip-RN50-quickgelu-yfcc15m-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'yfcc15m',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx32/open_clip/RN50-quickgelu/yfcc15m':
+            {
+                'name': 'onnx32/open_clip/RN50-quickgelu/yfcc15m',
+                'dimensions': 1024,
+                'type': 'clip_onnx',
+                'note': 'the onnx float32 version of open_clip RN50-quickgelu/yfcc15m',
+                'repo_id': 'Marqo/onnx-open_clip-RN50-quickgelu',
+                'visual_file': 'onnx32-open_clip-RN50-quickgelu-yfcc15m-visual.onnx',
+                'textual_file': 'onnx32-open_clip-RN50-quickgelu-yfcc15m-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'yfcc15m',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx16/open_clip/RN50-quickgelu/cc12m':
+            {
+                'name': 'onnx16/open_clip/RN50-quickgelu/cc12m',
+                'dimensions': 1024,
+                'type': 'clip_onnx',
+                'note': 'the onnx float16 version of open_clip RN50-quickgelu/cc12m',
+                'repo_id': 'Marqo/onnx-open_clip-RN50-quickgelu',
+                'visual_file': 'onnx16-open_clip-RN50-quickgelu-cc12m-visual.onnx',
+                'textual_file': 'onnx16-open_clip-RN50-quickgelu-cc12m-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'cc12m',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx32/open_clip/RN50-quickgelu/cc12m':
+            {
+                'name': 'onnx32/open_clip/RN50-quickgelu/cc12m',
+                'dimensions': 1024,
+                'type': 'clip_onnx',
+                'note': 'the onnx float32 version of open_clip RN50-quickgelu/cc12m',
+                'repo_id': 'Marqo/onnx-open_clip-RN50-quickgelu',
+                'visual_file': 'onnx32-open_clip-RN50-quickgelu-cc12m-visual.onnx',
+                'textual_file': 'onnx32-open_clip-RN50-quickgelu-cc12m-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'cc12m',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx16/open_clip/RN101/openai':
+            {
+                'name': 'onnx16/open_clip/RN101/openai',
+                'dimensions': 512,
+                'type': 'clip_onnx',
+                'note': 'the onnx float16 version of open_clip RN101/openai',
+                'repo_id': 'Marqo/onnx-open_clip-RN101',
+                'visual_file': 'onnx16-open_clip-RN101-openai-visual.onnx',
+                'textual_file': 'onnx16-open_clip-RN101-openai-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'openai',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx32/open_clip/RN101/openai':
+            {
+                'name': 'onnx32/open_clip/RN101/openai',
+                'dimensions': 512,
+                'type': 'clip_onnx',
+                'note': 'the onnx float32 version of open_clip RN101/openai',
+                'repo_id': 'Marqo/onnx-open_clip-RN101',
+                'visual_file': 'onnx32-open_clip-RN101-openai-visual.onnx',
+                'textual_file': 'onnx32-open_clip-RN101-openai-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'openai',
+                'image_mean': None,
+                'image_std': None,
+            },
+
+        'onnx16/open_clip/RN101/yfcc15m':
+            {
+                'name': 'onnx16/open_clip/RN101/yfcc15m',
+                'dimensions': 512,
+                'type': 'clip_onnx',
+                'note': 'the onnx float16 version of open_clip RN101/yfcc15m',
+                'repo_id': 'Marqo/onnx-open_clip-RN101',
+                'visual_file': 'onnx16-open_clip-RN101-yfcc15m-visual.onnx',
+                'textual_file': 'onnx16-open_clip-RN101-yfcc15m-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'yfcc15m',
+                'image_mean': None,
+                'image_std': None,
+            },
+
+        'onnx32/open_clip/RN101/yfcc15m':
+            {
+                'name': 'onnx32/open_clip/RN101/yfcc15m',
+                'dimensions': 512,
+                'type': 'clip_onnx',
+                'note': 'the onnx float32 version of open_clip RN101/yfcc15m',
+                'repo_id': 'Marqo/onnx-open_clip-RN101',
+                'visual_file': 'onnx32-open_clip-RN101-yfcc15m-visual.onnx',
+                'textual_file': 'onnx32-open_clip-RN101-yfcc15m-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'yfcc15m',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx16/open_clip/RN101-quickgelu/openai':
+            {
+                'name': 'onnx16/open_clip/RN101-quickgelu/openai',
+                'dimensions': 512,
+                'type': 'clip_onnx',
+                'note': 'the onnx float16 version of open_clip RN101-quickgelu/openai',
+                'repo_id': 'Marqo/onnx-open_clip-RN101-quickgelu',
+                'visual_file': 'onnx16-open_clip-RN101-quickgelu-openai-visual.onnx',
+                'textual_file': 'onnx16-open_clip-RN101-quickgelu-openai-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'openai',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx32/open_clip/RN101-quickgelu/openai':
+            {
+                'name': 'onnx32/open_clip/RN101-quickgelu/openai',
+                'dimensions': 512,
+                'type': 'clip_onnx',
+                'note': 'the onnx float32 version of open_clip RN101-quickgelu/openai',
+                'repo_id': 'Marqo/onnx-open_clip-RN101-quickgelu',
+                'visual_file': 'onnx32-open_clip-RN101-quickgelu-openai-visual.onnx',
+                'textual_file': 'onnx32-open_clip-RN101-quickgelu-openai-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'openai',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx16/open_clip/RN101-quickgelu/yfcc15m':
+            {'name': 'onnx16/open_clip/RN101-quickgelu/yfcc15m',
+             'dimensions': 512,
              'type': 'clip_onnx',
-             'note': 'the onnx float16 version of open_clip ViT-g-14/laion2b_s12b_b42k',
-             'repo_id': 'Marqo/onnx-open_clip-ViT-g-14',
-             'visual_file': 'onnx16-open_clip-ViT-g-14-visual.onnx',
-             'textual_file': 'onnx16-open_clip-ViT-g-14-textual.onnx',
+             'note': 'the onnx float16 version of open_clip RN101-quickgelu/yfcc15m',
+             'repo_id': 'Marqo/onnx-open_clip-RN101-quickgelu',
+             'visual_file': 'onnx16-open_clip-RN101-quickgelu-yfcc15m-visual.onnx',
+             'textual_file': 'onnx16-open_clip-RN101-quickgelu-yfcc15m-textual.onnx',
              'token': None,
              'resolution': 224,
-             'pretrained': 'laion2b_s12b_b42k',
+             'pretrained': 'yfcc15m',
              'image_mean': None,
              'image_std': None
              },
 
-        'onnx32/open_clip/ViT-g-14/laion2b_s12b_b42k':
-            {'name': 'onnx32/open_clip/ViT-g-14/laion2b_s12b_b42k',
-             'dimensions': 1024,
-             'type': 'clip_onnx',
-             'note': 'the onnx float32 version of open_clip ViT-g-14/laion2b_s12b_b42k',
-             'repo_id': 'Marqo/onnx-open_clip-ViT-g-14',
-             'visual_file': 'onnx32-open_clip-ViT-g-14-visual.zip',
-             'textual_file': 'onnx32-open_clip-ViT-g-14-textual.onnx',
-             'token': None,
-             'resolution': 224,
-             'pretrained': 'laion2b_s12b_b42k',
-             'image_mean': None,
-             'image_std': None
-             }
+        'onnx32/open_clip/RN101-quickgelu/yfcc15m':
+            {
+                'name': 'onnx32/open_clip/RN101-quickgelu/yfcc15m',
+                'dimensions': 512,
+                'type': 'clip_onnx',
+                'note': 'the onnx float32 version of open_clip RN101-quickgelu/yfcc15m',
+                'repo_id': 'Marqo/onnx-open_clip-RN101-quickgelu',
+                'visual_file': 'onnx32-open_clip-RN101-quickgelu-yfcc15m-visual.onnx',
+                'textual_file': 'onnx32-open_clip-RN101-quickgelu-yfcc15m-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'yfcc15m',
+                'image_mean': None,
+                'image_std': None
+            },
 
+        'onnx16/open_clip/RN50x4/openai':
+            {
+                'name': 'onnx16/open_clip/RN50x4/openai',
+                'dimensions': 640,
+                'type': 'clip_onnx',
+                'note': 'the onnx float16 version of open_clip RN50x4/openai',
+                'repo_id': 'Marqo/onnx-open_clip-RN50x4',
+                'visual_file': 'onnx16-open_clip-RN50x4-openai-visual.onnx',
+                'textual_file': 'onnx16-open_clip-RN50x4-openai-textual.onnx',
+                'token': None,
+                'resolution': 288,
+                'pretrained': 'openai',
+                'image_mean': None,
+                'image_std': None
+            },
 
+        'onnx32/open_clip/RN50x4/openai':
+            {
+                'name': 'onnx32/open_clip/RN50x4/openai',
+                'dimensions': 640,
+                'type': 'clip_onnx',
+                'note': 'the onnx float32 version of open_clip RN50x4/openai',
+                'repo_id': 'Marqo/onnx-open_clip-RN50x4',
+                'visual_file': 'onnx32-open_clip-RN50x4-openai-visual.onnx',
+                'textual_file': 'onnx32-open_clip-RN50x4-openai-textual.onnx',
+                'token': None,
+                'resolution': 288,
+                'pretrained': 'openai',
+                'image_mean': None,
+                'image_std': None
+            },
 
+        'onnx16/open_clip/RN50x16/openai':
+            {
+                'name': 'onnx16/open_clip/RN50x16/openai',
+                'dimensions': 768,
+                'type': 'clip_onnx',
+                'note': 'the onnx float16 version of open_clip RN50x16/openai',
+                'repo_id': 'Marqo/onnx-open_clip-RN50x16',
+                'visual_file': 'onnx16-open_clip-RN50x16-openai-visual.onnx',
+                'textual_file': 'onnx16-open_clip-RN50x16-openai-textual.onnx',
+                'token': None,
+                'resolution': 384,
+                'pretrained': 'openai',
+                'image_mean': None,
+                'image_std': None
+            },
 
+        'onnx32/open_clip/RN50x16/openai':
+            {
+                'name': 'onnx32/open_clip/RN50x16/openai',
+                'dimensions': 768,
+                'type': 'clip_onnx',
+                'note': 'the onnx float32 version of open_clip RN50x16/openai',
+                'repo_id': 'Marqo/onnx-open_clip-RN50x16',
+                'visual_file': 'onnx32-open_clip-RN50x16-openai-visual.onnx',
+                'textual_file': 'onnx32-open_clip-RN50x16-openai-textual.onnx',
+                'token': None,
+                'resolution': 384,
+                'pretrained': 'openai',
+                'image_mean': None,
+                'image_std': None
+            },
 
+        'onnx16/open_clip/RN50x64/openai':
+            {
+                'name': 'onnx16/open_clip/RN50x64/openai',
+                'dimensions': 1024,
+                'type': 'clip_onnx',
+                'note': 'the onnx float16 version of open_clip RN50x64/openai',
+                'repo_id': 'Marqo/onnx-open_clip-RN50x64',
+                'visual_file': 'onnx16-open_clip-RN50x64-openai-visual.onnx',
+                'textual_file': 'onnx16-open_clip-RN50x64-openai-textual.onnx',
+                'token': None,
+                'resolution': 448,
+                'pretrained': 'openai',
+                'image_mean': None,
+                'image_std': None
+            },
 
-
+        'onnx32/open_clip/RN50x64/openai':
+            {
+                'name': 'onnx32/open_clip/RN50x64/openai',
+                'dimensions': 1024,
+                'type': 'clip_onnx',
+                'note': 'the onnx float32 version of open_clip RN50x64/openai',
+                'repo_id': 'Marqo/onnx-open_clip-RN50x64',
+                'visual_file': 'onnx32-open_clip-RN50x64-openai-visual.onnx',
+                'textual_file': 'onnx32-open_clip-RN50x64-openai-textual.onnx',
+                'token': None,
+                'resolution': 448,
+                'pretrained': 'openai',
+                'image_mean': None,
+                'image_std': None
+            },
     }
     return ONNX_CLIP_MODEL_PROPERTIES
 
@@ -1111,8 +1525,8 @@ def _get_random_properties() -> Dict:
 def _get_model_load_mappings() -> Dict:
     return {'clip':CLIP,
             'open_clip': OPEN_CLIP,
-            'sbert':SBERT, 
-            'test':TEST, 
+            'sbert':SBERT,
+            'test':TEST,
             'sbert_onnx':SBERT_ONNX,
             'clip_onnx': CLIP_ONNX,
             'random':Random,

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -1014,8 +1014,8 @@ def _get_onnx_clip_properties() -> Dict:
                 'type': 'clip_onnx',
                 'note': 'the onnx float16 version of open_clip ViT-H-14/laion2b_s32b_b79k',
                 'repo_id': 'Marqo/onnx-open_clip-ViT-H-14',
-                'visual_file': 'onnx16-open_clip-ViT-H-14-laion2b_s32b_b79k-visual.onnx',
-                'textual_file': 'onnx16-open_clip-ViT-H-14-laion2b_s32b_b79k-textual.onnx',
+                'visual_file': 'onnx16-open_clip-ViT-H-14-visual.onnx',
+                'textual_file': 'onnx16-open_clip-ViT-H-14-textual.onnx',
                 'token': None,
                 'resolution': 224,
                 'pretrained': 'laion2b_s32b_b79k',
@@ -1030,14 +1030,16 @@ def _get_onnx_clip_properties() -> Dict:
                 'type': 'clip_onnx',
                 'note': 'the onnx float32 version of open_clip ViT-H-14/laion2b_s32b_b79k',
                 'repo_id': 'Marqo/onnx-open_clip-ViT-H-14',
-                'visual_file': 'onnx32-open_clip-ViT-H-14-laion2b_s32b_b79k-visual.onnx',
-                'textual_file': 'onnx32-open_clip-ViT-H-14-laion2b_s32b_b79k-textual.onnx',
+                'visual_file': 'onnx32-open_clip-ViT-H-14-visual.zip',
+                'textual_file': 'onnx32-open_clip-ViT-H-14-textual.onnx',
                 'token': None,
                 'resolution': 224,
                 'pretrained': 'laion2b_s32b_b79k',
                 'image_mean': None,
                 'image_std': None
             }
+
+
 
 
 

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -577,7 +577,7 @@ def _get_onnx_clip_properties() -> Dict:
                 "resolution": 224,
                 "pretrained": "laionb_s32b_b82k"
             },
-        "onnx16/open_clip/ViT-L-14/laion400m_e32":
+        "onnx16/open_clip/ViT-L-14/laionb_s32b_b82k":
             {
                 "name": "onnx16/open_clip/ViT-L-14/laionb_s32b_b82k",
                 "dimensions": 768,

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -943,6 +943,37 @@ def _get_onnx_clip_properties() -> Dict:
                 'pretrained': 'laion400m_e32',
                 'image_mean': None,
                 'image_std': None
+            },
+
+        'onnx16/open_clip/ViT-B-16-plus-240/laion400m_e31':
+            {
+                'name': 'onnx16/open_clip/ViT-B-16-plus-240/laion400m_e31',
+                'dimensions': 640,
+                'type': 'clip_onnx',
+                'note': 'the onnx float16 version of open_clip ViT-B-16-plus-240/laion400m_e31',
+                'repo_id': 'Marqo/onnx-open_clip-ViT-B-16-plus-240',
+                'visual_file': 'onnx16-open_clip-ViT-B-16-plus-240-laion400m_e31-visual.onnx',
+                'textual_file': 'onnx16-open_clip-ViT-B-16-plus-240-laion400m_e31-textual.onnx',
+                'token': None,
+                'resolution': 240,
+                'pretrained': 'laion400m_e31',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx32/open_clip/ViT-B-16-plus-240/laion400m_e31':
+            {
+                'name': 'onnx32/open_clip/ViT-B-16-plus-240/laion400m_e31',
+                'dimensions': 640, 'type': 'clip_onnx',
+                'note': 'the onnx float32 version of open_clip ViT-B-16-plus-240/laion400m_e31',
+                'repo_id': 'Marqo/onnx-open_clip-ViT-B-16-plus-240',
+                'visual_file': 'onnx32-open_clip-ViT-B-16-plus-240-laion400m_e31-visual.onnx',
+                'textual_file': 'onnx32-open_clip-ViT-B-16-plus-240-laion400m_e31-textual.onnx',
+                'token': None,
+                'resolution': 240,
+                'pretrained': 'laion400m_e31',
+                'image_mean': None,
+                'image_std': None
             }
 
 

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -754,6 +754,37 @@ def _get_onnx_clip_properties() -> Dict:
                 "image_std": None,
             },
 
+        'onnx32/open_clip/ViT-B-32-quickgelu/openai':
+            {
+              'name': 'onnx32/open_clip/ViT-B-32-quickgelu/openai',
+              'dimensions': 512,
+              'type': 'clip_onnx',
+              'note': 'the onnx float32 version of open_clip ViT-B-32-quickgelu/openai',
+              'repo_id': 'Marqo/onnx-open_clip-ViT-B-32-quickgelu',
+              'visual_file': 'onnx32-open_clip-ViT-B-32-quickgelu-openai-visual.onnx',
+              'textual_file': 'onnx32-open_clip-ViT-B-32-quickgelu-openai-textual.onnx',
+              'token': None,
+              'resolution': 224, 'pretrained': 'openai',
+              'image_mean': None,
+              'image_std': None
+             },
+
+        'onnx16/open_clip/ViT-B-32-quickgelu/openai':
+            {
+               'name': 'onnx16/open_clip/ViT-B-32-quickgelu/openai',
+               'dimensions': 512,
+               'type': 'clip_onnx',
+               'note': 'the onnx float16 version of open_clip ViT-B-32-quickgelu/openai',
+               'repo_id': 'Marqo/onnx-open_clip-ViT-B-32-quickgelu',
+               'visual_file': 'onnx16-open_clip-ViT-B-32-quickgelu-openai-visual.onnx',
+               'textual_file': 'onnx16-open_clip-ViT-B-32-quickgelu-openai-textual.onnx',
+               'token': None,
+               'resolution': 224,
+               'pretrained': 'openai',
+               'image_mean': None,
+               'image_std': None
+            }
+
 
 
 

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -575,7 +575,10 @@ def _get_onnx_clip_properties() -> Dict:
                 "textual_file": "onnx32-open_clip-ViT-L-14-laion2b_s32b_b82k-textual.onnx",
                 "token": None,
                 "resolution": 224,
-                "pretrained": "laionb_s32b_b82k"
+                "pretrained": "laionb_s32b_b82k",
+                "image_mean" : (0.5, 0.5, 0.5),
+                "image_std" : (0.5, 0.5, 0.5),
+
             },
         "onnx16/open_clip/ViT-L-14/laion2b_s32b_b82k":
             {
@@ -588,7 +591,9 @@ def _get_onnx_clip_properties() -> Dict:
                 "textual_file": "onnx16-open_clip-ViT-L-14-laion2b_s32b_b82k-textual.onnx",
                 "token": None,
                 "resolution": 224,
-                "pretrained": "laionb_s32b_b82k"
+                "pretrained": "laionb_s32b_b82k",
+                "image_mean": (0.5, 0.5, 0.5),
+                 "image_std": (0.5, 0.5, 0.5),
             },
 
 

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -538,7 +538,6 @@ def _get_onnx_clip_properties() -> Dict:
                 "token": None,
                 "resolution" : 224,
             },
-
         "onnx32/open_clip/ViT-L-14/laion400m_e32":
             {
                 "name" : "onnx32/open_clip/ViT-L-14/laion400m_e32",
@@ -551,7 +550,6 @@ def _get_onnx_clip_properties() -> Dict:
                 "token" : None,
                 "resolution" : 224,
             },
-
         "onnx16/open_clip/ViT-L-14/laion400m_e32":
             {
                 "name": "onnx16/open_clip/ViT-L-14/laion400m_e32",

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -783,6 +783,38 @@ def _get_onnx_clip_properties() -> Dict:
                'pretrained': 'openai',
                'image_mean': None,
                'image_std': None
+            },
+
+        'onnx32/open_clip/ViT-B-32-quickgelu/laion400m_e31':
+            {
+            'name': 'onnx32/open_clip/ViT-B-32-quickgelu/laion400m_e31',
+                'dimensions': 512,
+                'type': 'clip_onnx',
+            'note': 'the onnx float32 version of open_clip ViT-B-32-quickgelu/laion400m_e31',
+            'repo_id': 'Marqo/onnx-open_clip-ViT-B-32-quickgelu',
+            'visual_file': 'onnx32-open_clip-ViT-B-32-quickgelu-laion400m_e31-visual.onnx',
+            'textual_file': 'onnx32-open_clip-ViT-B-32-quickgelu-laion400m_e31-textual.onnx',
+                'token': None,
+            'resolution': 224,
+                'pretrained': 'laion400m_e31',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx16/open_clip/ViT-B-32-quickgelu/laion400m_e31':
+            {
+            'name': 'onnx16/open_clip/ViT-B-32-quickgelu/laion400m_e31',
+                'dimensions': 512,
+                'type': 'clip_onnx',
+            'note': 'the onnx float16 version of open_clip ViT-B-32-quickgelu/laion400m_e31',
+            'repo_id': 'Marqo/onnx-open_clip-ViT-B-32-quickgelu',
+            'visual_file': 'onnx16-open_clip-ViT-B-32-quickgelu-laion400m_e31-visual.onnx',
+            'textual_file': 'onnx16-open_clip-ViT-B-32-quickgelu-laion400m_e31-textual.onnx',
+                'token': None,
+            'resolution': 224,
+                'pretrained': 'laion400m_e31',
+                'image_mean': None,
+                'image_std': None
             }
 
 

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -691,6 +691,70 @@ def _get_onnx_clip_properties() -> Dict:
                 "image_std": None,
             },
 
+        "onnx32/open_clip/ViT-B-32/laion400m_e32":
+            {
+                "name": "onnx32/open_clip/ViT-B-32/laion400m_e32",
+                "dimensions": 512,
+                "type": "clip_onnx",
+                "note": "the onnx float32 version of open_clip ViT-B-32/laion400m_e32",
+                "repo_id": "Marqo/onnx-open_clip-ViT-B-32",
+                "visual_file": "onnx32-open_clip-ViT-B-32-laion400m_e32-visual.onnx",
+                "textual_file": "onnx32-open_clip-ViT-B-32-laion400m_e32-textual.onnx",
+                "token": None,
+                "resolution": 224,
+                "pretrained": "laion400m_e32",
+                "image_mean": None,
+                "image_std": None,
+            },
+        "onnx16/open_clip/ViT-B-32/laion400m_e32":
+            {
+                "name": "onnx16/open_clip/ViT-B-32/laion400m_e32",
+                "dimensions": 512,
+                "type": "clip_onnx",
+                "note": "the onnx float16 version of open_clip ViT-B-32/laion400m_e32",
+                "repo_id": "Marqo/onnx-open_clip-ViT-B-32",
+                "visual_file": "onnx16-open_clip-ViT-B-32-laion400m_e32-visual.onnx",
+                "textual_file": "onnx16-open_clip-ViT-B-32-laion400m_e32-textual.onnx",
+                "token": None,
+                "resolution": 224,
+                "pretrained": "laion400m_e32",
+                "image_mean": None,
+                "image_std": None,
+            },
+
+        "onnx32/open_clip/ViT-B-32/laion2b_e16":
+            {
+                "name": "onnx32/open_clip/ViT-B-32/laion2b_e16",
+                "dimensions": 512,
+                "type": "clip_onnx",
+                "note": "the onnx float32 version of open_clip ViT-B-32/laion2b_e16",
+                "repo_id": "Marqo/onnx-open_clip-ViT-B-32",
+                "visual_file": "onnx32-open_clip-ViT-B-32-laion2b_e16-visual.onnx",
+                "textual_file": "onnx32-open_clip-ViT-B-32-laion2b_e16-textual.onnx",
+                "token": None,
+                "resolution": 224,
+                "pretrained": "laion2b_e16",
+                "image_mean": None,
+                "image_std": None,
+            },
+
+        "onnx16/open_clip/ViT-B-32/laion2b_e16":
+            {
+                "name": "onnx16/open_clip/ViT-B-32/laion2b_e16",
+                "dimensions": 512,
+                "type": "clip_onnx",
+                "note": "the onnx float16 version of open_clip ViT-B-32/laion2b_e16",
+                "repo_id": "Marqo/onnx-open_clip-ViT-B-32",
+                "visual_file": "onnx16-open_clip-ViT-B-32-laion2b_e16-visual.onnx",
+                "textual_file": "onnx16-open_clip-ViT-B-32-laion2b_e16-textual.onnx",
+                "token": None,
+                "resolution": 224,
+                "pretrained": "laion2b_e16",
+                "image_mean": None,
+                "image_std": None,
+            },
+
+
 
 
 

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -787,15 +787,15 @@ def _get_onnx_clip_properties() -> Dict:
 
         'onnx32/open_clip/ViT-B-32-quickgelu/laion400m_e31':
             {
-            'name': 'onnx32/open_clip/ViT-B-32-quickgelu/laion400m_e31',
+                'name': 'onnx32/open_clip/ViT-B-32-quickgelu/laion400m_e31',
                 'dimensions': 512,
                 'type': 'clip_onnx',
-            'note': 'the onnx float32 version of open_clip ViT-B-32-quickgelu/laion400m_e31',
-            'repo_id': 'Marqo/onnx-open_clip-ViT-B-32-quickgelu',
-            'visual_file': 'onnx32-open_clip-ViT-B-32-quickgelu-laion400m_e31-visual.onnx',
-            'textual_file': 'onnx32-open_clip-ViT-B-32-quickgelu-laion400m_e31-textual.onnx',
+                'note': 'the onnx float32 version of open_clip ViT-B-32-quickgelu/laion400m_e31',
+                'repo_id': 'Marqo/onnx-open_clip-ViT-B-32-quickgelu',
+                'visual_file': 'onnx32-open_clip-ViT-B-32-quickgelu-laion400m_e31-visual.onnx',
+                'textual_file': 'onnx32-open_clip-ViT-B-32-quickgelu-laion400m_e31-textual.onnx',
                 'token': None,
-            'resolution': 224,
+                'resolution': 224,
                 'pretrained': 'laion400m_e31',
                 'image_mean': None,
                 'image_std': None
@@ -803,16 +803,48 @@ def _get_onnx_clip_properties() -> Dict:
 
         'onnx16/open_clip/ViT-B-32-quickgelu/laion400m_e31':
             {
-            'name': 'onnx16/open_clip/ViT-B-32-quickgelu/laion400m_e31',
+                'name': 'onnx16/open_clip/ViT-B-32-quickgelu/laion400m_e31',
                 'dimensions': 512,
                 'type': 'clip_onnx',
-            'note': 'the onnx float16 version of open_clip ViT-B-32-quickgelu/laion400m_e31',
-            'repo_id': 'Marqo/onnx-open_clip-ViT-B-32-quickgelu',
-            'visual_file': 'onnx16-open_clip-ViT-B-32-quickgelu-laion400m_e31-visual.onnx',
-            'textual_file': 'onnx16-open_clip-ViT-B-32-quickgelu-laion400m_e31-textual.onnx',
+                'note': 'the onnx float16 version of open_clip ViT-B-32-quickgelu/laion400m_e31',
+                'repo_id': 'Marqo/onnx-open_clip-ViT-B-32-quickgelu',
+                'visual_file': 'onnx16-open_clip-ViT-B-32-quickgelu-laion400m_e31-visual.onnx',
+                'textual_file': 'onnx16-open_clip-ViT-B-32-quickgelu-laion400m_e31-textual.onnx',
                 'token': None,
-            'resolution': 224,
+                'resolution': 224,
                 'pretrained': 'laion400m_e31',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx16/open_clip/ViT-B-32-quickgelu/laion400m_e32':
+            {
+                'name': 'onnx16/open_clip/ViT-B-32-quickgelu/laion400m_e32',
+                'dimensions': 512,
+                'type': 'clip_onnx',
+                'note': 'the onnx float16 version of open_clip ViT-B-32-quickgelu/laion400m_e32',
+                'repo_id': 'Marqo/onnx-open_clip-ViT-B-32-quickgelu',
+                'visual_file': 'onnx16-open_clip-ViT-B-32-quickgelu-laion400m_e32-visual.onnx',
+                'textual_file': 'onnx16-open_clip-ViT-B-32-quickgelu-laion400m_e32-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'laion400m_e32',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx32/open_clip/ViT-B-32-quickgelu/laion400m_e32':
+            {
+                'name': 'onnx32/open_clip/ViT-B-32-quickgelu/laion400m_e32',
+                'dimensions': 512,
+                'type': 'clip_onnx',
+                'note': 'the onnx float32 version of open_clip ViT-B-32-quickgelu/laion400m_e32',
+                'repo_id': 'Marqo/onnx-open_clip-ViT-B-32-quickgelu',
+                'visual_file': 'onnx32-open_clip-ViT-B-32-quickgelu-laion400m_e32-visual.onnx',
+                'textual_file': 'onnx32-open_clip-ViT-B-32-quickgelu-laion400m_e32-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'laion400m_e32',
                 'image_mean': None,
                 'image_std': None
             }

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -558,8 +558,8 @@ def _get_onnx_clip_properties() -> Dict:
                 "type": "clip_onnx",
                 "note": "the onnx float16 version of open_clip ViT-L-14/lainon400m_e32",
                 "repo_id": "Marqo/onnx-open_clip-ViT-L-14",
-                "visual_file": "onnx32-open_clip-ViT-L-14-laion400m_e16-visual.onnx",
-                "textual_file": "onnx32-open_clip-ViT-L-14-laion400m_e16-textual.onnx",
+                "visual_file": "onnx16-open_clip-ViT-L-14-laion400m_e32-visual.onnx",
+                "textual_file": "onnx16-open_clip-ViT-L-14-laion400m_e32-textual.onnx",
                 "token": None,
                 "resolution": 224,
                 "pretrained": "laion400m_e32"

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -627,6 +627,38 @@ def _get_onnx_clip_properties() -> Dict:
                 "image_std": None,
             },
 
+        "onnx32/open_clip/ViT-B-32/openai":
+            {
+                "name": "onnx32/open_clip/ViT-B-32/openai",
+                "dimensions": 512,
+                "type": "clip_onnx",
+                "note": "the onnx float32 version of open_clip ViT-B-32/openai",
+                "repo_id": "Marqo/onnx-open_clip-ViT-B-32",
+                "visual_file": "onnx32-open_clip-ViT-B-32-openai-visual.onnx",
+                "textual_file": "onnx32-open_clip-ViT-B-32-openai-textual.onnx",
+                "token": None,
+                "resolution": 224,
+                "pretrained": "openai",
+                "image_mean": None,
+                "image_std": None,
+            },
+
+        "onnx16/open_clip/ViT-B-32/openai":
+            {
+                "name": "onnx16/open_clip/ViT-B-32/openai",
+                "dimensions": 512,
+                "type": "clip_onnx",
+                "note": "the onnx float16 version of open_clip ViT-B-32/openai",
+                "repo_id": "Marqo/onnx-open_clip-ViT-B-32",
+                "visual_file": "onnx16-open_clip-ViT-B-32-openai-visual.onnx",
+                "textual_file": "onnx16-open_clip-ViT-B-32-openai-textual.onnx",
+                "token": None,
+                "resolution": 224,
+                "pretrained": "openai",
+                "image_mean": None,
+                "image_std": None,
+            },
+
 
 
 

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -1037,7 +1037,37 @@ def _get_onnx_clip_properties() -> Dict:
                 'pretrained': 'laion2b_s32b_b79k',
                 'image_mean': None,
                 'image_std': None
-            }
+            },
+
+        'onnx16/open_clip/ViT-g-14/laion2b_s12b_b42k':
+            {'name': 'onnx16/open_clip/ViT-g-14/laion2b_s12b_b42k',
+             'dimensions': 1024,
+             'type': 'clip_onnx',
+             'note': 'the onnx float16 version of open_clip ViT-g-14/laion2b_s12b_b42k',
+             'repo_id': 'Marqo/onnx-open_clip-ViT-g-14',
+             'visual_file': 'onnx16-open_clip-ViT-g-14-visual.onnx',
+             'textual_file': 'onnx16-open_clip-ViT-g-14-textual.onnx',
+             'token': None,
+             'resolution': 224,
+             'pretrained': 'laion2b_s12b_b42k',
+             'image_mean': None,
+             'image_std': None
+             },
+
+        'onnx32/open_clip/ViT-g-14/laion2b_s12b_b42k':
+            {'name': 'onnx32/open_clip/ViT-g-14/laion2b_s12b_b42k',
+             'dimensions': 1024,
+             'type': 'clip_onnx',
+             'note': 'the onnx float32 version of open_clip ViT-g-14/laion2b_s12b_b42k',
+             'repo_id': 'Marqo/onnx-open_clip-ViT-g-14',
+             'visual_file': 'onnx32-open_clip-ViT-g-14-visual.zip',
+             'textual_file': 'onnx32-open_clip-ViT-g-14-textual.onnx',
+             'token': None,
+             'resolution': 224,
+             'pretrained': 'laion2b_s12b_b42k',
+             'image_mean': None,
+             'image_std': None
+             }
 
 
 

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -566,7 +566,7 @@ def _get_onnx_clip_properties() -> Dict:
             },
         "onnx32/open_clip/ViT-L-14/laion2b_s32b_b82k":
             {
-                "name": "onnx32/open_clip/ViT-L-14/laionb_s32b_b82k",
+                "name": "onnx32/open_clip/ViT-L-14/laion2b_s32b_b82k",
                 "dimensions": 768,
                 "type": "clip_onnx",
                 "note": "the onnx float32 version of open_clip ViT-L-14/laion2b_s32b_b82k",
@@ -579,7 +579,7 @@ def _get_onnx_clip_properties() -> Dict:
             },
         "onnx16/open_clip/ViT-L-14/laion2b_s32b_b82k":
             {
-                "name": "onnx16/open_clip/ViT-L-14/laionb_s32b_b82k",
+                "name": "onnx16/open_clip/ViT-L-14/laion2b_s32b_b82k",
                 "dimensions": 768,
                 "type": "clip_onnx",
                 "note": "the onnx float16 version of open_clip ViT-L-14/laion2b_s32b_b82k",

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -564,6 +564,34 @@ def _get_onnx_clip_properties() -> Dict:
                 "resolution": 224,
                 "pretrained": "laion400m_e32"
             },
+        "onnx32/open_clip/ViT-L-14/laionb_s32b_b82k":
+            {
+                "name": "onnx32/open_clip/ViT-L-14/laionb_s32b_b82k",
+                "dimensions": 768,
+                "type": "clip_onnx",
+                "note": "the onnx float32 version of open_clip ViT-L-14/laionb_s32b_b82k",
+                "repo_id": "Marqo/onnx-open_clip-ViT-L-14",
+                "visual_file": "onnx32-open_clip-ViT-L-14-laionb_s32b_b82k-visual.onnx",
+                "textual_file": "onnx32-open_clip-ViT-L-14-laionb_s32b_b82k-textual.onnx",
+                "token": None,
+                "resolution": 224,
+                "pretrained": "laionb_s32b_b82k"
+            },
+        "onnx16/open_clip/ViT-L-14/laion400m_e32":
+            {
+                "name": "onnx16/open_clip/ViT-L-14/laionb_s32b_b82k",
+                "dimensions": 768,
+                "type": "clip_onnx",
+                "note": "the onnx float16 version of open_clip ViT-L-14/laionb_s32b_b82k",
+                "repo_id": "Marqo/onnx-open_clip-ViT-L-14",
+                "visual_file": "onnx16-open_clip-ViT-L-14-laionb_s32b_b82k-visual.onnx",
+                "textual_file": "onnx16-open_clip-ViT-L-14-laionb_s32b_b82k-textual.onnx",
+                "token": None,
+                "resolution": 224,
+                "pretrained": "laionb_s32b_b82k"
+            },
+
+
 
     }
     return ONNX_CLIP_MODEL_PROPERTIES

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -879,6 +879,37 @@ def _get_onnx_clip_properties() -> Dict:
                 'pretrained': 'openai',
                 'image_mean': None,
                 'image_std': None
+            },
+
+        'onnx16/open_clip/ViT-B-16/laion400m_e31':
+            {
+                'name': 'onnx16/open_clip/ViT-B-16/laion400m_e31',
+                'dimensions': 512,
+                'type': 'clip_onnx',
+                'note': 'the onnx float16 version of open_clip ViT-B-16/laion400m_e31',
+                'repo_id': 'Marqo/onnx-open_clip-ViT-B-16',
+                'visual_file': 'onnx16-open_clip-ViT-B-16-laion400m_e31-visual.onnx',
+                'textual_file': 'onnx16-open_clip-ViT-B-16-laion400m_e31-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'laion400m_e31',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx32/open_clip/ViT-B-16/laion400m_e31':
+            {
+                'name': 'onnx32/open_clip/ViT-B-16/laion400m_e31',
+                'dimensions': 512,
+                'type': 'clip_onnx',
+                'note': 'the onnx float32 version of open_clip ViT-B-16/laion400m_e31',
+                'repo_id': 'Marqo/onnx-open_clip-ViT-B-16',
+                'visual_file': 'onnx32-open_clip-ViT-B-16-laion400m_e31-visual.onnx',
+                'textual_file': 'onnx32-open_clip-ViT-B-16-laion400m_e31-textual.onnx',
+                'token': None,
+                'resolution': 224, 'pretrained': 'laion400m_e31',
+                'image_mean': None,
+                'image_std': None
             }
 
 

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -564,12 +564,12 @@ def _get_onnx_clip_properties() -> Dict:
                 "resolution": 224,
                 "pretrained": "laion400m_e32"
             },
-        "onnx32/open_clip/ViT-L-14/laionb_s32b_b82k":
+        "onnx32/open_clip/ViT-L-14/laion2b_s32b_b82k":
             {
                 "name": "onnx32/open_clip/ViT-L-14/laionb_s32b_b82k",
                 "dimensions": 768,
                 "type": "clip_onnx",
-                "note": "the onnx float32 version of open_clip ViT-L-14/laionb_s32b_b82k",
+                "note": "the onnx float32 version of open_clip ViT-L-14/laion2b_s32b_b82k",
                 "repo_id": "Marqo/onnx-open_clip-ViT-L-14",
                 "visual_file": "onnx32-open_clip-ViT-L-14-laion2b_s32b_b82k-visual.onnx",
                 "textual_file": "onnx32-open_clip-ViT-L-14-laion2b_s32b_b82k-textual.onnx",
@@ -577,12 +577,12 @@ def _get_onnx_clip_properties() -> Dict:
                 "resolution": 224,
                 "pretrained": "laionb_s32b_b82k"
             },
-        "onnx16/open_clip/ViT-L-14/laionb_s32b_b82k":
+        "onnx16/open_clip/ViT-L-14/laion2b_s32b_b82k":
             {
                 "name": "onnx16/open_clip/ViT-L-14/laionb_s32b_b82k",
                 "dimensions": 768,
                 "type": "clip_onnx",
-                "note": "the onnx float16 version of open_clip ViT-L-14/laionb_s32b_b82k",
+                "note": "the onnx float16 version of open_clip ViT-L-14/laion2b_s32b_b82k",
                 "repo_id": "Marqo/onnx-open_clip-ViT-L-14",
                 "visual_file": "onnx16-open_clip-ViT-L-14-laion2b_s32b_b82k-visual.onnx",
                 "textual_file": "onnx16-open_clip-ViT-L-14-laion2b_s32b_b82k-textual.onnx",

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -847,6 +847,38 @@ def _get_onnx_clip_properties() -> Dict:
                 'pretrained': 'laion400m_e32',
                 'image_mean': None,
                 'image_std': None
+            },
+
+        'onnx16/open_clip/ViT-B-16/openai':
+            {
+                'name': 'onnx16/open_clip/ViT-B-16/openai',
+                'dimensions': 512,
+                'type': 'clip_onnx',
+                'note': 'the onnx float16 version of open_clip ViT-B-16/openai',
+                'repo_id': 'Marqo/onnx-open_clip-ViT-B-16',
+                'visual_file': 'onnx16-open_clip-ViT-B-16-openai-visual.onnx',
+                'textual_file': 'onnx16-open_clip-ViT-B-16-openai-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'openai',
+                'image_mean': None,
+                'image_std': None
+             },
+
+        'onnx32/open_clip/ViT-B-16/openai':
+            {
+                'name': 'onnx32/open_clip/ViT-B-16/openai',
+                'dimensions': 512,
+                'type': 'clip_onnx',
+                'note': 'the onnx float32 version of open_clip ViT-B-16/openai',
+                'repo_id': 'Marqo/onnx-open_clip-ViT-B-16',
+                'visual_file': 'onnx32-open_clip-ViT-B-16-openai-visual.onnx',
+                'textual_file': 'onnx32-open_clip-ViT-B-16-openai-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'openai',
+                'image_mean': None,
+                'image_std': None
             }
 
 

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -519,15 +519,52 @@ def _get_onnx_clip_properties() -> Dict:
                 "name":"onnx32/openai/ViT-L/14",
                 "dimensions" : 768,
                 "type":"clip_onnx",
-                "note":"the onnx float32 version of openai ViT-L/14"
+                "note":"the onnx float32 version of openai ViT-L/14",
+                "repo_id": "Marqo/onnx-openai-ViT-L-14",
+                "visual_file": "onnx32-openai-ViT-L-14-visual.onnx",
+                "textual_file": "onnx32-openai-ViT-L-14-textual.onnx",
+                "token": None,
+                "resolution" : 224,
             },
         "onnx16/openai/ViT-L/14":
             {
                 "name": "onnx16/openai/ViT-L/14",
                 "dimensions": 768,
                 "type": "clip_onnx",
-                "note": "the onnx float16 version of openai ViT-L/14"
+                "note": "the onnx float16 version of openai ViT-L/14",
+                "repo_id": "Marqo/onnx-openai-ViT-L-14",
+                "visual_file": "onnx16-openai-ViT-L-14-visual.onnx",
+                "textual_file": "onnx16-openai-ViT-L-14-textual.onnx",
+                "token": None,
+                "resolution" : 224,
             },
+
+        "onnx32/open_clip/ViT-L-14/laion400m_e32":
+            {
+                "name" : "onnx32/open_clip/ViT-L-14/laion400m_e32",
+                "dimensions" : 768,
+                "type" : "clip_onnx",
+                "note": "the onnx float32 version of open_clip ViT-L-14/lainon400m_e32",
+                "repo_id" : "Marqo/onnx-open_clip-ViT-L-14",
+                "visual_file" : "onnx32-open_clip-ViT-L-14-laion400m_e32-visual.onnx",
+                "textual_file" : "onnx32-open_clip-ViT-L-14-laion400m_e32-textual.onnx",
+                "token" : None,
+                "resolution" : 224,
+            },
+
+        "onnx16/open_clip/ViT-L-14/laion400m_e32":
+            {
+                "name": "onnx16/open_clip/ViT-L-14/laion400m_e32",
+                "dimensions": 768,
+                "type": "clip_onnx",
+                "note": "the onnx float16 version of open_clip ViT-L-14/lainon400m_e32",
+                "repo_id": "Marqo/onnx-open_clip-ViT-L-14",
+                "visual_file": "onnx32-open_clip-ViT-L-14-laion400m_e16-visual.onnx",
+                "textual_file": "onnx32-open_clip-ViT-L-14-laion400m_e16-textual.onnx",
+                "token": None,
+                "resolution": 224,
+            },
+
     }
     return ONNX_CLIP_MODEL_PROPERTIES
 

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -1005,6 +1005,38 @@ def _get_onnx_clip_properties() -> Dict:
                 'pretrained': 'laion400m_e32',
                 'image_mean': None,
                 'image_std': None
+            },
+
+        'onnx16/open_clip/ViT-H-14/laion2b_s32b_b79k':
+            {
+                'name': 'onnx16/open_clip/ViT-H-14/laion2b_s32b_b79k',
+                'dimensions': 1024,
+                'type': 'clip_onnx',
+                'note': 'the onnx float16 version of open_clip ViT-H-14/laion2b_s32b_b79k',
+                'repo_id': 'Marqo/onnx-open_clip-ViT-H-14',
+                'visual_file': 'onnx16-open_clip-ViT-H-14-laion2b_s32b_b79k-visual.onnx',
+                'textual_file': 'onnx16-open_clip-ViT-H-14-laion2b_s32b_b79k-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'laion2b_s32b_b79k',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx32/open_clip/ViT-H-14/laion2b_s32b_b79k':
+            {
+                'name': 'onnx32/open_clip/ViT-H-14/laion2b_s32b_b79k',
+                'dimensions': 1024,
+                'type': 'clip_onnx',
+                'note': 'the onnx float32 version of open_clip ViT-H-14/laion2b_s32b_b79k',
+                'repo_id': 'Marqo/onnx-open_clip-ViT-H-14',
+                'visual_file': 'onnx32-open_clip-ViT-H-14-laion2b_s32b_b79k-visual.onnx',
+                'textual_file': 'onnx32-open_clip-ViT-H-14-laion2b_s32b_b79k-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'laion2b_s32b_b79k',
+                'image_mean': None,
+                'image_std': None
             }
 
 

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -595,6 +595,40 @@ def _get_onnx_clip_properties() -> Dict:
                 "image_mean": (0.5, 0.5, 0.5),
                  "image_std": (0.5, 0.5, 0.5),
             },
+        "onnx32/open_clip/ViT-L-14-336/openai":
+            {
+                "name": "onnx32/open_clip/ViT-L-14-336/openai",
+                "dimensions": 768,
+                "type": "clip_onnx",
+                "note": "the onnx float32 version of open_clip ViT-L-14-336/openai",
+                "repo_id": "Marqo/onnx-open_clip-ViT-L-14-336",
+                "visual_file": "onnx32-open_clip-ViT-L-14-336-openai-visual.onnx",
+                "textual_file": "onnx32-open_clip-ViT-L-14-336-openai-textual.onnx",
+                "token": None,
+                "resolution": 336,
+                "pretrained": "openai",
+                "image_mean": None,
+                "image_std": None,
+
+            },
+        "onnx16/open_clip/ViT-L-14-336/openai":
+            {
+                "name": "onnx16/open_clip/ViT-L-14-336/openai",
+                "dimensions": 768,
+                "type": "clip_onnx",
+                "note": "the onnx float16 version of open_clip ViT-L-14-336/openai",
+                "repo_id": "Marqo/onnx-open_clip-ViT-L-14-336",
+                "visual_file": "onnx16-open_clip-ViT-L-14-336-openai-visual.onnx",
+                "textual_file": "onnx16-open_clip-ViT-L-14-336-openai-textual.onnx",
+                "token": None,
+                "resolution": 336,
+                "pretrained": "openai",
+                "image_mean": None,
+                "image_std": None,
+
+            },
+
+
 
 
 

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -549,6 +549,7 @@ def _get_onnx_clip_properties() -> Dict:
                 "textual_file" : "onnx32-open_clip-ViT-L-14-laion400m_e32-textual.onnx",
                 "token" : None,
                 "resolution" : 224,
+                "pretrained" : "laion400m_e32"
             },
         "onnx16/open_clip/ViT-L-14/laion400m_e32":
             {
@@ -561,6 +562,7 @@ def _get_onnx_clip_properties() -> Dict:
                 "textual_file": "onnx32-open_clip-ViT-L-14-laion400m_e16-textual.onnx",
                 "token": None,
                 "resolution": 224,
+                "pretrained": "laion400m_e32"
             },
 
     }

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -974,8 +974,38 @@ def _get_onnx_clip_properties() -> Dict:
                 'pretrained': 'laion400m_e31',
                 'image_mean': None,
                 'image_std': None
-            }
+            },
 
+        'onnx16/open_clip/ViT-B-16-plus-240/laion400m_e32':
+            {
+                'name': 'onnx16/open_clip/ViT-B-16-plus-240/laion400m_e32',
+                'dimensions': 640,
+                'type': 'clip_onnx',
+                'note': 'the onnx float16 version of open_clip ViT-B-16-plus-240/laion400m_e32',
+                'repo_id': 'Marqo/onnx-open_clip-ViT-B-16-plus-240',
+                'visual_file': 'onnx16-open_clip-ViT-B-16-plus-240-laion400m_e32-visual.onnx',
+                'textual_file': 'onnx16-open_clip-ViT-B-16-plus-240-laion400m_e32-textual.onnx',
+                'token': None,
+                'resolution': 240,
+                'pretrained': 'laion400m_e32',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx32/open_clip/ViT-B-16-plus-240/laion400m_e32':
+            {
+                'name': 'onnx32/open_clip/ViT-B-16-plus-240/laion400m_e32',
+                'dimensions': 640, 'type': 'clip_onnx',
+                'note': 'the onnx float32 version of open_clip ViT-B-16-plus-240/laion400m_e32',
+                'repo_id': 'Marqo/onnx-open_clip-ViT-B-16-plus-240',
+                'visual_file': 'onnx32-open_clip-ViT-B-16-plus-240-laion400m_e32-visual.onnx',
+                'textual_file': 'onnx32-open_clip-ViT-B-16-plus-240-laion400m_e32-textual.onnx',
+                'token': None,
+                'resolution': 240,
+                'pretrained': 'laion400m_e32',
+                'image_mean': None,
+                'image_std': None
+            }
 
 
 

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -907,7 +907,40 @@ def _get_onnx_clip_properties() -> Dict:
                 'visual_file': 'onnx32-open_clip-ViT-B-16-laion400m_e31-visual.onnx',
                 'textual_file': 'onnx32-open_clip-ViT-B-16-laion400m_e31-textual.onnx',
                 'token': None,
-                'resolution': 224, 'pretrained': 'laion400m_e31',
+                'resolution': 224,
+                'pretrained': 'laion400m_e31',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx16/open_clip/ViT-B-16/laion400m_e32':
+            {
+                'name': 'onnx16/open_clip/ViT-B-16/laion400m_e32',
+                'dimensions': 512,
+                'type': 'clip_onnx',
+                'note': 'the onnx float16 version of open_clip ViT-B-16/laion400m_e32',
+                'repo_id': 'Marqo/onnx-open_clip-ViT-B-16',
+                'visual_file': 'onnx16-open_clip-ViT-B-16-laion400m_e32-visual.onnx',
+                'textual_file': 'onnx16-open_clip-ViT-B-16-laion400m_e32-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'laion400m_e32',
+                'image_mean': None,
+                'image_std': None
+            },
+
+        'onnx32/open_clip/ViT-B-16/laion400m_e32':
+            {
+                'name': 'onnx32/open_clip/ViT-B-16/laion400m_e32',
+                'dimensions': 512,
+                'type': 'clip_onnx',
+                'note': 'the onnx float32 version of open_clip ViT-B-16/laion400m_e32',
+                'repo_id': 'Marqo/onnx-open_clip-ViT-B-16',
+                'visual_file': 'onnx32-open_clip-ViT-B-16-laion400m_e32-visual.onnx',
+                'textual_file': 'onnx32-open_clip-ViT-B-16-laion400m_e32-textual.onnx',
+                'token': None,
+                'resolution': 224,
+                'pretrained': 'laion400m_e32',
                 'image_mean': None,
                 'image_std': None
             }

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -571,8 +571,8 @@ def _get_onnx_clip_properties() -> Dict:
                 "type": "clip_onnx",
                 "note": "the onnx float32 version of open_clip ViT-L-14/laionb_s32b_b82k",
                 "repo_id": "Marqo/onnx-open_clip-ViT-L-14",
-                "visual_file": "onnx32-open_clip-ViT-L-14-laionb_s32b_b82k-visual.onnx",
-                "textual_file": "onnx32-open_clip-ViT-L-14-laionb_s32b_b82k-textual.onnx",
+                "visual_file": "onnx32-open_clip-ViT-L-14-laion2b_s32b_b82k-visual.onnx",
+                "textual_file": "onnx32-open_clip-ViT-L-14-laion2b_s32b_b82k-textual.onnx",
                 "token": None,
                 "resolution": 224,
                 "pretrained": "laionb_s32b_b82k"
@@ -584,8 +584,8 @@ def _get_onnx_clip_properties() -> Dict:
                 "type": "clip_onnx",
                 "note": "the onnx float16 version of open_clip ViT-L-14/laionb_s32b_b82k",
                 "repo_id": "Marqo/onnx-open_clip-ViT-L-14",
-                "visual_file": "onnx16-open_clip-ViT-L-14-laionb_s32b_b82k-visual.onnx",
-                "textual_file": "onnx16-open_clip-ViT-L-14-laionb_s32b_b82k-textual.onnx",
+                "visual_file": "onnx16-open_clip-ViT-L-14-laion2b_s32b_b82k-visual.onnx",
+                "textual_file": "onnx16-open_clip-ViT-L-14-laion2b_s32b_b82k-textual.onnx",
                 "token": None,
                 "resolution": 224,
                 "pretrained": "laionb_s32b_b82k"

--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -659,6 +659,38 @@ def _get_onnx_clip_properties() -> Dict:
                 "image_std": None,
             },
 
+        "onnx32/open_clip/ViT-B-32/laion400m_e31":
+            {
+                "name": "onnx32/open_clip/ViT-B-32/laion400m_e31",
+                "dimensions": 512,
+                "type": "clip_onnx",
+                "note": "the onnx float32 version of open_clip ViT-B-32/laion400m_e31",
+                "repo_id": "Marqo/onnx-open_clip-ViT-B-32",
+                "visual_file": "onnx32-open_clip-ViT-B-32-laion400m_e31-visual.onnx",
+                "textual_file": "onnx32-open_clip-ViT-B-32-laion400m_e31-textual.onnx",
+                "token": None,
+                "resolution": 224,
+                "pretrained": "laion400m_e31",
+                "image_mean": None,
+                "image_std": None,
+            },
+
+        "onnx16/open_clip/ViT-B-32/laion400m_e31":
+            {
+                "name": "onnx16/open_clip/ViT-B-32/laion400m_e31",
+                "dimensions": 512,
+                "type": "clip_onnx",
+                "note": "the onnx float16 version of open_clip ViT-B-32/laion400m_e31",
+                "repo_id": "Marqo/onnx-open_clip-ViT-B-32",
+                "visual_file": "onnx16-open_clip-ViT-B-32-laion400m_e31-visual.onnx",
+                "textual_file": "onnx16-open_clip-ViT-B-32-laion400m_e31-textual.onnx",
+                "token": None,
+                "resolution": 224,
+                "pretrained": "laion400m_e31",
+                "image_mean": None,
+                "image_std": None,
+            },
+
 
 
 

--- a/src/marqo/s2_inference/onnx_clip_utils.py
+++ b/src/marqo/s2_inference/onnx_clip_utils.py
@@ -175,13 +175,12 @@ class CLIP_ONNX(object):
         file_path = hf_hub_download(repo_id=repo_id, filename=filename,
                                     cache_dir=cache_dir)
         if file_path.endswith(".zip"):
-            file_path = file_path.replace(".zip", ".onnx")
-
             if not os.path.isfile(file_path.replace(".zip", ".onnx")):
                 logger.info(f"Unzip onnx model = {file_path}")
                 with ZipFile(file_path) as zipobj:
                     zipobj.extractall(os.path.dirname(file_path))
                     #shutil.unpack_archive(filename, os.path.dirname(file_path))
+            file_path = file_path.replace(".zip", ".onnx")
 
         return file_path
 

--- a/src/marqo/s2_inference/onnx_clip_utils.py
+++ b/src/marqo/s2_inference/onnx_clip_utils.py
@@ -179,6 +179,6 @@ class CLIP_ONNX(object):
             with ZipFile(file_path) as zipobj:
                 zipobj.extractall(os.path.dirname(file_path))
                 #shutil.unpack_archive(filename, os.path.dirname(file_path))
-            file_path = file_path.replace(".zip", ".onnx")
+        file_path = file_path.replace(".zip", ".onnx")
         return file_path
 

--- a/src/marqo/s2_inference/onnx_clip_utils.py
+++ b/src/marqo/s2_inference/onnx_clip_utils.py
@@ -176,8 +176,8 @@ class CLIP_ONNX(object):
                                     cache_dir=cache_dir)
         if file_path.endswith(".zip") and (not os.path.isfile(file_path.replace(".zip", ".onnx"))):
             logger.info(f"Unzip onnx model = {file_path}")
-            with ZipFile(file_path, 'r') as zipobj:
-                zipobj.extractall()
+            with ZipFile(file_path) as zipobj:
+                zipobj.extractall(os.path.dirname(file_path))
                 #shutil.unpack_archive(filename, os.path.dirname(file_path))
             file_path = file_path.replace(".zip", ".onnx")
         return file_path

--- a/src/marqo/s2_inference/onnx_clip_utils.py
+++ b/src/marqo/s2_inference/onnx_clip_utils.py
@@ -179,7 +179,7 @@ class CLIP_ONNX(object):
     def download_model(repo_id: str, filename: str, cache_dir: str = None) -> str:
         file_path = hf_hub_download(repo_id=repo_id, filename=filename,
                                     cache_dir=cache_dir)
-        if file_path.endswith(".zip"):
+        if file_path.endswith(".zip") and (not os.path.isfile(file_path.replace(".zip", ".onnx"))):
             shutil.unpack_archive(filename, os.path.dirname(file_path))
             file_path = file_path.replace(".zip", ".onnx")
         return file_path

--- a/src/marqo/s2_inference/onnx_clip_utils.py
+++ b/src/marqo/s2_inference/onnx_clip_utils.py
@@ -93,8 +93,8 @@ class CLIP_ONNX(object):
 
         elif self.source == "open_clip":
             clip_name, _ = self.clip_model.split("/", 2)
-            self.clip_preprocess = _get_transform(self.n_px)
-            self.tokenizer = open_clip.get_tokenizer(clip_name, self.model_info.get("image_mean", None), self.model_info.get("image_std", None))
+            self.clip_preprocess = _get_transform(self.n_px, self.model_info.get("image_mean", None), self.model_info.get("image_std", None))
+            self.tokenizer = open_clip.get_tokenizer(clip_name)
 
     def encode_text(self, sentence, normalize=True):
         text = clip.tokenize(sentence, truncate=self.truncate).cpu()

--- a/src/marqo/s2_inference/onnx_clip_utils.py
+++ b/src/marqo/s2_inference/onnx_clip_utils.py
@@ -174,11 +174,14 @@ class CLIP_ONNX(object):
     def download_model(repo_id: str, filename: str, cache_dir: str = None) -> str:
         file_path = hf_hub_download(repo_id=repo_id, filename=filename,
                                     cache_dir=cache_dir)
-        if file_path.endswith(".zip") and (not os.path.isfile(file_path.replace(".zip", ".onnx"))):
-            logger.info(f"Unzip onnx model = {file_path}")
-            with ZipFile(file_path) as zipobj:
-                zipobj.extractall(os.path.dirname(file_path))
-                #shutil.unpack_archive(filename, os.path.dirname(file_path))
-        file_path = file_path.replace(".zip", ".onnx")
+        if file_path.endswith(".zip"):
+            file_path = file_path.replace(".zip", ".onnx")
+
+            if not os.path.isfile(file_path.replace(".zip", ".onnx")):
+                logger.info(f"Unzip onnx model = {file_path}")
+                with ZipFile(file_path) as zipobj:
+                    zipobj.extractall(os.path.dirname(file_path))
+                    #shutil.unpack_archive(filename, os.path.dirname(file_path))
+
         return file_path
 

--- a/src/marqo/s2_inference/onnx_clip_utils.py
+++ b/src/marqo/s2_inference/onnx_clip_utils.py
@@ -16,8 +16,12 @@ import onnxruntime as ort
 
 # Loading shared functions from clip_utils.py. This part should be decoupled from models in the future
 from marqo.s2_inference.clip_utils import get_allowed_image_types, format_and_load_CLIP_image, format_and_load_CLIP_images, load_image_from_path,_is_image
+from model_registry import _get_onnx_clip_properties
 
 logger = get_logger(__name__)
+
+
+ONNX_CLIP_PROPERTIES = _get_onnx_clip_properties()
 
 _HF_MODEL_DOWNLOAD = {
 

--- a/src/marqo/s2_inference/onnx_clip_utils.py
+++ b/src/marqo/s2_inference/onnx_clip_utils.py
@@ -15,7 +15,7 @@ from marqo.s2_inference.logger import get_logger
 import onnxruntime as ort
 from torchvision.transforms import Compose, Resize, CenterCrop, ToTensor, Normalize
 import marqo.s2_inference.model_registry as model_registry
-import shutil
+from zipfile import ZipFile
 
 # Loading shared functions from clip_utils.py. This part should be decoupled from models in the future
 from marqo.s2_inference.clip_utils import get_allowed_image_types, format_and_load_CLIP_image, \
@@ -176,7 +176,9 @@ class CLIP_ONNX(object):
                                     cache_dir=cache_dir)
         if file_path.endswith(".zip") and (not os.path.isfile(file_path.replace(".zip", ".onnx"))):
             logger.info(f"Unzip onnx model = {file_path}")
-            shutil.unpack_archive(filename, os.path.dirname(file_path))
+            with ZipFile(file_path, 'r') as zipobj:
+                zipobj.extractall()
+                #shutil.unpack_archive(filename, os.path.dirname(file_path))
             file_path = file_path.replace(".zip", ".onnx")
         return file_path
 

--- a/src/marqo/s2_inference/onnx_clip_utils.py
+++ b/src/marqo/s2_inference/onnx_clip_utils.py
@@ -175,6 +175,7 @@ class CLIP_ONNX(object):
         file_path = hf_hub_download(repo_id=repo_id, filename=filename,
                                     cache_dir=cache_dir)
         if file_path.endswith(".zip") and (not os.path.isfile(file_path.replace(".zip", ".onnx"))):
+            logger.info(f"Unzip onnx model = {file_path}")
             shutil.unpack_archive(filename, os.path.dirname(file_path))
             file_path = file_path.replace(".zip", ".onnx")
         return file_path

--- a/src/marqo/s2_inference/onnx_clip_utils.py
+++ b/src/marqo/s2_inference/onnx_clip_utils.py
@@ -163,11 +163,6 @@ class CLIP_ONNX(object):
 
     def load_onnx(self):
 
-        # We may need to download the whole repo for certain onnx models
-        # since they need external data
-        if self.model_info.get("repo_download_flag", False) is True:
-            self.download_repo(self.model_info["repo_id"])
-
         self.visual_file = self.download_model(self.model_info["repo_id"], self.model_info["visual_file"])
         self.textual_file = self.download_model(self.model_info["repo_id"], self.model_info["textual_file"])
         self.visual_session = ort.InferenceSession(self.visual_file, providers=self.provider)
@@ -184,6 +179,3 @@ class CLIP_ONNX(object):
             file_path = file_path.replace(".zip", ".onnx")
         return file_path
 
-    @staticmethod
-    def download_repo(repo_id:str, cache_dir: str = None) -> str:
-        repo_path = hf_hub_download(repo_id = repo_id, cache_dir = cache_dir)

--- a/src/marqo/s2_inference/onnx_clip_utils.py
+++ b/src/marqo/s2_inference/onnx_clip_utils.py
@@ -16,6 +16,8 @@ import onnxruntime as ort
 from torchvision.transforms import Compose, Resize, CenterCrop, ToTensor, Normalize
 import marqo.s2_inference.model_registry as model_registry
 from zipfile import ZipFile
+from huggingface_hub.utils import RevisionNotFoundError,RepositoryNotFoundError, EntryNotFoundError, LocalEntryNotFoundError
+from marqo.s2_inference.errors import ModelDownloadError
 
 # Loading shared functions from clip_utils.py. This part should be decoupled from models in the future
 from marqo.s2_inference.clip_utils import get_allowed_image_types, format_and_load_CLIP_image, \
@@ -179,8 +181,13 @@ class CLIP_ONNX(object):
 
     @staticmethod
     def download_model(repo_id: str, filename: str, cache_dir: str = None) -> str:
-        file_path = hf_hub_download(repo_id=repo_id, filename=filename,
-                                    cache_dir=cache_dir)
+        try:
+            file_path = hf_hub_download(repo_id=repo_id, filename=filename,
+                                        cache_dir=cache_dir)
+        except (EnvironmentError, OSError, ValueError, RepositoryNotFoundError, RevisionNotFoundError, EntryNotFoundError,
+            LocalEntryNotFoundError) as e:
+            raise ModelDownloadError(e)
+
         if file_path.endswith(".zip"):
             if not os.path.isfile(file_path.replace(".zip", ".onnx")):
                 logger.info(f"Unzip onnx model = {file_path}")

--- a/tests/s2_inference/test_encoding.py
+++ b/tests/s2_inference/test_encoding.py
@@ -24,7 +24,8 @@ class TestEncoding(unittest.TestCase):
 
     def test_vectorize(self):
 
-        names = ["all-MiniLM-L6-v1", "all_datasets_v4_MiniLM-L6", "hf/all-MiniLM-L6-v1", "hf/all_datasets_v4_MiniLM-L6",
+        names = ["onnx16/open_clip/ViT-B-32/laion400m_e32", 'onnx32/open_clip/ViT-B-32-quickgelu/laion400m_e32',
+                 'onnx32/open_clip/ViT-g-14/laion2b_s12b_b42k',"all-MiniLM-L6-v1", "all_datasets_v4_MiniLM-L6", "hf/all-MiniLM-L6-v1", "hf/all_datasets_v4_MiniLM-L6",
                  "onnx/all-MiniLM-L6-v1", "onnx/all_datasets_v4_MiniLM-L6"]
         sentences = ['hello', 'this is a test sentence. so is this.', ['hello', 'this is a test sentence. so is this.']]
         device = 'cpu'
@@ -44,7 +45,8 @@ class TestEncoding(unittest.TestCase):
                 assert abs(torch.FloatTensor(output_m) - torch.FloatTensor(output_v)).sum() < eps
 
     def test_load_clip_text_model(self):
-        names = ['RN50', "ViT-B/16"]
+        names = ["onnx16/open_clip/ViT-B-32/laion400m_e32", 'onnx32/open_clip/ViT-B-32-quickgelu/laion400m_e32',
+                 'onnx32/open_clip/ViT-g-14/laion2b_s12b_b42k', 'RN50', "ViT-B/16"]
         device = 'cpu'
         eps = 1e-9
         texts = ['hello', 'big', 'asasasasaaaaaaaaaaaa', '', 'a word. another one!?. #$#.']
@@ -106,7 +108,8 @@ class TestEncoding(unittest.TestCase):
                 assert abs(model_onnx.encode(sentence) - model_sbert.encode(sentence)).sum() < eps
 
     def test_model_outputs(self):
-        names = ["onnx32/openai/ViT-L/14", "onnx16/openai/ViT-L/14",
+        names = ["onnx16/open_clip/ViT-B-32/laion400m_e32", 'onnx32/open_clip/ViT-B-32-quickgelu/laion400m_e32',
+                 'onnx32/open_clip/ViT-g-14/laion2b_s12b_b42k', "onnx32/openai/ViT-L/14", "onnx16/openai/ViT-L/14",
             'open_clip/ViT-B-32/laion400m_e32', "all-MiniLM-L6-v1",
                  "all_datasets_v4_MiniLM-L6", "hf/all-MiniLM-L6-v1",
                  "hf/all_datasets_v4_MiniLM-L6", "onnx/all-MiniLM-L6-v1", "onnx/all_datasets_v4_MiniLM-L6"]
@@ -122,7 +125,8 @@ class TestEncoding(unittest.TestCase):
                 assert _check_output_type(_convert_vectorized_output(output))
 
     def test_model_normalization(self):
-        names = ["onnx32/openai/ViT-L/14", "onnx16/openai/ViT-L/14",
+        names = ["onnx16/open_clip/ViT-B-32/laion400m_e32", 'onnx32/open_clip/ViT-B-32-quickgelu/laion400m_e32',
+                 'onnx32/open_clip/ViT-g-14/laion2b_s12b_b42k', "onnx32/openai/ViT-L/14", "onnx16/openai/ViT-L/14",
                  'open_clip/ViT-B-32/laion400m_e32', 'RN50', "ViT-B/16", "all-MiniLM-L6-v1",
                  "all_datasets_v4_MiniLM-L6", "hf/all-MiniLM-L6-v1", "hf/all_datasets_v4_MiniLM-L6",
                  "onnx/all-MiniLM-L6-v1", "onnx/all_datasets_v4_MiniLM-L6"]
@@ -208,7 +212,8 @@ class TestEncoding(unittest.TestCase):
 
     def test_onnx_clip_vectorise(self):
 
-        names = ["onnx32/openai/ViT-L/14", "onnx16/openai/ViT-L/14"]
+        names = ["onnx16/open_clip/ViT-B-32/laion400m_e32", 'onnx32/open_clip/ViT-B-32-quickgelu/laion400m_e32',
+                 'onnx32/open_clip/ViT-g-14/laion2b_s12b_b42k', "onnx32/openai/ViT-L/14", "onnx16/openai/ViT-L/14"]
 
         sentences = ['hello', 'this is a test sentence. so is this.',
                      ['hello', 'this is a test sentence. so is this.']]

--- a/tests/s2_inference/test_encoding.py
+++ b/tests/s2_inference/test_encoding.py
@@ -65,6 +65,7 @@ class TestEncoding(unittest.TestCase):
 
             clear_loaded_models()
 
+
     def test_load_sbert_text_model(self):
         names = ["all-MiniLM-L6-v1", "all_datasets_v4_MiniLM-L6"]
         device = 'cpu'
@@ -76,6 +77,7 @@ class TestEncoding(unittest.TestCase):
             assert abs(model.encode('hello') - model.encode(['hello'])).sum() < eps
 
             clear_loaded_models()
+
 
     def test_load_hf_text_model(self):
         names = ["hf/all-MiniLM-L6-v1", "hf/all_datasets_v4_MiniLM-L6"]
@@ -89,6 +91,7 @@ class TestEncoding(unittest.TestCase):
 
             clear_loaded_models()
 
+
     def test_load_onnx_sbert_text_model(self):
         names = ["onnx/all-MiniLM-L6-v1", "onnx/all_datasets_v4_MiniLM-L6"]
         device = 'cpu'
@@ -100,6 +103,7 @@ class TestEncoding(unittest.TestCase):
             assert abs(model.encode('hello') - model.encode(['hello'])).sum() < eps
 
             clear_loaded_models()
+
 
     def test_compare_onnx_sbert_text_models(self):
         names_sbert_onnx = [("all-MiniLM-L6-v1", "onnx/all-MiniLM-L6-v1"),
@@ -120,10 +124,11 @@ class TestEncoding(unittest.TestCase):
 
             clear_loaded_models()
 
+
     def test_model_outputs(self):
         names = ["onnx16/open_clip/ViT-B-32/laion400m_e32", 'onnx32/open_clip/ViT-B-32-quickgelu/laion400m_e32',
                  'onnx32/open_clip/ViT-g-14/laion2b_s12b_b42k', "onnx32/openai/ViT-L/14", "onnx16/openai/ViT-L/14",
-            'open_clip/ViT-B-32/laion400m_e32', "all-MiniLM-L6-v1",
+                'open_clip/ViT-B-32/laion400m_e32', "all-MiniLM-L6-v1",
                  "all_datasets_v4_MiniLM-L6", "hf/all-MiniLM-L6-v1",
                  "hf/all_datasets_v4_MiniLM-L6", "onnx/all-MiniLM-L6-v1", "onnx/all_datasets_v4_MiniLM-L6"]
         sentences = ['hello', 'this is a test sentence. so is this.', ['hello', 'this is a test sentence. so is this.']]
@@ -138,6 +143,7 @@ class TestEncoding(unittest.TestCase):
                 assert _check_output_type(_convert_vectorized_output(output))
 
             clear_loaded_models()
+
 
     def test_model_normalization(self):
         names = ["onnx16/open_clip/ViT-B-32/laion400m_e32", 'onnx32/open_clip/ViT-B-32-quickgelu/laion400m_e32',
@@ -163,6 +169,7 @@ class TestEncoding(unittest.TestCase):
                 assert abs(min_output_norm - 1) < eps, f"{name}, {sentence}"
 
             clear_loaded_models()
+
 
     def test_model_un_normalization(self):
         # note: sbert native seems to provide normalized embeddings even with = False, needs more investigation
@@ -212,6 +219,7 @@ class TestEncoding(unittest.TestCase):
 
             clear_loaded_models()
 
+
     def test_open_clip_embedding_size(self):
 
         # This is a full test as the list includes all the models. Note that the training dataset does not affect the
@@ -233,6 +241,7 @@ class TestEncoding(unittest.TestCase):
                 assert registered_dimension == output_dimension
 
             clear_loaded_models()
+
 
     def test_onnx_clip_vectorise(self):
 

--- a/tests/s2_inference/test_encoding.py
+++ b/tests/s2_inference/test_encoding.py
@@ -44,6 +44,9 @@ class TestEncoding(unittest.TestCase):
 
                 assert abs(torch.FloatTensor(output_m) - torch.FloatTensor(output_v)).sum() < eps
 
+             clear_loaded_models()
+
+
     def test_load_clip_text_model(self):
         names = ["onnx16/open_clip/ViT-B-32/laion400m_e32", 'onnx32/open_clip/ViT-B-32-quickgelu/laion400m_e32',
                  'onnx32/open_clip/ViT-g-14/laion2b_s12b_b42k', 'RN50', "ViT-B/16"]
@@ -60,6 +63,8 @@ class TestEncoding(unittest.TestCase):
                 assert abs(model.encode_text(text) - model.encode([text])).sum() < eps
                 assert abs(model.encode(text) - model.encode_text([text])).sum() < eps
 
+            clear_loaded_models()
+
     def test_load_sbert_text_model(self):
         names = ["all-MiniLM-L6-v1", "all_datasets_v4_MiniLM-L6"]
         device = 'cpu'
@@ -69,6 +74,8 @@ class TestEncoding(unittest.TestCase):
             model_properties = get_model_properties_from_registry(name)
             model = _load_model(model_properties['name'], model_properties=model_properties, device=device)
             assert abs(model.encode('hello') - model.encode(['hello'])).sum() < eps
+
+            clear_loaded_models()
 
     def test_load_hf_text_model(self):
         names = ["hf/all-MiniLM-L6-v1", "hf/all_datasets_v4_MiniLM-L6"]
@@ -80,6 +87,8 @@ class TestEncoding(unittest.TestCase):
             model = _load_model(model_properties['name'], model_properties=model_properties, device=device)
             assert abs(model.encode('hello') - model.encode(['hello'])).sum() < eps
 
+            clear_loaded_models()
+
     def test_load_onnx_sbert_text_model(self):
         names = ["onnx/all-MiniLM-L6-v1", "onnx/all_datasets_v4_MiniLM-L6"]
         device = 'cpu'
@@ -89,6 +98,8 @@ class TestEncoding(unittest.TestCase):
             model_properties = get_model_properties_from_registry(name)
             model = _load_model(model_properties['name'], model_properties=model_properties, device=device)
             assert abs(model.encode('hello') - model.encode(['hello'])).sum() < eps
+
+            clear_loaded_models()
 
     def test_compare_onnx_sbert_text_models(self):
         names_sbert_onnx = [("all-MiniLM-L6-v1", "onnx/all-MiniLM-L6-v1"),
@@ -107,6 +118,8 @@ class TestEncoding(unittest.TestCase):
 
                 assert abs(model_onnx.encode(sentence) - model_sbert.encode(sentence)).sum() < eps
 
+            clear_loaded_models()
+
     def test_model_outputs(self):
         names = ["onnx16/open_clip/ViT-B-32/laion400m_e32", 'onnx32/open_clip/ViT-B-32-quickgelu/laion400m_e32',
                  'onnx32/open_clip/ViT-g-14/laion2b_s12b_b42k', "onnx32/openai/ViT-L/14", "onnx16/openai/ViT-L/14",
@@ -123,6 +136,8 @@ class TestEncoding(unittest.TestCase):
             for sentence in sentences:
                 output = model.encode(sentence)
                 assert _check_output_type(_convert_vectorized_output(output))
+
+            clear_loaded_models()
 
     def test_model_normalization(self):
         names = ["onnx16/open_clip/ViT-B-32/laion400m_e32", 'onnx32/open_clip/ViT-B-32-quickgelu/laion400m_e32',
@@ -147,6 +162,8 @@ class TestEncoding(unittest.TestCase):
                 assert abs(max_output_norm - 1) < eps, f"{name}, {sentence}"
                 assert abs(min_output_norm - 1) < eps, f"{name}, {sentence}"
 
+            clear_loaded_models()
+
     def test_model_un_normalization(self):
         # note: sbert native seems to provide normalized embeddings even with = False, needs more investigation
         # , 
@@ -169,6 +186,9 @@ class TestEncoding(unittest.TestCase):
                 assert abs(max_output_norm - 1) > eps, f"{name}, {sentence}"
                 assert abs(min_output_norm - 1) > eps, f"{name}, {sentence}"
 
+            clear_loaded_models()
+
+
     def test_open_clip_vectorize(self):
 
         names = ['open_clip/ViT-B-32/laion400m_e32', 'open_clip/RN50/openai']
@@ -190,6 +210,8 @@ class TestEncoding(unittest.TestCase):
 
                 assert abs(torch.FloatTensor(output_m) - torch.FloatTensor(output_v)).sum() < eps
 
+            clear_loaded_models()
+
     def test_open_clip_embedding_size(self):
 
         # This is a full test as the list includes all the models. Note that the training dataset does not affect the
@@ -209,6 +231,8 @@ class TestEncoding(unittest.TestCase):
                 output_dimension = len(output_v[0])
 
                 assert registered_dimension == output_dimension
+
+            clear_loaded_models()
 
     def test_onnx_clip_vectorise(self):
 
@@ -232,4 +256,6 @@ class TestEncoding(unittest.TestCase):
                 output_m = model.encode(sentence, normalize=True)
 
                 assert abs(torch.FloatTensor(output_m) - torch.FloatTensor(output_v)).sum() < eps
+
+            clear_loaded_models()
 

--- a/tests/s2_inference/test_encoding.py
+++ b/tests/s2_inference/test_encoding.py
@@ -44,7 +44,7 @@ class TestEncoding(unittest.TestCase):
 
                 assert abs(torch.FloatTensor(output_m) - torch.FloatTensor(output_v)).sum() < eps
 
-             clear_loaded_models()
+            clear_loaded_models()
 
 
     def test_load_clip_text_model(self):


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
features


* **What is the current behavior?** (You can also link to an open issue here)
we do not support open_clip onnx
we do not take the image preprocess out


* **What is the new behavior (if this is a feature change)?**
we now support open_clip onnx
the image preprocess is decoupled from the clip model


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
NO


* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
will add soon


* **Related Python client changes** (link commit/PR here)
no

* **Related documentation changes** (link commit/PR here)
will add soon

* **Other information**:


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

