### PR TITLE
remove hard-coded reputation field

### DIFF
--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -2161,8 +2161,7 @@ def _create_score_modifiers_tensor_search_query(score_modifiers, result_count, o
                         "path": TensorField.chunks,
                         "inner_hits": {
                             "_source": {
-                                "include": ["__chunks.__field_content", "__chunks.__field_name",
-                                            "__chunks.reputation"]
+                                "include": ["__chunks.__field_content", "__chunks.__field_name"]
                             }
                         },
                         "query": {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug-fix

* **What is the current behavior?** (You can also link to an open issue here)
reputation field, a remnant of previous POC, is requested to be returned from OpenSearch

* **What is the new behavior (if this is a feature change)?**
this unnecessary field is removed

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no
