### PR TITLE
Opensearch's team fix for reducing search latency

### DIFF
--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -90,7 +90,9 @@ def create_vector_index(
             "index": {
                 "knn": True,
                 "knn.algo_param.ef_search": 100,
-                "refresh_interval": refresh_interval
+                "refresh_interval": refresh_interval,
+                "store.hybrid.mmap.extensions": ["nvd", "dvd", "tim", "tip", "dim", "kdd", "kdi", "cfs", "doc", "vec",
+                                                 "vex"]
             },
             "number_of_shards": the_index_settings[NsField.number_of_shards],
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Opensearch's 2.4 release led to serious speed latency issues because of new segmentation strategy of the Lucene 9.4 #265     
    This pr adds new index setting that would prevent further issues and in total leads to:
    - Significant search speed optimisation on high scale 
    - reduce of index total size 
    - little speed up of indexing


* **What is the current behavior?** (You can also link to an open issue here)
#265 
"took" field from executing single vector search on a 10mil vector index:
![image](https://user-images.githubusercontent.com/107251367/213944807-badfcf48-9fb1-4d65-b9ee-da14ee65c803.png)

* **What is the new behavior (if this is a feature change)?**
After fix "took" field from executing single vector search on a 10mil vector index:
![image](https://user-images.githubusercontent.com/107251367/213944775-57eff8fa-fc8f-4861-9398-dbdadeafe1df.png)

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
All the tensor_search passed while some model testing failed, probably this is related to M1 architecture.
As well tested index creation and verified that settings are applied and indeed affect index performance 


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

