### PR TITLE
Opensearch disk watermark breach handling

### DIFF
--- a/src/marqo/_httprequests.py
+++ b/src/marqo/_httprequests.py
@@ -139,10 +139,9 @@ def convert_to_marqo_web_error_and_raise(response: requests.Response, err: reque
     Raises:
         MarqoWebError - some type of Marqo Web error
     """
+
     try:
         response_dict = response.json()
-        print("DEBUG: OpenSearch error response: ")
-        pprint.pprint(response_dict)
     except JSONDecodeError:
         raise_catchall_http_as_marqo_error(response=response, err=err)
 
@@ -169,7 +168,6 @@ def convert_to_marqo_web_error_and_raise(response: requests.Response, err: reque
                 raise IndexMaxFieldsError(message="Exceeded maximum number of "
                                                   "allowed fields for this index.")
         elif open_search_error_type == "cluster_block_exception":
-            # TODO: change the open search error type depending on experiment results
             raise DiskWatermarkBreachError(message="OpenSearch cluster indexing has been blocked, most likely due to breach \
                                            of the `flood_stage` disk watermark. For more information, please refer \
                                            to your cluster settings: `cluster.routing.allocation.disk.watermark` at \

--- a/src/marqo/_httprequests.py
+++ b/src/marqo/_httprequests.py
@@ -168,10 +168,10 @@ def convert_to_marqo_web_error_and_raise(response: requests.Response, err: reque
                 raise IndexMaxFieldsError(message="Exceeded maximum number of "
                                                   "allowed fields for this index.")
         elif open_search_error_type == "cluster_block_exception":
-            raise DiskWatermarkBreachError(message="OpenSearch cluster indexing has been blocked, most likely due to breach \
-                                           of the `flood_stage` disk watermark. For more information, please refer \
-                                           to your cluster settings: `cluster.routing.allocation.disk.watermark` at \
-                                           https://opensearch.org/docs/2.7/api-reference/cluster-api/cluster-settings/")
+            raise DiskWatermarkBreachError(message="OpenSearch cluster indexing has been blocked, most likely due to breach "
+                                           "of the `flood_stage` disk watermark. Try freeing up disk space on your OpenSearch instances. "
+                                           "For more information, please refer to cluster settings: `cluster.routing.allocation.disk.watermark` at "
+                                           "https://opensearch.org/docs/2.7/api-reference/cluster-api/cluster-settings/")
     except KeyError:
         pass
 

--- a/src/marqo/_httprequests.py
+++ b/src/marqo/_httprequests.py
@@ -143,6 +143,7 @@ def convert_to_marqo_web_error_and_raise(response: requests.Response, err: reque
     except JSONDecodeError:
         raise_catchall_http_as_marqo_error(response=response, err=err)
     if response.status_code == 429:
+        # TODO, raise a different marqo error here.
         raise TooManyRequestsError(
             message="Marqo-OS received too many requests! "
                     "Please try reducing the frequency of add_documents and update_documents calls.")

--- a/src/marqo/_httprequests.py
+++ b/src/marqo/_httprequests.py
@@ -140,6 +140,8 @@ def convert_to_marqo_web_error_and_raise(response: requests.Response, err: reque
     """
     try:
         response_dict = response.json()
+        print("DEBUG: OpenSearch error response: ")
+        pprint.pprint(response_dict)
     except JSONDecodeError:
         raise_catchall_http_as_marqo_error(response=response, err=err)
     if response.status_code == 429:

--- a/src/marqo/errors.py
+++ b/src/marqo/errors.py
@@ -215,3 +215,8 @@ class ConfigurationError(InternalError):
     code = "server_configuration_error"
     status_code = HTTPStatus.INTERNAL_SERVER_ERROR
 
+
+class DiskWatermarkBreachError(InternalError):
+    """Error when OpenSearch disk watermark is breached"""
+    code = "disk_watermark_breach_error"
+    status_code = HTTPStatus.INSUFFICIENT_STORAGE

--- a/src/marqo/tensor_search/constants.py
+++ b/src/marqo/tensor_search/constants.py
@@ -28,5 +28,7 @@ NON_OFFICIAL_LUCENE_SPECIAL_CHARS = {
     ' '
 }
 
-# If the OpenSearch cluster is this percent full, health should return red
-OPENSEARCH_DISK_BREACH_WATERMARK = .85
+# Order is important here: transient, persistent, then defaults.
+OPENSEARCH_CLUSTER_SETTINGS_TYPES = ["transient", "persistent", "defaults"]
+
+BYTE_SUFFIXES = ['b', 'kb', 'mb', 'gb', 'tb', 'pb', 'eb', 'zb', 'yb']

--- a/src/marqo/tensor_search/constants.py
+++ b/src/marqo/tensor_search/constants.py
@@ -31,4 +31,16 @@ NON_OFFICIAL_LUCENE_SPECIAL_CHARS = {
 # Order is important here: transient, persistent, then defaults.
 OPENSEARCH_CLUSTER_SETTINGS_TYPES = ["transient", "persistent", "defaults"]
 
-BYTE_SUFFIXES = ['b', 'kb', 'mb', 'gb', 'tb', 'pb', 'eb', 'zb', 'yb']
+# To convert from {key} to bytes, we multiply by 1024 ** {value}
+# eg. 10kb = 10 * (1024 ** 1) bytes, 5mb = 5 * (1024 ** 2) bytes
+BYTE_SUFFIX_EXPONENTS = {
+    'b': 0, 
+    'kb': 1, 
+    'mb': 2, 
+    'gb': 3, 
+    'tb': 4, 
+    'pb': 5, 
+    'eb': 6, 
+    'zb': 7, 
+    'yb': 8
+}

--- a/src/marqo/tensor_search/constants.py
+++ b/src/marqo/tensor_search/constants.py
@@ -27,3 +27,6 @@ LUCENE_SPECIAL_CHARS = {
 NON_OFFICIAL_LUCENE_SPECIAL_CHARS = {
     ' '
 }
+
+# If the OpenSearch cluster is this percent full, health should return red
+OPENSEARCH_DISK_BREACH_WATERMARK = .85

--- a/src/marqo/tensor_search/enums.py
+++ b/src/marqo/tensor_search/enums.py
@@ -153,10 +153,10 @@ class HealthStatuses(str, Enum):
     yellow = "yellow"
     red = "red"
 
-    def __lt__(self, other):
+    def __gt__(self, other):
         # Define the custom comparison logic
         status_order = [self.green, self.yellow, self.red]
-        return status_order.index(self) < status_order.index(other)
+        return status_order.index(self) > status_order.index(other)
     
 
 

--- a/src/marqo/tensor_search/enums.py
+++ b/src/marqo/tensor_search/enums.py
@@ -153,11 +153,15 @@ class HealthStatuses(str, Enum):
     yellow = "yellow"
     red = "red"
 
-    def __gt__(self, other):
-        # Define the custom comparison logic
+    def _status_index(self):
         status_order = [self.green, self.yellow, self.red]
-        return status_order.index(self) > status_order.index(other)
-    
+        return status_order.index(self)
+
+    def __gt__(self, other):
+        return self._status_index() > other._status_index()
+
+    def __lt__(self, other):
+        return self._status_index() < other._status_index()
 
 
 

--- a/src/marqo/tensor_search/health.py
+++ b/src/marqo/tensor_search/health.py
@@ -1,0 +1,103 @@
+from marqo.tensor_search import constants
+from marqo.tensor_search import validation
+from marqo._httprequests import HttpRequests
+from marqo.config import Config
+from marqo import errors
+from marqo.tensor_search.tensor_search_logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def convert_watermark_to_bytes(watermark: str, total_in_bytes: str = None):
+    """
+    Converts a value to bytes.
+    It could possible be:
+    1. Bytes (eg 123.4gb) - do nothing
+    2. MB, GB, TB, etc, (eg 123.4gb) - divide by some power of 1024 to get bytes
+    3. Ratio (e.g. 0.9) - multiply by total_in_bytes to get bytes
+    4. Percentage (e.g. 90%) - convert to ratio then multiply by total_in_bytes to get bytes
+
+    Returns: watermark in bytes (float)
+    """
+
+    # Initial validation
+    if watermark is None:
+        raise errors.InternalError("OpenSearch disk watermark cannot be None.")
+    watermark = watermark.replace(" ", "")
+    if watermark == "":
+        raise errors.InternalError("OpenSearch disk watermark cannot be empty string.")
+    
+    if total_in_bytes is not None:
+        total_in_bytes = validation.validate_nonnegative_number(total_in_bytes, "OpenSearch disk total size in bytes")
+    
+    if watermark[-2:].lower() in constants.BYTE_SUFFIXES:
+        # Watermark in KB/MB/GB/TB format
+        # Bytes represent MIN disk space AVAILABLE
+        # TODO: Do we use 1000 or 1024 for conversion?
+        numeric_watermark = validation.validate_nonnegative_number(watermark[:-2], "OpenSearch disk watermark value")
+        multiplier = 1024 ** constants.BYTE_SUFFIXES.index(watermark[-2:].lower())
+        return numeric_watermark * multiplier
+        
+    elif watermark[-1].lower() == "b":
+        # Watermark in BYTE format
+        # Bytes represent MIN disk space AVAILABLE
+        numeric_watermark = validation.validate_nonnegative_number(watermark[:-1], "OpenSearch disk watermark value")
+        return numeric_watermark
+    
+    # Percentage or Ratio calculation
+    if watermark[-1] == "%":
+        # Watermark in PERCENTAGE format
+        # Ratio & percentage represent MAX disk space USED
+        numeric_watermark = validation.validate_nonnegative_number(watermark[:-1], "OpenSearch disk watermark value")
+        ratio_watermark = (100 - numeric_watermark) / 100
+    else:
+        # Watermark in RATIO format
+        # Ratio & percentage represent MAX disk space USED
+        numeric_watermark = validation.validate_nonnegative_number(watermark, "OpenSearch disk watermark value")
+        ratio_watermark = 1 - numeric_watermark
+
+    if ratio_watermark < 0 or ratio_watermark > 1:
+        raise errors.InternalError("OpenSearch watermark ratio or percentage cannot be negative or more than 100%.")
+    if total_in_bytes is None:
+        raise errors.InternalError("total_in_bytes must be provided for ratio or percentage watermark.")
+    
+    return total_in_bytes * ratio_watermark
+
+
+def check_opensearch_disk_watermark_breach(config: Config):
+    """
+    Checks if the OpenSearch disk watermark is breached:
+    1. Check disk watermark from the settings endpoint.
+      - Check transient, persistent, then default settings
+      - convert it to a size in BYTES (it could initially be a percentage, ratio, or size in B, GB, MB, etc.)
+    2. Check the current available disk space from the stats endpoint.
+    3. Compare current avilable space to watermark value.
+
+    Returns: red if watermark is breached, green otherwise.
+    """
+
+    # TODO: Check for disk threshhold enabled?
+    # Query opensearch for watermark
+    raw_flood_stage_watermark = None
+    for settings_type in constants.OPENSEARCH_CLUSTER_SETTINGS_TYPES:
+        try:
+            # Check for transient, persistent, then defaults settings
+            opensearch_disk_settings = HttpRequests(config).get(path="_cluster/settings?include_defaults=true")\
+                [settings_type]["cluster"]["routing"]["allocation"]["disk"]
+            # TODO: Should we use flood stage? or high? or low?
+            raw_flood_stage_watermark = opensearch_disk_settings["watermark"]["flood_stage"]
+            logger.debug(f"Found disk flood stage watermark in {settings_type} settings: {raw_flood_stage_watermark}")
+            break
+        except KeyError:
+            logger.debug(f"Flood stage watermark not found in {settings_type} settings.")
+    
+    if not raw_flood_stage_watermark:
+        raise errors.BackendCommunicationError("Could not find disk flood stage watermark in OpenSearch settings.")
+    
+    # Query opensearch for disk space
+    filesystem_stats = HttpRequests(config).get(path="_cluster/stats")["nodes"]["fs"]
+    minimum_available_disk_space = convert_watermark_to_bytes(watermark=raw_flood_stage_watermark, total_in_bytes=filesystem_stats["total_in_bytes"])
+
+    if filesystem_stats["available_in_bytes"] < minimum_available_disk_space:
+        return "red"
+    return "green"

--- a/src/marqo/tensor_search/health.py
+++ b/src/marqo/tensor_search/health.py
@@ -13,7 +13,7 @@ from marqo.tensor_search import validation
 logger = get_logger(__name__)
 
 
-def convert_watermark_to_bytes(watermark: str, total_in_bytes: int = None):
+def convert_watermark_to_bytes(watermark: str, total_in_bytes: int = None) -> int:
     """
     Converts a value to bytes.
     It could possible be:
@@ -35,12 +35,11 @@ def convert_watermark_to_bytes(watermark: str, total_in_bytes: int = None):
     if total_in_bytes is not None and total_in_bytes < 0:
         raise errors.InternalError("OpenSearch cluster stats fs: total_in_bytes cannot be negative.")
 
-    if watermark[-2:].lower() in constants.BYTE_SUFFIXES:
+    if watermark[-2:].lower() in constants.BYTE_SUFFIX_EXPONENTS:
         # Watermark in KB/MB/GB/TB format
         # Bytes represent MIN disk space AVAILABLE
-        # TODO: Do we use 1000 or 1024 for conversion?
         numeric_watermark = validation.validate_nonnegative_number(watermark[:-2], "OpenSearch disk watermark value")
-        multiplier = 1024 ** constants.BYTE_SUFFIXES.index(watermark[-2:].lower())
+        multiplier = 1024 ** constants.BYTE_SUFFIX_EXPONENTS[watermark[-2:].lower()]
         return numeric_watermark * multiplier
         
     elif watermark[-1].lower() == "b":
@@ -93,7 +92,7 @@ def check_opensearch_disk_watermark_breach(config: Config):
             logger.debug(f"Found disk flood stage watermark in {settings_type} settings: {raw_flood_stage_watermark}")
             break
         except KeyError:
-            logger.debug(f"Flood stage watermark not found in {settings_type} settings.")
+            pass
     
     if not raw_flood_stage_watermark:
         raise errors.InternalError("Could not find disk flood stage watermark in OpenSearch settings.")

--- a/src/marqo/tensor_search/health.py
+++ b/src/marqo/tensor_search/health.py
@@ -13,7 +13,7 @@ from marqo.tensor_search import validation
 logger = get_logger(__name__)
 
 
-def convert_watermark_to_bytes(watermark: str, total_in_bytes: int = None) -> int:
+def convert_watermark_to_bytes(watermark: str, total_in_bytes: int = None):
     """
     Converts a value to bytes.
     It could possible be:

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -1826,7 +1826,6 @@ def check_health(config: Config):
     except errors.BackendCommunicationError:
         marqo_os_status = "red"
 
-    # Check marqo-os health endpoint
     if marqo_os_health_check is not None:
         if "status" in marqo_os_health_check:
             marqo_os_status = marqo_os_health_check['status']

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -61,7 +61,6 @@ from marqo.tensor_search.models.external_apis.abstract_classes import ExternalAu
 from marqo.tensor_search.telemetry import RequestMetricsStore
 from marqo.tensor_search.utils import add_timing
 from marqo.tensor_search import delete_docs
-from marqo.tensor_search import constants
 from marqo.s2_inference.processing import text as text_processor
 from marqo.s2_inference.processing import image as image_processor
 from marqo.s2_inference.clip_utils import _is_image
@@ -1836,15 +1835,7 @@ def check_health(config: Config):
     else:
         marqo_os_status = "red"
 
-    # Check if disk space is below watermark
-    # Query opensearch for disk space
-    filesystem_stats = HttpRequests(config).get(path="_cluster/stats")["nodes"]["fs"]
-    current_percent_disk_remaining = filesystem_stats["available_in_bytes"] / filesystem_stats["total_in_bytes"]
-    minimum_percent_disk_remaining = 1 - constants.OPENSEARCH_DISK_BREACH_WATERMARK
-
-    if current_percent_disk_remaining < minimum_percent_disk_remaining:
-        # if disk space is below watermark, return red
-        marqo_os_status = "red"
+    
 
     # if marqo os returns anything worse than green, return it
     marqo_status = marqo_status if statuses[marqo_status] >= statuses[marqo_os_status] else marqo_os_status

--- a/src/marqo/tensor_search/validation.py
+++ b/src/marqo/tensor_search/validation.py
@@ -621,3 +621,27 @@ def validate_delete_docs_request(delete_request: MqDeleteDocsRequest, max_delete
 
     return delete_request
 
+
+def validate_nonnegative_number(input_string: str, field_description: str = "Input"):
+    """Validates that a string is a non-negative number
+
+    Args:
+        input_string: the string to validate
+
+    Returns:
+        input_string converted to a float, if it is a non-negative number
+
+    Raises:
+        InternalError if the string is not a non-negative number,
+        with a message dependent on field_description
+    """
+    try:
+        output_number = float(input_string)
+    except ValueError:
+        raise InternalError(f"`{field_description} must be a valid number! It is currently: {input_string}.`")
+    if output_number < 0:
+        raise InternalError(f"{field_description} cannot be a negative number! It is currently: `{input_string}`.")
+    return output_number
+
+
+

--- a/src/marqo/tensor_search/validation.py
+++ b/src/marqo/tensor_search/validation.py
@@ -627,10 +627,11 @@ def validate_nonnegative_number(input_string: str, field_description: str = "Inp
 
     Args:
         input_string: the string to validate
+        field_description: description of the value being validated, to be used in error messages
 
     Returns:
         input_string converted to a float, if it is a non-negative number
-
+        
     Raises:
         InternalError if the string is not a non-negative number,
         with a message dependent on field_description

--- a/tests/tensor_search/test__httprequests.py
+++ b/tests/tensor_search/test__httprequests.py
@@ -76,8 +76,8 @@ class Test_HttpRequests(MarqoTestCase):
                     )
                 )
                 raise AssertionError
-            except DiskWatermarkBreachError:
-                pass
+            except DiskWatermarkBreachError as e:
+                print(e.message)
             return True
         assert run()
         

--- a/tests/tensor_search/test__httprequests.py
+++ b/tests/tensor_search/test__httprequests.py
@@ -77,7 +77,7 @@ class Test_HttpRequests(MarqoTestCase):
                 )
                 raise AssertionError
             except DiskWatermarkBreachError as e:
-                print(e.message)
+                pass
             return True
         assert run()
         

--- a/tests/tensor_search/test__httprequests.py
+++ b/tests/tensor_search/test__httprequests.py
@@ -4,7 +4,7 @@ from marqo.tensor_search.models.add_docs_objects import AddDocsParams
 from unittest import mock
 from marqo.tensor_search import tensor_search
 from marqo.errors import (
-    IndexNotFoundError, TooManyRequestsError
+    IndexNotFoundError, TooManyRequestsError, DiskWatermarkBreachError
 )
 
 class Test_HttpRequests(MarqoTestCase):
@@ -19,10 +19,13 @@ class Test_HttpRequests(MarqoTestCase):
             pass
 
     def test_too_many_reqs_error(self):
+        # Generic 429, we assume the cause is TooManyRequestsError
+        # TODO: OpenSearch seems to raise 429 for any requestRejected: https://opensearch.org/docs/2.7/data-prepper/pipelines/configuration/sources/http-source/
+        # Therefore, we should use response.error.type instead of response.status_code
         mock_post = mock.MagicMock()
         mock_response = requests.Response()
         mock_response.status_code = 429
-        mock_response.json = lambda: '{"a":"b"}'
+        mock_response.json = lambda: {'error': {'type': 'too_many_requests'}} # TODO: confirm if this is really what opensearch returns
         mock_post.return_value = mock_response
         tensor_search.create_vector_index(config=self.config, index_name=self.index_name_1)
 
@@ -41,4 +44,42 @@ class Test_HttpRequests(MarqoTestCase):
                 pass
             return True
         assert run()
+    
+    def test_opensearch_cluster_block_exception(self):
+        mock_post = mock.MagicMock()
+        mock_response = requests.Response()
+        mock_response.status_code = 429
+        mock_response.json = lambda: \
+        {'error': 
+            {'reason': 'index [TEST-INDEX] blocked by: '
+                        '[TOO_MANY_REQUESTS/12/disk usage exceeded flood-stage '
+                        'watermark, index has read-only-allow-delete block];',
+            'root_cause': [{'reason': 'index [TEST-INDEX] blocked by: '
+                                        '[TOO_MANY_REQUESTS/12/disk usage '
+                                        'exceeded flood-stage watermark, index '
+                                        'has read-only-allow-delete block];',
+                            'type': 'cluster_block_exception'}],
+            'type': 'cluster_block_exception'},
+            'status': 429
+        }
+        mock_post.return_value = mock_response
+        tensor_search.create_vector_index(config=self.config, index_name=self.index_name_1)
+
+        @mock.patch('requests.post', mock_post)
+        @mock.patch('marqo._httprequests.ALLOWED_OPERATIONS', {mock_post, requests.get, requests.put})
+        def run():
+            try:
+                res = tensor_search.add_documents(
+                    config=self.config, add_docs_params=AddDocsParams(
+                        index_name=self.index_name_1,
+                        docs=[{"some ": "doc"}], auto_refresh=True, device="cpu"
+                    )
+                )
+                raise AssertionError
+            except DiskWatermarkBreachError:
+                pass
+            return True
+        assert run()
+        
+
 

--- a/tests/tensor_search/test_healthcheck.py
+++ b/tests/tensor_search/test_healthcheck.py
@@ -13,6 +13,7 @@ from tests.marqo_test import MarqoTestCase
 from marqo.tensor_search.enums import IndexSettingsField as NsField
 from marqo import errors
 from marqo.tensor_search import health
+from unittest import mock
 
 
 class TestHealthCheck(MarqoTestCase):
@@ -53,53 +54,479 @@ class TestHealthCheck(MarqoTestCase):
     def test_convert_watermark_to_bytes(self):
         test_cases = [
             # byte watermarks (total_in_bytes is ignored)
-            ("0b", "99999", 0),
-            ("21b", "99999", 21),
-            ("21B", "99999", 21),
-            ("2.1B", "99999", 2.1),
-            ("2.1 b", "99999", 2.1),
-            ("2.1garbage1b", "99999", errors.InternalError),
+            ("0b", 99999, 0),
+            ("21b", 99999, 21),
+            ("21B", 99999, 21),
+            ("2.1B", 99999, 2.1),
+            ("2.1 b", 99999, 2.1),
+            ("2.1garbage1b", 99999, errors.InternalError),
             # kb/gb/mb/tb watermarks (total_in_bytes is ignored)
-            ("0kb", "99999", 0),
-            ("21kb", "99999", 21 * 1024),
-            ("2.1MB", "99999", 2.1 * 1024 ** 2),
-            ("21GB", "99999", 21 * 1024 ** 3),
-            ("2.1 TB", "99999", 2.1 * 1024 ** 4),
-            ("2.1garbagePB", "99999", errors.InternalError),
-            ("2.1XB", "99999", errors.InternalError),
+            ("0kb", 99999, 0),
+            ("21kb", 99999, 21 * 1024),
+            ("2.1MB", 99999, 2.1 * 1024 ** 2),
+            ("21GB", 99999, 21 * 1024 ** 3),
+            ("2.1 TB", 99999, 2.1 * 1024 ** 4),
+            ("2.1garbagePB", 99999, errors.InternalError),
+            ("2.1XB", 99999, errors.InternalError),
 
             # percentage watermarks
-            ("0%", "1000", 1000),
-            ("80%", "1000", 200),
-            ("100%", "1000", 0),
-            ("40.%", "1000", 600),
-            ("0.5%", "1000", 995),
-            ("1garbage2%", "1000", errors.InternalError),
-            ("-1%", "1000", errors.InternalError),
-            ("101%", "1000", errors.InternalError),
- 
+            ("0%", 1000, 1000),
+            ("80%", 1000, 200),
+            ("95%", 10000000, 500000),    # 95% of 10MB Volume
+            ("100%", 1000, 0),
+            ("40.%", 1000, 600),
+            ("0.5%", 1000, 995),
+            ("1garbage2%", 1000, errors.InternalError),
+            ("-1%", 1000, errors.InternalError),
+            ("101%", 1000, errors.InternalError),
+
             # ratio watermarks
-            ("0", "1000", 1000),
-            (".80", "1000", 200),
-            ("1.00", "1000", 0),
-            ("0.4", "1000", 600),
-            (".005", "1000", 995),
-            ("0.1garbage2", "1000", errors.InternalError),
-            ("-.01", "1000", errors.InternalError),
-            ("1.01", "1000", errors.InternalError),
+            ("0", 1000, 1000),
+            (".80", 1000, 200),
+            ("1.00", 1000, 0),
+            ("0.4", 1000, 600),
+            (".005", 1000, 995),
+            ("0.1garbage2", 1000, errors.InternalError),
+            ("-.01", 1000, errors.InternalError),
+            ("1.01", 1000, errors.InternalError),
 
             # edge cases
-            ("", "99999", errors.InternalError),
-            (" ", "99999", errors.InternalError),
-            (None, "99999", errors.InternalError),
+            ("", 99999, errors.InternalError),
+            (" ", 99999, errors.InternalError),
+            (None, 99999, errors.InternalError)
         ]
 
         for watermark, total_in_bytes, expected in test_cases:
             try:
                 result = health.convert_watermark_to_bytes(watermark, total_in_bytes)
                 self.assertAlmostEqual(result, expected)
-            except expected:
-                pass
+            except Exception as e:
+                assert isinstance(e, expected)
     
 
-    def test_check_opensearch_disk_watermark_breach
+    def test_check_opensearch_disk_watermark_breach(self):
+        # Note that percentages and ratios are USED SPACE CEILINGS (90%, 0.85, etc)
+        # while bytes, kb, mb, gb, tb are MINIMUM AVAILABLE SPACE FLOORS (1gb [out of 10gb], 15kb [out of 100kb], etc])
+        test_cases = [
+            # Watermark in transient settings only
+            {   
+                "SETTINGS_OBJECT": {
+                    "transient": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {"flood_stage": "1kb"}}}}}
+                    },
+                    "persistent": {},
+                    "defaults": {}
+                },
+                "STATS_OBJECT": {
+                    "nodes": {
+                        "fs": {"total_in_bytes": 5000, "available_in_bytes": 1025}
+                    }
+                },
+                "EXPECTED": "green"
+            },
+            # Watermark in persistent settings only
+            {   
+                "SETTINGS_OBJECT": {
+                    "transient": {},
+                    "persistent": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {
+                            "flood_stage": "1kb"
+                        }}}}}
+                    },
+                    "defaults": {}
+                },
+                "STATS_OBJECT": {
+                    "nodes": {
+                        "fs": {"total_in_bytes": 5000, "available_in_bytes": 1025}
+                    }
+                },
+                "EXPECTED": "green"
+            },
+            # Watermark in defaults settings only
+            {   
+                "SETTINGS_OBJECT": {
+                    "transient": {},
+                    "persistent": {},
+                    "defaults": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {
+                            "flood_stage": "1kb"
+                        }}}}}
+                    }
+                },
+                "STATS_OBJECT": {
+                    "nodes": {
+                        "fs": {"total_in_bytes": 5000, "available_in_bytes": 1025}
+                    }
+                },
+                "EXPECTED": "green"
+            },
+            # Watermark in transient and persistent settings
+            {
+                "SETTINGS_OBJECT": {
+                    "transient": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {"flood_stage": "1kb"}}}}}
+                    },
+                    "persistent": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {"flood_stage": "2kb"}}}}}
+                    },
+                    "defaults": {}
+                },
+                "STATS_OBJECT": {
+                    "nodes": {
+                        "fs": {"total_in_bytes": 5000, "available_in_bytes": 1025}
+                    }
+                },
+                "EXPECTED": "green"
+            },
+
+            # Watermark in transient and defaults settings
+            {
+                "SETTINGS_OBJECT": {
+                    "transient": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {"flood_stage": "1kb"}}}}}
+                    },
+                    "persistent": {},
+                    "defaults": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {"flood_stage": "3kb"}}}}}
+                    }
+                },
+                "STATS_OBJECT": {
+                    "nodes": {
+                        "fs": {"total_in_bytes": 5000, "available_in_bytes": 1025}
+                    }
+                },
+                "EXPECTED": "green"
+            },
+
+            # Watermark in persistent and defaults settings
+            {
+                "SETTINGS_OBJECT": {
+                    "transient": {},
+                    "persistent": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {"flood_stage": "2kb"}}}}}
+                    },
+                    "defaults": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {"flood_stage": "3kb"}}}}}
+                    }
+                },
+                "STATS_OBJECT": {
+                    "nodes": {
+                        "fs": {"total_in_bytes": 5000, "available_in_bytes": 2049}
+                    }
+                },
+                "EXPECTED": "green"
+            },
+
+            # Watermark in all 3 settings
+            {
+                "SETTINGS_OBJECT": {
+                    "transient": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {"flood_stage": "1kb"}}}}}
+                    },
+                    "persistent": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {"flood_stage": "2kb"}}}}}
+                    },
+                    "defaults": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {"flood_stage": "3kb"}}}}}
+                    }
+                },
+                "STATS_OBJECT": {
+                    "nodes": {
+                        "fs": {"total_in_bytes": 5000, "available_in_bytes": 1025}
+                    }
+                },
+                "EXPECTED": "green"
+            },
+            
+            # Watermark in none of the settings
+            {
+                "SETTINGS_OBJECT": {
+                    "transient": {},
+                    "persistent": {},
+                    "defaults": {}
+                },
+                "STATS_OBJECT": {
+                    "nodes": {
+                        "fs": {"total_in_bytes": 5000, "available_in_bytes": 2000}
+                    }
+                },
+                "EXPECTED": errors.InternalError
+            },
+
+            # Watermark in B format, not breached
+            {
+                "SETTINGS_OBJECT": {
+                    "transient": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {"flood_stage": "1b"}}}}}
+                    },
+                    "persistent": {},
+                    "defaults": {}
+                },
+                "STATS_OBJECT": {
+                    "nodes": {
+                        "fs": {"total_in_bytes": 5000, "available_in_bytes": 2}
+                    }
+                },
+                "EXPECTED": "green"
+            },
+
+            # Watermark in B format, EXACTLY ON THE LIMIT
+            {
+                "SETTINGS_OBJECT": {
+                    "transient": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {"flood_stage": "2b"}}}}}
+                    },
+                    "persistent": {},
+                    "defaults": {}
+                },
+                "STATS_OBJECT": {
+                    "nodes": {
+                        "fs": {"total_in_bytes": 5000, "available_in_bytes": 2}
+                    }
+                },
+                "EXPECTED": "red"   # exactly on the limit is means BREACHED
+            },
+
+            # Watermark in B format, breached
+            {
+                "SETTINGS_OBJECT": {
+                    "transient": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {"flood_stage": "3b"}}}}}
+                    },
+                    "persistent": {},
+                    "defaults": {}
+                },
+                "STATS_OBJECT": {
+                    "nodes": {
+                        "fs": {"total_in_bytes": 5000, "available_in_bytes": 2}
+                    }
+                },
+                "EXPECTED": "red"
+            },
+
+            # Watermark in GB format
+            {
+                "SETTINGS_OBJECT": {
+                    "transient": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {"flood_stage": "1gb"}}}}}
+                    },
+                    "persistent": {},
+                    "defaults": {}
+                },
+                "STATS_OBJECT": {
+                    "nodes": {
+                        "fs": {"total_in_bytes": 1024**3 * 5, "available_in_bytes": 20}
+                    }
+                },
+                "EXPECTED": "red"
+            },
+
+            # Watermark in percent format
+            {
+                "SETTINGS_OBJECT": {
+                    "transient": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {"flood_stage": "90%"}}}}}
+                    },
+                    "persistent": {},
+                    "defaults": {}
+                },
+                "STATS_OBJECT": {
+                    "nodes": {
+                        "fs": {"total_in_bytes": 5000, "available_in_bytes": 501}
+                    }
+                },
+                "EXPECTED": "green"
+            },
+
+            # Watermark in percent format, EXACTLY ON THE LIMIT
+            {
+                "SETTINGS_OBJECT": {
+                    "transient": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {"flood_stage": "90%"}}}}}
+                    },
+                    "persistent": {},
+                    "defaults": {}
+                },
+                "STATS_OBJECT": {
+                    "nodes": {
+                        "fs": {"total_in_bytes": 5000, "available_in_bytes": 500}
+                    }
+                },
+                "EXPECTED": "red"
+            },
+
+            # Watermark in percent format, breached
+            {
+                "SETTINGS_OBJECT": {
+                    "transient": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {"flood_stage": "90%"}}}}}
+                    },
+                    "persistent": {},
+                    "defaults": {}
+                },
+                "STATS_OBJECT": {
+                    "nodes": {
+                        "fs": {"total_in_bytes": 5000, "available_in_bytes": 499}
+                    }
+                },
+                "EXPECTED": "red"
+            },
+
+            # Watermark in ratio format
+            {
+                "SETTINGS_OBJECT": {
+                    "transient": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {"flood_stage": "0.9"}}}}}
+                    },
+                    "persistent": {},
+                    "defaults": {}
+                },
+                "STATS_OBJECT": {
+                    "nodes": {
+                        "fs": {"total_in_bytes": 5000, "available_in_bytes": 501}
+                    }
+                },
+                "EXPECTED": "green"
+            },
+            # Watermark in ratio format, EXACTLY ON THE LIMIT
+            {
+                "SETTINGS_OBJECT": {
+                    "transient": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {"flood_stage": "0.9"}}}}}
+                    },
+                    "persistent": {},
+                    "defaults": {}
+                },
+                "STATS_OBJECT": {
+                    "nodes": {
+                        "fs": {"total_in_bytes": 5000, "available_in_bytes": 500}
+                    }
+                },
+                "EXPECTED": "red"
+            },
+            # Watermark in ratio format, breached
+            {
+                "SETTINGS_OBJECT": {
+                    "transient": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {"flood_stage": "0.9"}}}}}
+                    },
+                    "persistent": {},
+                    "defaults": {}
+                },
+                "STATS_OBJECT": {
+                    "nodes": {
+                        "fs": {"total_in_bytes": 5000, "available_in_bytes": 499}
+                    }
+                },
+                "EXPECTED": "red"
+            },
+            # Realistic values: Percentage, not breached
+            {
+                "SETTINGS_OBJECT": {
+                    "transient": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {"flood_stage": "95%"}}}}}
+                    },
+                    "persistent": {},
+                    "defaults": {}
+                },
+                "STATS_OBJECT": {
+                    "nodes": {
+                        "fs": {
+                            "total_in_bytes": 100094816512,     # ~100GB Storage
+                            "available_in_bytes": 5123456789    # ~5GB Available
+                        },
+                    }
+                },
+                "EXPECTED": "green"
+            },
+            # Realistic values: Percentage, breached
+            {
+                "SETTINGS_OBJECT": {
+                    "transient": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {"flood_stage": "95%"}}}}}
+                    },
+                    "persistent": {},
+                    "defaults": {}
+                },
+                "STATS_OBJECT": {
+                    "nodes": {
+                        "fs": {
+                            "total_in_bytes": 100094816512,     # ~100GB Storage
+                            "available_in_bytes": 4123456789    # ~4GB Available
+                        },
+                    }
+                },
+                "EXPECTED": "red"
+            },
+            # Realistic values: GB, not breached
+            {
+                "SETTINGS_OBJECT": {
+                    "transient": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {"flood_stage": "0.48404636383056643gb"}}}}}
+                    },
+                    "persistent": {},
+                    "defaults": {}
+                },
+                "STATS_OBJECT": {
+                    "nodes": {
+                        "fs": {
+                            "total_in_bytes": 10394816512,
+                            "available_in_bytes": 492272384
+                        },
+                    }
+                },
+                "EXPECTED": "red"
+            },
+            # Realistic values: GB, breached
+            {
+                "SETTINGS_OBJECT": {
+                    "transient": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {"flood_stage": "0.48404636383056643gb"}}}}}
+                    },
+                    "persistent": {},
+                    "defaults": {}
+                },
+                "STATS_OBJECT": {
+                    "nodes": {
+                        "fs": {
+                            "total_in_bytes": 10394816512,
+                            "available_in_bytes": 352272384
+                        },
+                    }
+                },
+                "EXPECTED": "red"
+            },
+            # Negative total_in_bytes
+            {
+                "SETTINGS_OBJECT": {
+                    "transient": {
+                        "cluster": {"routing": {"allocation": {"disk": {"watermark": {"flood_stage": "1kb"}}}}}
+                    },
+                    "persistent": {},
+                    "defaults": {}
+                },
+                "STATS_OBJECT": {
+                    "nodes": {
+                        "fs": {"total_in_bytes": -1000, "available_in_bytes": 1001}
+                    }
+                },
+                "EXPECTED": errors.InternalError
+            }
+        ]
+
+        for test_case in test_cases:
+            def mock_http_get(path):
+                if path == "_cluster/settings?include_defaults=true&filter_path=**.disk*":
+                    return test_case["SETTINGS_OBJECT"]
+                elif path == "_cluster/stats":
+                    return test_case["STATS_OBJECT"]
+                else:
+                    raise Exception(f"Unexpected path: {path}")
+            
+            with mock.patch("marqo._httprequests.HttpRequests.get", side_effect=mock_http_get):
+                try:
+                    assert health.check_opensearch_disk_watermark_breach(self.config) == test_case["EXPECTED"]
+                except Exception as e:
+                    if isinstance(e, AssertionError):
+                        raise e
+                    assert isinstance(e, test_case["EXPECTED"])

--- a/tests/tensor_search/test_healthcheck.py
+++ b/tests/tensor_search/test_healthcheck.py
@@ -11,6 +11,8 @@ from marqo.tensor_search import tensor_search
 from marqo.tensor_search import configs
 from tests.marqo_test import MarqoTestCase
 from marqo.tensor_search.enums import IndexSettingsField as NsField
+from marqo import errors
+from marqo.tensor_search import health
 
 
 class TestHealthCheck(MarqoTestCase):
@@ -47,3 +49,57 @@ class TestHealthCheck(MarqoTestCase):
             assert health_check_status['backend']['status'] == 'red'
             return True
         assert run()
+    
+    def test_convert_watermark_to_bytes(self):
+        test_cases = [
+            # byte watermarks (total_in_bytes is ignored)
+            ("0b", "99999", 0),
+            ("21b", "99999", 21),
+            ("21B", "99999", 21),
+            ("2.1B", "99999", 2.1),
+            ("2.1 b", "99999", 2.1),
+            ("2.1garbage1b", "99999", errors.InternalError),
+            # kb/gb/mb/tb watermarks (total_in_bytes is ignored)
+            ("0kb", "99999", 0),
+            ("21kb", "99999", 21 * 1024),
+            ("2.1MB", "99999", 2.1 * 1024 ** 2),
+            ("21GB", "99999", 21 * 1024 ** 3),
+            ("2.1 TB", "99999", 2.1 * 1024 ** 4),
+            ("2.1garbagePB", "99999", errors.InternalError),
+            ("2.1XB", "99999", errors.InternalError),
+
+            # percentage watermarks
+            ("0%", "1000", 1000),
+            ("80%", "1000", 200),
+            ("100%", "1000", 0),
+            ("40.%", "1000", 600),
+            ("0.5%", "1000", 995),
+            ("1garbage2%", "1000", errors.InternalError),
+            ("-1%", "1000", errors.InternalError),
+            ("101%", "1000", errors.InternalError),
+ 
+            # ratio watermarks
+            ("0", "1000", 1000),
+            (".80", "1000", 200),
+            ("1.00", "1000", 0),
+            ("0.4", "1000", 600),
+            (".005", "1000", 995),
+            ("0.1garbage2", "1000", errors.InternalError),
+            ("-.01", "1000", errors.InternalError),
+            ("1.01", "1000", errors.InternalError),
+
+            # edge cases
+            ("", "99999", errors.InternalError),
+            (" ", "99999", errors.InternalError),
+            (None, "99999", errors.InternalError),
+        ]
+
+        for watermark, total_in_bytes, expected in test_cases:
+            try:
+                result = health.convert_watermark_to_bytes(watermark, total_in_bytes)
+                self.assertAlmostEqual(result, expected)
+            except expected:
+                pass
+    
+
+    def test_check_opensearch_disk_watermark_breach


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
1. When OpenSearch returns a 429 error, Marqo automatically converts it to `TooManyRequests`, when sometimes it can be a `rejectedRequest` due to breached flood stage disk watermark.
2. Health check is unaffected by breached flood stage disk watermark.

* **What is the new behavior (if this is a feature change)?**
1. OpenSearch errors with the error type `cluster_block_exception` are now returned as 507 Insufficient Storage errors, as they are caused by a breached flood stage disk watermark.
2. Health check will now return "red" if available OpenSearch disk space is below the flood stage disk watermark.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
In progress

* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

