### PR TITLE
allow list fields as metadata in Marqo (#277)

### DIFF
--- a/src/marqo/tensor_search/backend.py
+++ b/src/marqo/tensor_search/backend.py
@@ -112,7 +112,18 @@ def add_customer_field_properties(config: Config, index_name: str,
             body["properties"][enums.TensorField.chunks]["properties"][validation.validate_field_name(field_name[0])] = {
                 "type": enums.OpenSearchDataType.keyword,
                 "ignore_above": 32766  # this is the Marqo-OS bytes limit
-        }
+            }
+
+        if field_name[1] == enums.OpenSearchDataType.list:
+            body["properties"][enums.TensorField.chunks]["properties"][validation.validate_field_name(field_name[0])] = {
+                "type": enums.OpenSearchDataType.keyword,
+                "fields": {
+                    "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 32766
+                    }
+                }
+            }
 
     mapping_res = HttpRequests(config).put(path=F"{index_name}/_mapping", body=json.dumps(body))
 

--- a/src/marqo/tensor_search/backend.py
+++ b/src/marqo/tensor_search/backend.py
@@ -114,17 +114,6 @@ def add_customer_field_properties(config: Config, index_name: str,
                 "ignore_above": 32766  # this is the Marqo-OS bytes limit
             }
 
-        if field_name[1] == enums.OpenSearchDataType.list:
-            body["properties"][enums.TensorField.chunks]["properties"][validation.validate_field_name(field_name[0])] = {
-                "type": enums.OpenSearchDataType.keyword,
-                "fields": {
-                    "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 32766
-                    }
-                }
-            }
-
     mapping_res = HttpRequests(config).put(path=F"{index_name}/_mapping", body=json.dumps(body))
 
     merged_chunk_properties = {

--- a/src/marqo/tensor_search/constants.py
+++ b/src/marqo/tensor_search/constants.py
@@ -8,4 +8,4 @@ INDEX_NAME_PREFIXES_TO_IGNORE = {
 
 ILLEGAL_CUSTOMER_FIELD_NAME_CHARS = {'.', '/', '\n'}
 
-ALLOWED_CUSTOMER_FIELD_TYPES = [str, int, float, bool]
+ALLOWED_CUSTOMER_FIELD_TYPES = [str, int, float, bool, list]

--- a/src/marqo/tensor_search/enums.py
+++ b/src/marqo/tensor_search/enums.py
@@ -72,7 +72,6 @@ class OpenSearchDataType:
     int = "int"
     float = "float"
     integer = "integer"
-    list = "list"
     to_be_defined = "to_be_defined"  # to be defined by OpenSearch
 
 

--- a/src/marqo/tensor_search/enums.py
+++ b/src/marqo/tensor_search/enums.py
@@ -72,6 +72,7 @@ class OpenSearchDataType:
     int = "int"
     float = "float"
     integer = "integer"
+    list = "list"
     to_be_defined = "to_be_defined"  # to be defined by OpenSearch
 
 

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -331,9 +331,7 @@ def _infer_opensearch_data_type(
         Exception if sample_field_content list or dict
     """
     if isinstance(sample_field_content, dict):
-        raise errors.InvalidArgError("Field content can't be objects or lists!")
-    elif isinstance(sample_field_content, List):
-        raise errors.InvalidArgError("Field content can't be objects or lists!")
+        raise errors.InvalidArgError("Field content can't be an object.")
     elif isinstance(sample_field_content, str):
         return OpenSearchDataType.text
     else:
@@ -432,7 +430,7 @@ def add_documents(config: Config, index_name: str, docs: List[dict], auto_refres
         for field in copied:
 
             try:
-                field_content = validation.validate_field_content(copied[field])
+                field_content = validation.validate_field_content(copied[field], field in non_tensor_fields)
             except errors.InvalidArgError as err:
                 document_is_valid = False
                 unsuccessful_docs.append(
@@ -554,7 +552,8 @@ def add_documents(config: Config, index_name: str, docs: List[dict], auto_refres
                     chunk_values_for_filtering = {}
                     for key, value in copied.items():
                         if not (isinstance(value, str) or isinstance(value, float)
-                                or isinstance(value, bool) or isinstance(value, int)):
+                                or isinstance(value, bool) or isinstance(value, int)
+                                or isinstance(value, list)):
                             continue
                         chunk_values_for_filtering[key] = value
                     chunks.append({

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -328,11 +328,18 @@ def _infer_opensearch_data_type(
         sample_field_content: typing.Any) -> Union[OpenSearchDataType, None]:
     """
     Raises:
-        Exception if sample_field_content list or dict
+        Exception if sample_field_content is a dict
     """
-    if isinstance(sample_field_content, dict):
+    if isinstance(sample_field_content, Sequence) and len(sample_field_content) > 0:
+        # OpenSearch requires that all content of an array be the same type.
+        # This function doesn't validate.
+        to_check = sample_field_content[0]
+    else:
+        to_check = sample_field_content
+
+    if isinstance(to_check, dict):
         raise errors.InvalidArgError("Field content can't be an object.")
-    elif isinstance(sample_field_content, str):
+    elif isinstance(to_check, str):
         return OpenSearchDataType.text
     else:
         return None
@@ -430,7 +437,9 @@ def add_documents(config: Config, index_name: str, docs: List[dict], auto_refres
         for field in copied:
 
             try:
-                field_content = validation.validate_field_content(copied[field], field in non_tensor_fields)
+                field_content = validation.validate_field_content(
+                    field_content=copied[field], is_non_tensor_field=field in non_tensor_fields
+                )
             except errors.InvalidArgError as err:
                 document_is_valid = False
                 unsuccessful_docs.append(

--- a/src/marqo/tensor_search/validation.py
+++ b/src/marqo/tensor_search/validation.py
@@ -99,7 +99,7 @@ def validate_field_content(field_content: typing.Any, is_non_tensor_field: bool)
         InvalidArgError if field_content is not acceptable
     """
     if type(field_content) in constants.ALLOWED_CUSTOMER_FIELD_TYPES:
-        if type(field_content) is list:
+        if isinstance(field_content, list):
             validate_list(field_content, is_non_tensor_field)
         return field_content
     else:

--- a/src/marqo/tensor_search/validation.py
+++ b/src/marqo/tensor_search/validation.py
@@ -68,7 +68,28 @@ def validate_str_against_enum(value: Any, enum_class: Type[Enum], case_sensitive
     return value
 
 
-def validate_field_content(field_content: typing.Any) -> typing.Any:
+def list_contains_only_strings(field_content: typing.List) -> bool:
+    return all(isinstance(s, str) for s in field_content)
+
+
+def validate_list(field_content: typing.List, is_non_tensor_field: bool):
+    if type(field_content) is list and not list_contains_only_strings(field_content):
+        # if the field content is a list, it should only contain strings.
+        raise InvalidArgError(
+            f"Field content `{field_content}` \n"
+            f"of type `{type(field_content).__name__}` is not of valid content type!"
+            f"Lists can only contain strings."
+        )
+    if not is_non_tensor_field:
+        raise InvalidArgError(
+            f"Field content `{field_content}` \n"
+            f"of type `{type(field_content).__name__}` is not of valid content."
+            f"Lists can only be non_tensor fields."
+        )
+    return True
+
+
+def validate_field_content(field_content: typing.Any, is_non_tensor_field: bool) -> typing.Any:
     """
 
     Returns
@@ -78,6 +99,8 @@ def validate_field_content(field_content: typing.Any) -> typing.Any:
         InvalidArgError if field_content is not acceptable
     """
     if type(field_content) in constants.ALLOWED_CUSTOMER_FIELD_TYPES:
+        if type(field_content) is list:
+            validate_list(field_content, is_non_tensor_field)
         return field_content
     else:
         raise InvalidArgError(

--- a/tests/tensor_search/test_add_documents.py
+++ b/tests/tensor_search/test_add_documents.py
@@ -36,8 +36,7 @@ class TestAddDocuments(MarqoTestCase):
         except IndexNotFoundError as s:
             pass
 
-
-    def _match_all(self, index_name, verbose=True):
+    def _match_all(self, index_name, verbose=False):
         """Helper function"""
         res = requests.get(
             F"{self.endpoint}/{index_name}/_search",
@@ -869,7 +868,7 @@ class TestAddDocuments(MarqoTestCase):
         docs_ = [{"_id": "789", "Title": "Story of Alice Appleseed", "Description": "Alice grew up in Houston, Texas."}]
         tensor_search.add_documents(config=self.config, index_name=self.index_name_1, docs=docs_, auto_refresh=True, non_tensor_fields=["Title"])
         tensor_search.add_documents(config=self.config, index_name=self.index_name_1, docs=docs_, auto_refresh=True)
-        resp = tensor_search.get_document_by_id(config=self.config, index_name=self.index_name_1, document_id="789", show_vectors=True)        
+        resp = tensor_search.get_document_by_id(config=self.config, index_name=self.index_name_1, document_id="789", show_vectors=True)
 
         assert len(resp[enums.TensorField.tensor_facets]) == 2
         assert enums.TensorField.embedding in resp[enums.TensorField.tensor_facets][0]
@@ -881,7 +880,7 @@ class TestAddDocuments(MarqoTestCase):
     def test_add_document_with_non_tensor_field(self):
         docs_ = [{"_id": "789", "Title": "Story of Alice Appleseed", "Description": "Alice grew up in Houston, Texas."}]
         tensor_search.add_documents(config=self.config, index_name=self.index_name_1, docs=docs_, auto_refresh=True, non_tensor_fields=["Title"])
-        resp = tensor_search.get_document_by_id(config=self.config, index_name=self.index_name_1, document_id="789", show_vectors=True)        
+        resp = tensor_search.get_document_by_id(config=self.config, index_name=self.index_name_1, document_id="789", show_vectors=True)
 
         assert len(resp[enums.TensorField.tensor_facets]) == 1
         assert enums.TensorField.embedding in resp[enums.TensorField.tensor_facets][0]
@@ -1003,7 +1002,6 @@ class TestAddDocuments(MarqoTestCase):
                           ],
                     auto_refresh=True, update_mode='update')
                 items = update_res['items']
-                pprint.pprint(items)
                 assert not update_res['errors']
                 assert 'error' not in items[0]
                 assert items[0]['result'] in ['created', 'updated']

--- a/tests/tensor_search/test_add_documents.py
+++ b/tests/tensor_search/test_add_documents.py
@@ -284,17 +284,16 @@ class TestAddDocuments(MarqoTestCase):
                 assert all(['error' in item for item in add_res['items'] if item['_id'].startswith('to_fail')])
 
     def test_add_documents_list_success(self):
-        bad_doc_args = [
+        good_docs = [
             [{"_id": "to_fail_123", "my_field": ["wow", "this", "is"]}]
         ]
         for update_mode in ('replace', 'update'):
-            for bad_doc_arg in bad_doc_args:
+            for bad_doc_arg in good_docs:
                 add_res = tensor_search.add_documents(
                     config=self.config, index_name=self.index_name_1,
                     docs=bad_doc_arg, auto_refresh=True, update_mode=update_mode,
                     non_tensor_fields=["my_field"])
-        assert add_res['errors'] is Truev
-        assert all(['error' in item for item in add_res['items'] if item['_id'].startswith('to_fail')])
+                assert add_res['errors'] is False
 
     def test_add_documents_list_data_type_validation(self):
         """These bad docs should return errors"""

--- a/tests/tensor_search/test_search.py
+++ b/tests/tensor_search/test_search.py
@@ -310,7 +310,7 @@ class TestVectorSearch(MarqoTestCase):
             search_method=SearchMethod.TENSOR)
         assert len(s_res["hits"]) > 0
 
-    def test_filtering_list_case(self):
+    def test_filtering_list_case_tensor(self):
         tensor_search.add_documents(
             config=self.config, index_name=self.index_name_1, docs=[
                 {"abc": "some text", "other field": "baaadd", "_id": "5678", "my_string": "b"},
@@ -336,6 +336,7 @@ class TestVectorSearch(MarqoTestCase):
             index_name=self.index_name_1, config=self.config, text="", filter="my_list:(tag2 some)")
 
         assert res_exists["hits"][0]["_id"] == "1235"
+        assert res_exists["hits"][0]["_highlights"] == {"abc": "some text"}
         assert len(res_exists["hits"]) == 1
 
         assert len(res_not_exists["hits"]) == 0
@@ -345,6 +346,84 @@ class TestVectorSearch(MarqoTestCase):
 
         assert len(res_should_only_match_keyword_bad["hits"]) == 0
         assert len(res_should_only_match_keyword_good["hits"]) == 1
+
+    def test_filtering_list_case_lexical(self):
+        tensor_search.add_documents(
+            config=self.config, index_name=self.index_name_1, docs=[
+                {"abc": "some text", "other field": "baaadd", "_id": "5678", "my_string": "b"},
+                {"abc": "some text", "other field": "Close match hehehe", "_id": "1234", "an_int": 2},
+                {"abc": "some text", "_id": "1235",  "my_list": ["tag1", "tag2 some"]}
+            ], auto_refresh=True, non_tensor_fields=["my_list"])
+        base_search_args = {
+            'index_name': self.index_name_1, "config": self.config, "text": "some",
+            "search_method": SearchMethod.LEXICAL
+        }
+        res_exists = tensor_search.search(**{'filter': "my_list:tag1", **base_search_args})
+
+        res_not_exists = tensor_search.search(**{'filter': "my_list:tag55", **base_search_args})
+
+        res_other = tensor_search.search(**{'filter': "my_string:b", **base_search_args})
+
+        # Because lexical search is over the original documents, the strings we are filtering over are texts,
+        # not keywords. This allows us to search at the token level. Compare this to test_filtering_list_case_tensor()
+        # where filtering is only possible for exact matches (including the space)
+        res_should_only_match_keyword_non_exact = tensor_search.search(
+            **{'filter': "my_list:tag2", **base_search_args})
+        res_should_only_match_keyword_good = tensor_search.search(
+            **{'filter': "my_list:(tag2 some)", **base_search_args})
+
+        assert res_exists["hits"][0]["_id"] == "1235"
+        assert len(res_exists["hits"]) == 1
+
+        assert len(res_not_exists["hits"]) == 0
+
+        assert res_other["hits"][0]["_id"] == "5678"
+        assert len(res_other["hits"]) == 1
+
+        assert len(res_should_only_match_keyword_non_exact["hits"]) == 1
+        assert len(res_should_only_match_keyword_good["hits"]) == 1
+
+    def test_filtering_list_case_image(self):
+        settings = {"index_defaults": {"treat_urls_and_pointers_as_images": True, "model": "ViT-B/32"}}
+        tensor_search.create_vector_index(index_name=self.index_name_1, index_settings=settings, config=self.config)
+        hippo_img = 'https://raw.githubusercontent.com/marqo-ai/marqo-api-tests/mainline/assets/ai_hippo_realistic.png'
+        tensor_search.add_documents(
+            config=self.config, index_name=self.index_name_1, docs=[
+                {"img": hippo_img, "abc": "some text", "other field": "baaadd", "_id": "5678", "my_string": "b"},
+                {"img": hippo_img, "abc": "some text", "other field": "Close match hehehe", "_id": "1234", "an_int": 2},
+                {"img": hippo_img, "abc": "some text", "_id": "1235", "my_list": ["tag1", "tag2 some"]}
+            ], auto_refresh=True, non_tensor_fields=["my_list"])
+        # TENSOR SEARCH:
+        tensor_search_base_args = {'index_name': self.index_name_1, "config": self.config, 'search_method': 'TENSOR'}
+
+        res_img_2_img = tensor_search.search(**{'filter': "my_list:tag1", 'text': hippo_img, **tensor_search_base_args})
+        assert res_img_2_img["hits"][0]["_id"] == "1235"
+        assert len(res_img_2_img["hits"]) == 1
+        assert res_img_2_img["hits"][0]["_highlights"] == {"img": hippo_img}
+
+        res_img_2_img_none = tensor_search.search(**{'filter': "my_list:not_exist", 'text': hippo_img,
+                                                     **tensor_search_base_args})
+        assert len(res_img_2_img_none["hits"]) == 0
+
+        res_txt_2_img = tensor_search.search(**{'filter': "my_list:tag1", 'text': "some", **tensor_search_base_args})
+        assert res_txt_2_img["hits"][0]["_id"] == "1235"
+        assert res_txt_2_img["hits"][0]["_highlights"] == {"abc": "some text"}
+        assert len(res_txt_2_img["hits"]) == 1
+
+        res_txt_2_img_none = tensor_search.search(**{'filter': "my_list:not_exist", 'text': "some",
+                                                     **tensor_search_base_args})
+        assert len(res_txt_2_img_none["hits"]) == 0
+        # LEXICAL SEARCH:
+        res_lex = tensor_search.search(
+            **{'filter': "my_list:tag1", 'text': "some", 'index_name': self.index_name_1,
+               "config": self.config, 'search_method': 'LEXICAL'})
+        assert res_lex["hits"][0]["_id"] == "1235"
+        assert len(res_lex["hits"]) == 1
+
+        res_lex_none = tensor_search.search(
+            **{'filter': "my_list:not_exist", 'text': "some", 'index_name': self.index_name_1,
+               "config": self.config, 'search_method': 'LEXICAL'})
+        assert len(res_lex_none["hits"]) == 0
 
     def test_filtering(self):
         tensor_search.add_documents(

--- a/tests/tensor_search/test_search.py
+++ b/tests/tensor_search/test_search.py
@@ -1,5 +1,4 @@
 import math
-import pprint
 from unittest import mock
 from marqo.tensor_search.enums import TensorField, SearchMethod, EnvVars, IndexSettingsField
 from marqo.errors import (
@@ -357,47 +356,47 @@ class TestVectorSearch(MarqoTestCase):
 
         res_doesnt_exist = tensor_search.search(
             config=self.config, index_name=self.index_name_1, text="some text", result_count=3,
-            filter="my_string:c", verbose=1
+            filter="my_string:c", verbose=0
         )
 
         res_exists_int = tensor_search.search(
             config=self.config, index_name=self.index_name_1, text="some text", result_count=3,
-            filter="an_int:2", verbose=1
+            filter="an_int:2", verbose=0
         )
 
         res_exists_string = tensor_search.search(
             config=self.config, index_name=self.index_name_1, text="some text", result_count=3,
-            filter="my_string:b", verbose=1
+            filter="my_string:b", verbose=0
         )
 
         res_field_doesnt_exist = tensor_search.search(
             config=self.config, index_name=self.index_name_1, text="some text", result_count=3,
-            filter="my_int_something:5", verbose=1
+            filter="my_int_something:5", verbose=0
         )
 
         res_range_doesnt_exist = tensor_search.search(
             config=self.config, index_name=self.index_name_1, text="some text", result_count=3,
-            filter="an_int:[5 TO 30]", verbose=1
+            filter="an_int:[5 TO 30]", verbose=0
         )
 
         res_range_exists = tensor_search.search(
             config=self.config, index_name=self.index_name_1, text="some text", result_count=3,
-            filter="an_int:[0 TO 30]", verbose=1
+            filter="an_int:[0 TO 30]", verbose=0
         )
 
         res_bool = tensor_search.search(
             config=self.config, index_name=self.index_name_1, text="some text", result_count=3,
-            filter="my_bool:true", verbose=1
+            filter="my_bool:true", verbose=0
         )
 
         res_multi = tensor_search.search(
             config=self.config, index_name=self.index_name_1, text="some text", result_count=3,
-            filter="an_int:[0 TO 30] OR my_bool:true", verbose=1
+            filter="an_int:[0 TO 30] OR my_bool:true", verbose=0
         )
 
         res_complex = tensor_search.search(
             config=self.config, index_name=self.index_name_1, text="some text", result_count=3,
-            filter="(an_int:[0 TO 30] and an_int:2) AND abc:(some text)", verbose=1
+            filter="(an_int:[0 TO 30] and an_int:2) AND abc:(some text)", verbose=0
         )
 
         assert res_exists_int["hits"][0]["_id"] == "1234"
@@ -422,7 +421,7 @@ class TestVectorSearch(MarqoTestCase):
 
         assert 3 == len(tensor_search.search(
             config=self.config, index_name=self.index_name_1, text="some text", result_count=4,
-            filter="*:*", verbose=1
+            filter="*:*", verbose=0
         )["hits"])
 
     def test_filter_spaced_fields(self):
@@ -464,7 +463,7 @@ class TestVectorSearch(MarqoTestCase):
         try:
             res_doesnt_exist = tensor_search.search(
                 config=self.config, index_name=self.index_name_1, text="some text", result_count=3,
-                filter="(other field):baaadd", verbose=1
+                filter="(other field):baaadd", verbose=0
             )
             raise AssertionError
         except InvalidArgError:
@@ -966,7 +965,6 @@ class TestVectorSearch(MarqoTestCase):
         )
         assert len(res['hits']) == 2
         assert {hit['image_field'] for hit in res['hits']} == {url_2, url_1}
-        # print([hit['_highlights']['image_field'] for hit in res['hits']])
         assert {hit['_highlights']['image_field'] for hit in res['hits']} == {url_2, url_1}
 
     def test_multi_search(self):

--- a/tests/tensor_search/test_search.py
+++ b/tests/tensor_search/test_search.py
@@ -311,12 +311,38 @@ class TestVectorSearch(MarqoTestCase):
             search_method=SearchMethod.TENSOR)
         assert len(s_res["hits"]) > 0
 
+    def test_filtering_list_case(self):
+        tensor_search.add_documents(
+            config=self.config, index_name=self.index_name_1, docs=[
+                {"abc": "some text", "other field": "baaadd", "_id": "5678", "my_string": "b"},
+                {"abc": "some text", "other field": "Close match hehehe", "_id": "1234", "an_int": 2},
+                {"abc": "some text", "_id": "1235",  "my_list": ["tag1", "tag2 some"]}
+            ], auto_refresh=True)
+
+        res_exists = tensor_search.search("", filter="my_list:tag1")
+
+        res_not_exists = tensor_search.search("", filter="my_list:tag55")
+
+        res_other = tensor_search.search("", filter="my_string:b")
+
+        res_should_only_match_keyword = tensor_search.search("", filter="my_list:tag2")
+
+        assert res_exists["hits"][0]["_id"] == "1235"
+        assert len(res_exists["hits"]) == 1
+
+        assert len(res_not_exists["hits"]) == 0
+
+        assert res_other["hits"][0]["_id"] == "5678"
+        assert len(res_not_exists["hits"]) == 1
+
+        assert len(res_should_only_match_keyword["hits"]) == 0
+
     def test_filtering(self):
         tensor_search.add_documents(
             config=self.config, index_name=self.index_name_1, docs=[
                 {"abc": "some text", "other field": "baaadd", "_id": "5678", "my_string": "b"},
                 {"abc": "some text", "other field": "Close match hehehe", "_id": "1234", "an_int": 2},
-                {"abc": "some text", "other field": "Close match hehehe", "_id": "1233", "my_bool": True},
+                {"abc": "some text", "other field": "Close match hehehe", "_id": "1233", "my_bool": True}
             ], auto_refresh=True)
 
         res_doesnt_exist = tensor_search.search(

--- a/tests/tensor_search/test_validation.py
+++ b/tests/tensor_search/test_validation.py
@@ -177,21 +177,42 @@ class TestValidation(unittest.TestCase):
 
     def test_validate_field_content_bad(self):
         bad_field_content = [
-            {123}, [], None, {"abw": "cjnk"}
+            {123}, None, {"abw": "cjnk"}, ['not 100% strings', 134, 1.4, False],
+            ['not 100% strings', True]
         ]
-        for bad_content in bad_field_content:
-            try:
-                validation.validate_field_content(bad_content)
-                raise AssertionError
-            except InvalidArgError as e:
-                pass
+        for non_tensor_field in (True, False):
+            for bad_content in bad_field_content:
+                print('bad_content',bad_content)
+                try:
+                    validation.validate_field_content(bad_content, is_non_tensor_field=non_tensor_field)
+                    raise AssertionError
+                except InvalidArgError as e:
+                    pass
 
     def test_validate_field_content_good(self):
         good_field_content = [
             123, "heehee", 12.4, False
         ]
+        for non_tensor_field in (True, False):
+            for good_content in good_field_content:
+                assert good_content == validation.validate_field_content(good_content, is_non_tensor_field=non_tensor_field)
+
+    def test_validate_field_content_list(self):
+        good_field_content = [
+            [], [''], ['abc', 'efg', '123'], ['', '']
+        ]
         for good_content in good_field_content:
-            assert good_content == validation.validate_field_content(good_content)
+            assert good_content == validation.validate_field_content(good_content, is_non_tensor_field=True)
+
+        for good_content in good_field_content:
+            # fails when non tensor field
+            try:
+                validation.validate_field_content(good_content, is_non_tensor_field=False)
+                raise AssertionError
+            except InvalidArgError:
+                pass
+
+
 
     def test_validate_id_good(self):
         bad_ids = [

--- a/tests/tensor_search/test_validation.py
+++ b/tests/tensor_search/test_validation.py
@@ -182,7 +182,6 @@ class TestValidation(unittest.TestCase):
         ]
         for non_tensor_field in (True, False):
             for bad_content in bad_field_content:
-                print('bad_content',bad_content)
                 try:
                     validation.validate_field_content(bad_content, is_non_tensor_field=non_tensor_field)
                     raise AssertionError


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This change means that marqo is able to accept non-tensor list fields. This is useful so that users can do "contains" operations on list metadata. https://github.com/marqo-ai/marqo/issues/277

* **What is the current behavior?** (You can also link to an open issue here)
Currently, marqo does not allow users to add lists as metadata.

* **What is the new behavior (if this is a feature change)?**
Marqo allows users to add metadata as non_tensor fields, meaning they are available for filtering and lexical search

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
pending succesful unit test run, handing this off for completion for now by @pandu-k 

* **Related Python client changes** (link commit/PR here)
none

* **Related documentation changes** (link commit/PR here)
pending

* **Other information**:


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

