### PR TITLE
refresh on interval function refreshes index_info if enough time has …

### DIFF
--- a/src/marqo/tensor_search/index_meta_cache.py
+++ b/src/marqo/tensor_search/index_meta_cache.py
@@ -6,6 +6,7 @@ index in the search DB via a plugin.
 import asyncio
 import datetime
 import time
+import traceback
 from multiprocessing import Process, Manager
 from marqo.tensor_search.models.index_info import IndexInfo
 from typing import Dict
@@ -89,8 +90,10 @@ def refresh_index_info_on_interval(config: Config, index_name: str, interval_sec
             # any other exception is problematic. We reset the index to the last_refreshed_time to
             # let another thread refresh the index's index_info
             index_last_refreshed_time[index_name] = last_refreshed_time
-            logger.warning("error during refresh_index_info_on_interval(). Reason:"
+            logger.warning("refresh_index_info_on_interval(): error during background index_info refresh. Reason:"
                            f"\n{e2}")
+            logger.debug("refresh_index_info_on_interval(): error during background index_info refresh. "
+                         f"Traceback: \n{traceback.print_stack()}")
             raise e2
 
 

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -867,10 +867,11 @@ def search(config: Config, index_name: str, text: Union[str, dict],
     if index_name not in index_meta_cache.get_cache():
         backend.get_index_info(config=config, index_name=index_name)
 
+    REFRESH_INTERVAL_SECONDS = 2
     # update cache in the background
     cache_update_thread = threading.Thread(
-        target=index_meta_cache.refresh_index,
-        args=(config, index_name))
+        target=index_meta_cache.refresh_index_info_on_interval,
+        args=(config, index_name, REFRESH_INTERVAL_SECONDS))
     cache_update_thread.start()
 
     if search_method.upper() == SearchMethod.TENSOR:

--- a/tests/tensor_search/test_index_meta_cache.py
+++ b/tests/tensor_search/test_index_meta_cache.py
@@ -204,7 +204,8 @@ class TestIndexMetaCache(MarqoTestCase):
             index_name=self.index_name_1, config=self.config, text="a line of text",
             return_doc_ids=True, search_method=SearchMethod.LEXICAL)
         assert len(result["hits"]) == 0
-        time.sleep(1)
+        # REFRESH INTERVAL IS 2 seconds
+        time.sleep(4)
         result_2 = tensor_search.search(
             index_name=self.index_name_1, config=self.config, text="a line of text",
             return_doc_ids=True, search_method=SearchMethod.LEXICAL)


### PR DESCRIPTION

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Optimisation

* **What is the current behavior?** (You can also link to an open issue here)
The index_info cache is refreshed on every search() call. This leads to 2 Marqo-OS requests for every search request.

* **What is the new behavior (if this is a feature change)?**
The index_info cache is refreshed for a search() call only if the refresh interval time has elapsed since the previous index_info refresh. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
In progress: 
- https://github.com/marqo-ai/marqo/actions/runs/4204373279
- https://github.com/marqo-ai/marqo/actions/runs/4204368777

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

