### PR TITLE
Updates to OpenSearch Disk Breach Check

### DIFF
--- a/src/marqo/_httprequests.py
+++ b/src/marqo/_httprequests.py
@@ -168,10 +168,8 @@ def convert_to_marqo_web_error_and_raise(response: requests.Response, err: reque
                 raise IndexMaxFieldsError(message="Exceeded maximum number of "
                                                   "allowed fields for this index.")
         elif open_search_error_type == "cluster_block_exception":
-            raise DiskWatermarkBreachError(message="OpenSearch cluster indexing has been blocked, most likely due to breach "
-                                           "of the `flood_stage` disk watermark. Try freeing up disk space on your OpenSearch instances. "
-                                           "For more information, please refer to cluster settings: `cluster.routing.allocation.disk.watermark` at "
-                                           "https://opensearch.org/docs/2.7/api-reference/cluster-api/cluster-settings/")
+            raise DiskWatermarkBreachError(message="Your Marqo storage is full. "
+                                           "Please delete documents before attempting to add any new documents.")
     except KeyError:
         pass
 

--- a/src/marqo/errors.py
+++ b/src/marqo/errors.py
@@ -219,4 +219,4 @@ class ConfigurationError(InternalError):
 class DiskWatermarkBreachError(InternalError):
     """Error when OpenSearch disk watermark is breached"""
     code = "disk_watermark_breach_error"
-    status_code = HTTPStatus.INSUFFICIENT_STORAGE
+    status_code = HTTPStatus.TOO_MANY_REQUESTS

--- a/src/marqo/errors.py
+++ b/src/marqo/errors.py
@@ -219,4 +219,4 @@ class ConfigurationError(InternalError):
 class DiskWatermarkBreachError(InternalError):
     """Error when OpenSearch disk watermark is breached"""
     code = "disk_watermark_breach_error"
-    status_code = HTTPStatus.TOO_MANY_REQUESTS
+    status_code = HTTPStatus.BAD_REQUEST

--- a/src/marqo/tensor_search/enums.py
+++ b/src/marqo/tensor_search/enums.py
@@ -162,6 +162,3 @@ class HealthStatuses(str, Enum):
 
     def __lt__(self, other):
         return self._status_index() < other._status_index()
-
-
-

--- a/src/marqo/tensor_search/health.py
+++ b/src/marqo/tensor_search/health.py
@@ -1,6 +1,6 @@
 import math
 import copy
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple
 
 from marqo import errors
 from marqo._httprequests import HttpRequests
@@ -16,8 +16,8 @@ logger = get_logger(__name__)
 def convert_watermark_to_bytes(watermark: str, total_in_bytes: int = None) -> int:
     """
     Converts a value to bytes.
-    It could possible be:
-    1. Bytes (eg 123.4gb) - do nothing
+    It could possibly be:
+    1. Bytes (eg 1234b) - do nothing
     2. MB, GB, TB, etc, (eg 123.4gb) - multiply by some power of 1024 to get bytes
     3. Ratio (e.g. 0.9) - multiply by total_in_bytes to get bytes
     4. Percentage (e.g. 90%) - convert to ratio then multiply by total_in_bytes to get bytes
@@ -107,23 +107,24 @@ def check_opensearch_disk_watermark_breach(config: Config):
 def generate_heath_check_response(config: Config, index_name: Optional[str] = None) -> dict:
     """Generate the health check response for check_heath(), check_index_health() APIs in tensor_search"""
     marqo_status = get_marqo_status()
-    marqo_os_status = get_marqo_os_status(config, index_name=index_name)
+    marqo_os_status, marqo_os_storage_is_available = get_marqo_os_status(config, index_name=index_name)
     aggregated_marqo_status, marqo_os_status = aggregate_status(marqo_status, marqo_os_status)
 
     return {
-        "status": aggregated_marqo_status,
+        "status": aggregated_marqo_status.value,
         "backend": {
-            "status": marqo_os_status
+            "status": marqo_os_status.value,
+            "storage_is_available": marqo_os_storage_is_available
         }
     }
 
 
-def get_marqo_status() -> Union[str, HealthStatuses]:
+def get_marqo_status() -> HealthStatuses:
     """Check the Marqo instance status."""
     return HealthStatuses.green
 
 
-def get_marqo_os_status(config: Config, index_name: Optional[str] = None) -> Union[str, HealthStatuses]:
+def get_marqo_os_status(config: Config, index_name: Optional[str] = None) -> Tuple[HealthStatuses, bool]:
     """
     Check the Marqo-os backend status.
 
@@ -152,14 +153,20 @@ def get_marqo_os_status(config: Config, index_name: Optional[str] = None) -> Uni
     else:
         marqo_os_status = HealthStatuses.red
 
-    # Returns red if disk watermark is breached.
-    marqo_os_status = max(marqo_os_status, check_opensearch_disk_watermark_breach(config))
+    marqo_os_disk_watermark_breached = check_opensearch_disk_watermark_breach(config)
+    # Storage is available if disk watermark is not breached (green).
+    if marqo_os_disk_watermark_breached == HealthStatuses.green:
+        marqo_os_storage_is_available = True
+    else:
+        marqo_os_storage_is_available = False
+    # Returns red status if disk watermark is breached.
+    marqo_os_status = max(marqo_os_status, marqo_os_disk_watermark_breached)
 
-    return marqo_os_status
+    return marqo_os_status, marqo_os_storage_is_available
 
 
-def aggregate_status(marqo_status: Union[str, HealthStatuses], marqo_os_status: Union[str, HealthStatuses]) \
-        -> Tuple[Union[str,HealthStatuses], Union[str, HealthStatuses]]:
+def aggregate_status(marqo_status: HealthStatuses, marqo_os_status: HealthStatuses) \
+        -> Tuple[HealthStatuses, HealthStatuses]:
     """Aggregate the Marqo instance and Marqo-os backend status."""
     aggregated_marqo_status = max(marqo_status, marqo_os_status)
     return aggregated_marqo_status, marqo_os_status

--- a/src/marqo/tensor_search/health.py
+++ b/src/marqo/tensor_search/health.py
@@ -78,7 +78,7 @@ def check_opensearch_disk_watermark_breach(config: Config):
     2. Check the current available disk space from the stats endpoint.
     3. Compare current avilable space to watermark value.
 
-    Returns: red if watermark is breached, green otherwise.
+    Returns: yellow if watermark is breached, green otherwise.
     """
 
     # Query opensearch for watermark
@@ -100,7 +100,7 @@ def check_opensearch_disk_watermark_breach(config: Config):
     filesystem_stats = HttpRequests(config).get(path="_cluster/stats")["nodes"]["fs"]
     minimum_available_disk_space = convert_watermark_to_bytes(watermark=raw_flood_stage_watermark, total_in_bytes=filesystem_stats["total_in_bytes"])
     if filesystem_stats["available_in_bytes"] <= minimum_available_disk_space:
-        return HealthStatuses.red
+        return HealthStatuses.yellow
     return HealthStatuses.green
 
 
@@ -154,14 +154,14 @@ def get_marqo_os_status(config: Config, index_name: Optional[str] = None) -> Tup
         marqo_os_status = HealthStatuses.red
 
     marqo_os_disk_watermark_breached = check_opensearch_disk_watermark_breach(config)
+    
     # Storage is available if disk watermark is not breached (green).
     if marqo_os_disk_watermark_breached == HealthStatuses.green:
         marqo_os_storage_is_available = True
     else:
         marqo_os_storage_is_available = False
-    # Returns red status if disk watermark is breached.
+    
     marqo_os_status = max(marqo_os_status, marqo_os_disk_watermark_breached)
-
     return marqo_os_status, marqo_os_storage_is_available
 
 

--- a/tests/tensor_search/test__httprequests.py
+++ b/tests/tensor_search/test__httprequests.py
@@ -6,6 +6,7 @@ from marqo.tensor_search import tensor_search
 from marqo.errors import (
     IndexNotFoundError, TooManyRequestsError, DiskWatermarkBreachError
 )
+from http import HTTPStatus
 
 class Test_HttpRequests(MarqoTestCase):
 
@@ -77,7 +78,11 @@ class Test_HttpRequests(MarqoTestCase):
                 )
                 raise AssertionError
             except DiskWatermarkBreachError as e:
-                pass
+                # Disk breach is a 429 error
+                assert e.code == "disk_watermark_breach_error"
+                assert e.status_code == HTTPStatus.TOO_MANY_REQUESTS
+                assert "Marqo storage is full" in e.message
+
             return True
         assert run()
         

--- a/tests/tensor_search/test__httprequests.py
+++ b/tests/tensor_search/test__httprequests.py
@@ -78,9 +78,9 @@ class Test_HttpRequests(MarqoTestCase):
                 )
                 raise AssertionError
             except DiskWatermarkBreachError as e:
-                # Disk breach is a 429 error
+                # Disk breach is a 400 error
                 assert e.code == "disk_watermark_breach_error"
-                assert e.status_code == HTTPStatus.TOO_MANY_REQUESTS
+                assert e.status_code == HTTPStatus.BAD_REQUEST
                 assert "Marqo storage is full" in e.message
 
             return True

--- a/tests/tensor_search/test_healthcheck.py
+++ b/tests/tensor_search/test_healthcheck.py
@@ -125,7 +125,7 @@ class TestHealthCheck(MarqoTestCase):
                         "fs": {"total_in_bytes": 5000, "available_in_bytes": 500}
                     }
                 },
-                "EXPECTED": ("red", False)
+                "EXPECTED": ("yellow", False)
             },
             # Health yellow and disk watermark NOT breached
             {
@@ -159,7 +159,7 @@ class TestHealthCheck(MarqoTestCase):
                         "fs": {"total_in_bytes": 5000, "available_in_bytes": 500}
                     }
                 },
-                "EXPECTED": ("red", False)
+                "EXPECTED": ("yellow", False)
             },
             # Health red and disk watermark NOT breached
             {
@@ -210,7 +210,7 @@ class TestHealthCheck(MarqoTestCase):
                         "fs": {"total_in_bytes": 1000000000, "available_in_bytes": 500}
                     }
                 },
-                "EXPECTED": ("red", False)
+                "EXPECTED": ("yellow", False)
             },
             # Ratio watermark
             {
@@ -227,7 +227,7 @@ class TestHealthCheck(MarqoTestCase):
                         "fs": {"total_in_bytes": 100, "available_in_bytes": 40}
                     }
                 },
-                "EXPECTED": ("red", False)
+                "EXPECTED": ("yellow", False)
             },
             # Percentage watermark
             {
@@ -244,7 +244,7 @@ class TestHealthCheck(MarqoTestCase):
                         "fs": {"total_in_bytes": 100, "available_in_bytes": 40}
                     }
                 },
-                "EXPECTED": ("red", False)
+                "EXPECTED": ("yellow", False)
             },
             # Missing watermark
             {
@@ -560,7 +560,7 @@ class TestHealthCheck(MarqoTestCase):
                         "fs": {"total_in_bytes": 5000, "available_in_bytes": 2}
                     }
                 },
-                "EXPECTED": "red"   # exactly on the limit is means BREACHED
+                "EXPECTED": "yellow"   # exactly on the limit is means BREACHED
             },
 
             # Watermark in B format, breached
@@ -577,7 +577,7 @@ class TestHealthCheck(MarqoTestCase):
                         "fs": {"total_in_bytes": 5000, "available_in_bytes": 2}
                     }
                 },
-                "EXPECTED": "red"
+                "EXPECTED": "yellow"
             },
 
             # Watermark in GB format
@@ -594,7 +594,7 @@ class TestHealthCheck(MarqoTestCase):
                         "fs": {"total_in_bytes": 1024**3 * 5, "available_in_bytes": 20}
                     }
                 },
-                "EXPECTED": "red"
+                "EXPECTED": "yellow"
             },
 
             # Watermark in percent format
@@ -628,7 +628,7 @@ class TestHealthCheck(MarqoTestCase):
                         "fs": {"total_in_bytes": 5000, "available_in_bytes": 500}
                     }
                 },
-                "EXPECTED": "red"
+                "EXPECTED": "yellow"
             },
 
             # Watermark in percent format, breached
@@ -645,7 +645,7 @@ class TestHealthCheck(MarqoTestCase):
                         "fs": {"total_in_bytes": 5000, "available_in_bytes": 499}
                     }
                 },
-                "EXPECTED": "red"
+                "EXPECTED": "yellow"
             },
 
             # Watermark in ratio format
@@ -678,7 +678,7 @@ class TestHealthCheck(MarqoTestCase):
                         "fs": {"total_in_bytes": 5000, "available_in_bytes": 500}
                     }
                 },
-                "EXPECTED": "red"
+                "EXPECTED": "yellow"
             },
             # Watermark in ratio format, breached
             {
@@ -694,7 +694,7 @@ class TestHealthCheck(MarqoTestCase):
                         "fs": {"total_in_bytes": 5000, "available_in_bytes": 499}
                     }
                 },
-                "EXPECTED": "red"
+                "EXPECTED": "yellow"
             },
             # Realistic values: Percentage, not breached
             {
@@ -732,7 +732,7 @@ class TestHealthCheck(MarqoTestCase):
                         },
                     }
                 },
-                "EXPECTED": "red"
+                "EXPECTED": "yellow"
             },
             # Realistic values: GB, not breached
             {
@@ -747,11 +747,11 @@ class TestHealthCheck(MarqoTestCase):
                     "nodes": {
                         "fs": {
                             "total_in_bytes": 10394816512,
-                            "available_in_bytes": 492272384
+                            "available_in_bytes": 522272384
                         },
                     }
                 },
-                "EXPECTED": "red"
+                "EXPECTED": "green"
             },
             # Realistic values: GB, breached
             {
@@ -770,7 +770,7 @@ class TestHealthCheck(MarqoTestCase):
                         },
                     }
                 },
-                "EXPECTED": "red"
+                "EXPECTED": "yellow"
             },
             # Negative total_in_bytes
             {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature update

* **What is the current behavior?** (You can also link to an open issue here)
1. 507 error when OpenSearch is full
2. No storage status for health check backend
3. Health check functions allow `str` instead of `HealthStatuses` as parameters.

* **What is the new behavior (if this is a feature change)?**
1. OpenSearch disk breach error is now 429, with more user-friendly error message
2. Health check now has `["backend"]["storage_is_available"]` which is a boolean determined by if the flood stage watermark is breached.
3. Stricter parameter types for health check functions: Only `HealthStatuses` allowed, as basic string comparison can lead to unexpected results (eg: `"yellow" > "red"`)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
in progress

* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

