### PR TITLE
[WIP] Search query optional when there are context vectors

### DIFF
--- a/src/marqo/tensor_search/models/api_models.py
+++ b/src/marqo/tensor_search/models/api_models.py
@@ -12,6 +12,7 @@ from marqo.tensor_search.enums import SearchMethod
 from marqo.tensor_search.models.private_models import ModelAuth
 from marqo.tensor_search.models.score_modifiers_object import ScoreModifier
 from marqo.tensor_search.models.search import SearchContext, SearchContextTensor
+from marqo import errors
 
 
 class BaseMarqoModel(BaseModel):
@@ -21,7 +22,7 @@ class BaseMarqoModel(BaseModel):
 
 
 class SearchQuery(BaseMarqoModel):
-    q: Union[str, Dict[str, float]]
+    q: Optional[Union[str, Dict[str, float]]] = None
     searchableAttributes: Union[None, List[str]] = None
     searchMethod: Union[None, str] = "TENSOR"
     limit: int = 10
@@ -43,9 +44,28 @@ class SearchQuery(BaseMarqoModel):
             case_sensitive=False
         )
     
+    @pydantic.root_validator
+    def validate_query_and_context(cls, values):
+        """
+        Validates that if LEXICAL search, query must be present.
+        If TENSOR search, either query or context must be present.
+        """
+        search_method = values.get("searchMethod")
+        query = values.get("q")
+        context = values.get("context")
+
+        if search_method == SearchMethod.LEXICAL:
+            if query is None:
+                raise errors.InvalidArgError("Query must be provided when using lexical search.")
+        elif search_method == SearchMethod.TENSOR:
+            if query is None and context is None:
+                raise errors.InvalidArgError("Either query or context vectors must be provided when using tensor search.")
+        return values
+
     def get_context_tensor(self) -> Optional[List[SearchContextTensor]]:
         """Extract the tensor from the context, if provided"""
         return self.context.tensor if self.context is not None else None
+    
 
 class BulkSearchQueryEntity(SearchQuery):
     index: str

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -1008,8 +1008,9 @@ def search(config: Config, index_name: str, text: Union[str, dict],
     if offset < 0:
         raise errors.IllegalRequestedDocCount("search result offset cannot be less than 0!")
 
-        # validate query
-    validation.validate_query(q=text, search_method=search_method)
+    # validate query (if it exists)
+    if text is not None:
+        validation.validate_query(q=text, search_method=search_method)
 
     # Validate result_count + offset <= int(max_docs_limit)
     max_docs_limit = utils.read_env_vars_and_defaults(EnvVars.MARQO_MAX_RETRIEVABLE_DOCS)
@@ -1513,7 +1514,7 @@ def get_query_vectors_from_jobs(
                  content
                 ) for content, weight in ordered_queries
             ]
-            # TODO how doe we ensure order?
+            # TODO how do we ensure order?
             weighted_vectors = [np.asarray(vec) * weight for vec, weight, content in vectorised_ordered_queries]
 
             context_tensors = q.get_context_tensor()

--- a/src/marqo/tensor_search/validation.py
+++ b/src/marqo/tensor_search/validation.py
@@ -176,11 +176,11 @@ def validate_field_content(field_content: Any, is_non_tensor_field: bool) -> Any
             f"Allowed content types: {[ty.__name__ for ty in constants.ALLOWED_CUSTOMER_FIELD_TYPES]}"
         )
 
-def validate_context(context: Optional[SearchContext], search_method: SearchMethod, query: Union[str, Dict[str, Any]]): 
+def validate_context(context: Optional[SearchContext], search_method: SearchMethod, query: Union[None, str, Dict[str, Any]]): 
     """Validate the SearchContext.
 
     'validate_context' ensures that if the context is provided for a tensor search
-    operation, the query must be a dictionary (not a str). 'context' 
+    operation, the query must be a dictionary (not a str) or None. 'context' 
     structure is validated internally.
     
     """


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
Query is required for search and bulk search requests

* **What is the new behavior (if this is a feature change)?**
Query is now optional for search and bulk search when search method is tensor and context vectors are given.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No. It should not affect existing usage patterns, and it will allow new ones.

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
Not yet

* **Related Python client changes** (link commit/PR here)
None yet

* **Related documentation changes** (link commit/PR here)
None yet

* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

