### PR TITLE
Add documents concurrency fix

### DIFF
--- a/src/marqo/tensor_search/backend.py
+++ b/src/marqo/tensor_search/backend.py
@@ -13,7 +13,9 @@ from marqo import errors
 #
 from typing import Iterable, List, Union, Optional, Tuple, Dict
 from marqo.tensor_search.index_meta_cache import get_cache
+from marqo.tensor_search.index_meta_cache import get_index_info as get_cached_index_info
 import pprint
+
 
 def get_index_info(config: Config, index_name: str) -> IndexInfo:
     """Gets useful information about the index. Also updates the IndexInfo cache
@@ -108,7 +110,7 @@ def add_customer_field_properties(config: Config, index_name: str,
             }
         }
     }
-    existing_info = get_index_info(config=config, index_name=index_name)
+    existing_info = get_cached_index_info(config=config, index_name=index_name)
     new_index_properties = existing_info.properties.copy()
 
     # copy fields to the chunk for prefiltering. If it is text, convert it to a keyword type to save space

--- a/src/marqo/tensor_search/backend.py
+++ b/src/marqo/tensor_search/backend.py
@@ -108,7 +108,7 @@ def add_customer_field_properties(config: Config, index_name: str,
             }
         }
     }
-    existing_info = get_cache()[index_name]
+    existing_info = get_index_info(config=config, index_name=index_name)
     new_index_properties = existing_info.properties.copy()
 
     # copy fields to the chunk for prefiltering. If it is text, convert it to a keyword type to save space

--- a/tests/tensor_search/test_index_meta_cache.py
+++ b/tests/tensor_search/test_index_meta_cache.py
@@ -184,7 +184,8 @@ class TestIndexMetaCache(MarqoTestCase):
             )
         # set cache to t0 state:
         index_meta_cache.index_info_cache = copy.deepcopy(cache_t0)
-        time.sleep(1)
+        # search refreshes index cache every 2 seconds
+        time.sleep(2.1)
         if check_only_in_external_cache is not None:
             assert check_only_in_external_cache not in \
                    index_meta_cache.get_cache()[index_name].properties[TensorField.chunks]["properties"]


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
During the add documents call, if another user deletes the index, the add_documents user gets a 500 due to a keyerror during the mappings update.

* **What is the new behavior (if this is a feature change)?**
Now, the add_documents call attempts to find index mappings from Marqo-os if it isn't in the cache. If the index has been deleted in this time, the add_documents user will get "IndexNotFound" error. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
In progress

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

