### PR TITLE
Revert "Call `_cat/shards/{index_name}?format=json` to get number_of_shards (#437)"

### DIFF
--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -15,6 +15,7 @@ from marqo.tensor_search.models.api_models import BulkSearchQuery, SearchQuery
 from marqo.tensor_search.web import api_validation, api_utils
 from marqo.tensor_search.on_start_script import on_start
 from marqo import version
+from marqo.tensor_search.backend import get_index_info
 from marqo.tensor_search.enums import RequestType
 from marqo.tensor_search.throttling.redis_throttle import throttle
 from marqo.tensor_search.utils import add_timing
@@ -261,7 +262,9 @@ def get_indexes(marqo_config: config.Config = Depends(generate_config)):
 
 @app.get("/indexes/{index_name}/settings")
 def get_settings(index_name: str, marqo_config: config.Config = Depends(generate_config)):
-    return tensor_search.get_settings(index_name, marqo_config)
+    index_info = get_index_info(config=marqo_config, index_name=index_name)
+    return index_info.index_settings
+
 
 @app.get("/models")
 def get_loaded_models():

--- a/src/marqo/tensor_search/backend.py
+++ b/src/marqo/tensor_search/backend.py
@@ -17,12 +17,6 @@ from marqo.tensor_search.index_meta_cache import get_index_info as get_cached_in
 import pprint
 
 
-def get_num_shards(config: Config, index_name: str) -> int:
-    """Returns the number of shards assigned to an index from Opensearch"""
-    resp  = HttpRequests(config).get(path=F"_cat/shards/{index_name}?format=json")
-    return len(set(d["shard"] for d in resp))
-
-
 def get_index_info(config: Config, index_name: str) -> IndexInfo:
     """Gets useful information about the index. Also updates the IndexInfo cache
 

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -2572,13 +2572,3 @@ def delete_documents(config: Config, index_name: str, doc_ids: List[str], auto_r
             document_ids=doc_ids,
             auto_refresh=auto_refresh)
     )
-
-
-def get_settings(index_name: str, marqo_config: Config):
-    """Get the settings for a specific index."""
-    shards = backend.get_num_shards(config=marqo_config, index_name=index_name)
-
-    index_info = backend.get_index_info(config=marqo_config, index_name=index_name)
-    index_info.index_settings["number_of_shards"] = shards
-
-    return index_info.index_settings

--- a/tests/tensor_search/test_backend.py
+++ b/tests/tensor_search/test_backend.py
@@ -1,16 +1,14 @@
 import copy
 import json
 import pprint
-from unittest import mock
 
 import requests
-
 from marqo.tensor_search import enums, backend, utils
 from marqo.tensor_search import tensor_search
 from marqo.tensor_search.configs import get_default_ann_parameters
-from marqo.tensor_search.models.index_info import IndexInfo
 from marqo.errors import MarqoApiError, IndexNotFoundError
 from tests.marqo_test import MarqoTestCase
+from unittest import mock
 
 
 class TestBackend(MarqoTestCase):
@@ -47,35 +45,6 @@ class TestBackend(MarqoTestCase):
                 config=self.config, index_name=self.index_name_1)
         except IndexNotFoundError as s:
             pass
-
-    @mock.patch('marqo._httprequests.HttpRequests.get', side_effect=[
-        [
-            {
-                "index": "my-test-index-1",
-                "shard": f"{i}",
-                "prirep": "r",
-                "state": "UNASSIGNED",
-                "docs": None,
-                "store": None,
-                "ip": None,
-                "node": None
-            } for i in range(10)
-        ] + [
-            {
-                "index": "my-test-index-1",
-                "shard": f"{i}",
-                "prirep": "p",
-                "state": "UNASSIGNED",
-                "docs": None,
-                "store": None,
-                "ip": None,
-                "node": None
-            } for i in range(10)
-        ]
-    ])
-    def test_get_num_shards(self, mock_http_get):
-        assert backend.get_num_shards(config=self.config, index_name=self.index_name_1) == 10
-        mock_http_get.assert_called_with(path=F"_cat/shards/{self.index_name_1}?format=json")
 
     def test_get_cluster_indices(self):
         tensor_search.create_vector_index(

--- a/tests/tensor_search/test_get_settings.py
+++ b/tests/tensor_search/test_get_settings.py
@@ -1,9 +1,6 @@
-from unittest import mock
-
-from marqo.errors import IndexNotFoundError
 from tests.marqo_test import MarqoTestCase
-from marqo.tensor_search.models.index_info import IndexInfo
 from marqo.tensor_search import tensor_search, backend
+from marqo.errors import IndexNotFoundError
 
 
 class TestGetSettings(MarqoTestCase):
@@ -68,17 +65,3 @@ class TestGetSettings(MarqoTestCase):
         self.assertIn('number_of_shards', index_settings)
         self.assertIn('number_of_replicas', index_settings)
         self.assertTrue(fields.issubset(set(index_settings['index_defaults'])))
-
-
-    @mock.patch("marqo.tensor_search.backend.get_index_info", return_value=IndexInfo(
-        index_settings={"number_of_shards": 5}, model_name="model_name", properties={}
-    ))
-    @mock.patch('marqo._httprequests.HttpRequests.get', side_effect=[[{"shard": f"{i}"} for i in range(10)]])
-    def test_get_settings_ensure_shard_count_call(self, mock_http_get, mock_get_index_info):
-        tensor_search.create_vector_index(
-            config=self.config, index_name=self.index_name
-        )
-        index_settings = tensor_search.get_settings(
-            marqo_config=self.config, index_name=self.index_name)
-
-        assert index_settings["number_of_shards"] == 10 


### PR DESCRIPTION
This reverts commit [36f8c079cb99337f3b4de452e49521b978846f0a](https://github.com/marqo-ai/marqo/tree/36f8c079cb99337f3b4de452e49521b978846f0a).