### PR TITLE
Fix validation bug for create index

### DIFF
--- a/src/marqo/tensor_search/models/index_settings.py
+++ b/src/marqo/tensor_search/models/index_settings.py
@@ -51,8 +51,9 @@ class IndexSettings(StrictBaseModel):
                     if '_' in key:
                         raise ValueError(f"Invalid field name '{key}'. "
                                          f"See Create Index API reference here https://docs.marqo.ai/2.0.0/API-Reference/Indexes/create_index/")
-                    
-                    validate_keys(d[key])
+
+                    if key != 'dependentFields':
+                        validate_keys(d[key])
             elif isinstance(d, list):
                 for item in d:
                     validate_keys(item)

--- a/src/marqo/tensor_search/models/index_settings.py
+++ b/src/marqo/tensor_search/models/index_settings.py
@@ -52,7 +52,7 @@ class IndexSettings(StrictBaseModel):
                         raise ValueError(f"Invalid field name '{key}'. "
                                          f"See Create Index API reference here https://docs.marqo.ai/2.0.0/API-Reference/Indexes/create_index/")
 
-                    if key != 'dependentFields':
+                    if key not in ['dependentFields', 'modelProperties']:
                         validate_keys(d[key])
             elif isinstance(d, list):
                 for item in d:

--- a/tests/tensor_search/test_api.py
+++ b/tests/tensor_search/test_api.py
@@ -211,6 +211,14 @@ class TestApiErrors(MarqoTestCase):
                      }
                  ],
                  "tensorFields": ['field_3'],
+                 "model": "ViT-L/14",
+                 "modelProperties": {
+                     "name": "ViT-L/14",
+                     "dimensions": 768,
+                     "url": "https://7b4d1a66-507d-43f1-b99f-7368b655de46.s3.amazonaws.com/e5a7d9c7-0736-4301-a037-b1307f43a314/23fa0cb1-68d5-40f6-8039-e9e1265b6103.pt",
+                     "type": "open_clip",
+                     "field_1": "sth"
+                 }
              }, 'Snake case in field name is valid'),
         ]
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
Validation fails when a field name has underscore in it and is a multimodal dependent field

* **What is the new behavior (if this is a feature change)?**
Exclude `dependentFields` from validation recursion

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
* Noe


* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
Yes

* **Related Python client changes** (link commit/PR here)
No

* **Related documentation changes** (link commit/PR here)
No

* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

