### PR TITLE
Lexical restructure from query strings to should/match and must/match_phrase

### DIFF
--- a/src/marqo/tensor_search/utils.py
+++ b/src/marqo/tensor_search/utils.py
@@ -191,7 +191,8 @@ def parse_lexical_query(text: str) -> Tuple[List[str], str]:
     All other terms go into optional_blob, separated by whitespace.
 
     Syntax:
-        Required strings must be enclosed by quotes
+        Required strings must be enclosed by quotes. These quotes must be enclosed by spaces or the start
+        or end of the text
 
     Notes:
         Double quote can be either opening, closing, or escaped.

--- a/src/marqo/tensor_search/utils.py
+++ b/src/marqo/tensor_search/utils.py
@@ -102,7 +102,7 @@ def contextualise_filter(filter_string: str, simple_properties: typing.Iterable)
     contextualised_filter = filter_string
     for field in simple_properties:
         if ' ' in field:
-            field_with_escaped_space = field.replace(' ', '\ ')
+            field_with_escaped_space = field.replace(' ', r'\ ') # monitor this: fixed the invalid escape sequence (Deprecation warning).
             contextualised_filter = contextualised_filter.replace(f'{field_with_escaped_space}:', f'{enums.TensorField.chunks}.{field_with_escaped_space}:')
         else:
             contextualised_filter = contextualised_filter.replace(f'{field}:', f'{enums.TensorField.chunks}.{field}:')

--- a/tests/tensor_search/test_utils.py
+++ b/tests/tensor_search/test_utils.py
@@ -170,6 +170,9 @@ class TestUtils(unittest.TestCase):
             ('just a "string"', (["string"], 'just a')),
             ('just "a" string', (["a"], 'just string')),
             ('"just" a string', (["just"], 'a string')),
+            ('just "a long long " string', (["a long long "], 'just string')),
+            ('"required 1 " not required " required2" again', (["required 1 ", " required2"], 'not required again')),
+            ('"just" "just" "" a string', (["just", "just", ""], 'a string')),
 
             ('朋友你好', ([], '朋友你好')),
             ('朋友 "你好"', (["你好"], '朋友')),

--- a/tests/tensor_search/test_utils.py
+++ b/tests/tensor_search/test_utils.py
@@ -162,3 +162,56 @@ class TestUtils(unittest.TestCase):
                 assert expected == utils.read_env_vars_and_defaults(var=key)
                 return True
             assert run()
+
+    def test_parse_lexical_query(self):
+        # 2-tuples of input text, and expected parse_lexical_query() output
+        cases = [
+            ('just a string', ([], 'just a string')),
+            ('just a "string"', (["string"], 'just a')),
+            ('just "a" string', (["a"], 'just string')),
+            ('"just" a string', (["just"], 'a string')),
+
+            ('朋友你好', ([], '朋友你好')),
+            ('朋友 "你好"', (["你好"], '朋友')),
+            # spaces get introduced, even though Chinese doesn't use them:
+            ('你好 "老" 朋友', (["老"], '你好 朋友')),
+            ('"朋友" 你好', (["朋友"], '你好')),
+
+            ('', ([], '')),
+            ('"cookie"', (["cookie"], '')),
+            ('"朋友"', (["朋友"], '')),
+            ('"', ([], '"')),
+            ('"""hello', ([], '"""hello')),
+            ('""" python docstring appeared"""', ([], '""" python docstring appeared"""')),
+            ('""', ([''], '')),
+            ('what about backticks `?', ([], 'what about backticks `?')),
+            ('\\" escaped quotes\\"  what happens here?', ([], '" escaped quotes" what happens here?')),
+            ('\\"朋友\\"', ([], '"朋友"')),
+            ('double  spaces  get  removed', ([], 'double spaces get removed')),
+            ('"go"od"', ([], '"go"od"')),
+            ('"ter"m1" term2', ([], '"ter"m1" term2')),
+            ('"term1" "term2" "term3', ([], '"term1" "term2" "term3')),
+            ('"good', ([], '"good')),
+            ('"朋友', ([], '"朋友')),
+
+            # on Lucene, these unusual structures seem to get passed straight through as well.
+            # The quotes seem to be completely ignored (with and without quotes yields identical results,
+            # including scores):
+            ('"go"od" a"', ([], '"go"od" a"')),
+            ('"sam"a', ([], '"sam"a')),
+            ('"sam"?', ([], '"sam"?')),
+            ('"朋友"你好', ([], '"朋友"你好')),
+
+        ]
+        for input, expected_output in cases:
+            assert utils.parse_lexical_query(input) == expected_output
+
+    def test_parse_lexical_query_non_string(self):
+        non_strings = [124, None, 1.4, False, dict(), [1, 2]]
+
+        for ns in non_strings:
+            try:
+                utils.parse_lexical_query(ns)
+                raise AssertionError
+            except TypeError as e:
+                assert "string as input" in str(e)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Updates to the lexical search structure

* **What is the current behavior?** (You can also link to an open issue here)
Currently, lexical search uses query strings and throws errors when the wrong DSL syntax is used.

* **What is the new behavior (if this is a feature change)?**
Lexical search now parses user queries into required and optional terms, and uses bool query to execute these. Optional terms are searched using should on match queries, while the required terms are searched using must on match_phrase queries.

Required terms are defined by wrapping the terms in double quotes. For example, a query like `'do not need this "i need this"'` will only return results that contain `"i need this"`. The optional terms will improve the scores of hits that contain them, but hits may be returned that do not have them.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
Yes

* **Related Python client changes** (link commit/PR here)
None

* **Related documentation changes** (link commit/PR here)
https://github.com/marqo-ai/marqodocs/commit/ad7cca6cf75ca37b992009f7d1bdeb17004b698b

* **Other information**:


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

