### PR TITLE
Remove prefix from e5 models

### DIFF
--- a/src/marqo/s2_inference/model_registry.py
+++ b/src/marqo/s2_inference/model_registry.py
@@ -509,8 +509,6 @@ def _get_hf_properties() -> Dict:
                  "tokens": 192,
                  "type": "hf",
                  "model_size": 0.1342,
-                 "text_query_prefix": "query: ",
-                 "text_chunk_prefix": "passage: ",
                  "notes": ""},
             "hf/e5-base":
                 {"name": 'intfloat/e5-base',
@@ -518,8 +516,6 @@ def _get_hf_properties() -> Dict:
                  "tokens": 192,
                  "type": "hf",
                  "model_size": 0.438,
-                 "text_query_prefix": "query: ",
-                 "text_chunk_prefix": "passage: ",
                  "notes": ""},
             "hf/e5-large":
                 {"name": 'intfloat/e5-large',
@@ -527,8 +523,6 @@ def _get_hf_properties() -> Dict:
                  "tokens": 192,
                  "type": "hf",
                  "model_size": 1.3,
-                 "text_query_prefix": "query: ",
-                 "text_chunk_prefix": "passage: ",
                  "notes": ""},
             "hf/e5-large-unsupervised":
                 {"name": 'intfloat/e5-large-unsupervised',
@@ -536,8 +530,6 @@ def _get_hf_properties() -> Dict:
                  "tokens": 128,
                  "type": "hf",
                  "model_size": 1.3,
-                 "text_query_prefix": "query: ",
-                 "text_chunk_prefix": "passage: ",
                  "notes": ""},
             "hf/e5-base-unsupervised":
                 {"name": 'intfloat/e5-base-unsupervised',
@@ -545,8 +537,6 @@ def _get_hf_properties() -> Dict:
                  "tokens": 128,
                  "type": "hf",
                  "model_size": 0.438,
-                 "text_query_prefix": "query: ",
-                 "text_chunk_prefix": "passage: ",
                  "notes": ""},
             "hf/e5-small-unsupervised":
                 {"name": 'intfloat/e5-small-unsupervised',
@@ -554,8 +544,6 @@ def _get_hf_properties() -> Dict:
                  "tokens": 128,
                  "type": "hf",
                  "model_size": 0.134,
-                 "text_query_prefix": "query: ",
-                 "text_chunk_prefix": "passage: ",
                  "notes": ""},
             "hf/multilingual-e5-small":
                 {"name": 'intfloat/multilingual-e5-small',
@@ -563,8 +551,6 @@ def _get_hf_properties() -> Dict:
                  "tokens": 512,
                  "type": "hf",
                  "model_size": 0.471,
-                 "text_query_prefix": "query: ",
-                 "text_chunk_prefix": "passage: ",
                  "notes": ""},
             "hf/multilingual-e5-base":
                 {"name": 'intfloat/multilingual-e5-base',
@@ -572,8 +558,6 @@ def _get_hf_properties() -> Dict:
                  "tokens": 512,
                  "type": "hf",
                  "model_size": 1.11,
-                 "text_query_prefix": "query: ",
-                 "text_chunk_prefix": "passage: ",
                  "notes": ""},
             "hf/multilingual-e5-large":
                 {"name": 'intfloat/multilingual-e5-large',
@@ -581,8 +565,6 @@ def _get_hf_properties() -> Dict:
                  "tokens": 512,
                  "type": "hf",
                  "model_size": 2.24,
-                 "text_query_prefix": "query: ",
-                 "text_chunk_prefix": "passage: ",
                  "notes": ""},
             "hf/e5-small-v2":
                 {"name": 'intfloat/e5-small-v2',
@@ -590,8 +572,6 @@ def _get_hf_properties() -> Dict:
                  "tokens": 512,
                  "type": "hf",
                  "model_size": 0.134,
-                 "text_query_prefix": "query: ",
-                 "text_chunk_prefix": "passage: ",
                  "notes": ""},
             "hf/e5-base-v2":
                 {"name": 'intfloat/e5-base-v2',
@@ -599,8 +579,6 @@ def _get_hf_properties() -> Dict:
                  "tokens": 512,
                  "type": "hf",
                  "model_size": 0.438,
-                 "text_query_prefix": "query: ",
-                 "text_chunk_prefix": "passage: ",
                  "notes": ""},
             "hf/e5-large-v2":
                 {"name": 'intfloat/e5-large-v2',
@@ -608,8 +586,6 @@ def _get_hf_properties() -> Dict:
                  "tokens": 512,
                  "type": "hf",
                  "model_size": 1.34,
-                 "text_query_prefix": "query: ",
-                 "text_chunk_prefix": "passage: ",
                  "notes": ""},
     }
     return HF_MODEL_PROPERTIES


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Model registry update

* **What is the current behavior?** (You can also link to an open issue here)
Default prefixes were in e5 models, but this would be a breaking change for existing indexes with e5 models.

* **What is the new behavior (if this is a feature change)?**
Default prefixes have been removed from e5 models.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)


* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [] Tests for the changes have been added (for bug fixes/features)
- [] Docs have been added / updated (for bug fixes / features)

