### PR TITLE
Add HNSW hyperparameters `m`, `ef_construction` to default `index_settings` config

### DIFF
--- a/src/marqo/tensor_search/backend.py
+++ b/src/marqo/tensor_search/backend.py
@@ -103,7 +103,6 @@ def add_customer_field_properties(config: Config, index_name: str,
             }
         }
     }
-    existing_info = get_cached_index_info(config=config, index_name=index_name)
     new_index_properties = existing_info.properties.copy()
 
     # copy fields to the chunk for prefiltering. If it is text, convert it to a keyword type to save space

--- a/src/marqo/tensor_search/backend.py
+++ b/src/marqo/tensor_search/backend.py
@@ -77,6 +77,7 @@ def add_customer_field_properties(config: Config, index_name: str,
         HTTP Response
     """
     engine = "lucene"
+    existing_info = get_cache()[index_name]
 
     # check if there is multimodal fie;ds and convert the fields name to a list with the same
     # format of customer_field_names
@@ -94,21 +95,13 @@ def add_customer_field_properties(config: Config, index_name: str,
                         utils.generate_vector_name(field_name[0])): {
                         "type": "knn_vector",
                         "dimension": model_properties["dimensions"],
-                        "method": {
-                            "name": "hnsw",
-                            "space_type": "cosinesimil",
-                            "engine": engine,
-                            "parameters": {
-                                "ef_construction": 128,
-                                "m": 16
-                            }
-                        }
+                        "method": existing_info.get_ann_parameters()
                     } for field_name in knn_field_names
                 }
             }
         }
     }
-    existing_info = get_cache()[index_name]
+
     new_index_properties = existing_info.properties.copy()
 
     # copy fields to the chunk for prefiltering. If it is text, convert it to a keyword type to save space

--- a/src/marqo/tensor_search/backend.py
+++ b/src/marqo/tensor_search/backend.py
@@ -79,7 +79,11 @@ def add_customer_field_properties(config: Config, index_name: str,
         HTTP Response
     """
     engine = "lucene"
+<<<<<<< HEAD
     existing_info = get_cache()[index_name]
+=======
+    existing_info = get_cached_index_info(config=config, index_name=index_name)
+>>>>>>> 624c1f2 (add hnsw hyperparameters m, ef_construction to default index_settings config)
 
     # check if there is multimodal fie;ds and convert the fields name to a list with the same
     # format of customer_field_names

--- a/src/marqo/tensor_search/backend.py
+++ b/src/marqo/tensor_search/backend.py
@@ -79,11 +79,7 @@ def add_customer_field_properties(config: Config, index_name: str,
         HTTP Response
     """
     engine = "lucene"
-<<<<<<< HEAD
-    existing_info = get_cache()[index_name]
-=======
     existing_info = get_cached_index_info(config=config, index_name=index_name)
->>>>>>> 624c1f2 (add hnsw hyperparameters m, ef_construction to default index_settings config)
 
     # check if there is multimodal fie;ds and convert the fields name to a list with the same
     # format of customer_field_names

--- a/src/marqo/tensor_search/configs.py
+++ b/src/marqo/tensor_search/configs.py
@@ -35,7 +35,7 @@ def get_default_ann_parameters():
         NsFields.ann_engine: "lucene",
         NsFields.ann_method_parameters: {
             NsFields.hnsw_ef_construction: 128,
-            NsFields.hnsw_m: 24
+            NsFields.hnsw_m: 16
         }
     }
 

--- a/src/marqo/tensor_search/configs.py
+++ b/src/marqo/tensor_search/configs.py
@@ -19,10 +19,24 @@ def get_default_index_settings():
             # TODO move these into a processing dict with sub-dicts
             NsFields.image_preprocessing: {
                 NsFields.patch_method: None
-            }
+            },
+            NsFields.ann_parameters: get_default_ann_parameters()
         },
         NsFields.number_of_shards: 5,
         NsFields.number_of_replicas : 1,
+    }
+
+def get_default_ann_parameters(): 
+    return {
+        NsFields.ann_method: "hnsw",
+        NsFields.ann_metric: "cosinesimil",
+
+        # `ann_engine` not exposed to customer (via index settings).
+        NsFields.ann_engine: "lucene",
+        NsFields.ann_method_parameters: {
+            NsFields.hnsw_ef_construction: 128,
+            NsFields.hnsw_m: 24
+        }
     }
 
 

--- a/src/marqo/tensor_search/configs.py
+++ b/src/marqo/tensor_search/configs.py
@@ -28,7 +28,7 @@ def get_default_index_settings():
 
 def get_default_ann_parameters(): 
     return {
-        NsFields.ann_method: "hnsw",
+        NsFields.ann_method_name: "hnsw",
         NsFields.ann_metric: "cosinesimil",
 
         # `ann_engine` not exposed to customer (via index settings).

--- a/src/marqo/tensor_search/enums.py
+++ b/src/marqo/tensor_search/enums.py
@@ -56,6 +56,16 @@ class IndexSettingsField:
     number_of_shards = "number_of_shards"
     number_of_replicas = "number_of_replicas"
 
+    ann_parameters = "ann_parameters"
+    ann_method = "method"
+    ann_metric = "space_type"
+    ann_engine = "engine"
+    ann_method_parameters = "method_parameters"
+
+    # method_parameters keys for "method"="hnsw"
+    hnsw_ef_construction = "ef_construction"
+    hnsw_m = "m"
+
 
 class SplitMethod:
     # consider moving this enum into processing

--- a/src/marqo/tensor_search/enums.py
+++ b/src/marqo/tensor_search/enums.py
@@ -58,9 +58,10 @@ class IndexSettingsField:
 
     ann_parameters = "ann_parameters"
     ann_method = "method"
+    ann_method_name = "name"
     ann_metric = "space_type"
     ann_engine = "engine"
-    ann_method_parameters = "method_parameters"
+    ann_method_parameters = "parameters"
 
     # method_parameters keys for "method"="hnsw"
     hnsw_ef_construction = "ef_construction"

--- a/src/marqo/tensor_search/models/index_info.py
+++ b/src/marqo/tensor_search/models/index_info.py
@@ -72,7 +72,7 @@ class IndexInfo(NamedTuple):
     def get_ann_parameters(self) -> Dict[str, Any]:
         """Gets the ANN parameters to use as the default for the index.
 
-        Preferentially use index settings (when present) over generic defaults.
+        Preferentially use index settings over generic defaults, when index settings exist.
 
         Returns:
             Dict of ann parameters. Structure can be seen at `configs.get_default_ann_parameters`.

--- a/src/marqo/tensor_search/models/index_info.py
+++ b/src/marqo/tensor_search/models/index_info.py
@@ -1,7 +1,8 @@
 import pprint
-from typing import NamedTuple, Any
+from typing import NamedTuple, Any, Dict
 from marqo.tensor_search import enums
-
+from marqo.tensor_search.enums import IndexSettingsField as NsFields
+from marqo.tensor_search import configs
 
 class IndexInfo(NamedTuple):
     """
@@ -67,3 +68,27 @@ class IndexInfo(NamedTuple):
             except KeyError:
                 continue
         return true_text_props
+    
+    def get_ann_parameters(self) -> Dict[str, Any]:
+        """Gets the ANN parameters to use as the default for the index.
+
+        Preferentially use index settings over generic defaults, when index settings exist.
+
+        Returns:
+            Dict of ann parameters. Structure can be seen at `configs.get_default_ann_parameters`.
+        
+        """
+        ann_default = configs.get_default_ann_parameters()
+        index_ann_defaults = self.index_settings[NsFields.index_defaults].get(NsFields.ann_parameters, {})
+
+        # index defaults override generic defaults
+        ann_params = {
+            **ann_default,
+            **index_ann_defaults
+        }
+        ann_params[NsFields.ann_method_parameters] = {
+            **ann_default[NsFields.ann_method_parameters],
+            **index_ann_defaults.get(NsFields.ann_method_parameters, {})
+        }
+
+        return ann_params

--- a/src/marqo/tensor_search/models/index_info.py
+++ b/src/marqo/tensor_search/models/index_info.py
@@ -72,7 +72,7 @@ class IndexInfo(NamedTuple):
     def get_ann_parameters(self) -> Dict[str, Any]:
         """Gets the ANN parameters to use as the default for the index.
 
-        Preferentially use index settings over generic defaults, when index settings exist.
+        Preferentially use index settings (when present) over generic defaults.
 
         Returns:
             Dict of ann parameters. Structure can be seen at `configs.get_default_ann_parameters`.

--- a/src/marqo/tensor_search/models/settings_object.py
+++ b/src/marqo/tensor_search/models/settings_object.py
@@ -96,7 +96,7 @@ settings_schema = {
                 NsFields.ann_parameters: {
                     "type": "object",
                     "required": [
-                        # None required for backwards compatibility
+                        # Non required for backwards compatibility
                     ],
                     "properties": {
                         NsFields.ann_method: {

--- a/src/marqo/tensor_search/models/settings_object.py
+++ b/src/marqo/tensor_search/models/settings_object.py
@@ -124,21 +124,13 @@ settings_schema = {
                                 NsFields.hnsw_m: {
                                     "type": "integer",
                                     "examples": [
-<<<<<<< HEAD
                                         16
-=======
-                                        24
->>>>>>> 624c1f2 (add hnsw hyperparameters m, ef_construction to default index_settings config)
                                     ]
                                 },
                             },
                             "examples": [{
                                 NsFields.hnsw_ef_construction: 128,
-<<<<<<< HEAD
                                 NsFields.hnsw_m: 16
-=======
-                                NsFields.hnsw_m: 24
->>>>>>> 624c1f2 (add hnsw hyperparameters m, ef_construction to default index_settings config)
                             }]
                         }
                     },
@@ -147,11 +139,7 @@ settings_schema = {
                         NsFields.ann_metric: "cosinesimil",
                         NsFields.ann_method_parameters: {
                             NsFields.hnsw_ef_construction: 128,
-<<<<<<< HEAD
                             NsFields.hnsw_m: 16
-=======
-                            NsFields.hnsw_m: 24
->>>>>>> 624c1f2 (add hnsw hyperparameters m, ef_construction to default index_settings config)
                         }
                     }]
                 }
@@ -173,11 +161,7 @@ settings_schema = {
                     NsFields.ann_metric: "cosinesimil",
                     NsFields.ann_method_parameters: {
                         NsFields.hnsw_ef_construction: 128,
-<<<<<<< HEAD
                         NsFields.hnsw_m: 16
-=======
-                        NsFields.hnsw_m: 24
->>>>>>> 624c1f2 (add hnsw hyperparameters m, ef_construction to default index_settings config)
                     }
                 }
             }]
@@ -215,11 +199,7 @@ settings_schema = {
                 NsFields.ann_metric: "cosinesimil",
                 NsFields.ann_method_parameters: {
                     NsFields.hnsw_ef_construction: 128,
-<<<<<<< HEAD
                     NsFields.hnsw_m: 16
-=======
-                    NsFields.hnsw_m: 24
->>>>>>> 624c1f2 (add hnsw hyperparameters m, ef_construction to default index_settings config)
                 }
             }
         },

--- a/src/marqo/tensor_search/models/settings_object.py
+++ b/src/marqo/tensor_search/models/settings_object.py
@@ -96,7 +96,7 @@ settings_schema = {
                 NsFields.ann_parameters: {
                     "type": "object",
                     "required": [
-                        # Non required for backwards compatibility
+                        # None required for backwards compatibility
                     ],
                     "properties": {
                         NsFields.ann_method: {
@@ -124,13 +124,13 @@ settings_schema = {
                                 NsFields.hnsw_m: {
                                     "type": "integer",
                                     "examples": [
-                                        24
+                                        16
                                     ]
                                 },
                             },
                             "examples": [{
                                 NsFields.hnsw_ef_construction: 128,
-                                NsFields.hnsw_m: 24
+                                NsFields.hnsw_m: 16
                             }]
                         }
                     },
@@ -139,7 +139,7 @@ settings_schema = {
                         NsFields.ann_metric: "cosinesimil",
                         NsFields.ann_method_parameters: {
                             NsFields.hnsw_ef_construction: 128,
-                            NsFields.hnsw_m: 24
+                            NsFields.hnsw_m: 16
                         }
                     }]
                 }
@@ -161,7 +161,7 @@ settings_schema = {
                     NsFields.ann_metric: "cosinesimil",
                     NsFields.ann_method_parameters: {
                         NsFields.hnsw_ef_construction: 128,
-                        NsFields.hnsw_m: 24
+                        NsFields.hnsw_m: 16
                     }
                 }
             }]
@@ -199,7 +199,7 @@ settings_schema = {
                 NsFields.ann_metric: "cosinesimil",
                 NsFields.ann_method_parameters: {
                     NsFields.hnsw_ef_construction: 128,
-                    NsFields.hnsw_m: 24
+                    NsFields.hnsw_m: 16
                 }
             }
         },

--- a/src/marqo/tensor_search/models/settings_object.py
+++ b/src/marqo/tensor_search/models/settings_object.py
@@ -124,13 +124,21 @@ settings_schema = {
                                 NsFields.hnsw_m: {
                                     "type": "integer",
                                     "examples": [
+<<<<<<< HEAD
                                         16
+=======
+                                        24
+>>>>>>> 624c1f2 (add hnsw hyperparameters m, ef_construction to default index_settings config)
                                     ]
                                 },
                             },
                             "examples": [{
                                 NsFields.hnsw_ef_construction: 128,
+<<<<<<< HEAD
                                 NsFields.hnsw_m: 16
+=======
+                                NsFields.hnsw_m: 24
+>>>>>>> 624c1f2 (add hnsw hyperparameters m, ef_construction to default index_settings config)
                             }]
                         }
                     },
@@ -139,7 +147,11 @@ settings_schema = {
                         NsFields.ann_metric: "cosinesimil",
                         NsFields.ann_method_parameters: {
                             NsFields.hnsw_ef_construction: 128,
+<<<<<<< HEAD
                             NsFields.hnsw_m: 16
+=======
+                            NsFields.hnsw_m: 24
+>>>>>>> 624c1f2 (add hnsw hyperparameters m, ef_construction to default index_settings config)
                         }
                     }]
                 }
@@ -161,7 +173,11 @@ settings_schema = {
                     NsFields.ann_metric: "cosinesimil",
                     NsFields.ann_method_parameters: {
                         NsFields.hnsw_ef_construction: 128,
+<<<<<<< HEAD
                         NsFields.hnsw_m: 16
+=======
+                        NsFields.hnsw_m: 24
+>>>>>>> 624c1f2 (add hnsw hyperparameters m, ef_construction to default index_settings config)
                     }
                 }
             }]
@@ -199,7 +215,11 @@ settings_schema = {
                 NsFields.ann_metric: "cosinesimil",
                 NsFields.ann_method_parameters: {
                     NsFields.hnsw_ef_construction: 128,
+<<<<<<< HEAD
                     NsFields.hnsw_m: 16
+=======
+                    NsFields.hnsw_m: 24
+>>>>>>> 624c1f2 (add hnsw hyperparameters m, ef_construction to default index_settings config)
                 }
             }
         },

--- a/src/marqo/tensor_search/models/settings_object.py
+++ b/src/marqo/tensor_search/models/settings_object.py
@@ -92,6 +92,56 @@ settings_schema = {
                     "examples": [{
                         NsFields.patch_method: None
                     }]
+                },
+                NsFields.ann_parameters: {
+                    "type": "object",
+                    "required": [
+                        # Non required for backwards compatibility
+                    ],
+                    "properties": {
+                        NsFields.ann_method: {
+                            "type": "string",
+                            "examples": [
+                                "hnsw"
+                            ]
+                        },
+                        NsFields.ann_metric: {
+                            "type": "string",
+                            "examples": [
+                                "cosinesimil"
+                            ]
+                        },
+                        NsFields.ann_method_parameters: {
+                            "type": "object",
+                            "required": [],
+                            "properties": {
+                                NsFields.hnsw_ef_construction: {
+                                    "type": "integer",
+                                    "examples": [
+                                        128
+                                    ]
+                                },
+                                NsFields.hnsw_m: {
+                                    "type": "integer",
+                                    "examples": [
+                                        24
+                                    ]
+                                },
+                            },
+                            "examples": [{
+                                NsFields.hnsw_ef_construction: 128,
+                                NsFields.hnsw_m: 24
+                            }]
+                        }
+                    },
+                    "examples": [{
+                        NsFields.ann_method: "hnsw",
+                        NsFields.ann_metric: "cosinesimil",
+                        NsFields.ann_method_parameters: {
+                            NsFields.hnsw_ef_construction: 128,
+                            NsFields.hnsw_m: 24
+                        }
+                    }]
                 }
             },
             "examples": [{
@@ -105,6 +155,14 @@ settings_schema = {
                 },
                 NsFields.image_preprocessing: {
                     NsFields.patch_method: None
+                },
+                NsFields.ann_parameters: {
+                    NsFields.ann_method: "hnsw",
+                    NsFields.ann_metric: "cosinesimil",
+                    NsFields.ann_method_parameters: {
+                        NsFields.hnsw_ef_construction: 128,
+                        NsFields.hnsw_m: 24
+                    }
                 }
             }]
         },
@@ -135,6 +193,14 @@ settings_schema = {
             },
             NsFields.image_preprocessing: {
                 NsFields.patch_method: None
+            },
+            NsFields.ann_parameters: {
+                NsFields.ann_method: "hnsw",
+                NsFields.ann_metric: "cosinesimil",
+                NsFields.ann_method_parameters: {
+                    NsFields.hnsw_ef_construction: 128,
+                    NsFields.hnsw_m: 24
+                }
             }
         },
         NsFields.number_of_shards: 5,

--- a/tests/tensor_search/test_backend.py
+++ b/tests/tensor_search/test_backend.py
@@ -115,7 +115,11 @@ class TestBackend(MarqoTestCase):
         args, kwargs0 = mock__put.call_args_list[0]
         sent_dict = json.loads(kwargs0["body"])
         assert sent_dict["properties"][enums.TensorField.chunks]["properties"][utils.generate_vector_name(field_name="f1")]["method"]['engine'] == "lucene"
+<<<<<<< HEAD
         assert sent_dict["properties"][enums.TensorField.chunks]["properties"][utils.generate_vector_name(field_name="f1")]["method"]["parameters"] == {
+=======
+        assert sent_dict["properties"][enums.TensorField.chunks]["properties"][utils.generate_vector_name(field_name="f1")]["method"]["method_parameters"] == {
+>>>>>>> 624c1f2 (add hnsw hyperparameters m, ef_construction to default index_settings config)
                             enums.IndexSettingsField.hnsw_ef_construction: 1,
                             enums.IndexSettingsField.hnsw_m: 2
                         }

--- a/tests/tensor_search/test_backend.py
+++ b/tests/tensor_search/test_backend.py
@@ -5,6 +5,7 @@ import pprint
 import requests
 from marqo.tensor_search import enums, backend, utils
 from marqo.tensor_search import tensor_search
+from marqo.tensor_search.configs import get_default_ann_parameters
 from marqo.errors import MarqoApiError, IndexNotFoundError
 from tests.marqo_test import MarqoTestCase
 from unittest import mock
@@ -69,3 +70,52 @@ class TestBackend(MarqoTestCase):
         sent_dict = json.loads(kwargs0["body"])
         assert "lucene" == sent_dict["properties"][enums.TensorField.chunks
             ]["properties"][utils.generate_vector_name(field_name="f1")]["method"]["engine"]
+    
+    def test_add_customer_field_properties_default_ann_parameters(self):
+        mock_config = copy.deepcopy(self.config)
+        mock__put = mock.MagicMock()
+
+        tensor_search.create_vector_index(
+            config=mock_config, index_name=self.index_name_1)
+        @mock.patch("marqo._httprequests.HttpRequests.put", mock__put)
+        def run():
+            tensor_search.add_documents(config=mock_config, docs=[{"f1": "doc"}, {"f2":"C"}],
+                                        index_name=self.index_name_1, auto_refresh=True)
+            return True
+        assert run()
+        args, kwargs0 = mock__put.call_args_list[0]
+        sent_dict = json.loads(kwargs0["body"])
+        assert sent_dict["properties"][enums.TensorField.chunks]["properties"][utils.generate_vector_name(field_name="f1")]["method"] == get_default_ann_parameters()
+
+
+    def test_add_customer_field_properties_index_ann_parameters(self):
+        mock_config = copy.deepcopy(self.config)
+        mock__put = mock.MagicMock()
+
+        tensor_search.create_vector_index(
+            config=mock_config,
+            index_name=self.index_name_1,
+            index_settings={
+                enums.IndexSettingsField.index_defaults: {
+                    enums.IndexSettingsField.ann_parameters: {
+                        enums.IndexSettingsField.ann_method_parameters: {
+                            enums.IndexSettingsField.hnsw_ef_construction: 1,
+                            enums.IndexSettingsField.hnsw_m: 2
+                        }
+                    }
+                }   
+            }
+        )
+        @mock.patch("marqo._httprequests.HttpRequests.put", mock__put)
+        def run():
+            tensor_search.add_documents(config=mock_config, docs=[{"f1": "doc"}, {"f2":"C"}],
+                                        index_name=self.index_name_1, auto_refresh=True)
+            return True
+        assert run()
+        args, kwargs0 = mock__put.call_args_list[0]
+        sent_dict = json.loads(kwargs0["body"])
+        assert sent_dict["properties"][enums.TensorField.chunks]["properties"][utils.generate_vector_name(field_name="f1")]["method"]['engine'] == "lucene"
+        assert sent_dict["properties"][enums.TensorField.chunks]["properties"][utils.generate_vector_name(field_name="f1")]["method"]["method_parameters"] == {
+                            enums.IndexSettingsField.hnsw_ef_construction: 1,
+                            enums.IndexSettingsField.hnsw_m: 2
+                        }

--- a/tests/tensor_search/test_backend.py
+++ b/tests/tensor_search/test_backend.py
@@ -115,11 +115,7 @@ class TestBackend(MarqoTestCase):
         args, kwargs0 = mock__put.call_args_list[0]
         sent_dict = json.loads(kwargs0["body"])
         assert sent_dict["properties"][enums.TensorField.chunks]["properties"][utils.generate_vector_name(field_name="f1")]["method"]['engine'] == "lucene"
-<<<<<<< HEAD
         assert sent_dict["properties"][enums.TensorField.chunks]["properties"][utils.generate_vector_name(field_name="f1")]["method"]["parameters"] == {
-=======
-        assert sent_dict["properties"][enums.TensorField.chunks]["properties"][utils.generate_vector_name(field_name="f1")]["method"]["method_parameters"] == {
->>>>>>> 624c1f2 (add hnsw hyperparameters m, ef_construction to default index_settings config)
                             enums.IndexSettingsField.hnsw_ef_construction: 1,
                             enums.IndexSettingsField.hnsw_m: 2
                         }

--- a/tests/tensor_search/test_backend.py
+++ b/tests/tensor_search/test_backend.py
@@ -115,7 +115,7 @@ class TestBackend(MarqoTestCase):
         args, kwargs0 = mock__put.call_args_list[0]
         sent_dict = json.loads(kwargs0["body"])
         assert sent_dict["properties"][enums.TensorField.chunks]["properties"][utils.generate_vector_name(field_name="f1")]["method"]['engine'] == "lucene"
-        assert sent_dict["properties"][enums.TensorField.chunks]["properties"][utils.generate_vector_name(field_name="f1")]["method"]["method_parameters"] == {
+        assert sent_dict["properties"][enums.TensorField.chunks]["properties"][utils.generate_vector_name(field_name="f1")]["method"]["parameters"] == {
                             enums.IndexSettingsField.hnsw_ef_construction: 1,
                             enums.IndexSettingsField.hnsw_m: 2
                         }

--- a/tests/tensor_search/test_create_index.py
+++ b/tests/tensor_search/test_create_index.py
@@ -80,7 +80,16 @@ class TestCreateIndex(MarqoTestCase):
                 IndexSettingsField.treat_urls_and_pointers_as_images: True,
                 IndexSettingsField.normalize_embeddings: False,
                 IndexSettingsField.text_preprocessing: default_text_preprocessing,
-                IndexSettingsField.image_preprocessing: default_image_preprocessing
+                IndexSettingsField.image_preprocessing: default_image_preprocessing,
+                IndexSettingsField.ann_parameters: {
+                    IndexSettingsField.ann_engine: 'lucene',
+                    IndexSettingsField.ann_method_name: 'hnsw',
+                    IndexSettingsField.ann_method_parameters: {
+                        IndexSettingsField.hnsw_ef_construction: 128,
+                        IndexSettingsField.hnsw_m: 16
+                    },
+                    IndexSettingsField.ann_metric: 'cosinesimil'
+                },
             },
             IndexSettingsField.number_of_shards: default_settings[IndexSettingsField.number_of_shards],
             IndexSettingsField.number_of_replicas: default_settings[IndexSettingsField.number_of_replicas]

--- a/tests/tensor_search/test_index_info.py
+++ b/tests/tensor_search/test_index_info.py
@@ -120,7 +120,7 @@ class TestIndexInfo(unittest.TestCase):
 
     def test_get_ann_parameters__use_specified_index_settings__overide_defaults(self):
         index_settings = configs.get_default_index_settings()
-        index_settings[NsFields.index_defaults][NsFields.ann_parameters][NsFields.ann_method] = "not-hnsw"
+        index_settings[NsFields.index_defaults][NsFields.ann_parameters][NsFields.ann_method_name] = "not-hnsw"
 
         ii = IndexInfo(
             model_name='some model',
@@ -129,10 +129,10 @@ class TestIndexInfo(unittest.TestCase):
         )
         actual = ii.get_ann_parameters()
         default = configs.get_default_ann_parameters()
-        assert actual[NsFields.ann_method] == "not-hnsw"
+        assert actual[NsFields.ann_method_name] == "not-hnsw"
         
-        del actual[NsFields.ann_method]
-        del default[NsFields.ann_method]
+        del actual[NsFields.ann_method_name]
+        del default[NsFields.ann_method_name]
 
         assert actual == default
 

--- a/tests/tensor_search/test_index_info.py
+++ b/tests/tensor_search/test_index_info.py
@@ -2,7 +2,7 @@ import pprint
 import unittest
 from marqo.tensor_search.models.index_info import IndexInfo
 from marqo.tensor_search.models import index_info
-from marqo.tensor_search.enums import TensorField
+from marqo.tensor_search.enums import IndexSettingsField as NsFields, TensorField
 from marqo.tensor_search import configs
 
 
@@ -98,3 +98,63 @@ class TestIndexInfo(unittest.TestCase):
             index_settings=configs.get_default_index_settings()
         )
         assert {"some_text_prop": {1:2334}, "cat": {"hat": "ter"}} == ii.get_text_properties()
+
+    def test_get_ann_parameters_default_index_param(self):
+        ii = IndexInfo(
+            model_name='some model',
+            properties={},
+            index_settings=configs.get_default_index_settings()
+        )
+        assert ii.get_ann_parameters() == configs.get_default_ann_parameters()
+
+    def test_get_ann_parameters_without_default_ann_parameters_use_defaults(self):
+        index_settings = configs.get_default_index_settings()
+        del index_settings[NsFields.index_defaults][NsFields.ann_parameters]
+
+        ii = IndexInfo(
+            model_name='some model',
+            properties={},
+            index_settings=index_settings
+        )
+        assert ii.get_ann_parameters() == configs.get_default_ann_parameters()
+
+    def test_get_ann_parameters_use_specified_index_settings(self):
+        index_settings = configs.get_default_index_settings()
+        index_settings[NsFields.index_defaults][NsFields.ann_parameters][NsFields.ann_method] = "not-hnsw"
+
+        ii = IndexInfo(
+            model_name='some model',
+            properties={},
+            index_settings=index_settings
+        )
+        actual = ii.get_ann_parameters()
+        default = configs.get_default_ann_parameters()
+        assert actual[NsFields.ann_method] == "not-hnsw"
+        
+        del actual[NsFields.ann_method]
+        del default[NsFields.ann_method]
+
+        assert actual == default
+
+    def test_get_ann_parameters_use_specified_ann_method_parameters(self):
+        index_settings = configs.get_default_index_settings()
+        index_settings[NsFields.index_defaults][NsFields.ann_parameters][NsFields.ann_method_parameters] = {
+            NsFields.hnsw_ef_construction: 1,
+            NsFields.hnsw_m: 2
+        }
+
+        ii = IndexInfo(
+            model_name='some model',
+            properties={},
+            index_settings=index_settings
+        )
+        default = configs.get_default_ann_parameters()
+        actual = ii.get_ann_parameters()
+        assert actual[NsFields.ann_method_parameters] == {
+            NsFields.hnsw_ef_construction: 1,
+            NsFields.hnsw_m: 2
+        }
+        del actual[NsFields.ann_method_parameters]
+        del default[NsFields.ann_method_parameters]
+        
+        assert actual == default

--- a/tests/tensor_search/test_index_info.py
+++ b/tests/tensor_search/test_index_info.py
@@ -99,7 +99,7 @@ class TestIndexInfo(unittest.TestCase):
         )
         assert {"some_text_prop": {1:2334}, "cat": {"hat": "ter"}} == ii.get_text_properties()
 
-    def test_get_ann_parameters_default_index_param(self):
+    def test_get_ann_parameters__default_index_param(self):
         ii = IndexInfo(
             model_name='some model',
             properties={},
@@ -107,7 +107,7 @@ class TestIndexInfo(unittest.TestCase):
         )
         assert ii.get_ann_parameters() == configs.get_default_ann_parameters()
 
-    def test_get_ann_parameters_without_default_ann_parameters_use_defaults(self):
+    def test_get_ann_parameters__without_default_ann_parameters__use_defaults(self):
         index_settings = configs.get_default_index_settings()
         del index_settings[NsFields.index_defaults][NsFields.ann_parameters]
 
@@ -118,7 +118,7 @@ class TestIndexInfo(unittest.TestCase):
         )
         assert ii.get_ann_parameters() == configs.get_default_ann_parameters()
 
-    def test_get_ann_parameters_use_specified_index_settings(self):
+    def test_get_ann_parameters__use_specified_index_settings__overide_defaults(self):
         index_settings = configs.get_default_index_settings()
         index_settings[NsFields.index_defaults][NsFields.ann_parameters][NsFields.ann_method] = "not-hnsw"
 
@@ -136,7 +136,7 @@ class TestIndexInfo(unittest.TestCase):
 
         assert actual == default
 
-    def test_get_ann_parameters_use_specified_ann_method_parameters(self):
+    def test_get_ann_parameters__use_specified_ann_method_parameters__default_unspecified_values(self):
         index_settings = configs.get_default_index_settings()
         index_settings[NsFields.index_defaults][NsFields.ann_parameters][NsFields.ann_method_parameters] = {
             NsFields.hnsw_ef_construction: 1,

--- a/tests/tensor_search/test_index_info.py
+++ b/tests/tensor_search/test_index_info.py
@@ -99,11 +99,7 @@ class TestIndexInfo(unittest.TestCase):
         )
         assert {"some_text_prop": {1:2334}, "cat": {"hat": "ter"}} == ii.get_text_properties()
 
-<<<<<<< HEAD
     def test_get_ann_parameters__default_index_param(self):
-=======
-    def test_get_ann_parameters_default_index_param(self):
->>>>>>> 624c1f2 (add hnsw hyperparameters m, ef_construction to default index_settings config)
         ii = IndexInfo(
             model_name='some model',
             properties={},
@@ -111,11 +107,7 @@ class TestIndexInfo(unittest.TestCase):
         )
         assert ii.get_ann_parameters() == configs.get_default_ann_parameters()
 
-<<<<<<< HEAD
     def test_get_ann_parameters__without_default_ann_parameters__use_defaults(self):
-=======
-    def test_get_ann_parameters_without_default_ann_parameters_use_defaults(self):
->>>>>>> 624c1f2 (add hnsw hyperparameters m, ef_construction to default index_settings config)
         index_settings = configs.get_default_index_settings()
         del index_settings[NsFields.index_defaults][NsFields.ann_parameters]
 
@@ -126,15 +118,9 @@ class TestIndexInfo(unittest.TestCase):
         )
         assert ii.get_ann_parameters() == configs.get_default_ann_parameters()
 
-<<<<<<< HEAD
     def test_get_ann_parameters__use_specified_index_settings__overide_defaults(self):
         index_settings = configs.get_default_index_settings()
         index_settings[NsFields.index_defaults][NsFields.ann_parameters][NsFields.ann_method_name] = "not-hnsw"
-=======
-    def test_get_ann_parameters_use_specified_index_settings(self):
-        index_settings = configs.get_default_index_settings()
-        index_settings[NsFields.index_defaults][NsFields.ann_parameters][NsFields.ann_method] = "not-hnsw"
->>>>>>> 624c1f2 (add hnsw hyperparameters m, ef_construction to default index_settings config)
 
         ii = IndexInfo(
             model_name='some model',
@@ -143,7 +129,6 @@ class TestIndexInfo(unittest.TestCase):
         )
         actual = ii.get_ann_parameters()
         default = configs.get_default_ann_parameters()
-<<<<<<< HEAD
         assert actual[NsFields.ann_method_name] == "not-hnsw"
         
         del actual[NsFields.ann_method_name]
@@ -152,16 +137,6 @@ class TestIndexInfo(unittest.TestCase):
         assert actual == default
 
     def test_get_ann_parameters__use_specified_ann_method_parameters__default_unspecified_values(self):
-=======
-        assert actual[NsFields.ann_method] == "not-hnsw"
-        
-        del actual[NsFields.ann_method]
-        del default[NsFields.ann_method]
-
-        assert actual == default
-
-    def test_get_ann_parameters_use_specified_ann_method_parameters(self):
->>>>>>> 624c1f2 (add hnsw hyperparameters m, ef_construction to default index_settings config)
         index_settings = configs.get_default_index_settings()
         index_settings[NsFields.index_defaults][NsFields.ann_parameters][NsFields.ann_method_parameters] = {
             NsFields.hnsw_ef_construction: 1,

--- a/tests/tensor_search/test_index_info.py
+++ b/tests/tensor_search/test_index_info.py
@@ -99,7 +99,11 @@ class TestIndexInfo(unittest.TestCase):
         )
         assert {"some_text_prop": {1:2334}, "cat": {"hat": "ter"}} == ii.get_text_properties()
 
+<<<<<<< HEAD
     def test_get_ann_parameters__default_index_param(self):
+=======
+    def test_get_ann_parameters_default_index_param(self):
+>>>>>>> 624c1f2 (add hnsw hyperparameters m, ef_construction to default index_settings config)
         ii = IndexInfo(
             model_name='some model',
             properties={},
@@ -107,7 +111,11 @@ class TestIndexInfo(unittest.TestCase):
         )
         assert ii.get_ann_parameters() == configs.get_default_ann_parameters()
 
+<<<<<<< HEAD
     def test_get_ann_parameters__without_default_ann_parameters__use_defaults(self):
+=======
+    def test_get_ann_parameters_without_default_ann_parameters_use_defaults(self):
+>>>>>>> 624c1f2 (add hnsw hyperparameters m, ef_construction to default index_settings config)
         index_settings = configs.get_default_index_settings()
         del index_settings[NsFields.index_defaults][NsFields.ann_parameters]
 
@@ -118,9 +126,15 @@ class TestIndexInfo(unittest.TestCase):
         )
         assert ii.get_ann_parameters() == configs.get_default_ann_parameters()
 
+<<<<<<< HEAD
     def test_get_ann_parameters__use_specified_index_settings__overide_defaults(self):
         index_settings = configs.get_default_index_settings()
         index_settings[NsFields.index_defaults][NsFields.ann_parameters][NsFields.ann_method_name] = "not-hnsw"
+=======
+    def test_get_ann_parameters_use_specified_index_settings(self):
+        index_settings = configs.get_default_index_settings()
+        index_settings[NsFields.index_defaults][NsFields.ann_parameters][NsFields.ann_method] = "not-hnsw"
+>>>>>>> 624c1f2 (add hnsw hyperparameters m, ef_construction to default index_settings config)
 
         ii = IndexInfo(
             model_name='some model',
@@ -129,6 +143,7 @@ class TestIndexInfo(unittest.TestCase):
         )
         actual = ii.get_ann_parameters()
         default = configs.get_default_ann_parameters()
+<<<<<<< HEAD
         assert actual[NsFields.ann_method_name] == "not-hnsw"
         
         del actual[NsFields.ann_method_name]
@@ -137,6 +152,16 @@ class TestIndexInfo(unittest.TestCase):
         assert actual == default
 
     def test_get_ann_parameters__use_specified_ann_method_parameters__default_unspecified_values(self):
+=======
+        assert actual[NsFields.ann_method] == "not-hnsw"
+        
+        del actual[NsFields.ann_method]
+        del default[NsFields.ann_method]
+
+        assert actual == default
+
+    def test_get_ann_parameters_use_specified_ann_method_parameters(self):
+>>>>>>> 624c1f2 (add hnsw hyperparameters m, ef_construction to default index_settings config)
         index_settings = configs.get_default_index_settings()
         index_settings[NsFields.index_defaults][NsFields.ann_parameters][NsFields.ann_method_parameters] = {
             NsFields.hnsw_ef_construction: 1,


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
(https://github.com/marqo-ai/marqo/issues/206)

**Have unit tests been run against this PR?** (Has there also been any additional testing?)
 - Yep, see the comments. 

**Related Python client changes** (link commit/PR here)
- No. Although some parameters are provided as kwargs to `Index.create(`, I don't think these are important enough to increase the complexity of the interface.

**Related documentation changes** (link commit/PR here)
 - https://github.com/marqo-ai/marqodocs/pull/65

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

