### PR TITLE
Lexical search filter string with `.`

### DIFF
--- a/tests/tensor_search/test_lexical_search.py
+++ b/tests/tensor_search/test_lexical_search.py
@@ -512,4 +512,3 @@ class TestLexicalSearch(MarqoTestCase):
 
         assert len(res["hits"]) == 3, "this is a bug at the moment. the filter is not applied. " \
                                       "fix it will introduce the error."
-

--- a/tests/tensor_search/test_lexical_search.py
+++ b/tests/tensor_search/test_lexical_search.py
@@ -7,6 +7,8 @@ import copy
 from marqo.errors import InvalidArgError, IndexNotFoundError
 from tests.marqo_test import MarqoTestCase
 import random
+import requests
+import json
 
 class TestLexicalSearch(MarqoTestCase):
 
@@ -480,3 +482,34 @@ class TestLexicalSearch(MarqoTestCase):
         res_wrong_attr = tensor_search.search(
             **{**base_search_args, "searchable_attributes": ["abc"]})
         assert len(res_wrong_attr['hits']) == 0
+
+    def test_lexical_search_filter_with_dot(self):
+        tensor_search.add_documents(
+            config=self.config, index_name=self.index_name_1, docs=[
+                {"content": "a man on a horse", "filename" : "Important_File_1.pdf", "_id":"123"},
+                {"content": "the horse is eating grass", "filename": "Important_File_2.pdf", "_id": "456"},
+                {"content": "what is the document", "filename": "Important_File_3.pdf", "_id": "789"},
+
+            ], auto_refresh=True)
+
+        res = tensor_search._lexical_search(config=self.config, index_name=self.index_name_1,
+                                            text="horse", return_doc_ids=True, searchable_attributes=["content"],
+                                            filter_string="filename: \"Important_File_1.pdf\"", result_count=8)
+
+        assert len(res["hits"]) == 1
+        assert res["hits"][0]["_id"] == "123"
+
+        res = tensor_search._vector_text_search(config=self.config, index_name=self.index_name_1,
+                                            query="horse", return_doc_ids=True, searchable_attributes=["content"],
+                                            filter_string="filename: Important_File_1.pdf", result_count=8)
+
+        assert len(res["hits"]) == 1
+        assert res["hits"][0]["_id"] == "123"
+
+        res = tensor_search._lexical_search(config=self.config, index_name=self.index_name_1,
+                                            text="horse", return_doc_ids=True, searchable_attributes=["content"],
+                                            filter_string="filename: Important_File_1.pdf", result_count=8)
+
+        assert len(res["hits"]) == 3, "this is a bug at the moment. the filter is not applied. " \
+                                      "fix it will introduce the error."
+


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
add test for `.` in filter string for lexical search and tensor search

* **What is the current behavior?** (You can also link to an open issue here)
we don't have test for these cases

* **What is the new behavior (if this is a feature change)?**
add new tests

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
yes

* **Related Python client changes** (link commit/PR here)
no

* **Related documentation changes** (link commit/PR here)
no

* **Other information**:

The primary difference in behavior between the query_string query within a bool query and the knn query is due to their distinct search mechanisms and how they process the query string.

The query_string query is a lexical search query designed to work with text fields. When using a query_string query, the search text is analyzed and tokenized based on the specified analyzer. This may require using double quotes for exact matches, especially when dealing with special characters like a dot (.).

The knn query is designed specifically for vector similarity searches, which typically work with numeric vector fields rather than text fields. The knn query does not tokenize or analyze the field value, so it does not require double quotes to perform an exact match.

The differences in behavior stem from the fact that these queries process the query string differently based on their specific search mechanisms and purposes.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

