### PR TITLE
Broaden catch download error

### DIFF
--- a/src/marqo/s2_inference/clip_utils.py
+++ b/src/marqo/s2_inference/clip_utils.py
@@ -99,7 +99,8 @@ def load_image_from_path(image_path: str, timeout=3) -> ImageType:
     elif validators.url(image_path):
         try:
             resp = requests.get(image_path, stream=True, timeout=timeout)
-        except (requests.exceptions.ConnectTimeout, requests.exceptions.ConnectionError) as e:
+        except (requests.exceptions.ConnectTimeout, requests.exceptions.ConnectionError,
+                requests.exceptions.RequestException) as e:
             raise UnidentifiedImageError(
                 f"image url `{image_path}` is unreachable, perhaps due to timeout. "
                 f"Timeout threshold is set to {timeout} seconds."

--- a/src/marqo/s2_inference/clip_utils.py
+++ b/src/marqo/s2_inference/clip_utils.py
@@ -100,7 +100,8 @@ def load_image_from_path(image_path: str, timeout=3) -> ImageType:
         try:
             resp = requests.get(image_path, stream=True, timeout=timeout)
         except (requests.exceptions.ConnectTimeout, requests.exceptions.ConnectionError,
-                requests.exceptions.RequestException) as e:
+                requests.exceptions.RequestException
+                ) as e:
             raise UnidentifiedImageError(
                 f"image url `{image_path}` is unreachable, perhaps due to timeout. "
                 f"Timeout threshold is set to {timeout} seconds."

--- a/tests/s2_inference/test_clip_utils.py
+++ b/tests/s2_inference/test_clip_utils.py
@@ -27,9 +27,10 @@ class TestEncoding(unittest.TestCase):
         # should be fine on regular timeout:
         clip_utils.load_image_from_path(good_url)
 
-        for err in [requests.exceptions.ReadTimeout(), requests.exceptions.HTTPError]:
+        for err in [requests.exceptions.ReadTimeout, requests.exceptions.HTTPError]:
             mock_get = mock.MagicMock()
-            mock_get.return_value.raiseError.side_effect = err
+            mock_get.side_effect = err
+
             @mock.patch('requests.get', mock_get)
             def run():
                 try:

--- a/tests/s2_inference/test_clip_utils.py
+++ b/tests/s2_inference/test_clip_utils.py
@@ -1,7 +1,8 @@
 import PIL
-
 from marqo.s2_inference import clip_utils, types
 import unittest
+from unittest import mock
+import requests
 
 
 class TestEncoding(unittest.TestCase):
@@ -17,3 +18,25 @@ class TestEncoding(unittest.TestCase):
             raise AssertionError
         except PIL.UnidentifiedImageError:
             pass
+
+    def test_load_image_from_path_all_req_errors(self):
+        """Do we catch other download errors?
+        The errors tested inherit from requests.exceptions.RequestException
+        """
+        good_url = 'https://raw.githubusercontent.com/marqo-ai/marqo-api-tests/mainline/assets/ai_hippo_realistic.png'
+        # should be fine on regular timeout:
+        clip_utils.load_image_from_path(good_url)
+
+        for err in [requests.exceptions.ReadTimeout(), requests.exceptions.HTTPError]:
+            mock_get = mock.MagicMock()
+            mock_get.return_value.raiseError.side_effect = err
+            @mock.patch('requests.get', mock_get)
+            def run():
+                try:
+                    clip_utils.load_image_from_path(good_url)
+                    raise AssertionError
+                except PIL.UnidentifiedImageError:
+                    pass
+                return True
+
+            run()

--- a/tests/tensor_search/test_add_documents.py
+++ b/tests/tensor_search/test_add_documents.py
@@ -1244,7 +1244,7 @@ class TestAddDocuments(MarqoTestCase):
 
     def test_image_download_timeout(self):
         mock_get = mock.MagicMock()
-        mock_get.return_value.raiseError.side_effect = requests.exceptions.RequestException()
+        mock_get.side_effect = requests.exceptions.RequestException
 
         @mock.patch('requests.get', mock_get)
         def run():


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
some requests errors weren't caught, during image downloading (ReadTimeout)

* **What is the new behavior (if this is a feature change)?**
load_image_from_path() now excepts from RequestException, which superclasses all other request errors

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
in progress


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

