### PR TITLE
fixed bug when index_defaults isn't set, and made test case.

### DIFF
--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -80,7 +80,8 @@ def create_vector_index(
     validation.validate_index_name(index_name)
 
     if index_settings is not None:
-        _check_model_name(index_settings)
+        if NsField.index_defaults in index_settings:
+            _check_model_name(index_settings)
         the_index_settings = _autofill_index_settings(index_settings=index_settings)
     else:
         the_index_settings = configs.get_default_index_settings()
@@ -145,7 +146,7 @@ def create_vector_index(
 
 
 def _check_model_name(index_settings):
-    """Checks if model_properties is given then model_name is given as well
+    """Ensures that if model_properties is given, then model_name is given as well
     """
     model_name = index_settings[NsField.index_defaults].get(NsField.model)
     model_properties = index_settings[NsField.index_defaults].get(NsField.model_properties)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
When creating an index while number_of_shards is set and index_defaults is not, a 500 error occurs. This is due to a call to 
model check before autofill index settings. See here: https://github.com/marqo-ai/marqo/blob/mainline/src/marqo/tensor_search/tensor_search.py#L83

* **What is the new behavior (if this is a feature change)?**
This bug no longer happens. model check is only called if index_defaults is explicity set.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
Yes

* **Related Python client changes** (link commit/PR here)
None

* **Related documentation changes** (link commit/PR here)
None

* **Other information**:


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

