### PR TITLE
Add summary job to run_all_tests workflow

### DIFF
--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -100,7 +100,7 @@ jobs:
 
         # Else, check if all tests succeeded or were skipped
         for job in run-arm64-tests run-cuda-dind-tests run-dind-os-tests run-largemodel-unit-tests run-local-os-tests run-unit-tests; do
-          if [[ "${{ needs[job].result }}" != "success" && "${{ needs[job].result }}" != "skipped" ]]; then
+          if [[ "${{ needs[job].result }}" != "success" && "${{ needs[job].result }}" != "skipped" && "${{ needs[job].result }}" != "" ]]; then
             echo "Job $job did not succeed."
             exit 1
           fi

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -84,3 +84,27 @@ jobs:
     if: needs.should-tests-run.outputs.decision == 'true'
     uses: ./.github/workflows/unit_test_200gb_CI.yml
     secrets: inherit
+    
+  summary:
+    name: Test Summary
+    needs: [should-tests-run, run-arm64-tests, run-cuda-dind-tests, run-dind-os-tests, run-largemodel-unit-tests, run-local-os-tests, run-unit-tests]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check test results
+      run: |
+        # If tests weren't intended to run, consider this a success
+        if [[ "${{ needs.should-tests-run.outputs.decision }}" != "true" ]]; then
+          echo "Tests were skipped. No further checks required."
+          exit 0
+        fi
+
+        # Else, check if all tests succeeded or were skipped
+        for job in run-arm64-tests run-cuda-dind-tests run-dind-os-tests run-largemodel-unit-tests run-local-os-tests run-unit-tests; do
+          if [[ "${{ needs[job].result }}" != "success" && "${{ needs[job].result }}" != "skipped" ]]; then
+            echo "Job $job did not succeed."
+            exit 1
+          fi
+        done
+        
+        echo "All tests either passed or were skipped."
+        

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -84,12 +84,12 @@ jobs:
     if: needs.should-tests-run.outputs.decision == 'true'
     uses: ./.github/workflows/unit_test_200gb_CI.yml
     secrets: inherit
-    
+
   summary:
+    if: ${{ always() }}
     name: Test Summary
     needs: [should-tests-run, run-arm64-tests, run-cuda-dind-tests, run-dind-os-tests, run-largemodel-unit-tests, run-local-os-tests, run-unit-tests]
     runs-on: ubuntu-latest
-    if: ${{ always() }}
     steps:
     - name: Check test results
       run: |
@@ -98,14 +98,37 @@ jobs:
           echo "Tests were skipped. No further checks required."
           exit 0
         fi
-
-        # Else, check if all tests succeeded or were skipped
-        for job in run-arm64-tests run-cuda-dind-tests run-dind-os-tests run-largemodel-unit-tests run-local-os-tests run-unit-tests; do
-          if [[ "${{ needs[job].result }}" != "success" && "${{ needs[job].result }}" != "skipped" && "${{ needs[job].result }}" != "" ]]; then
-            echo "Job $job did not succeed."
-            exit 1
-          fi
-        done
+  
+        if [[ "${{ needs.run-arm64-tests.result }}" != "success" && "${{ needs.run-arm64-tests.result }}" != "skipped" ]]; then
+          echo "Job run-arm64-tests did not succeed."
+          exit 1
+        fi
         
+        if [[ "${{ needs.run-cuda-dind-tests.result }}" != "success" && "${{ needs.run-cuda-dind-tests.result }}" != "skipped" ]]; then
+          echo "Job run-cuda-dind-tests did not succeed."
+          exit 1
+        fi
+  
+        if [[ "${{ needs.run-dind-os-tests.result }}" != "success" && "${{ needs.run-dind-os-tests.result }}" != "skipped" ]]; then
+          echo "Job run-dind-os-tests did not succeed."
+          exit 1
+        fi
+  
+        if [[ "${{ needs.run-largemodel-unit-tests.result }}" != "success" && "${{ needs.run-largemodel-unit-tests.result }}" != "skipped" ]]; then
+          echo "Job run-largemodel-unit-tests did not succeed."
+          exit 1
+        fi
+  
+        if [[ "${{ needs.run-local-os-tests.result }}" != "success" && "${{ needs.run-local-os-tests.result }}" != "skipped" ]]; then
+          echo "Job run-local-os-tests did not succeed."
+          exit 1
+        fi
+  
+        if [[ "${{ needs.run-unit-tests.result }}" != "success" && "${{ needs.run-unit-tests.result }}" != "skipped" ]]; then
+          echo "Job run-unit-tests did not succeed."
+          exit 1
+        fi
+  
         echo "All tests either passed or were skipped."
-        
+  
+          

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -89,6 +89,7 @@ jobs:
     name: Test Summary
     needs: [should-tests-run, run-arm64-tests, run-cuda-dind-tests, run-dind-os-tests, run-largemodel-unit-tests, run-local-os-tests, run-unit-tests]
     runs-on: ubuntu-latest
+    if: ${{ always() }}
     steps:
     - name: Check test results
       run: |


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- CI update and bug fix 

**What is the current behavior?** (You can also link to an open issue here)
- run_all_tests has no summary job, which reflects if all the tests passed or failed 
- This prevents us from having a branch protection status check on this workflow.
- We cannot put branch protection status checks on each individual test workflow because these workflows do not run for markdown-only changes. This means that markdown-only PRs will never be OK'd for merging.

**What is the new behavior (if this is a feature change)?**
- There is now a summary job, which passes only if all the tests passed or were skipped. Skipping occurs iff the changes only affected markdown files.  


**Have unit tests been run against this PR?** (Has there also been any additional testing?)

Yes. Manual tests: 
- Test summary correctly failed if unit tests failed: https://github.com/marqo-ai/marqo/actions/runs/5962528112/job/16175500826 (attempt 1) 
- We can rerun the failed workflow: https://github.com/marqo-ai/marqo/actions/runs/5962528112 (attempt 2). Only the failed test workflows rerun. Test summary correctly passes

We need to also check if markdown-only changes skips testing, and the test summary correctly passes. However, we need this update merged into mainline and then have a markdown-only PR into mainline approved in order to test this. 

**Other information**
- To rerun a failed test, restart the start-ec2-runner job that belongs to failed test workflow, not the test job itself: 
![image](https://github.com/marqo-ai/marqo/assets/107458762/1eaa970e-8ba8-4569-8988-f8e76a03e6a8)


 
 **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

