### PR TITLE
Validate index setting parameters when creating index

### DIFF
--- a/src/marqo/tensor_search/backend.py
+++ b/src/marqo/tensor_search/backend.py
@@ -78,7 +78,6 @@ def add_customer_field_properties(config: Config, index_name: str,
     Returns:
         HTTP Response
     """
-    engine = "lucene"
     existing_info = get_cached_index_info(config=config, index_name=index_name)
 
     # check if there is multimodal fie;ds and convert the fields name to a list with the same

--- a/src/marqo/tensor_search/configs.py
+++ b/src/marqo/tensor_search/configs.py
@@ -39,7 +39,6 @@ def get_default_ann_parameters():
         }
     }
 
-
 def default_env_vars() -> dict:
     """Returns a dict of default env vars.
     This is used by utils.read_env_vars_and_defaults() as the source for

--- a/src/marqo/tensor_search/models/settings_object.py
+++ b/src/marqo/tensor_search/models/settings_object.py
@@ -101,12 +101,21 @@ settings_schema = {
                     "properties": {
                         NsFields.ann_method: {
                             "type": "string",
+                            "enum": ["hnsw"],
                             "examples": [
                                 "hnsw"
                             ]
                         },
+                        NsFields.ann_engine: {
+                            "type": "string",
+                            "enum": ["lucene"],
+                            "examples": [
+                                "lucene"
+                            ]
+                        },
                         NsFields.ann_metric: {
                             "type": "string",
+                            "enum": ["l1", "l2", "linf", "cosinesimil"],
                             "examples": [
                                 "cosinesimil"
                             ]
@@ -117,12 +126,14 @@ settings_schema = {
                             "properties": {
                                 NsFields.hnsw_ef_construction: {
                                     "type": "integer",
+                                    "minimum": 1,
                                     "examples": [
                                         128
                                     ]
                                 },
                                 NsFields.hnsw_m: {
                                     "type": "integer",
+                                    "minimum": 1,
                                     "examples": [
                                         16
                                     ]
@@ -136,6 +147,7 @@ settings_schema = {
                     },
                     "examples": [{
                         NsFields.ann_method: "hnsw",
+                        NsFields.ann_engine: "lucene",
                         NsFields.ann_metric: "cosinesimil",
                         NsFields.ann_method_parameters: {
                             NsFields.hnsw_ef_construction: 128,
@@ -158,6 +170,7 @@ settings_schema = {
                 },
                 NsFields.ann_parameters: {
                     NsFields.ann_method: "hnsw",
+                    NsFields.ann_engine: "lucene",
                     NsFields.ann_metric: "cosinesimil",
                     NsFields.ann_method_parameters: {
                         NsFields.hnsw_ef_construction: 128,
@@ -196,6 +209,7 @@ settings_schema = {
             },
             NsFields.ann_parameters: {
                 NsFields.ann_method: "hnsw",
+                NsFields.ann_engine: "lucene",
                 NsFields.ann_metric: "cosinesimil",
                 NsFields.ann_method_parameters: {
                     NsFields.hnsw_ef_construction: 128,


### PR DESCRIPTION
# Changes
 - Validate `"ann_parameters"` index settings at creation time.
 - Currently, these settings, even if invalid, are stored as the index settings. It is only when we use these settings (e.g. `add_documents`), that an error occurs.
 - This PR validates correct parameters settings when we `create_index`