### PR TITLE
Delete docs result list

### DIFF
--- a/src/marqo/tensor_search/delete_docs.py
+++ b/src/marqo/tensor_search/delete_docs.py
@@ -17,11 +17,10 @@ def format_delete_docs_response(marqo_response: MqDeleteDocsResponse) -> dict:
     return {
         "index_name": marqo_response.index_name, "status": marqo_response.status_string,
         "type": "documentDeletion", 
+        "items": marqo_response.result_list,
         "details": {
             "receivedDocumentIds": len(marqo_response.document_ids),
             "deletedDocuments": marqo_response.deleted_docments_count,
-            "successfulDeletions": marqo_response.success_list,
-            "failedDeletions": marqo_response.failure_list,
         },
         "duration": utils.create_duration_string(marqo_response.deletion_end - marqo_response.deletion_start),
         "startedAt": utils.format_timestamp(marqo_response.deletion_start),
@@ -66,8 +65,6 @@ def delete_documents_marqo_os(config: Config, deletion_instruction: MqDeleteDocs
         path="_bulk",
         body=bulk_request_body,
     )
-    print("DEBUG: delete_res_backend")
-    pprint.pprint(delete_res_backend)
 
     if deletion_instruction.auto_refresh:
         refresh_response = HttpRequests(config).post(path=f"{deletion_instruction.index_name}/_refresh")
@@ -75,25 +72,23 @@ def delete_documents_marqo_os(config: Config, deletion_instruction: MqDeleteDocs
     t1 = datetime.datetime.utcnow()
 
     deleted_documents_count = 0
-    success_list = []
-    failure_list = []
+    result_list = []
 
     for item in delete_res_backend["items"]:
         if "delete" in item:
             delete_item_summary = {
                 "_id": item["delete"]["_id"],
+                "_shards": item["delete"]["_shards"],
                 "status": item["delete"]["status"],
-                "result": item["delete"]["result"] 
+                "result": item["delete"]["result"],
             }
             if item["delete"]["status"] == 200:
                 deleted_documents_count += 1
-                success_list.append(delete_item_summary)
-            else:
-                failure_list.append(delete_item_summary)
-
+            
+            result_list.append(delete_item_summary)
     mq_delete_res = MqDeleteDocsResponse(
         index_name=deletion_instruction.index_name, status_string='succeeded', document_ids=deletion_instruction.document_ids,
         deleted_docments_count=deleted_documents_count, deletion_start=t0,
-        deletion_end=t1, success_list=success_list, failure_list=failure_list
+        deletion_end=t1, result_list=result_list
     )
     return mq_delete_res

--- a/src/marqo/tensor_search/models/delete_docs_objects.py
+++ b/src/marqo/tensor_search/models/delete_docs_objects.py
@@ -13,6 +13,8 @@ class MqDeleteDocsResponse(NamedTuple):
     status_string: Literal["succeeded"]
     document_ids: List[str]
     deleted_docments_count: int
+    success_list: List[dict]
+    failure_list: List[dict]
     deletion_start: datetime.datetime
     deletion_end: datetime.datetime
 

--- a/src/marqo/tensor_search/models/delete_docs_objects.py
+++ b/src/marqo/tensor_search/models/delete_docs_objects.py
@@ -12,7 +12,7 @@ class MqDeleteDocsResponse(NamedTuple):
     index_name: str
     status_string: Literal["succeeded"]
     document_ids: List[str]
-    deleted_docments_count: int
+    deleted_documents_count: int
     result_list: List[dict]
     deletion_start: datetime.datetime
     deletion_end: datetime.datetime

--- a/src/marqo/tensor_search/models/delete_docs_objects.py
+++ b/src/marqo/tensor_search/models/delete_docs_objects.py
@@ -13,8 +13,7 @@ class MqDeleteDocsResponse(NamedTuple):
     status_string: Literal["succeeded"]
     document_ids: List[str]
     deleted_docments_count: int
-    success_list: List[dict]
-    failure_list: List[dict]
+    result_list: List[dict]
     deletion_start: datetime.datetime
     deletion_end: datetime.datetime
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
No confirmation on which docs were successfully deleted.

* **What is the new behavior (if this is a feature change)?**
Response object of `delete_documents` now has `items` key which lists all documents' result and status.

Example:
```
'items': [{'_id': 'doc1',
                        '_shards': {'failed': 0, 'successful': 1, 'total': 1},
                        'result': 'deleted',
                        'status': 200},
                    {'_id': 'doc2',
                        '_shards': {'failed': 0, 'successful': 1, 'total': 1},
                        'result': 'deleted',
                        'status': 200},
                    {'_id': 'doc3',
                        '_shards': {'failed': 0, 'successful': 1, 'total': 1},
                        'result': 'not_found',
                        'status': 404},
                    {'_id': 'doc4',
                        '_shards': {'failed': 0, 'successful': 1, 'total': 1},
                        'result': 'not_found',
                        'status': 404}]
```

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
Yes

* **Related Python client changes** (link commit/PR here)
None

* **Related documentation changes** (link commit/PR here)
Upcoming

* **Other information**:


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

