### PR TITLE
Preload / Prewarm custom models via URL on startup

### DIFF
--- a/src/marqo/s2_inference/s2_inference.py
+++ b/src/marqo/s2_inference/s2_inference.py
@@ -172,7 +172,7 @@ def _update_available_models(model_cache_key: str, model_name: str, validated_mo
                     f"and Marqo has access to the weights file.")
     else:
         most_recently_used_time = datetime.datetime.now()
-        logger.debug(f'renew {model_name} on device {device} with new time={most_recently_used_time}.')
+        logger.debug(f'renewed {model_name} on device {device} with new most recently time={most_recently_used_time}.')
         try:
             available_models[model_cache_key][AvailableModelsKey.most_recently_used_time] = most_recently_used_time
         except KeyError:

--- a/src/marqo/tensor_search/on_start_script.py
+++ b/src/marqo/tensor_search/on_start_script.py
@@ -182,8 +182,8 @@ def _preload_model(model, content, device):
             )
         except KeyError as e:
             raise errors.EnvVarError(
-                f"Your custom model {model} is missing either `model_name` or `model_properties`."
-                f"""To add a custom model, it must be a dict with keys `model` and `model_properties` as defined in `https://marqo.pages.dev/0.0.20/Models-Reference/bring_your_own_model/`"""
+                f"Your custom model {model} is missing either `model` or `model_properties`."
+                f"""To add a custom model, it must be a dict with keys `model` and `model_properties` as defined in `https://marqo.pages.dev/0.0.20/Advanced-Usage/configuration/#configuring-preloaded-models`"""
             ) from e
 
 

--- a/src/marqo/tensor_search/on_start_script.py
+++ b/src/marqo/tensor_search/on_start_script.py
@@ -12,6 +12,7 @@ from marqo._httprequests import HttpRequests
 from marqo import errors
 from marqo.tensor_search.throttling.redis_throttle import throttle
 from marqo.connections import redis_driver
+from marqo.s2_inference.s2_inference import vectorise
 
 
 def on_start(marqo_os_url: str):
@@ -131,7 +132,6 @@ class ModelsForCacheing:
         test_string = 'this is a test string'
         N = 10
         messages = []
-        self.logger.debug(f"DEBUG Models to load: {self.models}")
         for model in self.models:
             for device in self.default_devices:
                 self.logger.debug(f"Beginning loading for model: {model} on device: {device}")
@@ -162,7 +162,6 @@ def _preload_model(model, content, device):
         If `model is a dict, it should be an object containing `model_name` and `model_properties`
         Model properties will be passed to vectorise call if object exists
     """
-    from marqo.s2_inference.s2_inference import vectorise
     if isinstance(model, str):
         # For models IN REGISTRY
         _ = vectorise(

--- a/src/marqo/tensor_search/on_start_script.py
+++ b/src/marqo/tensor_search/on_start_script.py
@@ -120,8 +120,6 @@ class ModelsForCacheing:
                 ) from e
         else:
             self.models = warmed_models
-        
-        self.logger.debug(f"self.models is of data type {type(self.models)}. The value is {self.models}")
         # TBD to include cross-encoder/ms-marco-TinyBERT-L-2-v2
 
         self.default_devices = ['cpu'] if not torch.cuda.is_available() else ['cpu', 'cuda']

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.19"
+__version__ = "0.0.20"
 
 
 def get_version() -> str:

--- a/tests/tensor_search/test_on_start_script.py
+++ b/tests/tensor_search/test_on_start_script.py
@@ -85,7 +85,8 @@ class TestOnStartScript(MarqoTestCase):
             "open_clip", 
             "https://github.com/mlfoundations/open_clip/releases/download/v0.2-weights/vit_b_32-quickgelu-laion400m_avg-8a00ab3c.pt"
         )
-
+        
+        # So far has clip and open clip tests
         environ_expected_models = [
             ({enums.EnvVars.MARQO_MODELS_TO_PRELOAD: [clip_model_object, open_clip_model_object]}, [clip_model_expected, open_clip_model_expected]),
             ({enums.EnvVars.MARQO_MODELS_TO_PRELOAD: json.dumps([clip_model_object, open_clip_model_object])}, [clip_model_expected, open_clip_model_expected])

--- a/tests/tensor_search/test_on_start_script.py
+++ b/tests/tensor_search/test_on_start_script.py
@@ -10,7 +10,7 @@ from marqo import errors
 
 class TestOnStartScript(MarqoTestCase):
 
-    def test_preload_models(self):
+    def test_preload_registry_models(self):
         environ_expected_models = [
             ({enums.EnvVars.MARQO_MODELS_TO_PRELOAD: []}, []),
             ({enums.EnvVars.MARQO_MODELS_TO_PRELOAD: ""}, []),
@@ -47,6 +47,36 @@ class TestOnStartScript(MarqoTestCase):
                 print(str(e))
                 return True
         assert run()
+    
+    def test_preload_url_models(self):
+        environ_expected_models = [
+        ]
+        for mock_environ, expected in environ_expected_models:
+            mock_vectorise = mock.MagicMock()
+            @mock.patch("os.environ", mock_environ)
+            @mock.patch("marqo.s2_inference.s2_inference.vectorise", mock_vectorise)
+            def run():
+                model_caching_script = on_start_script.ModelsForCacheing()
+                model_caching_script.run()
+                loaded_models = {args[0] for args, kwargs in mock_vectorise.call_args_list}
+                assert loaded_models == set(expected)
+                return True
+            assert run()
+    
+    def test_preload_url_models_malformed(self):
+        environ_expected_models = [
+        ]
+        for mock_environ, expected in environ_expected_models:
+            mock_vectorise = mock.MagicMock()
+            @mock.patch("os.environ", mock_environ)
+            @mock.patch("marqo.s2_inference.s2_inference.vectorise", mock_vectorise)
+            def run():
+                model_caching_script = on_start_script.ModelsForCacheing()
+                model_caching_script.run()
+                loaded_models = {args[0] for args, kwargs in mock_vectorise.call_args_list}
+                assert loaded_models == set(expected)
+                return True
+            assert run()
 
 
 

--- a/tests/tensor_search/test_on_start_script.py
+++ b/tests/tensor_search/test_on_start_script.py
@@ -28,11 +28,11 @@ class TestOnStartScript(MarqoTestCase):
         for mock_environ, expected in environ_expected_models:
             mock_vectorise = mock.MagicMock()
             @mock.patch("os.environ", mock_environ)
-            @mock.patch("marqo.s2_inference.s2_inference.vectorise", mock_vectorise)
+            @mock.patch("marqo.tensor_search.on_start_script.vectorise", mock_vectorise)
             def run():
                 model_caching_script = on_start_script.ModelsForCacheing()
                 model_caching_script.run()
-                loaded_models = {args[0] for args, kwargs in mock_vectorise.call_args_list}
+                loaded_models = {kwargs["model_name"] for args, kwargs in mock_vectorise.call_args_list}
                 assert loaded_models == set(expected)
                 return True
             assert run()
@@ -49,35 +49,108 @@ class TestOnStartScript(MarqoTestCase):
         assert run()
     
     def test_preload_url_models(self):
+        clip_model_object = {
+            "model": "generic-clip-test-model-2",
+            "model_properties": {
+                "name": "ViT-B/32",
+                "dimensions": 512,
+                "type": "clip",
+                "url": "https://openaipublic.azureedge.net/clip/models/40d365715913c9da98579312b702a82c18be219cc2a73407c4526f58eba950af/ViT-B-32.pt"
+            }
+        }
+
+        clip_model_expected = (
+            "generic-clip-test-model-2", 
+            "ViT-B/32", 
+            512, 
+            "clip", 
+            "https://openaipublic.azureedge.net/clip/models/40d365715913c9da98579312b702a82c18be219cc2a73407c4526f58eba950af/ViT-B-32.pt"
+        )
+
+        open_clip_model_object = {
+            "model": "random-open-clip-1",
+            "model_properties": {
+                "name": "ViT-B-32-quickgelu",
+                "dimensions": 512,
+                "type": "open_clip",
+                "url": "https://github.com/mlfoundations/open_clip/releases/download/v0.2-weights/vit_b_32-quickgelu-laion400m_avg-8a00ab3c.pt"
+            }
+        }
+
+        # must be an immutable datatype
+        open_clip_model_expected = (
+            "random-open-clip-1", 
+            "ViT-B-32-quickgelu", 
+            512, 
+            "open_clip", 
+            "https://github.com/mlfoundations/open_clip/releases/download/v0.2-weights/vit_b_32-quickgelu-laion400m_avg-8a00ab3c.pt"
+        )
+
         environ_expected_models = [
+            ({enums.EnvVars.MARQO_MODELS_TO_PRELOAD: [clip_model_object, open_clip_model_object]}, [clip_model_expected, open_clip_model_expected]),
+            ({enums.EnvVars.MARQO_MODELS_TO_PRELOAD: json.dumps([clip_model_object, open_clip_model_object])}, [clip_model_expected, open_clip_model_expected])
         ]
         for mock_environ, expected in environ_expected_models:
             mock_vectorise = mock.MagicMock()
             @mock.patch("os.environ", mock_environ)
-            @mock.patch("marqo.s2_inference.s2_inference.vectorise", mock_vectorise)
+            @mock.patch("marqo.tensor_search.on_start_script.vectorise", mock_vectorise)
             def run():
                 model_caching_script = on_start_script.ModelsForCacheing()
                 model_caching_script.run()
-                loaded_models = {args[0] for args, kwargs in mock_vectorise.call_args_list}
+                loaded_models = {
+                    (
+                        kwargs["model_name"],
+                        kwargs["model_properties"]["name"],
+                        kwargs["model_properties"]["dimensions"],
+                        kwargs["model_properties"]["type"],
+                        kwargs["model_properties"]["url"]
+                    )
+                    for args, kwargs in mock_vectorise.call_args_list
+                }
                 assert loaded_models == set(expected)
                 return True
             assert run()
     
-    def test_preload_url_models_malformed(self):
-        environ_expected_models = [
-        ]
-        for mock_environ, expected in environ_expected_models:
-            mock_vectorise = mock.MagicMock()
-            @mock.patch("os.environ", mock_environ)
-            @mock.patch("marqo.s2_inference.s2_inference.vectorise", mock_vectorise)
-            def run():
+    def test_preload_url_missing_model(self):
+        open_clip_model_object = {
+            "model_properties": {
+                "name": "ViT-B-32-quickgelu",
+                "dimensions": 512,
+                "type": "open_clip",
+                "url": "https://github.com/mlfoundations/open_clip/releases/download/v0.2-weights/vit_b_32-quickgelu-laion400m_avg-8a00ab3c.pt"
+            }
+        }
+        mock_vectorise = mock.MagicMock()
+        @mock.patch("marqo.tensor_search.on_start_script.vectorise", mock_vectorise)
+        @mock.patch("os.environ", {enums.EnvVars.MARQO_MODELS_TO_PRELOAD: [open_clip_model_object]})
+        def run():
+            try:
                 model_caching_script = on_start_script.ModelsForCacheing()
+                # There should be a KeyError -> EnvVarError when attempting to call vectorise
                 model_caching_script.run()
-                loaded_models = {args[0] for args, kwargs in mock_vectorise.call_args_list}
-                assert loaded_models == set(expected)
+                raise AssertionError
+            except errors.EnvVarError as e:
                 return True
-            assert run()
-
+        assert run()
+    
+    def test_preload_url_missing_model_properties(self):
+        open_clip_model_object = {
+            "model": "random-open-clip-1"
+        }
+        mock_vectorise = mock.MagicMock()
+        @mock.patch("marqo.tensor_search.on_start_script.vectorise", mock_vectorise)
+        @mock.patch("os.environ", {enums.EnvVars.MARQO_MODELS_TO_PRELOAD: [open_clip_model_object]})
+        def run():
+            try:
+                model_caching_script = on_start_script.ModelsForCacheing()
+                # There should be a KeyError -> EnvVarError when attempting to call vectorise
+                model_caching_script.run()
+                raise AssertionError
+            except errors.EnvVarError as e:
+                return True
+        assert run()
+    
+    # TODO: test bad/no names/URLS in end-to-end tests, as this logic is done in vectorise call
 
 
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
Currently, the env var only accepts strings.

* **What is the new behavior (if this is a feature change)?**
This allows the env var `MARQO_MODELS_TO_PRELOAD` to accept custom models as dicts with `model` and `model_properties`. A sample declaration would look like this:

```
export MARQO_MODELS_TO_PRELOAD='[
        "ViT-L/14",
         {
            "model": "generic-clip-test-model-2",
            "model_properties": {
                "name": "ViT-B/32",
                "dimensions": 512,
                "type": "clip",
                "url": "https://openaipublic.azureedge.net/clip/models/40d365715913c9da98579312b702a82c18be219cc2a73407c4526f58eba950af/ViT-B-32.pt"
            }
        }
    ]'
```

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
Manual testing. Application tests will be made once the env var customization feature in Marqo API tests finishes

* **Related documentation changes** (link commit/PR here)
To follow

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

