### PR TITLE
Improve Vespa bootstrap error handling at startup

### DIFF
--- a/src/marqo/tensor_search/index_meta_cache.py
+++ b/src/marqo/tensor_search/index_meta_cache.py
@@ -111,7 +111,7 @@ def _check_refresh_thread(config: Config):
                                 f'if Marqo settings schema does not exist. Error: {e}'
                             )
                         else:
-                            logger.warn(
+                            logger.error(
                                 "Failed to connect to vector store. If you are using an external vector store, "
                                 "ensure that Marqo is configured properly for this. See "
                                 f"{documentation.configuring_marqo()} for more details. Error: {e}"

--- a/src/marqo/tensor_search/on_start_script.py
+++ b/src/marqo/tensor_search/on_start_script.py
@@ -43,12 +43,12 @@ class BootstrapVespa:
 
     def run(self):
         try:
-            logger.debug('Creating Marqo settings schema')
+            logger.debug('Bootstrapping Vespa')
             created = self.config.index_management.bootstrap_vespa()
             if created:
-                logger.debug('Marqo settings schema created')
+                logger.debug('Vespa configured successfully')
             else:
-                logger.debug('Marqo settings schema already exists. Skipping')
+                logger.debug('Vespa configuration already exists. Skipping bootstrap')
         except Exception as e:
             logger.error(
                 f"Failed to bootstrap vector store. If you are using an external vector store, "

--- a/src/marqo/tensor_search/on_start_script.py
+++ b/src/marqo/tensor_search/on_start_script.py
@@ -12,14 +12,13 @@ from marqo.s2_inference.s2_inference import vectorise
 from marqo.tensor_search import index_meta_cache, utils
 from marqo.tensor_search.enums import EnvVars
 from marqo.tensor_search.tensor_search_logging import get_logger
-from marqo.vespa.exceptions import VespaError
 
 logger = get_logger(__name__)
 
 
 def on_start(config: config.Config):
     to_run_on_start = (
-        CreateSettingsSchema(config),
+        BootstrapVespa(config),
         PopulateCache(config),
         DownloadStartText(),
         CUDAAvailable(),
@@ -36,7 +35,7 @@ def on_start(config: config.Config):
         thing_to_start.run()
 
 
-class CreateSettingsSchema:
+class BootstrapVespa:
     """Create the Marqo settings schema on Vespa"""
 
     def __init__(self, config: config.Config):
@@ -50,9 +49,9 @@ class CreateSettingsSchema:
                 logger.debug('Marqo settings schema created')
             else:
                 logger.debug('Marqo settings schema already exists. Skipping')
-        except VespaError as e:
-            logger.warn(
-                f"Could not create Marqo settings schema. If you are using an external vector store, "
+        except Exception as e:
+            logger.error(
+                f"Failed to bootstrap vector store. If you are using an external vector store, "
                 "ensure that Marqo is configured properly for this. See "
                 f"{documentation.configuring_marqo()} for more details. Error: {e}"
             )


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Improvement

* **What is the current behavior?** (You can also link to an open issue here)
Vespa bootstrap makes Marqo startup script fail if there is a connection error. Only non-200 status errors are handled

* **What is the new behavior (if this is a feature change)?**
Don't fail startup regardless. This is because Marqo can recover and configure Vespa as soon as Vespa is available after it starts and when an index is created.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Have unit tests been run against this PR?** (Has there also been any additional testing?)


* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

