### PR TITLE
Revised add punkt tokenizer download into Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,13 @@ RUN apt-get install python3.8-distutils -y # python3-distutils
 RUN apt-get  install python3.8 python3-pip -y # pip is 276 MB!
 # opencv requirements
 RUN apt-get install ffmpeg libsm6 libxext6 -y
+
+# Punkt Tokenizer
+RUN apt-get install unzip -y
+RUN mkdir -p /usr/local/share/nltk_data/tokenizers
+RUN curl https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages/tokenizers/punkt.zip -o /usr/local/share/nltk_data/tokenizers/punkt.zip
+RUN unzip /usr/local/share/nltk_data/tokenizers/punkt.zip  -d /usr/local/share/nltk_data/tokenizers/
+
 # TODO: up the RAM
 RUN echo Target platform is "$TARGETPLATFORM"
 COPY requirements.txt requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,9 @@ RUN apt-get install ffmpeg libsm6 libxext6 -y
 
 # Punkt Tokenizer
 RUN apt-get install unzip -y
-RUN mkdir -p /usr/local/share/nltk_data/tokenizers
-RUN curl https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages/tokenizers/punkt.zip -o /usr/local/share/nltk_data/tokenizers/punkt.zip
-RUN unzip /usr/local/share/nltk_data/tokenizers/punkt.zip  -d /usr/local/share/nltk_data/tokenizers/
+RUN mkdir -p /root/nltk_data/tokenizers
+RUN curl https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages/tokenizers/punkt.zip -o /root/nltk_data/tokenizers/punkt.zip
+RUN unzip /root/nltk_data/tokenizers/punkt.zip  -d /root/nltk_data/tokenizers/
 
 # TODO: up the RAM
 RUN echo Target platform is "$TARGETPLATFORM"

--- a/src/marqo/tensor_search/on_start_script.py
+++ b/src/marqo/tensor_search/on_start_script.py
@@ -110,11 +110,11 @@ class NLTK:
 
         try:
             nltk.data.find('tokenizers/punkt')
-            self.logger.info("nltk data: tokenizers/punkt already downloaded")
+            self.logger.debug("nltk data: tokenizers/punkt already downloaded")
         except LookupError:
-            self.logger.info("could not find nltk data. downloading it now....")
+            self.logger.debug("could not find nltk data. downloading it now....")
             nltk.download('punkt')        
-            self.logger.info("completed downloading nltk data")
+            self.logger.debug("completed downloading nltk data")
 
 
 class ModelsForCacheing:

--- a/src/marqo/tensor_search/on_start_script.py
+++ b/src/marqo/tensor_search/on_start_script.py
@@ -110,11 +110,11 @@ class NLTK:
 
         try:
             nltk.data.find('tokenizers/punkt')
-            self.logger.debug("nltk data: tokenizers/punkt already downloaded")
+            self.logger.debug("nltk data: successfully found tokenizers/punkt")
         except LookupError:
-            self.logger.debug("could not find nltk data. downloading it now....")
+            self.logger.warning("could not find nltk data. downloading it now....")
             nltk.download('punkt')        
-            self.logger.debug("completed downloading nltk data")
+            self.logger.warning("completed downloading nltk data (on start up)")
 
 
 class ModelsForCacheing:

--- a/src/marqo/tensor_search/on_start_script.py
+++ b/src/marqo/tensor_search/on_start_script.py
@@ -19,7 +19,6 @@ def on_start(marqo_os_url: str):
                         CUDAAvailable(), 
                         ModelsForCacheing(), 
                         InitializeRedis("localhost", 6379),    # TODO, have these variable
-                        NLTK(), 
                         DownloadFinishText(),
                         MarqoWelcome(),
                         MarqoPhrase()
@@ -92,28 +91,6 @@ class CUDAAvailable:
         for device_id in device_ids:
             device_names.append( {'id':device_id, 'name':id_to_device(device_id)})
         self.logger.info(f"found devices {device_names}")
-
-
-class NLTK:
-    """Pre-downloads the nltk stuff
-    """
-
-    logger = get_logger('NLTK setup')
-
-    def __init__(self):
-
-        pass 
-
-    def run(self):
-        self.logger.info("downloading nltk data....")
-        import nltk
-
-        try:
-            nltk.data.find('tokenizers/punkt')
-        except LookupError:
-            nltk.download('punkt')        
-        self.logger.info("completed loading nltk")
-
 
 class ModelsForCacheing:
     """warms the in-memory model cache by preloading good defaults

--- a/src/marqo/tensor_search/on_start_script.py
+++ b/src/marqo/tensor_search/on_start_script.py
@@ -19,6 +19,7 @@ def on_start(marqo_os_url: str):
                         CUDAAvailable(), 
                         ModelsForCacheing(), 
                         InitializeRedis("localhost", 6379),    # TODO, have these variable
+                        NLTK(), 
                         DownloadFinishText(),
                         MarqoWelcome(),
                         MarqoPhrase()
@@ -91,6 +92,30 @@ class CUDAAvailable:
         for device_id in device_ids:
             device_names.append( {'id':device_id, 'name':id_to_device(device_id)})
         self.logger.info(f"found devices {device_names}")
+
+
+class NLTK:
+    """Pre-downloads the nltk stuff
+    """
+
+    logger = get_logger('NLTK setup')
+
+    def __init__(self):
+
+        pass 
+
+    def run(self):
+        
+        import nltk
+
+        try:
+            nltk.data.find('tokenizers/punkt')
+            self.logger.info("nltk data: tokenizers/punkt already downloaded")
+        except LookupError:
+            self.logger.info("could not find nltk data. downloading it now....")
+            nltk.download('punkt')        
+            self.logger.info("completed downloading nltk data")
+
 
 class ModelsForCacheing:
     """warms the in-memory model cache by preloading good defaults


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Change to improve timing on start-up.

**What is the current behavior? (You can also link to an open issue here)**
On startup, a series of initialisations are run [link](https://github.com/marqo-ai/marqo/blob/mainline/src/marqo/tensor_search/on_start_script.py#L14), including loading nltk tokenizer support [link](https://github.com/marqo-ai/marqo/blob/mainline/src/marqo/tensor_search/on_start_script.py#L107)

**What is the new behavior (if this is a feature change)?**
Downloading and storing the tokenizers/punkt data into the Docker image. On startup, outputs log message 
```
nltk data: tokenizers/punkt already downloaded
```
to confirm that tokenizers have already been downloaded during buildtime.

**Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)**
No

**Have unit tests been run against this PR? (Has there also been any additional testing?)**
No

**Related Python client changes (link commit/PR here)**
No

**Related documentation changes (link commit/PR here)**
No

**Other information:**
No


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

