### PR TITLE
Change response format of update_documents

### DIFF
--- a/src/marqo/core/document/document.py
+++ b/src/marqo/core/document/document.py
@@ -140,8 +140,8 @@ class Document:
         for loc, error_info in unsuccessful_docs:
             new_items.insert(loc, error_info)
 
-        return MarqoUpdateDocumentsResponse(indexName=index_name, items=new_items,
-                                            preprocessingTime=(timer() - start_time) * 1000)
+        return MarqoUpdateDocumentsResponse(index_name=index_name, items=new_items,
+                                            processingTimeMs=(timer() - start_time) * 1000)
 
     def remove_duplicated_documents(self, documents: List) -> Tuple[List, set]:
         """Remove duplicated documents based on _id in the given list of documents.

--- a/src/marqo/core/models/marqo_update_documents_response.py
+++ b/src/marqo/core/models/marqo_update_documents_response.py
@@ -22,9 +22,9 @@ class MarqoUpdateDocumentsItem(MarqoBaseModel):
 
 class MarqoUpdateDocumentsResponse(MarqoBaseModel):
     errors: bool
-    indexName: str
+    indexName: str = Field(alias="index_name")
     items: List[MarqoUpdateDocumentsItem]
-    preprocessingTime: float
+    preprocessingTimeMs: float
 
     @root_validator(pre=True)
     def check_errors(cls, values):

--- a/src/marqo/core/models/marqo_update_documents_response.py
+++ b/src/marqo/core/models/marqo_update_documents_response.py
@@ -22,9 +22,9 @@ class MarqoUpdateDocumentsItem(MarqoBaseModel):
 
 class MarqoUpdateDocumentsResponse(MarqoBaseModel):
     errors: bool
-    indexName: str = Field(alias="index_name")
+    index_name: str
     items: List[MarqoUpdateDocumentsItem]
-    preprocessingTimeMs: float
+    processingTimeMs: float
 
     @root_validator(pre=True)
     def check_errors(cls, values):

--- a/tests/core/document/test_partial_document_update.py
+++ b/tests/core/document/test_partial_document_update.py
@@ -750,6 +750,8 @@ class TestUpdate(MarqoTestCase):
                                      index_name=self.structured_index_name,
                                      marqo_config=self.config)
 
+                if expected_status >= 400:
+                    self.assertIn("error", r["items"][0])
                 self.assertEqual(expected_error, r["errors"])
                 self.assertEqual(expected_status, r["items"][0]["status"])
                 self.assertEqual(expected_id, r["items"][0]["_id"])

--- a/tests/core/document/test_partial_document_update.py
+++ b/tests/core/document/test_partial_document_update.py
@@ -750,6 +750,8 @@ class TestUpdate(MarqoTestCase):
                                      index_name=self.structured_index_name,
                                      marqo_config=self.config)
 
+                print(r)
+
                 self.assertEqual(expected_error, r["errors"])
                 self.assertEqual(expected_status, r["items"][0]["status"])
                 self.assertEqual(expected_id, r["items"][0]["_id"])

--- a/tests/core/document/test_partial_document_update.py
+++ b/tests/core/document/test_partial_document_update.py
@@ -750,8 +750,6 @@ class TestUpdate(MarqoTestCase):
                                      index_name=self.structured_index_name,
                                      marqo_config=self.config)
 
-                print(r)
-
                 self.assertEqual(expected_error, r["errors"])
                 self.assertEqual(expected_status, r["items"][0]["status"])
                 self.assertEqual(expected_id, r["items"][0]["_id"])

--- a/tests/core/document/test_partial_document_update.py
+++ b/tests/core/document/test_partial_document_update.py
@@ -753,3 +753,5 @@ class TestUpdate(MarqoTestCase):
                 self.assertEqual(expected_error, r["errors"])
                 self.assertEqual(expected_status, r["items"][0]["status"])
                 self.assertEqual(expected_id, r["items"][0]["_id"])
+                self.assertIn("index_name", r)
+                self.assertIn("processingTimeMs", r)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
we return `indexName`, `preprocessingTime`

* **What is the new behavior (if this is a feature change)?**
we return `index_time`, `processingTimeMs` to be consistent with add_documents

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
no

* **Related Python client changes** (link commit/PR here)
no

* **Related documentation changes** (link commit/PR here)
no

* **Other information**:
no

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

