### PR TITLE
Update m2 developer instructions

### DIFF
--- a/src/marqo/README.md
+++ b/src/marqo/README.md
@@ -139,7 +139,7 @@ onnx
 protobuf
 ```
 
-9. Install marqo dependencies. 
+8. Install marqo dependencies. 
 ```
 pip install -r requirements.txt
 ```
@@ -149,7 +149,8 @@ pip install -r requirements.txt
 CWD=$(pwd)
 cd src/marqo/tensor_search/
 ```
-9. Run Marqo,
+
+10. Run Marqo,
 ```
 export OPENSEARCH_URL="https://localhost:9200" && 
     export PYTHONPATH="${PYTHONPATH}:${CWD}/src" &&

--- a/src/marqo/README.md
+++ b/src/marqo/README.md
@@ -133,7 +133,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs/ | sh;
 
 6. Set up redis (follow instructions in Option A)
 
-7. Install marqo dependencies. If you are using an M2 Mac specifically, then install use the requirements specified in [this gist](https://gist.github.com/pandu-k/f3cdf319b7abaa1d0e5c5e038e16377c#file-pip_requirements_for_m2_devs-txt) (this installs `onnx` and `protobuf` for M2 Macs properly). If you use this gist to install dependencies make sure you don't accidentally commit the gist. 
+7. Install marqo dependencies. If you are using an M2 Mac specifically, then install the requirements specified in [this gist](https://gist.github.com/pandu-k/f3cdf319b7abaa1d0e5c5e038e16377c#file-pip_requirements_for_m2_devs-txt) (this installs `onnx` and `protobuf` for M2 Macs properly). If you use this gist to install dependencies make sure you don't accidentally commit the gist. 
  
 ```
 pip install -r requirements.txt

--- a/src/marqo/README.md
+++ b/src/marqo/README.md
@@ -133,7 +133,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs/ | sh;
 
 6. Set up redis (follow instructions in Option A)
 
-7. If you are using an M2 Mac specifically, then edit `requirements.txt`. Find the `onnx` and `protobuf` entries, and remove their versions. Then, move onnx to be above protobuf. These two lines should end up looking like this: 
+7. If you are using an M2 Mac specifically, then install use the requirements specified in [this gist](https://gist.github.com/pandu-k/f3cdf319b7abaa1d0e5c5e038e16377c#file-pip_requirements_for_m2_devs-txt). `requirements.txt`. Find the `onnx` and `protobuf` entries, and remove their versions. Then, move onnx to be above protobuf. These two lines should end up looking like this: 
 ```
 onnx
 protobuf

--- a/src/marqo/README.md
+++ b/src/marqo/README.md
@@ -133,12 +133,18 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs/ | sh;
 
 6. Set up redis (follow instructions in Option A)
 
-7. Install marqo dependencies,
+7. If you are using an M2 Mac specifically, then edit `requirements.txt`. Find the `onnx` and `protobuf` entries, and remove their versions. Then, move onnx to be above protobuf. These two lines should end up looking like this: 
+```
+onnx
+protobuf
+```
+
+9. Install marqo dependencies. 
 ```
 pip install -r requirements.txt
 ```
 
-8. Change into the tensor search directory,
+9. Change into the tensor search directory,
 ```
 CWD=$(pwd)
 cd src/marqo/tensor_search/

--- a/src/marqo/README.md
+++ b/src/marqo/README.md
@@ -133,24 +133,19 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs/ | sh;
 
 6. Set up redis (follow instructions in Option A)
 
-7. If you are using an M2 Mac specifically, then install use the requirements specified in [this gist](https://gist.github.com/pandu-k/f3cdf319b7abaa1d0e5c5e038e16377c#file-pip_requirements_for_m2_devs-txt). `requirements.txt`. Find the `onnx` and `protobuf` entries, and remove their versions. Then, move onnx to be above protobuf. These two lines should end up looking like this: 
-```
-onnx
-protobuf
-```
-
-8. Install marqo dependencies. 
+7. Install marqo dependencies. If you are using an M2 Mac specifically, then install use the requirements specified in [this gist](https://gist.github.com/pandu-k/f3cdf319b7abaa1d0e5c5e038e16377c#file-pip_requirements_for_m2_devs-txt) (this installs `onnx` and `protobuf` for M2 Macs properly). If you use this gist to install dependencies make sure you don't accidentally commit the gist. 
+ 
 ```
 pip install -r requirements.txt
 ```
 
-9. Change into the tensor search directory,
+8. Change into the tensor search directory,
 ```
 CWD=$(pwd)
 cd src/marqo/tensor_search/
 ```
 
-10. Run Marqo,
+9. Run Marqo,
 ```
 export OPENSEARCH_URL="https://localhost:9200" && 
     export PYTHONPATH="${PYTHONPATH}:${CWD}/src" &&


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs update. As a developer with an M2 Mac, the dev setup instructions don't currently work. 

* **What is the new behavior (if this is a feature change)?**
 M2 Mac, the dev setup instructions updated to install ONNX and protobuf properly. 