### PR TITLE
Return InvalidArgError when pydantic validation fails on API objects

### DIFF
--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -1,14 +1,16 @@
 """The API entrypoint for Tensor Search"""
 import typing
 from fastapi.responses import JSONResponse
-from models.api_models import BulkSearchQuery, SearchQuery
 from fastapi import FastAPI, Request, Depends, HTTPException
-from marqo.errors import MarqoWebError, MarqoError
+from fastapi.exceptions import RequestValidationError
+from marqo.errors import InvalidArgError, MarqoWebError, MarqoError
 from fastapi import FastAPI, Query
+import json
 from marqo.tensor_search import tensor_search
 from marqo import config
 from typing import List, Dict
 import os
+from marqo.tensor_search.models.api_models import BulkSearchQuery, SearchQuery
 from marqo.tensor_search.web import api_validation, api_utils
 from marqo.tensor_search import utils
 from marqo.tensor_search.on_start_script import on_start
@@ -17,6 +19,7 @@ from marqo.tensor_search.backend import get_index_info
 from marqo.tensor_search.enums import RequestType
 from marqo.tensor_search.throttling.redis_throttle import throttle
 from marqo.tensor_search.utils import add_timing
+
 
 def replace_host_localhosts(OPENSEARCH_IS_INTERNAL: str, OS_URL: str):
     """Replaces a host's localhost URL with one that can be referenced from
@@ -41,12 +44,13 @@ def replace_host_localhosts(OPENSEARCH_IS_INTERNAL: str, OS_URL: str):
                 return replaced_str
     return OS_URL
 
-OPENSEARCH_URL = replace_host_localhosts(
-    os.environ.get("OPENSEARCH_IS_INTERNAL", None),
-    os.environ["OPENSEARCH_URL"])
+if __name__ in ["__main__", "api"]:
+    OPENSEARCH_URL = replace_host_localhosts(
+        os.environ.get("OPENSEARCH_IS_INTERNAL", None),
+        os.environ["OPENSEARCH_URL"]
+    )
+    on_start(OPENSEARCH_URL)
 
-
-on_start(OPENSEARCH_URL)
 app = FastAPI(
     title="Marqo",
     version=version.get_version()
@@ -60,7 +64,7 @@ def generate_config() -> config.Config:
 
 
 @app.exception_handler(MarqoWebError)
-def marqo_user_exception_handler(request, exc: MarqoWebError):
+def marqo_user_exception_handler(request: Request, exc: MarqoWebError) -> JSONResponse:
     """ Catch a MarqoWebError and return an appropriate HTTP response.
 
     We can potentially catch any type of Marqo exception. We can do isinstance() calls
@@ -79,6 +83,23 @@ def marqo_user_exception_handler(request, exc: MarqoWebError):
     else:
         return JSONResponse(content=body, status_code=exc.status_code)
 
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+    """Catch pydantic validation errors and rewrite as an InvalidArgError whilst keeping error messages from the ValidationError."""
+    error_messages = [{
+        'loc': error['loc'],
+        'msg': error['msg'],
+        'type': error['type']
+    } for error in exc.errors()]
+
+    body = {
+        "message": json.dumps(error_messages),
+        "code": InvalidArgError.code,
+        "type": InvalidArgError.error_type,
+        "link": InvalidArgError.link
+    }
+    return JSONResponse(content=body, status_code=InvalidArgError.status_code)
 
 @app.exception_handler(MarqoError)
 def marqo_internal_exception_handler(request, exc: MarqoError):

--- a/src/marqo/tensor_search/models/api_models.py
+++ b/src/marqo/tensor_search/models/api_models.py
@@ -9,8 +9,12 @@ from typing import Union, List, Dict, Optional
 from marqo.tensor_search.enums import SearchMethod, Device
 from marqo.tensor_search import validation
 
+class BaseMarqoModel(BaseModel):
+     class Config:
+         extra: str = "forbid"
+     pass
 
-class SearchQuery(BaseModel):
+class SearchQuery(BaseMarqoModel):
     q: Union[str, Dict[str, float]]
     searchableAttributes: Union[None, List[str]] = None
     searchMethod: Union[None, str] = "TENSOR"
@@ -39,7 +43,7 @@ class BulkSearchQueryEntity(SearchQuery):
         return SearchQuery(**self.dict())
 
 
-class BulkSearchQuery(BaseModel):
+class BulkSearchQuery(BaseMarqoModel):
     queries: List[BulkSearchQueryEntity]
 
 

--- a/tests/tensor_search/test_api_exception_handler.py
+++ b/tests/tensor_search/test_api_exception_handler.py
@@ -1,0 +1,180 @@
+import pydantic
+from unittest import mock
+import pytest
+
+from fastapi import Request
+from starlette.datastructures import Headers
+from starlette.types import Scope
+
+
+from marqo.errors import InvalidArgError
+from tests.marqo_test import MarqoTestCase
+from marqo.tensor_search.api import validation_exception_handler
+
+class BaseMarqoModel(pydantic.BaseModel):
+    class Config:
+        extra: str = "forbid"
+    pass
+
+class TestApiValidation(MarqoTestCase):
+    
+    def setUp(self) -> None:
+        super().setUp()
+        self.normal_request = mock.MagicMock()
+        # Create a request instance with headers and a JSON body
+        headers = {'Content-Type': 'application/json'}
+        body = b'{"name": "Alice", "age": 30}'
+
+        # Create a mock request object
+        self.normal_request = mock.MagicMock()
+        self.normal_request.headers = headers
+        self.normal_request.content = body
+
+
+    async def test_validation_exception_handler_valid_error(self):
+        error = pydantic.ValidationError(errors=[{'loc': ('field',), 'msg': 'error message', 'type': 'value_error'}], model=BaseMarqoModel)
+        response = validation_exception_handler(self.normal_request, error)
+        assert response.status_code == InvalidArgError.status_code
+        assert response.json() == {
+            "message": '[{"loc": ["field"], "msg": "error message", "type": "value_error"}]',
+            "code": InvalidArgError.code,
+            "type": InvalidArgError.error_type,
+            "link": InvalidArgError.link
+        }
+
+    async def test_validation_exception_handler_empty_error(self):
+        error = pydantic.ValidationError(errors=[], model=BaseMarqoModel)
+        response = validation_exception_handler(self.normal_request, error)
+        assert response.status_code == InvalidArgError.status_code
+        assert response.json() == {
+            "message": '[]',
+            "code": InvalidArgError.code,
+            "type": InvalidArgError.error_type,
+            "link": InvalidArgError.link
+        }
+
+    async def test_validation_exception_handler_multiple_errors(self):
+        error = pydantic.ValidationError(errors=[
+            {'loc': ('field1',), 'msg': 'error message 1', 'type': 'value_error'},
+            {'loc': ('field2',), 'msg': 'error message 2', 'type': 'value_error'},
+            {'loc': ('field3',), 'msg': 'error message 3', 'type': 'value_error'}
+        ], model=BaseMarqoModel)
+        response = validation_exception_handler(self.normal_request, error)
+        assert response.status_code == InvalidArgError.status_code
+        assert response.json() == {
+            "message": '[{"loc": ["field1"], "msg": "error message 1", "type": "value_error"}, '
+                    '{"loc": ["field2"], "msg": "error message 2", "type": "value_error"}, '
+                    '{"loc": ["field3"], "msg": "error message 3", "type": "value_error"}]',
+            "code": InvalidArgError.code,
+            "type": InvalidArgError.error_type,
+            "link": InvalidArgError.link
+        }
+
+    async def test_validation_exception_handler_missing_fields_loc(self):
+        error = pydantic.ValidationError(errors=[{'msg': 'error message', 'type': 'value_error'}], model=BaseMarqoModel)
+        response = validation_exception_handler(self.normal_request, error)
+        assert response.status_code == InvalidArgError.status_code
+        assert response.json() == {
+            "message": '[{"loc": "", "msg": "error message", "type": "value_error"}]',
+            "code": InvalidArgError.code,
+            "type": InvalidArgError.error_type,
+            "link": InvalidArgError.link
+        }
+
+    async def test_validation_exception_handler_missing_fields_msg(self):
+        error = pydantic.ValidationError(errors=[{'loc': ('field',), 'type': 'value_error'}], model=BaseMarqoModel)
+        response = validation_exception_handler(self.normal_request, error)
+        assert response.status_code == InvalidArgError.status_code
+        assert response.json() == {
+            "message": '[{"loc": ["field"], "msg": "", "type": "value_error"}]',
+            "code": InvalidArgError.code,
+            "type": InvalidArgError.error_type,
+            "link": InvalidArgError.link
+        }
+
+    async def test_validation_exception_handler_missing_fields_type(self):
+        error = pydantic.ValidationError(errors=[{'loc': ('field',), 'msg': 'error message'}], model=BaseMarqoModel)
+        response = validation_exception_handler(self.normal_request, error)
+        assert response.status_code == InvalidArgError.status_code
+        assert response.json() == {
+            "message": '[{"loc": ["field"], "msg": "error message", "type": ""}]',
+            "code": InvalidArgError.code,
+            "type": InvalidArgError.error_type,
+            "link": InvalidArgError.link
+        }
+
+    async def test_validation_exception_handler_different_error_types(self):
+        errors = [
+            pydantic.ValidationError(errors=[{'loc': ('field',), 'msg': 'type error', 'type': 'type_error.integer'}], model=BaseMarqoModel),
+            pydantic.ValidationError(errors=[{'loc': ('field',), 'msg': 'value error', 'type': 'value_error'}], model=BaseMarqoModel),
+            pydantic.ValidationError(errors=[{'loc': ('field',), 'msg': 'custom error', 'type': 'custom_error'}], model=BaseMarqoModel)
+        ]
+        for error in errors:
+            response = validation_exception_handler(self.normal_request, error)
+            assert response.status_code == InvalidArgError.status_code
+            assert response.json() == {
+                "message": f'[{{"loc": ["field"], "msg": "{error.errors[0]["msg"]}", "type": "{error.errors[0]["type"]}"}}]',
+                "code": InvalidArgError.code,
+                "type": InvalidArgError.error_type,
+                "link": InvalidArgError.link
+            }
+
+    async def test_validation_exception_handler_non_validation_error(self):
+        error = ValueError('some error')
+        with pytest.raises(ValueError):
+            validation_exception_handler(self.normal_request, error)
+
+    async def test_validation_exception_handler_custom_error_message(self):
+        error = pydantic.ValidationError(errors=[{'loc': ('field',), 'msg': 'custom error message', 'type': 'value_error'}], model=BaseMarqoModel)
+        response = validation_exception_handler(self.normal_request, error)
+        assert response.status_code == InvalidArgError.status_code
+        assert response.json() == {
+            "message": '[{"loc": ["field"], "msg": "custom error message", "type": "value_error"}]',
+            "code": InvalidArgError.code,
+            "type": InvalidArgError.error_type,
+            "link": InvalidArgError.link
+        }
+
+    async def test_validation_exception_handler_different_request_objects(self):
+
+        # valid request object
+        request = mock.MagicMock()
+        request.method = 'POST'
+        request.headers = {'content-type': 'application/json'}
+        request.url = 'https://example.com'
+        request.json = lambda: {"field": "value"}
+
+        error = pydantic.ValidationError(errors=[{'loc': ('field',), 'msg': 'error message', 'type': 'value_error'}], model=BaseMarqoModel)
+        response = validation_exception_handler(request, error)
+        assert response.status_code == InvalidArgError.status_code
+
+        # invalid request object with missing json method
+        request = mock.MagicMock()
+        request.method = 'POST'
+        request.headers = {'content-type': 'application/json'}
+        request.url = URL('https://example.com')
+        with pytest.raises(AttributeError):
+            validation_exception_handler(request, error)
+
+        # invalid request object with missing headers
+        request = mock.MagicMock()
+        request.method = 'POST'
+        request.url = URL('https://example.com')
+        with pytest.raises(AttributeError):
+            validation_exception_handler(request, error)
+
+    async def test_validation_exception_handler_response_content(self):
+        error = pydantic.ValidationError(errors=[{'loc': ('field',), 'msg': 'error message', 'type': 'value_error'}], model=BaseMarqoModel)
+        response = validation_exception_handler(self.normal_request, error)
+        content = response.json()
+        assert 'message' in content
+        assert 'code' in content
+        assert 'type' in content
+        assert 'link' in content
+
+    async def test_validation_exception_handler_response_status_code(self):
+        error = pydantic.ValidationError(errors=[{'loc': ('field',), 'msg': 'error message', 'type': 'value_error'}], model=BaseMarqoModel)
+        response = validation_exception_handler(self.normal_request, error)
+        assert response.status_code == InvalidArgError.status_code
+
+

--- a/tests/tensor_search/test_api_validation.py
+++ b/tests/tensor_search/test_api_validation.py
@@ -1,6 +1,3 @@
-import requests
-from marqo.tensor_search import enums, backend
-from marqo.tensor_search import tensor_search
 from marqo.tensor_search.web import api_validation
 from marqo.errors import InvalidArgError
 from tests.marqo_test import MarqoTestCase

--- a/tests/tensor_search/test_bulk_search.py
+++ b/tests/tensor_search/test_bulk_search.py
@@ -9,11 +9,14 @@ from marqo.tensor_search.enums import TensorField, SearchMethod, EnvVars, IndexS
 from marqo.errors import (
     BackendCommunicationError, IndexNotFoundError, InvalidArgError, IllegalRequestedDocCount, BadRequestError
 )
+from marqo.tensor_search import api
 from marqo.tensor_search.models.api_models import BulkSearchQuery, BulkSearchQueryEntity
 from marqo.tensor_search import tensor_search, constants, index_meta_cache, utils
+from fastapi.exceptions import RequestValidationError
 import numpy as np
 from tests.marqo_test import MarqoTestCase
 from typing import List
+import pydantic
 
 
 def pass_through_vectorise(*arg, **kwargs):
@@ -42,6 +45,19 @@ class TestBulkSearch(MarqoTestCase):
             except IndexNotFoundError as s:
                 pass
 
+    def test_bulk_search_w_extra_parameters__raise_exception(self):
+        tensor_search.add_documents(
+            config=self.config, index_name=self.index_name_1, docs=[
+                {"abc": "Exact match hehehe", "other field": "baaadd", "_id": "id1-first"},
+                {"abc": "random text", "other field": "Close match hehehe", "_id": "id1-second"},
+            ], auto_refresh=True
+        ) 
+        with self.assertRaises(RequestValidationError):
+            api.bulk_search(BulkSearchQuery(queries=[{
+                "index": self.index_name_1,
+                "q": "title about some doc",
+                "parameter-not-expected": 1,
+            }]))
 
     def test_bulk_search_no_queries_return_early(self):
         tensor_search.add_documents(
@@ -809,7 +825,7 @@ class TestBulkSearch(MarqoTestCase):
             results = tensor_search.bulk_search(
                 marqo_config=self.config, query=BulkSearchQuery(
                     queries=[BulkSearchQueryEntity(
-                        index=self.index_name_1, q=str(to_search), search_method=SearchMethod.LEXICAL,
+                        index=self.index_name_1, q=str(to_search), searchMethod=SearchMethod.LEXICAL,
                         filter=f"{field}:{to_search}")])
             )
             assert "hits" in results["result"][0]

--- a/tests/tensor_search/test_bulk_search.py
+++ b/tests/tensor_search/test_bulk_search.py
@@ -52,7 +52,7 @@ class TestBulkSearch(MarqoTestCase):
                 {"abc": "random text", "other field": "Close match hehehe", "_id": "id1-second"},
             ], auto_refresh=True
         ) 
-        with self.assertRaises(RequestValidationError):
+        with self.assertRaises(pydantic.ValidationError):
             api.bulk_search(BulkSearchQuery(queries=[{
                 "index": self.index_name_1,
                 "q": "title about some doc",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- When a user passes in extra parameters (see pydantic `extra: str = "forbid"`) to the body of `/bulk/search/`, they receive an InvalidArgsError.

**What is the current behavior?** (You can also link to an open issue here)
- extra parameters are ignored silently

* **What is the new behavior (if this is a feature change)?**
- Raise InvalidArgsError with body
```
{
        "message": json.dumps(error_messages),
        "code": InvalidArgError.code,
        "type": InvalidArgError.error_type,
        "link": InvalidArgError.link
}
```

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
Yes

* **Related Python client changes** (link commit/PR here)
Not needed.

* **Related documentation changes** (link commit/PR here)
Same


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

