### PR TITLE
(docs): correct CONTRIBUTING.md spelling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ also push it to the latest tag (add `-t marqoai/marqo:latest`).
 [github release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) 
 (with a short summary of changes) that links to the changes in `RELEASE.md`.
 - For releases that change the API, update py-marqo to make those changes accessible. 
-- To release a change to py-marqo, bump py-marqo's version (major.minor.patch, see below for more details), run all the tests, build the package and push to it PyPi. py-marqo's verson is independent from Marqo.  
+- To release a change to py-marqo, bump py-marqo's version (major.minor.patch, see below for more details), run all the tests, build the package and push it to PyPi. py-marqo's version is independent from Marqo.  
 
 - Then, use the following format for releasing changes:
   - . # Release x.y.z 


### PR DESCRIPTION
#### **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- Improve grammar
- Correct spelling

#### **What is the current behavior?** (You can also link to an open issue here)

N/A

#### **What is the new behavior (if this is a feature change)?**

N/A

#### **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

N/A

#### **Have unit tests been run against this PR?** (Has there also been any additional testing?)

N/A

#### **Related Python client changes** (link commit/PR here)

N/A

#### **Related documentation changes** (link commit/PR here)

#577

#### **Other information**:

> - [X] The commit message follows our guidelines

I don't see any guidelines defined in [CONTRIBUTING.md](https://github.com/marqo-ai/marqo/blob/mainline/CONTRIBUTING.md) for commit messages, nor do previous commits seem to follow a convention.

I will amend my commit message if need be.

#### **Please check if the PR fulfills these requirements**

- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)