### PR TITLE
Fix use_existing tensors bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,5 @@ dump.rdb
 
 # VSCode
 .vscode/
+
+.DS_Store

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -1042,9 +1042,18 @@ def get_documents_by_ids(
             marqo_document = vespa_index.to_marqo_document(response.document.dict())
 
             if show_vectors:
-                marqo_document[TensorField.tensor_facets] = _get_tensor_facets(
-                    marqo_document[constants.MARQO_DOC_TENSORS])
-            del marqo_document[constants.MARQO_DOC_TENSORS]
+                if constants.MARQO_DOC_TENSORS in marqo_document:
+                    marqo_document[TensorField.tensor_facets] = _get_tensor_facets(
+                        marqo_document[constants.MARQO_DOC_TENSORS])
+                else:
+                    marqo_document[TensorField.tensor_facets] = []
+
+            if not show_vectors:
+                if unstructured_common.MARQO_DOC_MULTIMODAL_PARAMS in marqo_document:
+                    del marqo_document[unstructured_common.MARQO_DOC_MULTIMODAL_PARAMS]
+
+            if constants.MARQO_DOC_TENSORS in marqo_document:
+                del marqo_document[constants.MARQO_DOC_TENSORS]
 
             to_return['results'].append(
                 {

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -164,7 +164,7 @@ def _add_documents_unstructured(config: Config, add_docs_params: AddDocsParams, 
             ids = [doc["_id"] for doc in add_docs_params.docs if "_id" in doc]
             existing_docs_dict: Dict[str, dict] = {}
             if len(ids) > 0:
-                existing_docs = _get_marqo_documents_by_ids(config, marqo_index.name, ids)
+                existing_docs = _get_marqo_documents_by_ids(config, marqo_index.name, ids, ignore_invalid_ids=True)
                 for doc in existing_docs:
                     id = doc["_id"]
                     if id in existing_docs_dict:
@@ -571,7 +571,7 @@ def _add_documents_structured(config: Config, add_docs_params: AddDocsParams, ma
         if add_docs_params.use_existing_tensors:
             existing_docs_dict: Dict[str, dict] = {}
             if len(doc_ids) > 0:
-                existing_docs = _get_marqo_documents_by_ids(config, marqo_index.name, doc_ids)
+                existing_docs = _get_marqo_documents_by_ids(config, marqo_index.name, doc_ids, ignore_invalid_ids=True)
                 for doc in existing_docs:
                     if not isinstance(doc, dict):
                         continue
@@ -985,10 +985,22 @@ def get_document_by_id(
 
 
 def _get_marqo_documents_by_ids(
-        config: Config, index_name: str, document_ids
+        config: Config, index_name: str, document_ids, ignore_invalid_ids: bool = False
 ):
+    validated_ids = []
+    for doc_id in document_ids:
+        try:
+            validated_ids.append(validation.validate_id(doc_id))
+        except api_exceptions.InvalidDocumentIdError as e:
+            if not ignore_invalid_ids:
+                raise e
+            logger.debug(f'Invalid document ID {doc_id} ignored')
+
+    if len(validated_ids) == 0:  # Can only happen when ignore_invalid_ids is True
+        return []
+
     marqo_index = index_meta_cache.get_index(config=config, index_name=index_name)
-    batch_get = config.vespa_client.get_batch(document_ids, marqo_index.schema_name)
+    batch_get = config.vespa_client.get_batch(validated_ids, marqo_index.schema_name)
     vespa_index = vespa_index_factory(marqo_index)
 
     return [vespa_index.to_marqo_document(response.document.dict()) for response in batch_get.responses

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -384,7 +384,7 @@ def _add_documents_unstructured(config: Config, add_docs_params: AddDocsParams, 
                                     field_name] == multimodal_params and
                                 field_name in existing_doc[constants.MARQO_DOC_TENSORS]
                         ):
-                            combo_chunk = f"{field_name}::{existing_doc[constants.MARQO_DOC_TENSORS][field_name][constants.MARQO_DOC_CHUNKS]}"
+                            combo_chunk = f"{field_name}::{existing_doc[constants.MARQO_DOC_TENSORS][field_name][constants.MARQO_DOC_CHUNKS][0]}"
                             combo_embeddings = existing_doc[constants.MARQO_DOC_TENSORS][field_name][
                                 constants.MARQO_DOC_EMBEDDINGS]
 

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -376,11 +376,12 @@ def _add_documents_unstructured(config: Config, add_docs_params: AddDocsParams, 
                     ):
                         existing_doc = existing_docs_dict[doc_id]
                         current_field_contents = utils.extract_multimodal_content(existing_doc, multimodal_params)
-                        current_multimodal_params = existing_doc[unstructured_common.MARQO_DOC_MULTIMODAL_PARAMS][
-                            field_name]
                         if (
                                 field_content == current_field_contents and
-                                current_multimodal_params == multimodal_params and
+                                unstructured_common.MARQO_DOC_MULTIMODAL_PARAMS in existing_doc and
+                                field_name in existing_doc[unstructured_common.MARQO_DOC_MULTIMODAL_PARAMS] and
+                                existing_doc[unstructured_common.MARQO_DOC_MULTIMODAL_PARAMS][
+                                    field_name] == multimodal_params and
                                 field_name in existing_doc[constants.MARQO_DOC_TENSORS]
                         ):
                             combo_chunk = f"{field_name}::{existing_doc[constants.MARQO_DOC_TENSORS][field_name][constants.MARQO_DOC_CHUNKS]}"

--- a/src/marqo/vespa/vespa_client.py
+++ b/src/marqo/vespa/vespa_client.py
@@ -37,7 +37,7 @@ class VespaClient:
             self.converged = converged
 
     def __init__(self, config_url: str, document_url: str, query_url: str,
-                 content_cluster_name: str, pool_size: int = 10, ):
+                 content_cluster_name: str, pool_size: int = 10):
         """
         Create a VespaClient object.
         Args:

--- a/src/marqo/vespa/vespa_client.py
+++ b/src/marqo/vespa/vespa_client.py
@@ -37,7 +37,7 @@ class VespaClient:
             self.converged = converged
 
     def __init__(self, config_url: str, document_url: str, query_url: str,
-                 content_cluster_name: str, pool_size: int = 10,):
+                 content_cluster_name: str, pool_size: int = 10, ):
         """
         Create a VespaClient object.
         Args:
@@ -60,11 +60,12 @@ class VespaClient:
         """
         self.http_client.close()
 
-    def deploy_application(self, application: str):
+    def deploy_application(self, application: str, timeout: int = 60) -> None:
         """
         Deploy a Vespa application.
         Args:
             application: Path to the Vespa application root directory
+            timeout: Timeout in seconds
         """
         endpoint = f'{self.config_url}/application/v2/tenant/default/prepareandactivate'
 
@@ -73,7 +74,8 @@ class VespaClient:
         response = self.http_client.post(
             endpoint,
             headers={'Content-Type': 'application/x-gzip'},
-            data=gzip_stream.read()
+            data=gzip_stream.read(),
+            timeout=timeout
         )
 
         self._raise_for_status(response)

--- a/tests/marqo_test.py
+++ b/tests/marqo_test.py
@@ -166,7 +166,7 @@ class MarqoTestCase(unittest.TestCase):
     def unstructured_marqo_index_request(
             cls,
             name: Optional[str] = None,
-            model: Model = Model(name='hf/all_datasets_v4_MiniLM-L6'),
+            model: Model = Model(name='random/small'),
             normalize_embeddings: bool = True,
             text_preprocessing: TextPreProcessing = TextPreProcessing(
                 split_length=2,

--- a/tests/tensor_search/integ_tests/test_search_unstructured.py
+++ b/tests/tensor_search/integ_tests/test_search_unstructured.py
@@ -24,7 +24,9 @@ class TestSearchUnstructured(MarqoTestCase):
     def setUpClass(cls) -> None:
         super().setUpClass()
 
-        default_text_index = cls.unstructured_marqo_index_request()
+        default_text_index = cls.unstructured_marqo_index_request(
+            model=Model(name='hf/all_datasets_v4_MiniLM-L6')
+        )
         default_text_index_encoded_name = cls.unstructured_marqo_index_request(
             name='a-b_' + str(uuid.uuid4()).replace('-', '')
         )
@@ -1132,7 +1134,7 @@ class TestSearchUnstructured(MarqoTestCase):
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
                 docs=docs,
-                tensor_fields = []
+                tensor_fields=[]
             )
         )
         lexical_search_result = tensor_search.search(
@@ -1171,5 +1173,5 @@ class TestSearchUnstructured(MarqoTestCase):
         for hit in tensor_search_result['hits']:
             self.assertIn("_highlights", hit)
             self.assertTrue(isinstance(hit["_highlights"], list))
-            self.assertEqual(1, len(hit["_highlights"])) # We only have 1 highlight now
+            self.assertEqual(1, len(hit["_highlights"]))  # We only have 1 highlight now
             self.assertTrue(isinstance(hit["_highlights"][0], dict))

--- a/tests/tensor_search/test_add_documents_use_existing_tensors.py
+++ b/tests/tensor_search/test_add_documents_use_existing_tensors.py
@@ -216,7 +216,8 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
                     self.assertEqual("content 1", search_res["hits"][0]["text_field_1"])
                     self.assertEqual("content 2", search_res["hits"][0]["text_field_2"])
                     self.assertEqual(1, len(get_doc_res["_tensor_facets"]))
-                    self.assertEqual("content 1", get_doc_res["_tensor_facets"][0]["text_field_1"])
+                    self.assertEqual('{"text_field_1": "content 1", "text_field_2": "content 2"}',
+                                     get_doc_res["_tensor_facets"][0]["multimodal_field"])
 
     def test_use_existing_tensor_multimodal_added(self):
         """
@@ -256,8 +257,6 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
                         )
                     )
 
-                    self.assertEqual(1, mock_vectorise.call_count, 'vectorise should be called once')
-
                 with mock.patch.object(s2_inference,
                                        'vectorise',
                                        side_effect=original_vectorise) as mock_vectorise:
@@ -272,7 +271,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
                         )
                     )
 
-                    self.assertEqual(0, mock_vectorise.call_count, 'vectorise should not be called')
+                    self.assertEqual(1, mock_vectorise.call_count, 'vectorise should be called')
 
                     search_res = tensor_search.search(config=self.config, index_name=index_name, text="content")
                     get_doc_res = tensor_search.get_document_by_id(config=self.config, index_name=index_name,
@@ -281,7 +280,8 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
                     self.assertEqual("content 1", search_res["hits"][0]["text_field_1"])
                     self.assertEqual("content 2", search_res["hits"][0]["text_field_2"])
                     self.assertEqual(1, len(get_doc_res["_tensor_facets"]))
-                    self.assertEqual("content 1", get_doc_res["_tensor_facets"][0]["text_field_1"])
+                    self.assertEqual('{"text_field_1": "content 1", "text_field_2": "content 2"}',
+                                     get_doc_res["_tensor_facets"][0]["multimodal_field"])
 
     def test_use_existing_tensor_multimodal_changed(self):
         """


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
Add docs `use_existing_tensords`:
  * Does not pick up existing vectors and revectorises regardless
  * Fails when reindexing a doc with no change and a multimodal field
  * Fails when existing doc does not have a multimodal field, but the new doc being indexed does (unstructured only)
  * Reindexing an unstructured document with a multimodal field adds the wrong chunk values by adding a list to a list

Also: get_documents_by_ids fails when a document has no vectors
  

* **What is the new behavior (if this is a feature change)?**
Issues above fixed

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
Running

* **Related Python client changes** (link commit/PR here)
None

* **Related documentation changes** (link commit/PR here)
None

* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

