### PR TITLE
Error out for old request format without non_tensor_fields

### DIFF
--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -174,7 +174,7 @@ def add_or_replace_documents(
         index_name: str,
         refresh: bool = True,
         marqo_config: config.Config = Depends(generate_config),
-        non_tensor_fields: Optional[List[str]] = Query(default=[]),
+        non_tensor_fields: Optional[List[str]] = Query(default=None),
         device: str = Depends(api_validation.validate_device),
         use_existing_tensors: Optional[bool] = False,
         image_download_headers: Optional[dict] = Depends(
@@ -286,7 +286,6 @@ def get_cpu_info():
 @app.get("/device/cuda")
 def get_cuda_info():
     return tensor_search.get_cuda_info()
-
 
 # try these curl commands:
 

--- a/src/marqo/tensor_search/web/api_utils.py
+++ b/src/marqo/tensor_search/web/api_utils.py
@@ -189,7 +189,9 @@ def add_docs_params_orchestrator(index_name: str, body: Union[AddDocsBodyParams,
             raise BadRequestError('Required parameter `tensorFields` is missing from the request body. '
                                   'This endpoint now requires `tensorFields` in request body. Providing '
                                   'a list of documents as body has been deprecated and will not be '
-                                  'supported in Marqo 2.0.0')
+                                  'supported in Marqo 2.0.0. See '
+                                  'https://docs.marqo.ai/1.0.0/API-Reference/documents/#add-or-replace-documents '
+                                  'for usage of this endpoint.')
 
         return AddDocsParams(
             index_name=index_name, docs=docs, auto_refresh=auto_refresh,

--- a/src/marqo/tensor_search/web/api_utils.py
+++ b/src/marqo/tensor_search/web/api_utils.py
@@ -136,7 +136,7 @@ def decode_mappings(mappings: Optional[str] = None) -> dict:
 
 
 def add_docs_params_orchestrator(index_name: str, body: Union[AddDocsBodyParams, List[Dict]],
-                                device: str, auto_refresh: bool = True, non_tensor_fields: Optional[List[str]] = [],
+                                device: str, auto_refresh: bool = True, non_tensor_fields: Optional[List[str]] = None,
                                 mappings: Optional[dict] = dict(), model_auth: Optional[ModelAuth] = None,
                                 image_download_headers: Optional[dict] = dict(),
                                 use_existing_tensors: Optional[bool] = False, query_parameters: Optional[Dict] = dict()) -> AddDocsParams:
@@ -184,6 +184,12 @@ def add_docs_params_orchestrator(index_name: str, body: Union[AddDocsBodyParams,
 
     elif isinstance(body, list) and all(isinstance(item, dict) for item in body):
         docs = body
+
+        if non_tensor_fields is None:
+            raise BadRequestError('Required parameter `tensorFields` is missing from the request body. '
+                                  'This endpoint now requires `tensorFields` in request body. Providing '
+                                  'a list of documents as body has been deprecated and will not be '
+                                  'supported in Marqo 2.0.0')
 
         return AddDocsParams(
             index_name=index_name, docs=docs, auto_refresh=auto_refresh,

--- a/tests/tensor_search/test_api.py
+++ b/tests/tensor_search/test_api.py
@@ -48,10 +48,11 @@ class ApiTests(MarqoTestCase):
     def test_add_or_replace_documents_non_tensor_fields_query_param(self):
         with mock.patch('marqo.tensor_search.tensor_search.add_documents') as mock_add_documents:
             response = self.client.post(
-                "/indexes/index1/documents?device=cpu&non_tensor_fields=['text']",
+                "/indexes/index1/documents?device=cpu&non_tensor_fields=text&non_tensor_fields=title",
                 json=[
                     {
                         "id": "1",
+                        "title": "My doc",
                         "text": "This is a test document",
                     }
                 ]

--- a/tests/tensor_search/test_api.py
+++ b/tests/tensor_search/test_api.py
@@ -1,0 +1,91 @@
+from unittest import mock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import marqo.tensor_search.api as api
+from tests.marqo_test import MarqoTestCase
+
+
+class ApiTests(MarqoTestCase):
+    def setUp(self):
+        api.OPENSEARCH_URL = 'http://localhost:0000'
+        self.client = TestClient(api.app)
+
+    def test_add_or_replace_documents_tensor_fields(self):
+        with mock.patch('marqo.tensor_search.tensor_search.add_documents') as mock_add_documents:
+            response = self.client.post(
+                "/indexes/index1/documents?device=cpu",
+                json={
+                    "documents": [
+                        {
+                            "id": "1",
+                            "text": "This is a test document",
+                        }
+                    ],
+                    "tensorFields": ['text']
+                },
+            )
+            self.assertEqual(response.status_code, 200)
+            mock_add_documents.assert_called_once()
+
+    def test_add_or_replace_documents_non_tensor_fields(self):
+        with mock.patch('marqo.tensor_search.tensor_search.add_documents') as mock_add_documents:
+            response = self.client.post(
+                "/indexes/index1/documents?device=cpu",
+                json={
+                    "documents": [
+                        {
+                            "id": "1",
+                            "text": "This is a test document",
+                        }
+                    ],
+                    "nonTensorFields": ['text']
+                },
+            )
+            self.assertEqual(response.status_code, 200)
+            mock_add_documents.assert_called_once()
+
+    def test_add_or_replace_documents_non_tensor_fields_query_param(self):
+        with mock.patch('marqo.tensor_search.tensor_search.add_documents') as mock_add_documents:
+            response = self.client.post(
+                "/indexes/index1/documents?device=cpu&non_tensor_fields=['text']",
+                json=[
+                    {
+                        "id": "1",
+                        "text": "This is a test document",
+                    }
+                ]
+            )
+            self.assertEqual(response.status_code, 200)
+            mock_add_documents.assert_called_once()
+
+    def test_add_or_replace_documents_tensor_fields_undefined_body(self):
+        with mock.patch('marqo.tensor_search.tensor_search.add_documents') as mock_add_documents:
+            response = self.client.post(
+                "/indexes/index1/documents?device=cpu",
+                json={
+                    "documents": [
+                        {
+                            "id": "1",
+                            "text": "This is a test document",
+                        }
+                    ]
+                },
+            )
+            self.assertEqual(response.status_code, 400)
+            mock_add_documents.assert_not_called()
+
+    def test_add_or_replace_documents_fields_undefined_query_param(self):
+        with mock.patch('marqo.tensor_search.tensor_search.add_documents') as mock_add_documents:
+            response = self.client.post(
+                "/indexes/index1/documents?device=cpu",
+                json=
+                [
+                    {
+                        "id": "1",
+                        "text": "This is a test document",
+                    }
+                ]
+            )
+            self.assertEqual(response.status_code, 400)
+            mock_add_documents.assert_not_called()


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
`POST /indexes/{index_name}/documents` with old request format (list of docs as body) and no `non_tensor_fields` query parameter defaults to `non_tensor_fields=[]`. This default is not valid any longer and fields must be specified explicitly.

* **What is the new behavior (if this is a feature change)?**
Error out for such requests and suggest using the new request format (body) and `nonTensorFields`. Advise of upcoming removal of this request format in 2.0.0.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
In progress 

* **Related Python client changes** (link commit/PR here)
None

* **Related documentation changes** (link commit/PR here)
None

* **Other information**:


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

