### PR TITLE
Set index default replicas=0, shards=1

### DIFF
--- a/src/marqo/tensor_search/configs.py
+++ b/src/marqo/tensor_search/configs.py
@@ -21,8 +21,8 @@ def get_default_index_settings():
             },
             NsFields.ann_parameters: get_default_ann_parameters()
         },
-        NsFields.number_of_shards: 5,
-        NsFields.number_of_replicas : 1,
+        NsFields.number_of_shards: 1,
+        NsFields.number_of_replicas : 0,
     }
 
 def get_default_ann_parameters():


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Breaking default configuration change

* **What is the current behavior?** (You can also link to an open issue here)
Default shards=5 and replicas=1. This is a suboptimal and storage intensive default. 

* **What is the new behavior (if this is a feature change)?**
Default shards=1 and replicas=0.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
A minor one. If users programmatically create Marqo indexes, and don't explicitly set these values, they will get an unexpected index configuration. 

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
Tests:
- unit tests: https://github.com/marqo-ai/marqo/actions/runs/5527339268
- cuda tests: https://github.com/marqo-ai/marqo/actions/runs/5527340765


* **Related Python client changes** (link commit/PR here)
n/a

* **Related documentation changes** (link commit/PR here)
TODO


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

