### PR TITLE
Skip preloading for no_model

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,8 @@
+# Release 1.5.1
+## Bug fixes and minor changes
+- Adding `no_model` to `MARQO_MODELS_TO_PRELOAD` no longer causes an error on startup. Preloading process is simply skipped for this model [#657](https://github.com/marqo-ai/marqo/pull/657).
+
+
 # Release 1.5.0
 ## New Features
 - Separate model for search and add documents (https://github.com/marqo-ai/marqo/pull/633). Using the `search_model` and `search_model_properties` key in `index_defaults` allows you to specify a model specifically to be used for searching. This is useful for using a different model for search than what is used for add_documents. Learn how to use `search_model` [here](https://docs.marqo.ai/1.5.0/API-Reference/Indexes/create_index/#search-model).

--- a/src/marqo/tensor_search/constants.py
+++ b/src/marqo/tensor_search/constants.py
@@ -9,6 +9,8 @@ INDEX_NAME_PREFIXES_TO_IGNORE = {
 
 MARQO_OBJECT_TYPES = {MappingsObjectType.multimodal_combination, MappingsObjectType.custom_vector}
 
+MODELS_TO_SKIP_PRELOADING = {"no_model"}
+
 ILLEGAL_CUSTOMER_FIELD_NAME_CHARS = {'.', '/', '\n'}
 
 ALLOWED_CUSTOMER_FIELD_TYPES = [str, int, float, bool, list, dict]

--- a/src/marqo/tensor_search/on_start_script.py
+++ b/src/marqo/tensor_search/on_start_script.py
@@ -7,6 +7,7 @@ from marqo.tensor_search.enums import EnvVars
 # we need to import backend before index_meta_cache to prevent circular import error:
 from marqo.tensor_search import backend, index_meta_cache, utils
 from marqo import config
+from marqo.tensor_search import constants
 from marqo.tensor_search.web import api_utils
 from marqo import errors
 from marqo.tensor_search.throttling.redis_throttle import throttle
@@ -152,6 +153,15 @@ class ModelsForCacheing:
         N = 10
         messages = []
         for model in self.models:
+            # Skip preloading of models that can't be preloaded (eg. no_model)
+            if isinstance(model, str):
+                model_name = model
+            elif isinstance(model, dict):
+                model_name = model["model"]
+            if model_name in constants.MODELS_TO_SKIP_PRELOADING:
+                self.logger.info(f"Skipping preloading of `{model_name}`.")
+                continue
+
             for device in self.default_devices:
                 self.logger.debug(f"Beginning loading for model: {model} on device: {device}")
                 

--- a/src/marqo/tensor_search/on_start_script.py
+++ b/src/marqo/tensor_search/on_start_script.py
@@ -157,7 +157,13 @@ class ModelsForCacheing:
             if isinstance(model, str):
                 model_name = model
             elif isinstance(model, dict):
-                model_name = model["model"]
+                try:
+                    model_name = model["model"]
+                except KeyError as e:
+                    raise errors.EnvVarError(
+                        f"Your custom model {model} is missing `model` key."
+                        f"""To add a custom model, it must be a dict with keys `model` and `model_properties` as defined in `https://marqo.pages.dev/0.0.20/Advanced-Usage/configuration/#configuring-preloaded-models`"""
+                    ) from e
             if model_name in constants.MODELS_TO_SKIP_PRELOADING:
                 self.logger.info(f"Skipping preloading of `{model_name}`.")
                 continue

--- a/tests/tensor_search/test_on_start_script.py
+++ b/tests/tensor_search/test_on_start_script.py
@@ -151,6 +151,22 @@ class TestOnStartScript(MarqoTestCase):
                 return True
         assert run()
     
+    def test_preload_no_model(self):
+        no_model_object = {
+            "model": "no_model",
+            "model_properties": {
+                "dimensions": 123
+            }
+        }
+        mock_preload = mock.MagicMock()
+        @mock.patch("marqo.tensor_search.on_start_script._preload_model", mock_preload)
+        @mock.patch.dict(os.environ, {enums.EnvVars.MARQO_MODELS_TO_PRELOAD: json.dumps([no_model_object])})
+        def run():
+            model_caching_script = on_start_script.ModelsForCacheing()
+            model_caching_script.run()
+            mock_preload.assert_not_called()    # The preloading function should never be called for no_model
+        run()
+    
     # TODO: test bad/no names/URLS in end-to-end tests, as this logic is done in vectorise call
 
     def test_set_best_available_device(self):


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
adding `no_model` to Marqo models to preload causes a 400 error, due to calling `vectorise` function in preloading function.

* **What is the new behavior (if this is a feature change)?**
Skip call to preload if model is `no_model`

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
In progress

* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

