### PR TITLE
Update clip_utils.py

### DIFF
--- a/src/marqo/s2_inference/clip_utils.py
+++ b/src/marqo/s2_inference/clip_utils.py
@@ -400,7 +400,7 @@ class OPEN_CLIP(CLIP):
         tokenizer_name = self.model_properties.get("tokenizer", "clip")
 
         if tokenizer_name == "clip":
-            return clip.tokenize
+            return open_clip.tokenize
         else:
             logger.info(f"Custom HFTokenizer is provided. Loading...")
             return HFTokenizer(tokenizer_name)


### PR DESCRIPTION
update custom open_clip models to use open_clip base tokenizer instead of clip

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It replaces the clip default tokenzier with the open_clip default tokenizer when loading custom open_clip models

* **What is the current behavior?** (You can also link to an open issue here)
it loads the clip tokenzier. see https://github.com/marqo-ai/marqo/issues/350

* **What is the new behavior (if this is a feature change)?**
it loads the open_clip tokenizer

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
no

* **Related Python client changes** (link commit/PR here)
no

* **Related documentation changes** (link commit/PR here)
no

* **Other information**:


* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

