### PR TITLE
Fixed bug in test_use_existing_tensors_all_data_types

### DIFF
--- a/tests/tensor_search/test_add_documents.py
+++ b/tests/tensor_search/test_add_documents.py
@@ -714,6 +714,7 @@ class TestAddDocuments(MarqoTestCase):
             updated_doc = tensor_search.get_document_by_id(
                 config=self.config, index_name=self.index_name_1, document_id=doc_id
             )
+
             for field, expected_value in check_dict.items():
                 assert updated_doc[field] == expected_value
 

--- a/tests/tensor_search/test_add_documents_use_existing_tensors.py
+++ b/tests/tensor_search/test_add_documents_use_existing_tensors.py
@@ -53,10 +53,12 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
         r2 = tensor_search.add_documents(
             config=self.config, index_name=self.index_name_1, docs=[d1, d1],
             auto_refresh=True, use_existing_tensors=True)
+
         for item in r1['items']:
             assert item['result'] == 'created'
         for item in r2['items']:
             assert item['result'] == 'created'
+        
 
     def test_use_existing_tensors_non_existing(self):
         """check parity between a doc created with and without use_existing_tensors, then overwritten,
@@ -504,17 +506,20 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
         Ensure no errors occur even with chunkless docs. (only int, only bool, etc)
         Replacing doc doesn't change the content
         """
+        self.maxDiff = None
+
         doc_args = [
             # Each doc only has 1 type
-            [{"_id": "1", "title": "hello world"},
-            {"_id": "2", "title": True},
-            {"_id": "3", "title": 12345},
-            {"_id": "4", "title": [1, 2, 3]}],
+            [{"_id": "1", "field1": "hello world"},
+            {"_id": "2", "field2": True},
+            {"_id": "3", "field3": 12345},
+            {"_id": "4", "field4": [1, 2, 3]}],
 
             # Doc with all types
-            [{"_id": "1", "field1": "hello world", "field2": True, "field3": 12345, "field4": [1, 2, 3]}]
+            [{"_id": "1", "field1": "hello world", "field2": True, "field3": 12345, "field4": [1, 2, 3]}],
         ]
-        
+
+
         for doc_arg in doc_args:
             # Add doc normally without use_existing_tensors
             add_res = tensor_search.add_documents(
@@ -534,4 +539,4 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
                 config=self.config, index_name=self.index_name_1,
                 document_ids=[doc["_id" ]for doc in doc_arg], show_vectors=True)
             
-            self.assertEqual(d1, d2)
+            self.assertAlmostEqual(d1, d2)

--- a/tests/tensor_search/test_add_documents_use_existing_tensors.py
+++ b/tests/tensor_search/test_add_documents_use_existing_tensors.py
@@ -538,5 +538,5 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
             d2 = tensor_search.get_documents_by_ids(
                 config=self.config, index_name=self.index_name_1,
                 document_ids=[doc["_id" ]for doc in doc_arg], show_vectors=True)
-            
-            self.assertAlmostEqual(d1, d2)
+
+            self.assertEqual(d1, d2)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
Every 3-4 runs of unit tests in github actions, an assertion error occurs with `test_use_existing_tensors_all_data_types`

* **What is the new behavior (if this is a feature change)?**
Errors no longer occur in the test (see runs unit_test_CI #365 to unit_test_CI #370)
- Test uses `assertAlmostEqual` instead of `assertEqual`
- Fixed error of multiple documents adding values of different datatypes to `Title` field

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
Yes


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

