### PR TITLE
Using 16gb RAM arm64 machine for CI pipeline

### DIFF
--- a/.github/workflows/arm64_local_os_CI.yml
+++ b/.github/workflows/arm64_local_os_CI.yml
@@ -42,7 +42,7 @@ jobs:
 
           # ARM Runner Image
           ec2-image-id: ${{ secrets.ARM_EC2_IMAGE_ID }}
-          ec2-instance-type: a1.xlarge
+          ec2-instance-type: a1.2xlarge
           subnet-id: ${{ secrets.ARM_SUBNET_ID }}
           security-group-id: ${{ secrets.ARM_SECURITY_GROUP_ID }}
 

--- a/.github/workflows/arm64_local_os_CI.yml
+++ b/.github/workflows/arm64_local_os_CI.yml
@@ -42,7 +42,7 @@ jobs:
 
           # ARM Runner Image
           ec2-image-id: ${{ secrets.ARM_EC2_IMAGE_ID }}
-          ec2-instance-type: a1.2xlarge
+          ec2-instance-type: t4g.xlarge
           subnet-id: ${{ secrets.ARM_SUBNET_ID }}
           security-group-id: ${{ secrets.ARM_SECURITY_GROUP_ID }}
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
arm64 CI pipeline consistently breaks. This is probably due to the existing arm64 runner only has 8 GB RAM

* **What is the new behavior (if this is a feature change)?**
switch arm64 runner type to t4g.xlarge (which has 16 GB RAM)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No 

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
arm64 API test, passes. 

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

