### PR TITLE
[BUG FIX] removed s2search logic

### DIFF
--- a/src/marqo/config.py
+++ b/src/marqo/config.py
@@ -17,7 +17,6 @@ class Config:
             The url to the S2Search API (ex: http://localhost:9200)
         """
         self.cluster_is_remote = False
-        self.cluster_is_s2search = False
         self.url = self.set_url(url)
         self.timeout = timeout
         default_device = enums.Device.cpu
@@ -33,7 +32,5 @@ class Config:
             self.cluster_is_remote = False
         else:
             self.cluster_is_remote = True
-            if "s2search.io" in lowered_url:
-                self.cluster_is_s2search = True
         self.url = url
         return self.url

--- a/src/marqo/tensor_search/backend.py
+++ b/src/marqo/tensor_search/backend.py
@@ -75,10 +75,7 @@ def add_customer_field_properties(config: Config, index_name: str,
     Returns:
         HTTP Response
     """
-    if config.cluster_is_s2search:
-        engine = "nmslib"
-    else:
-        engine = "lucene"
+    engine = "lucene"
 
     body = {
         "properties": {

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -1041,12 +1041,6 @@ def _vector_text_search(
         - max result count should be in a config somewhere
         - searching a non existent index should return a HTTP-type error
     """
-
-    if config.cluster_is_s2search and filter_string is not None:
-        raise errors.InvalidArgError(
-            "filtering not yet implemented for S2Search cloud!"
-        )
-    
     # SEARCH TIMER-LOGGER (pre-processing)
     start_preprocess_time = timer()
     try:

--- a/tests/tensor_search/test_backend.py
+++ b/tests/tensor_search/test_backend.py
@@ -53,28 +53,8 @@ class TestBackend(MarqoTestCase):
         assert isinstance(cluster_indices, set)
         assert self.index_name_1 in cluster_indices
 
-    def test_add_customer_field_properties_nmslib_for_s2search(self):
-        mock_config = copy.deepcopy(self.config)
-        mock_config.cluster_is_s2search = True
-        mock__put = mock.MagicMock()
-
-        tensor_search.create_vector_index(
-            config=mock_config, index_name=self.index_name_1)
-
-        @mock.patch("marqo._httprequests.HttpRequests.put", mock__put)
-        def run():
-            tensor_search.add_documents(config=mock_config, docs=[{"f1": "doc"}, {"f2":"C"}],
-                                        index_name=self.index_name_1, auto_refresh=True)
-            return True
-        assert run()
-        args, kwargs0 = mock__put.call_args_list[0]
-        sent_dict = json.loads(kwargs0["body"])
-        assert "nmslib" == sent_dict["properties"][enums.TensorField.chunks
-            ]["properties"][utils.generate_vector_name(field_name="f1")]["method"]["engine"]
-
     def test_add_customer_field_properties_defaults_lucene(self):
         mock_config = copy.deepcopy(self.config)
-        mock_config.cluster_is_s2search = False
         mock__put = mock.MagicMock()
 
         tensor_search.create_vector_index(

--- a/tests/tensor_search/test_config.py
+++ b/tests/tensor_search/test_config.py
@@ -73,12 +73,3 @@ class TestConfig(MarqoTestCase):
             assert not c.cluster_is_remote
             return True
         assert run()
-
-
-    def test_url_is_s2search(self):
-        c = config.Config(url="https://s2search.io/abdcde:9200")
-        assert c.cluster_is_s2search
-
-    def test_url_is_not_s2search(self):
-        c = config.Config(url="https://som_random_cluster/abdcde:9200")
-        assert not c.cluster_is_s2search

--- a/tests/tensor_search/test_search.py
+++ b/tests/tensor_search/test_search.py
@@ -542,37 +542,6 @@ class TestVectorSearch(MarqoTestCase):
                 assert 1 == len(check_res["hits"])
                 assert expected == check_res["hits"][0]["_id"]
 
-    def test_vector_search_error_if_tensor_search_against_s2search(self):
-        mock_config = copy.deepcopy(self.config)
-        mock_config.cluster_is_s2search = True
-
-        tensor_search.add_documents(
-            config=self.config, index_name=self.index_name_1, docs=[
-                {
-                    "doc title": "The captain bravely lead her followers into battle."
-                                 " She directed her soldiers to and fro.",
-                    "field X": "some text",
-                    "field1": "other things", "my_bool": True,
-                    "_id": "123456", "a_float": 0.61
-                },
-                {
-                    "_id": "other doc", "a_float": 0.66, "bfield": "some text too", "my_int": 5,
-                    "fake_int": "234", "fake_float": "1.23", "gapped field_name": "gap"
-                }
-            ], auto_refresh=True)
-
-        # Lexical filtering should work:
-        assert tensor_search.search(
-            config=mock_config, text=" ", filter="a_float:[0.62 TO 0.7]", index_name=self.index_name_1,
-            search_method=SearchMethod.LEXICAL)["hits"][0]["_id"] == "other doc"
-        try:
-            # Tensor search errors out:
-            tensor_search.search(config=mock_config, text=" ", filter="a_float:[0.5 TO 0.7]",
-                                 index_name=self.index_name_1, search_method=SearchMethod.TENSOR)
-            raise AssertionError
-        except InvalidArgError:
-            pass
-
     def test_attributes_to_retrieve_vector(self):
         docs = {
             "5678": {"abc": "Exact match hehehe", "other field": "baaadd",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
[BUG FIX] removed s2search logic

* **What is the current behavior?** (You can also link to an open issue here)
requests do not get sent to prod S2Search when providing a custom DNS (e.g. https://test.s2search.io) as a docker run `OPENSEARCH_URL` environment variable. 
This is due to s2search code logic setting the engine to nmslib if `s2search.io` is part of url domain

* **What is the new behavior (if this is a feature change)?**
Removes all logic that prevents this, allowing custom DNS for cloud S2search

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
Yes
![image](https://user-images.githubusercontent.com/112362822/216270602-0d2b3a82-7ed9-4774-87b9-4fe93c5dbb72.png)
Tests were ran on custom docker image (w/ fixes) hitting marqo cloud s2search cluster using new custom DNS (xxxx.s2search.io)

* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

