### PR TITLE
No image download if it's a non_tensor_field

### DIFF
--- a/src/marqo/s2_inference/random_utils.py
+++ b/src/marqo/s2_inference/random_utils.py
@@ -1,14 +1,23 @@
 # implements a 'model' that returns a random vector, irrespective of 
 # input. does not require a model and is completely random
 # used for testing purposes
+import functools
 from marqo.s2_inference.sbert_utils import Model
-from marqo.s2_inference.types import Union, FloatTensor, List, ndarray
+from marqo.s2_inference.types import Union, FloatTensor, List, ndarray, ImageType
 
 import numpy as np
 import hashlib
 
 def sentence_to_hash(sentence):
-    return int(hashlib.sha256(sentence.encode('utf-8')).hexdigest(), 16) % 10**8
+    # for speed reasons we hash
+    if isinstance(sentence, ImageType):
+        pixel_data = list(sentence.getdata())
+        pixel_averages = [sum(channels)/len(channels) for channels in pixel_data]
+        image_average = functools.reduce(lambda x, y: x + y, pixel_averages)/len(pixel_data)
+        return int(hashlib.sha256(str(image_average).encode('utf-8')).hexdigest(), 16) % 10 ** 8
+    else:
+        return int(hashlib.sha256(sentence.encode('utf-8')).hexdigest(), 16) % 10**8
+
 
 class Random(Model):
 

--- a/src/marqo/tensor_search/add_docs.py
+++ b/src/marqo/tensor_search/add_docs.py
@@ -38,6 +38,8 @@ def threaded_download_images(allocated_docs: List[dict], image_repo: dict, non_t
             if field in non_tensor_fields:
                 continue
             if isinstance(doc[field], str) and _is_image(doc[field]):
+                if doc[field] in image_repo:
+                    continue
                 try:
                     image_repo[doc[field]] = load_image_from_path(doc[field], timeout=TIMEOUT_SECONDS)
                 except PIL.UnidentifiedImageError as e:

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -392,7 +392,7 @@ def add_documents(config: Config, index_name: str, docs: List[dict], auto_refres
 
     if index_info.index_settings[NsField.index_defaults][NsField.treat_urls_and_pointers_as_images]:
         ti_0 = timer()
-        image_repo = add_docs.download_images(docs=docs, thread_count=20)
+        image_repo = add_docs.download_images(docs=docs, thread_count=20, non_tensor_fields=tuple(non_tensor_fields))
         logger.info(f"          add_documents image download: took {(timer() - ti_0):.3f}s to concurrently download "
                     f"images for {batch_size} docs using {image_download_thread_count} threads ")
 

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -493,8 +493,10 @@ def add_documents(config: Config, index_name: str, docs: List[dict], auto_refres
                             content_chunks, text_chunks = image_processor.chunk_image(
                                 image_data, device=selected_device, method=image_method)
                         else:
-                            # if we are not chunking, then we set both chunks to the image URL
-                            content_chunks, text_chunks = [field_content], [field_content]
+                            # if we are not chunking, then we set the chunks as 1-len lists
+                            # content_chunk is the PIL image
+                            # text_chunk refers to URL
+                            content_chunks, text_chunks = [image_data], [field_content]
                     except s2_inference_errors.S2InferenceError as e:
                         document_is_valid = False
                         unsuccessful_docs.append(
@@ -515,7 +517,9 @@ def add_documents(config: Config, index_name: str, docs: List[dict], auto_refres
 
                     # ADD DOCS TIMER-LOGGER (4)
                     start_time = timer()
-                    vector_chunks = s2_inference.vectorise(model_name=index_info.model_name, model_properties=_get_model_properties(index_info), content=content_chunks,
+                    vector_chunks = s2_inference.vectorise(
+                        model_name=index_info.model_name,
+                        model_properties=_get_model_properties(index_info), content=content_chunks,
                         device=selected_device, normalize_embeddings=normalize_embeddings,
                         infer=infer_if_image)
 

--- a/tests/tensor_search/test_add_documents.py
+++ b/tests/tensor_search/test_add_documents.py
@@ -1059,7 +1059,7 @@ class TestAddDocuments(MarqoTestCase):
                     assert len(facet['_embedding']) > 0
             return True
 
-        doc_counts = 1, 2, 3, 10, 20, 100
+        doc_counts = 1, 2, 25
         for update_mode in ('replace', 'update'):
             for c in doc_counts:
                 try:


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Optimisation

* **What is the current behavior?** (You can also link to an open issue here)
Images were downloaded, even if they were in a non_tensor_field

* **What is the new behavior (if this is a feature change)?**
Images aren't downloaded if they are in a non_tensor_field


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
New unit tests made. Unit tests in progress

* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes/features)
- [] Docs have been added / updated (for bug fixes / features)

