### PR TITLE
Refactor Add_documents API

### DIFF
--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -169,6 +169,7 @@ def search(search_query: SearchQuery, index_name: str, device: str = Depends(api
 @app.post("/indexes/{index_name}/documents")
 @throttle(RequestType.INDEX)
 def add_or_replace_documents(
+        request: Request,
         body: typing.Union[AddDocsBodyParamsNew, AddDocsBodyParamsOld],
         index_name: str,
         refresh: bool = True,
@@ -185,7 +186,7 @@ def add_or_replace_documents(
         mappings: Optional[dict] = Depends(api_utils.decode_mappings)):
 
     """add_documents endpoint (replace existing docs with the same id)"""
-    add_docs_params = api_utils.add_docs_params_ochestrator(index_name=index_name, body=body, auto_refresh=refresh,
+    add_docs_params = api_utils.add_docs_params_ochestrator(request=request, index_name=index_name, body=body, auto_refresh=refresh,
         device=device, non_tensor_fields=non_tensor_fields, use_existing_tensors=use_existing_tensors,
         image_download_headers=image_download_headers, mappings=mappings, model_auth=model_auth)
 

--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -191,7 +191,8 @@ def add_or_replace_documents(
                                                              non_tensor_fields=non_tensor_fields, mappings=mappings,
                                                              model_auth=model_auth,
                                                              image_download_headers=image_download_headers,
-                                                             use_existing_tensors=use_existing_tensors, query_parameters=request.query_params)
+                                                             use_existing_tensors=use_existing_tensors,
+                                                             query_parameters=request.query_params)
 
     with RequestMetricsStore.for_request().time(f"POST /indexes/{index_name}/documents"):
         return tensor_search.add_documents(

--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -186,12 +186,12 @@ def add_or_replace_documents(
         mappings: Optional[dict] = Depends(api_utils.decode_mappings)):
 
     """add_documents endpoint (replace existing docs with the same id)"""
-    add_docs_params = api_utils.add_docs_params_orchestrator(request=request, index_name=index_name, body=body,
+    add_docs_params = api_utils.add_docs_params_orchestrator(index_name=index_name, body=body,
                                                              device=device, auto_refresh=refresh,
                                                              non_tensor_fields=non_tensor_fields, mappings=mappings,
                                                              model_auth=model_auth,
                                                              image_download_headers=image_download_headers,
-                                                             use_existing_tensors=use_existing_tensors)
+                                                             use_existing_tensors=use_existing_tensors, query_parameters=request.query_params)
 
     with RequestMetricsStore.for_request().time(f"POST /indexes/{index_name}/documents"):
         return tensor_search.add_documents(

--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -186,9 +186,12 @@ def add_or_replace_documents(
         mappings: Optional[dict] = Depends(api_utils.decode_mappings)):
 
     """add_documents endpoint (replace existing docs with the same id)"""
-    add_docs_params = api_utils.add_docs_params_ochestrator(request=request, index_name=index_name, body=body, auto_refresh=refresh,
-        device=device, non_tensor_fields=non_tensor_fields, use_existing_tensors=use_existing_tensors,
-        image_download_headers=image_download_headers, mappings=mappings, model_auth=model_auth)
+    add_docs_params = api_utils.add_docs_params_orchestrator(request=request, index_name=index_name, body=body,
+                                                             device=device, auto_refresh=refresh,
+                                                             non_tensor_fields=non_tensor_fields, mappings=mappings,
+                                                             model_auth=model_auth,
+                                                             image_download_headers=image_download_headers,
+                                                             use_existing_tensors=use_existing_tensors)
 
     with RequestMetricsStore.for_request().time(f"POST /indexes/{index_name}/documents"):
         return tensor_search.add_documents(

--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -15,8 +15,8 @@ from marqo.errors import InvalidArgError, MarqoWebError, MarqoError, BadRequestE
 from marqo.tensor_search import tensor_search
 from marqo.tensor_search.backend import get_index_info
 from marqo.tensor_search.enums import RequestType
-from marqo.tensor_search.models.add_docs_objects import (AddDocsParams, ModelAuth, AddDocsBodyParamsOld,
-                                                         AddDocsBodyParamsNew)
+from marqo.tensor_search.models.add_docs_objects import (AddDocsParams, ModelAuth,
+                                                         AddDocsBodyParams)
 from marqo.tensor_search.models.api_models import BulkSearchQuery, SearchQuery
 from marqo.tensor_search.on_start_script import on_start
 from marqo.tensor_search.telemetry import RequestMetricsStore, TelemetryMiddleware
@@ -170,7 +170,7 @@ def search(search_query: SearchQuery, index_name: str, device: str = Depends(api
 @throttle(RequestType.INDEX)
 def add_or_replace_documents(
         request: Request,
-        body: typing.Union[AddDocsBodyParamsNew, List[Dict]],
+        body: typing.Union[AddDocsBodyParams, List[Dict]],
         index_name: str,
         refresh: bool = True,
         marqo_config: config.Config = Depends(generate_config),

--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -170,7 +170,7 @@ def search(search_query: SearchQuery, index_name: str, device: str = Depends(api
 @throttle(RequestType.INDEX)
 def add_or_replace_documents(
         request: Request,
-        body: typing.Union[AddDocsBodyParamsNew, AddDocsBodyParamsOld],
+        body: typing.Union[AddDocsBodyParamsNew, List[Dict]],
         index_name: str,
         refresh: bool = True,
         marqo_config: config.Config = Depends(generate_config),

--- a/src/marqo/tensor_search/models/add_docs_objects.py
+++ b/src/marqo/tensor_search/models/add_docs_objects.py
@@ -9,11 +9,23 @@ from marqo.tensor_search.enums import EnvVars
 from marqo.errors import InternalError
 from pydantic import BaseModel
 from marqo.tensor_search.utils import get_best_available_device
+from typing import List, Dict
 
 
 class AddDocsParamsConfig:
     arbitrary_types_allowed = True
 
+
+class AddDocsBodyParamsOld(BaseModel):
+    __root__: List[Dict]
+
+class AddDocsBodyParamsNew(BaseModel):
+    non_tensor_fields: List[str] = []
+    use_existing_tensors: bool = False
+    image_download_headers: Optional[dict]
+    model_auth: Optional[ModelAuth]
+    mappings: Optional[dict]
+    documents: List[Dict]
 
 class AddDocsParams(BaseModel):
     """Represents the parameters of the tensor_search.add_documents() function

--- a/src/marqo/tensor_search/models/add_docs_objects.py
+++ b/src/marqo/tensor_search/models/add_docs_objects.py
@@ -25,10 +25,10 @@ class AddDocsBodyParamsNew(BaseModel):
         arbitrary_types_allowed = True
         allow_mutation = False
 
-    non_tensor_fields: List = Field(default_factory=list)
-    use_existing_tensors: bool = False
-    image_download_headers: dict = Field(default_factory=dict)
-    model_auth: Optional[ModelAuth] = None
+    nonTensorFields: List = Field(default_factory=list)
+    useExistingTensors: bool = False
+    imageDownloadHeaders: dict = Field(default_factory=dict)
+    modelAuth: Optional[ModelAuth] = None
     mappings: Optional[dict] = None
     documents: Union[Sequence[Union[dict, Any]], np.ndarray]
 

--- a/src/marqo/tensor_search/models/add_docs_objects.py
+++ b/src/marqo/tensor_search/models/add_docs_objects.py
@@ -16,11 +16,8 @@ class AddDocsParamsConfig:
     arbitrary_types_allowed = True
 
 
-class AddDocsBodyParamsOld(BaseModel):
-    __root__: List[Union[dict, Any]]
-
-
-class AddDocsBodyParamsNew(BaseModel):
+class AddDocsBodyParams(BaseModel):
+    """The parameters of the body parameters of tensor_search_add_documents() function"""
     class Config:
         arbitrary_types_allowed = True
         allow_mutation = False
@@ -32,6 +29,7 @@ class AddDocsBodyParamsNew(BaseModel):
     modelAuth: Optional[ModelAuth] = None
     mappings: Optional[dict] = None
     documents: Union[Sequence[Union[dict, Any]], np.ndarray]
+
 
 class AddDocsParams(BaseModel):
     """Represents the parameters of the tensor_search.add_documents() function

--- a/src/marqo/tensor_search/models/add_docs_objects.py
+++ b/src/marqo/tensor_search/models/add_docs_objects.py
@@ -17,15 +17,23 @@ class AddDocsParamsConfig:
 
 
 class AddDocsBodyParamsOld(BaseModel):
-    documents: List[Dict]
+    class Config:
+        arbitrary_types_allowed = True
+        allow_mutation = False
+
+    documents: Union[Sequence[Union[dict, Any]], np.ndarray]
 
 class AddDocsBodyParamsNew(BaseModel):
-    non_tensor_fields: List[str] = []
+    class Config:
+        arbitrary_types_allowed = True
+        allow_mutation = False
+
+    non_tensor_fields: List = Field(default_factory=list)
     use_existing_tensors: bool = False
-    image_download_headers: Optional[dict]
-    model_auth: Optional[ModelAuth]
-    mappings: Optional[dict]
-    documents: List[Dict]
+    image_download_headers: dict = Field(default_factory=dict)
+    model_auth: Optional[ModelAuth] = None
+    mappings: Optional[dict] = None
+    documents: Union[Sequence[Union[dict, Any]], np.ndarray]
 
 class AddDocsParams(BaseModel):
     """Represents the parameters of the tensor_search.add_documents() function

--- a/src/marqo/tensor_search/models/add_docs_objects.py
+++ b/src/marqo/tensor_search/models/add_docs_objects.py
@@ -24,7 +24,7 @@ class AddDocsBodyParamsNew(BaseModel):
     class Config:
         arbitrary_types_allowed = True
         allow_mutation = False
-        extra = "forbi" # Raise error on unknown fields
+        extra = "forbid" # Raise error on unknown fields
 
     nonTensorFields: List = Field(default_factory=list)
     useExistingTensors: bool = False

--- a/src/marqo/tensor_search/models/add_docs_objects.py
+++ b/src/marqo/tensor_search/models/add_docs_objects.py
@@ -24,6 +24,7 @@ class AddDocsBodyParamsNew(BaseModel):
     class Config:
         arbitrary_types_allowed = True
         allow_mutation = False
+        extra = "forbi" # Raise error on unknown fields
 
     nonTensorFields: List = Field(default_factory=list)
     useExistingTensors: bool = False

--- a/src/marqo/tensor_search/models/add_docs_objects.py
+++ b/src/marqo/tensor_search/models/add_docs_objects.py
@@ -17,11 +17,8 @@ class AddDocsParamsConfig:
 
 
 class AddDocsBodyParamsOld(BaseModel):
-    class Config:
-        arbitrary_types_allowed = True
-        allow_mutation = False
+    __root__: List[Union[dict, Any]]
 
-    documents: Union[Sequence[Union[dict, Any]], np.ndarray]
 
 class AddDocsBodyParamsNew(BaseModel):
     class Config:

--- a/src/marqo/tensor_search/models/add_docs_objects.py
+++ b/src/marqo/tensor_search/models/add_docs_objects.py
@@ -17,7 +17,7 @@ class AddDocsParamsConfig:
 
 
 class AddDocsBodyParamsOld(BaseModel):
-    __root__: List[Dict]
+    documents: List[Dict]
 
 class AddDocsBodyParamsNew(BaseModel):
     non_tensor_fields: List[str] = []

--- a/src/marqo/tensor_search/web/api_utils.py
+++ b/src/marqo/tensor_search/web/api_utils.py
@@ -156,7 +156,8 @@ def add_docs_params_orchestrator(index_name: str, body: Union[AddDocsBodyParamsO
             raise BadRequestError("Marqo is not accepting any of the following parameters in the query string: "
                                   "`non_tensor_fields`, `use_existing_tensors`, `image_download_headers`, `model_auth`, `mappings`. "
                                   "Please move these parameters to the request body as "
-                                  "`nonTensorFields, useExistingTensors, imageDownloadHeaders, modelAuth, mappings`. and try again.")
+                                  "`nonTensorFields, useExistingTensors, imageDownloadHeaders, modelAuth, mappings`. and try again. "
+                                  "Please check `https://docs.marqo.ai/latest/API-Reference/documents/` for the correct APIs.")
 
         mappings = body.mappings
         non_tensor_fields = body.nonTensorFields

--- a/src/marqo/tensor_search/web/api_utils.py
+++ b/src/marqo/tensor_search/web/api_utils.py
@@ -163,7 +163,7 @@ def add_docs_params_ochestrator(index_name: str, body: Union[AddDocsBodyParamsOl
         image_download_headers = body.image_download_headers
 
     elif isinstance(body, AddDocsBodyParamsOld):
-        docs = body.documents
+        docs = body.__root__
 
     else:
         raise BadRequestError("Invalid request body")

--- a/src/marqo/tensor_search/web/api_utils.py
+++ b/src/marqo/tensor_search/web/api_utils.py
@@ -156,7 +156,7 @@ def add_docs_params_orchestrator(index_name: str, body: Union[AddDocsBodyParams,
             raise BadRequestError("Marqo is not accepting any of the following parameters in the query string: "
                                   "`non_tensor_fields`, `use_existing_tensors`, `image_download_headers`, `model_auth`, `mappings`. "
                                   "Please move these parameters to the request body as "
-                                  "`nonTensorFields, useExistingTensors, imageDownloadHeaders, modelAuth, mappings`. and try again. "
+                                  "`nonTensorFields`,` useExistingTensors`, `imageDownloadHeaders`, `modelAuth`, `mappings`. and try again. "
                                   "Please check `https://docs.marqo.ai/latest/API-Reference/documents/` for the correct APIs.")
 
         mappings = body.mappings
@@ -169,8 +169,7 @@ def add_docs_params_orchestrator(index_name: str, body: Union[AddDocsBodyParams,
         docs = body
 
     else:
-        raise BadRequestError("Invalid request body type for `/documents` API. "
-                              "Please check `https://docs.marqo.ai/latest/API-Reference/documents/` for the correct APIs.")
+        raise InternalError(f"Unexpected request body type `{type(body).__name__} for `/documents` API. ")
 
     return AddDocsParams(
         index_name=index_name, docs=docs, auto_refresh=auto_refresh,

--- a/src/marqo/tensor_search/web/api_utils.py
+++ b/src/marqo/tensor_search/web/api_utils.py
@@ -135,10 +135,10 @@ def decode_mappings(mappings: Optional[str] = None) -> dict:
 
 
 def add_docs_params_ochestrator(index_name: str, body: Union[AddDocsBodyParamsOld, AddDocsBodyParamsNew],
-                                device: str, non_tensor_fields: Optional[List[str]], mappings: Optional[dict],
-                                model_auth: Optional[ModelAuth], image_download_headers: Optional[dict],
-                                use_existing_tensors: Optional[bool] = False,
-                                auto_refresh: bool = True) -> AddDocsParams:
+                                device: str, auto_refresh: bool = True, non_tensor_fields: Optional[List[str]] = [],
+                                mappings: Optional[dict] = dict(), model_auth: Optional[ModelAuth] = None,
+                                image_download_headers: Optional[dict] = dict(),
+                                use_existing_tensors: Optional[bool] = False,) -> AddDocsParams:
     """An orchestrator for the add_documents API to support both old and new versions of the API.
     All the arguments are decoded and validated in the API function. This function is only responsible for orchestrating.
 
@@ -149,11 +149,12 @@ def add_docs_params_ochestrator(index_name: str, body: Union[AddDocsBodyParamsOl
     if isinstance(body, AddDocsBodyParamsNew):
         docs = body.documents
 
-        # Check for parameter duplication
-        if any([non_tensor_fields, use_existing_tensors, image_download_headers, model_auth, mappings]) and \
-                any([body.non_tensor_fields, body.use_existing_tensors, body.image_download_headers,
-                     body.model_auth, body.mappings]):
-            raise BadRequestError("Parameters provided in both body and query string")
+        # Check for query parameters that are not supported in the new API
+        if any([non_tensor_fields, use_existing_tensors is not False, image_download_headers, model_auth, mappings]):
+            raise BadRequestError("Marqo is not accepting any of the following parameters in the query string: "
+                                  "`non_tensor_fields`, `use_existing_tensors`, `image_download_headers`, "
+                                  "`model_auth`, `mappings`. "
+                                  "Please move these parameters to the request body instead and try again.")
 
         mappings = body.mappings
         non_tensor_fields = body.non_tensor_fields

--- a/src/marqo/tensor_search/web/api_utils.py
+++ b/src/marqo/tensor_search/web/api_utils.py
@@ -135,11 +135,11 @@ def decode_mappings(mappings: Optional[str] = None) -> dict:
             raise InvalidArgError(f"Error parsing mappings. Message: {e}")
 
 
-def add_docs_params_orchestrator(request: Request, index_name: str, body: Union[AddDocsBodyParamsOld, AddDocsBodyParamsNew],
+def add_docs_params_orchestrator(index_name: str, body: Union[AddDocsBodyParamsOld, AddDocsBodyParamsNew],
                                 device: str, auto_refresh: bool = True, non_tensor_fields: Optional[List[str]] = [],
                                 mappings: Optional[dict] = dict(), model_auth: Optional[ModelAuth] = None,
                                 image_download_headers: Optional[dict] = dict(),
-                                use_existing_tensors: Optional[bool] = False) -> AddDocsParams:
+                                use_existing_tensors: Optional[bool] = False, query_parameters: Optional[Dict] = dict()) -> AddDocsParams:
     """An orchestrator for the add_documents API to support both old and new versions of the API.
     All the arguments are decoded and validated in the API function. This function is only responsible for orchestrating.
 
@@ -152,7 +152,7 @@ def add_docs_params_orchestrator(request: Request, index_name: str, body: Union[
 
         # Check for query parameters that are not supported in the new API
         deprecated_fields = ["non_tensor_fields", "use_existing_tensors", "image_download_headers", "model_auth", "mappings"]
-        if any(field in dict(request.query_params) for field in deprecated_fields):
+        if any(field in query_parameters for field in deprecated_fields):
             raise BadRequestError("Marqo is not accepting any of the following parameters in the query string: "
                                   "`non_tensor_fields`, `use_existing_tensors`, `image_download_headers`, `model_auth`, `mappings`. "
                                   "Please move these parameters to the request body as "

--- a/src/marqo/tensor_search/web/api_utils.py
+++ b/src/marqo/tensor_search/web/api_utils.py
@@ -168,7 +168,8 @@ def add_docs_params_orchestrator(index_name: str, body: Union[AddDocsBodyParamsO
         docs = body.__root__
 
     else:
-        raise BadRequestError("Invalid request body")
+        raise BadRequestError("Invalid request body type for `/documents` API. "
+                              "Please check `https://docs.marqo.ai/latest/API-Reference/documents/` for the correct APIs.")
 
     return AddDocsParams(
         index_name=index_name, docs=docs, auto_refresh=auto_refresh,

--- a/src/marqo/tensor_search/web/api_utils.py
+++ b/src/marqo/tensor_search/web/api_utils.py
@@ -135,7 +135,7 @@ def decode_mappings(mappings: Optional[str] = None) -> dict:
             raise InvalidArgError(f"Error parsing mappings. Message: {e}")
 
 
-def add_docs_params_ochestrator(request: Request, index_name: str, body: Union[AddDocsBodyParamsOld, AddDocsBodyParamsNew],
+def add_docs_params_orchestrator(request: Request, index_name: str, body: Union[AddDocsBodyParamsOld, AddDocsBodyParamsNew],
                                 device: str, auto_refresh: bool = True, non_tensor_fields: Optional[List[str]] = [],
                                 mappings: Optional[dict] = dict(), model_auth: Optional[ModelAuth] = None,
                                 image_download_headers: Optional[dict] = dict(),

--- a/src/marqo/tensor_search/web/api_utils.py
+++ b/src/marqo/tensor_search/web/api_utils.py
@@ -5,7 +5,7 @@ from marqo.tensor_search import enums
 from typing import Optional
 from marqo.tensor_search.utils import construct_authorized_url
 from marqo.tensor_search.models.add_docs_objects import ModelAuth
-from marqo.tensor_search.models.add_docs_objects import AddDocsParams, AddDocsBodyParamsOld, AddDocsBodyParamsNew
+from marqo.tensor_search.models.add_docs_objects import AddDocsParams, AddDocsBodyParams
 from marqo.errors import BadRequestError
 from typing import Union, List, Optional, Dict
 from fastapi import Request
@@ -135,7 +135,7 @@ def decode_mappings(mappings: Optional[str] = None) -> dict:
             raise InvalidArgError(f"Error parsing mappings. Message: {e}")
 
 
-def add_docs_params_orchestrator(index_name: str, body: Union[AddDocsBodyParamsOld, AddDocsBodyParamsNew],
+def add_docs_params_orchestrator(index_name: str, body: Union[AddDocsBodyParams, List[Dict]],
                                 device: str, auto_refresh: bool = True, non_tensor_fields: Optional[List[str]] = [],
                                 mappings: Optional[dict] = dict(), model_auth: Optional[ModelAuth] = None,
                                 image_download_headers: Optional[dict] = dict(),
@@ -147,7 +147,7 @@ def add_docs_params_orchestrator(index_name: str, body: Union[AddDocsBodyParamsO
         AddDocsParams: An AddDocsParams object for internal use
     """
 
-    if isinstance(body, AddDocsBodyParamsNew):
+    if isinstance(body, AddDocsBodyParams):
         docs = body.documents
 
         # Check for query parameters that are not supported in the new API
@@ -165,8 +165,8 @@ def add_docs_params_orchestrator(index_name: str, body: Union[AddDocsBodyParamsO
         model_auth = body.modelAuth
         image_download_headers = body.imageDownloadHeaders
 
-    elif isinstance(body, AddDocsBodyParamsOld):
-        docs = body.__root__
+    elif isinstance(body, list) and all(isinstance(item, dict) for item in body):
+        docs = body
 
     else:
         raise BadRequestError("Invalid request body type for `/documents` API. "

--- a/tests/tensor_search/test_api_utils.py
+++ b/tests/tensor_search/test_api_utils.py
@@ -165,8 +165,8 @@ class TestAddDocsParamsOchestrator(unittest.TestCase):
         except BadRequestError as e:
             self.assertIn("Invalid request body", str(e))
 
-    def test_add_docs_params_orchestrator_duplication_error(self):
-        # Test the case where the function should raise an error due to parameter duplication
+    def test_add_docs_params_orchestrator_depreciated_query_parameters_error(self):
+        # Test the case where the function should raise an error due to depreciated query parameters
         index_name = "test-index"
         model_auth = ModelAuth(s3=S3Auth(aws_secret_access_key="test", aws_access_key_id="test"))
         device = "test-device"
@@ -186,6 +186,7 @@ class TestAddDocsParamsOchestrator(unittest.TestCase):
             kwargs = {key: None for key in params.keys()}
             kwargs[param] = value
             try:
-                add_docs_params_orchestrator(index_name, body, device, auto_refresh=auto_refresh, **kwargs)
+                add_docs_params_orchestrator(index_name, body, device, auto_refresh=auto_refresh,
+                                             query_parameters=kwargs, **kwargs)
             except BadRequestError as e:
                 self.assertIn("Marqo is not accepting any of the following parameters in the query string", str(e))

--- a/tests/tensor_search/test_api_utils.py
+++ b/tests/tensor_search/test_api_utils.py
@@ -85,10 +85,10 @@ class TestAddDocsParamsOchestrator(unittest.TestCase):
         # Set up the arguments for the function
         index_name = "test-index"
         body = AddDocsBodyParamsNew(documents=[{"test": "doc"}],
-                                    non_tensor_fields=["field1"],
-                                    use_existing_tensors=True,
-                                    image_download_headers={"header1": "value1"},
-                                    model_auth=ModelAuth(s3=S3Auth(aws_secret_access_key="test", aws_access_key_id="test")),
+                                    nonTensorFields=["field1"],
+                                    useExistingTensors=True,
+                                    imageDownloadHeaders={"header1": "value1"},
+                                    modelAuth=ModelAuth(s3=S3Auth(aws_secret_access_key="test", aws_access_key_id="test")),
                                     mappings={"map1": "value1"})
         device = "test-device"
         auto_refresh = True
@@ -119,7 +119,7 @@ class TestAddDocsParamsOchestrator(unittest.TestCase):
         index_name = "test-index"
         model_auth = ModelAuth(s3=S3Auth(aws_secret_access_key="test", aws_access_key_id="test"))
 
-        body = AddDocsBodyParamsOld(documents=[{"test": "doc"}])
+        body = AddDocsBodyParamsOld(__root__= [{"test": "doc"}])
 
         device = "test-device"
         non_tensor_fields = ["field1"]
@@ -136,7 +136,7 @@ class TestAddDocsParamsOchestrator(unittest.TestCase):
         # Assert that the result is as expected
         assert isinstance(result, AddDocsParams)
         assert result.index_name == "test-index"
-        assert result.docs == body.documents
+        assert result.docs == body.__root__
         assert result.device == "test-device"
         assert result.non_tensor_fields == ["field1"]
         assert result.use_existing_tensors == True
@@ -172,10 +172,10 @@ class TestAddDocsParamsOchestrator(unittest.TestCase):
         device = "test-device"
         auto_refresh = True
         body = AddDocsBodyParamsNew(documents=[{"test": "doc"}],
-                                    non_tensor_fields=["field1"],
-                                    use_existing_tensors=True,
-                                    image_download_headers={"header1": "value1"},
-                                    model_auth=model_auth,
+                                    nonTensorFields=["field1"],
+                                    useExistingTensors=True,
+                                    imageDownloadHeaders={"header1": "value1"},
+                                    modelAuth=ModelAuth(s3=S3Auth(aws_secret_access_key="test", aws_access_key_id="test")),
                                     mappings={"map1": "value1"})
 
         params = {"non_tensor_fields": ["what"], "use_existing_tensors": True,

--- a/tests/tensor_search/test_api_utils.py
+++ b/tests/tensor_search/test_api_utils.py
@@ -163,7 +163,7 @@ class TestAddDocsParamsOchestrator(unittest.TestCase):
            _ = add_docs_params_orchestrator(index_name, body, device, auto_refresh, non_tensor_fields, mappings,
                                             model_auth, image_download_headers, use_existing_tensors)
         except BadRequestError as e:
-            self.assertIn("Invalid request body", str(e))
+            self.assertIn("Invalid request body type for `/documents` API.", str(e))
 
     def test_add_docs_params_orchestrator_depreciated_query_parameters_error(self):
         # Test the case where the function should raise an error due to depreciated query parameters

--- a/tests/tensor_search/test_api_utils.py
+++ b/tests/tensor_search/test_api_utils.py
@@ -1,6 +1,5 @@
 import pydantic
-from marqo.tensor_search.models.add_docs_objects import ModelAuth, AddDocsParams, AddDocsBodyParamsOld, \
-    AddDocsBodyParamsNew
+from marqo.tensor_search.models.add_docs_objects import ModelAuth, AddDocsParams, AddDocsBodyParams
 from marqo.tensor_search.web.api_utils import add_docs_params_orchestrator
 from marqo.tensor_search.models.private_models import S3Auth
 import urllib.parse
@@ -80,11 +79,11 @@ class TestDecodeQueryStringModelAuth(MarqoTestCase):
             api_utils.decode_query_string_model_auth("invalid_url_encoded_string")
 
 
-class TestAddDocsParamsOchestrator(unittest.TestCase):
-    def test_add_docs_params_orchestrator_new(self):
+class TestAddDocsParamsOrchestrator(unittest.TestCase):
+    def test_add_docs_params_orchestrator(self):
         # Set up the arguments for the function
         index_name = "test-index"
-        body = AddDocsBodyParamsNew(documents=[{"test": "doc"}],
+        body = AddDocsBodyParams(documents=[{"test": "doc"}],
                                     nonTensorFields=["field1"],
                                     useExistingTensors=True,
                                     imageDownloadHeaders={"header1": "value1"},
@@ -114,12 +113,12 @@ class TestAddDocsParamsOchestrator(unittest.TestCase):
         assert result.docs == [{"test": "doc"}]
         assert result.image_download_headers == {"header1": "value1"}
 
-    def test_add_docs_params_orchestrator_old(self):
+    def test_add_docs_params_orchestrator_deprecated_query_parameters(self):
         # Set up the arguments for the function
         index_name = "test-index"
         model_auth = ModelAuth(s3=S3Auth(aws_secret_access_key="test", aws_access_key_id="test"))
 
-        body = AddDocsBodyParamsOld(__root__= [{"test": "doc"}])
+        body = [{"test": "doc"}]
 
         device = "test-device"
         non_tensor_fields = ["field1"]
@@ -136,7 +135,7 @@ class TestAddDocsParamsOchestrator(unittest.TestCase):
         # Assert that the result is as expected
         assert isinstance(result, AddDocsParams)
         assert result.index_name == "test-index"
-        assert result.docs == body.__root__
+        assert result.docs == body
         assert result.device == "test-device"
         assert result.non_tensor_fields == ["field1"]
         assert result.use_existing_tensors == True
@@ -145,7 +144,7 @@ class TestAddDocsParamsOchestrator(unittest.TestCase):
 
     def test_add_docs_params_orchestrator_error(self):
         # Test the case where the function should raise an error due to invalid input
-        body = "invalid body type"  # Not an instance of AddDocsBodyParamsNew or AddDocsBodyParamsOld
+        body = "invalid body type"  # Not an instance of AddDocsBodyParams or List[Dict]
 
         index_name = "test-index"
         model_auth = ModelAuth(s3=S3Auth(aws_secret_access_key="test", aws_access_key_id="test"))
@@ -171,7 +170,7 @@ class TestAddDocsParamsOchestrator(unittest.TestCase):
         model_auth = ModelAuth(s3=S3Auth(aws_secret_access_key="test", aws_access_key_id="test"))
         device = "test-device"
         auto_refresh = True
-        body = AddDocsBodyParamsNew(documents=[{"test": "doc"}],
+        body = AddDocsBodyParams(documents=[{"test": "doc"}],
                                     nonTensorFields=["field1"],
                                     useExistingTensors=True,
                                     imageDownloadHeaders={"header1": "value1"},

--- a/tests/tensor_search/test_api_utils.py
+++ b/tests/tensor_search/test_api_utils.py
@@ -161,8 +161,8 @@ class TestAddDocsParamsOrchestrator(unittest.TestCase):
         try:
            _ = add_docs_params_orchestrator(index_name, body, device, auto_refresh, non_tensor_fields, mappings,
                                             model_auth, image_download_headers, use_existing_tensors)
-        except BadRequestError as e:
-            self.assertIn("Invalid request body type for `/documents` API.", str(e))
+        except InternalError as e:
+            self.assertIn("Unexpected request body type", str(e))
 
     def test_add_docs_params_orchestrator_deprecated_query_parameters_error(self):
         # Test the case where the function should raise an error due to deprecated query parameters

--- a/tests/tensor_search/test_api_utils.py
+++ b/tests/tensor_search/test_api_utils.py
@@ -1,10 +1,11 @@
 import pydantic
-from marqo.tensor_search.models.add_docs_objects import ModelAuth, AddDocsParams, AddDocsBodyParamsOld, AddDocsBodyParamsNew
+from marqo.tensor_search.models.add_docs_objects import ModelAuth, AddDocsParams, AddDocsBodyParamsOld, \
+    AddDocsBodyParamsNew
 from marqo.tensor_search.web.api_utils import add_docs_params_ochestrator
 from marqo.tensor_search.models.private_models import S3Auth
 import urllib.parse
 from marqo.tensor_search.web import api_utils
-from marqo.errors import InvalidArgError, InternalError
+from marqo.errors import InvalidArgError, InternalError, BadRequestError
 from tests.marqo_test import MarqoTestCase
 import unittest
 
@@ -28,15 +29,17 @@ class TestApiUtils(MarqoTestCase):
 
     def test_generate_config(self):
         for opensearch_url, authorized_url in [
-                ("http://admin:admin@localhost:9200", "http://admin:admin@localhost:9200"),
-                ("http://localhost:9200", "http://admin:admin@localhost:9200"),
-                ("https://admin:admin@localhost:9200", "https://admin:admin@localhost:9200"),
-                ("https://localhost:9200", "https://admin:admin@localhost:9200"),
-                ("http://king_user:mysecretpw@unusual.com/happy@chappy:9200", "http://king_user:mysecretpw@unusual.com/happy@chappy:9200"),
-                ("http://unusual.com/happy@chappy:9200", "http://admin:admin@unusual.com/happy@chappy:9200"),
-                ("http://www.unusual.com/happy@@@@#chappy:9200", "http://admin:admin@www.unusual.com/happy@@@@#chappy:9200"),
-                ("://", "://admin:admin@")
-                ]:
+            ("http://admin:admin@localhost:9200", "http://admin:admin@localhost:9200"),
+            ("http://localhost:9200", "http://admin:admin@localhost:9200"),
+            ("https://admin:admin@localhost:9200", "https://admin:admin@localhost:9200"),
+            ("https://localhost:9200", "https://admin:admin@localhost:9200"),
+            ("http://king_user:mysecretpw@unusual.com/happy@chappy:9200",
+             "http://king_user:mysecretpw@unusual.com/happy@chappy:9200"),
+            ("http://unusual.com/happy@chappy:9200", "http://admin:admin@unusual.com/happy@chappy:9200"),
+            (
+            "http://www.unusual.com/happy@@@@#chappy:9200", "http://admin:admin@www.unusual.com/happy@@@@#chappy:9200"),
+            ("://", "://admin:admin@")
+        ]:
             c = api_utils.upconstruct_authorized_url(opensearch_url=opensearch_url)
             assert authorized_url == c
 
@@ -47,7 +50,8 @@ class TestApiUtils(MarqoTestCase):
                 raise AssertionError
             except InternalError:
                 pass
-            
+
+
 class TestDecodeQueryStringModelAuth(MarqoTestCase):
 
     def test_decode_query_string_model_auth_none(self):
@@ -75,61 +79,113 @@ class TestDecodeQueryStringModelAuth(MarqoTestCase):
         with self.assertRaises(pydantic.ValidationError):
             api_utils.decode_query_string_model_auth("invalid_url_encoded_string")
 
+
 class TestAddDocsParamsOchestrator(unittest.TestCase):
-    def test_add_docs_params_ochestrator_new(self):
+    def test_add_docs_params_orchestrator_new(self):
         # Set up the arguments for the function
         index_name = "test-index"
-        model_auth = ModelAuth(s3=S3Auth(aws_secret_access_key= "test", aws_access_key_id= "test"))
+        body = AddDocsBodyParamsNew(documents=[{"test": "doc"}],
+                                    non_tensor_fields=["field1"],
+                                    use_existing_tensors=True,
+                                    image_download_headers={"header1": "value1"},
+                                    model_auth=ModelAuth(s3=S3Auth(aws_secret_access_key="test", aws_access_key_id="test")),
+                                    mappings={"map1": "value1"})
+        device = "test-device"
+        auto_refresh = True
 
+        # Query parameters should be parsed as default values
+        non_tensor_fields = []
+        use_existing_tensors = False
+        image_download_headers = dict()
+        model_auth = None
+        mappings = dict()
+
+        # Call the function with the arguments
+        result = add_docs_params_ochestrator(index_name, body, device, auto_refresh, non_tensor_fields, mappings,
+                                             model_auth, image_download_headers, use_existing_tensors)
+
+        # Assert that the result is as expected
+        assert isinstance(result, AddDocsParams)
+        assert result.index_name == "test-index"
+        assert result.docs == body.documents
+        assert result.device == "test-device"
+        assert result.non_tensor_fields == ["field1"]
+        assert result.use_existing_tensors == True
+        assert result.docs == [{"test": "doc"}]
+        assert result.image_download_headers == {"header1": "value1"}
+
+    def test_add_docs_params_orchestrator_old(self):
+        # Set up the arguments for the function
+        index_name = "test-index"
+        model_auth = ModelAuth(s3=S3Auth(aws_secret_access_key="test", aws_access_key_id="test"))
+
+        body = AddDocsBodyParamsOld(documents=[{"test": "doc"}])
+
+        device = "test-device"
+        non_tensor_fields = ["field1"]
+        use_existing_tensors = True
+        image_download_headers = {"header1": "value1"}
+        model_auth = model_auth
+        mappings = {"map1": "value1"}
+        auto_refresh = True
+
+        # Call the function with the arguments
+        result = add_docs_params_ochestrator(index_name, body, device, auto_refresh, non_tensor_fields, mappings,
+                                             model_auth, image_download_headers, use_existing_tensors)
+
+        # Assert that the result is as expected
+        assert isinstance(result, AddDocsParams)
+        assert result.index_name == "test-index"
+        assert result.docs == body.documents
+        assert result.device == "test-device"
+        assert result.non_tensor_fields == ["field1"]
+        assert result.use_existing_tensors == True
+        assert result.docs == [{"test": "doc"}]
+        assert result.image_download_headers == {"header1": "value1"}
+
+    def test_add_docs_params_orchestrator_error(self):
+        # Test the case where the function should raise an error due to invalid input
+        body = "invalid body type"  # Not an instance of AddDocsBodyParamsNew or AddDocsBodyParamsOld
+
+        index_name = "test-index"
+        model_auth = ModelAuth(s3=S3Auth(aws_secret_access_key="test", aws_access_key_id="test"))
+
+        device = "test-device"
+        non_tensor_fields = ["field1"]
+        use_existing_tensors = True
+        image_download_headers = {"header1": "value1"}
+        model_auth = model_auth
+        mappings = {"map1": "value1"}
+        auto_refresh = True
+
+        # Use pytest.raises to check for the error
+        try:
+           _ = add_docs_params_ochestrator(index_name, body, device, auto_refresh, non_tensor_fields, mappings,
+                                                 model_auth, image_download_headers, use_existing_tensors)
+        except BadRequestError as e:
+            self.assertIn("Invalid request body", str(e))
+
+    def test_add_docs_params_orchestrator_duplication_error(self):
+        # Test the case where the function should raise an error due to parameter duplication
+        index_name = "test-index"
+        model_auth = ModelAuth(s3=S3Auth(aws_secret_access_key="test", aws_access_key_id="test"))
+        device = "test-device"
+        auto_refresh = True
         body = AddDocsBodyParamsNew(documents=[{"test": "doc"}],
                                     non_tensor_fields=["field1"],
                                     use_existing_tensors=True,
                                     image_download_headers={"header1": "value1"},
                                     model_auth=model_auth,
                                     mappings={"map1": "value1"})
-        device = "test-device"
-        non_tensor_fields = None
-        use_existing_tensors = None
-        image_download_headers = None
-        model_auth = None
-        mappings = None
-        auto_refresh = True
 
-        # Call the function with the arguments
-        result = add_docs_params_ochestrator(index_name, body, device, non_tensor_fields, mappings, model_auth,
-                                             image_download_headers, use_existing_tensors, auto_refresh)
+        params = {"non_tensor_fields": ["what"], "use_existing_tensors": True,
+                  "image_download_headers": {"header2": "value2"}, "model_auth": model_auth,
+                  "mappings": {"map2": "value2"}}
 
-        # Assert that the result is as expected
-        assert isinstance(result, AddDocsParams)
-        assert result.index_name == "test-index"
-        assert result.docs == body.documents
-        # Add more assertions for all the parameters as needed...
-
-    # def test_add_docs_params_ochestrator_old(self):
-    #
-    # # Similar to the above test but with `body` being an instance of `AddDocsBodyParamsOld`
-    # # ...
-    #
-    # def test_add_docs_params_ochestrator_error(self):
-    #     # Test the case where the function should raise an error due to invalid input
-    #     body = "invalid body type"  # Not an instance of AddDocsBodyParamsNew or AddDocsBodyParamsOld
-    #
-    #     # Use pytest.raises to check for the error
-    #     with pytest.raises(BadRequestError):
-    #         add_docs_params_ochestrator(index_name, body, device, non_tensor_fields, mappings, model_auth,
-    #                                     image_download_headers, use_existing_tensors, auto_refresh)
-    #
-    # def test_add_docs_params_ochestrator_duplication_error(self):
-    #     # Test the case where the function should raise an error due to parameter duplication
-    #     body = AddDocsBodyParamsNew(documents=[{"test": "doc"}],
-    #                                 non_tensor_fields=["field1"],
-    #                                 use_existing_tensors=True,
-    #                                 image_download_headers={"header1": "value1"},
-    #                                 model_auth={"auth1": "value1"},
-    #                                 mappings={"map1": "value1"})
-    #     non_tensor_fields = ["field2"]  # Duplicate parameter
-    #
-    #     # Use pytest.raises to check for the error
-    #     with pytest.raises(BadRequestError):
-    #         add_docs_params_ochestrator(index_name, body, device, non_tensor_fields, mappings, model_auth,
-    #                                     image_download_headers, use_existing_tensors, auto_refresh)
+        for param, value in params.items():
+            kwargs = {key: None for key in params.keys()}
+            kwargs[param] = value
+            try:
+                add_docs_params_ochestrator(index_name, body, device, **kwargs, auto_refresh=auto_refresh)
+            except BadRequestError as e:
+                self.assertIn("Marqo is not accepting any of the following parameters in the query string", str(e))

--- a/tests/tensor_search/test_api_utils.py
+++ b/tests/tensor_search/test_api_utils.py
@@ -1,7 +1,7 @@
 import pydantic
 from marqo.tensor_search.models.add_docs_objects import ModelAuth, AddDocsParams, AddDocsBodyParamsOld, \
     AddDocsBodyParamsNew
-from marqo.tensor_search.web.api_utils import add_docs_params_ochestrator
+from marqo.tensor_search.web.api_utils import add_docs_params_orchestrator
 from marqo.tensor_search.models.private_models import S3Auth
 import urllib.parse
 from marqo.tensor_search.web import api_utils
@@ -101,8 +101,8 @@ class TestAddDocsParamsOchestrator(unittest.TestCase):
         mappings = dict()
 
         # Call the function with the arguments
-        result = add_docs_params_ochestrator(index_name, body, device, auto_refresh, non_tensor_fields, mappings,
-                                             model_auth, image_download_headers, use_existing_tensors)
+        result = add_docs_params_orchestrator(index_name, body, device, auto_refresh, non_tensor_fields, mappings,
+                                              model_auth, image_download_headers, use_existing_tensors)
 
         # Assert that the result is as expected
         assert isinstance(result, AddDocsParams)
@@ -130,8 +130,8 @@ class TestAddDocsParamsOchestrator(unittest.TestCase):
         auto_refresh = True
 
         # Call the function with the arguments
-        result = add_docs_params_ochestrator(index_name, body, device, auto_refresh, non_tensor_fields, mappings,
-                                             model_auth, image_download_headers, use_existing_tensors)
+        result = add_docs_params_orchestrator(index_name, body, device, auto_refresh, non_tensor_fields, mappings,
+                                              model_auth, image_download_headers, use_existing_tensors)
 
         # Assert that the result is as expected
         assert isinstance(result, AddDocsParams)
@@ -160,8 +160,8 @@ class TestAddDocsParamsOchestrator(unittest.TestCase):
 
         # Use pytest.raises to check for the error
         try:
-           _ = add_docs_params_ochestrator(index_name, body, device, auto_refresh, non_tensor_fields, mappings,
-                                                 model_auth, image_download_headers, use_existing_tensors)
+           _ = add_docs_params_orchestrator(index_name, body, device, auto_refresh, non_tensor_fields, mappings,
+                                            model_auth, image_download_headers, use_existing_tensors)
         except BadRequestError as e:
             self.assertIn("Invalid request body", str(e))
 
@@ -186,6 +186,6 @@ class TestAddDocsParamsOchestrator(unittest.TestCase):
             kwargs = {key: None for key in params.keys()}
             kwargs[param] = value
             try:
-                add_docs_params_ochestrator(index_name, body, device, **kwargs, auto_refresh=auto_refresh)
+                add_docs_params_orchestrator(index_name, body, device, auto_refresh=auto_refresh, **kwargs)
             except BadRequestError as e:
                 self.assertIn("Marqo is not accepting any of the following parameters in the query string", str(e))

--- a/tests/tensor_search/test_api_utils.py
+++ b/tests/tensor_search/test_api_utils.py
@@ -1,10 +1,12 @@
 import pydantic
-from marqo.tensor_search.models.add_docs_objects import ModelAuth
+from marqo.tensor_search.models.add_docs_objects import ModelAuth, AddDocsParams, AddDocsBodyParamsOld, AddDocsBodyParamsNew
+from marqo.tensor_search.web.api_utils import add_docs_params_ochestrator
 from marqo.tensor_search.models.private_models import S3Auth
 import urllib.parse
 from marqo.tensor_search.web import api_utils
 from marqo.errors import InvalidArgError, InternalError
 from tests.marqo_test import MarqoTestCase
+import unittest
 
 
 class TestApiUtils(MarqoTestCase):
@@ -72,3 +74,62 @@ class TestDecodeQueryStringModelAuth(MarqoTestCase):
     def test_decode_query_string_model_auth_invalid(self):
         with self.assertRaises(pydantic.ValidationError):
             api_utils.decode_query_string_model_auth("invalid_url_encoded_string")
+
+class TestAddDocsParamsOchestrator(unittest.TestCase):
+    def test_add_docs_params_ochestrator_new(self):
+        # Set up the arguments for the function
+        index_name = "test-index"
+        model_auth = ModelAuth(s3=S3Auth(aws_secret_access_key= "test", aws_access_key_id= "test"))
+
+        body = AddDocsBodyParamsNew(documents=[{"test": "doc"}],
+                                    non_tensor_fields=["field1"],
+                                    use_existing_tensors=True,
+                                    image_download_headers={"header1": "value1"},
+                                    model_auth=model_auth,
+                                    mappings={"map1": "value1"})
+        device = "test-device"
+        non_tensor_fields = None
+        use_existing_tensors = None
+        image_download_headers = None
+        model_auth = None
+        mappings = None
+        auto_refresh = True
+
+        # Call the function with the arguments
+        result = add_docs_params_ochestrator(index_name, body, device, non_tensor_fields, mappings, model_auth,
+                                             image_download_headers, use_existing_tensors, auto_refresh)
+
+        # Assert that the result is as expected
+        assert isinstance(result, AddDocsParams)
+        assert result.index_name == "test-index"
+        assert result.docs == body.documents
+        # Add more assertions for all the parameters as needed...
+
+    # def test_add_docs_params_ochestrator_old(self):
+    #
+    # # Similar to the above test but with `body` being an instance of `AddDocsBodyParamsOld`
+    # # ...
+    #
+    # def test_add_docs_params_ochestrator_error(self):
+    #     # Test the case where the function should raise an error due to invalid input
+    #     body = "invalid body type"  # Not an instance of AddDocsBodyParamsNew or AddDocsBodyParamsOld
+    #
+    #     # Use pytest.raises to check for the error
+    #     with pytest.raises(BadRequestError):
+    #         add_docs_params_ochestrator(index_name, body, device, non_tensor_fields, mappings, model_auth,
+    #                                     image_download_headers, use_existing_tensors, auto_refresh)
+    #
+    # def test_add_docs_params_ochestrator_duplication_error(self):
+    #     # Test the case where the function should raise an error due to parameter duplication
+    #     body = AddDocsBodyParamsNew(documents=[{"test": "doc"}],
+    #                                 non_tensor_fields=["field1"],
+    #                                 use_existing_tensors=True,
+    #                                 image_download_headers={"header1": "value1"},
+    #                                 model_auth={"auth1": "value1"},
+    #                                 mappings={"map1": "value1"})
+    #     non_tensor_fields = ["field2"]  # Duplicate parameter
+    #
+    #     # Use pytest.raises to check for the error
+    #     with pytest.raises(BadRequestError):
+    #         add_docs_params_ochestrator(index_name, body, device, non_tensor_fields, mappings, model_auth,
+    #                                     image_download_headers, use_existing_tensors, auto_refresh)

--- a/tests/tensor_search/test_api_utils.py
+++ b/tests/tensor_search/test_api_utils.py
@@ -165,8 +165,8 @@ class TestAddDocsParamsOchestrator(unittest.TestCase):
         except BadRequestError as e:
             self.assertIn("Invalid request body type for `/documents` API.", str(e))
 
-    def test_add_docs_params_orchestrator_depreciated_query_parameters_error(self):
-        # Test the case where the function should raise an error due to depreciated query parameters
+    def test_add_docs_params_orchestrator_deprecated_query_parameters_error(self):
+        # Test the case where the function should raise an error due to deprecated query parameters
         index_name = "test-index"
         model_auth = ModelAuth(s3=S3Auth(aws_secret_access_key="test", aws_access_key_id="test"))
         device = "test-device"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
we move the query parameters `non_tensor_fields`, `use_existing_tensors`, `image_download_headers`, `model_auth`, `mappings` to the request body.

* **What is the current behavior?** (You can also link to an open issue here)
`non_tensor_fields`, `use_existing_tensors`, `image_download_headers`, `model_auth`, `mappings` are query parameters

* **What is the new behavior (if this is a feature change)?**
they are now moved to the query body as `nonTensorFields, useExistingTensors, imageDownloadHeaders, modelAuth, mappings`


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
yes. 
for py-marqo users, they need to upgrade the py-marqo version
for bash curl users, they need to change their requests

marqo will still support old APIs recently but my remove them in the near future.


* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
running


* **Related Python client changes** (link commit/PR here)
working on

* **Related documentation changes** (link commit/PR here)
finished

* **Other information**:


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

