### PR TITLE
Catch connectionreseterror error in image download

### DIFF
--- a/src/marqo/s2_inference/clip_utils.py
+++ b/src/marqo/s2_inference/clip_utils.py
@@ -11,7 +11,7 @@ from PIL import Image, UnidentifiedImageError
 from multilingual_clip import pt_multilingual_clip
 from torchvision.transforms import Compose, Resize, CenterCrop, ToTensor, Normalize
 from torchvision.transforms import InterpolationMode
-from urllib3.exceptions import ProtocolError
+from urllib3.exceptions import HTTPError as urllib3_HTTPError
 
 from marqo.api.exceptions import InternalError
 from marqo.s2_inference.configs import ModelCache
@@ -117,7 +117,7 @@ def load_image_from_path(image_path: str, image_download_headers: dict, timeout=
                 metrics_obj.stop(f"image_download.{image_path}")
 
         except (requests.exceptions.ConnectTimeout, requests.exceptions.ConnectionError,
-                requests.exceptions.RequestException, ConnectionResetError, ProtocolError
+                requests.exceptions.RequestException, ConnectionError, urllib3_HTTPError
                 ) as e:
             raise UnidentifiedImageError(
                 f"image url `{image_path}` is unreachable, perhaps due to timeout. "

--- a/src/marqo/s2_inference/clip_utils.py
+++ b/src/marqo/s2_inference/clip_utils.py
@@ -1,24 +1,27 @@
 import os
-from marqo.tensor_search.enums import ModelProperties, InferenceParams
-from marqo.tensor_search.models.private_models import ModelLocation, ModelAuth
-import validators
-import requests
-import numpy as np
+
 import clip
-import torch
-from PIL import Image, UnidentifiedImageError
+import numpy as np
 import open_clip
-from multilingual_clip import pt_multilingual_clip
+import requests
+import torch
 import transformers
-from marqo.s2_inference.types import *
-from marqo.s2_inference.logger import get_logger
-from marqo.s2_inference.errors import IncompatibleModelDeviceError, InvalidModelPropertiesError
+import validators
+from PIL import Image, UnidentifiedImageError
+from multilingual_clip import pt_multilingual_clip
 from torchvision.transforms import Compose, Resize, CenterCrop, ToTensor, Normalize
-from marqo.s2_inference.processing.custom_clip_utils import HFTokenizer, download_model
 from torchvision.transforms import InterpolationMode
-from marqo.s2_inference.configs import ModelCache
+from urllib3.exceptions import ProtocolError
+
 from marqo.api.exceptions import InternalError
-from marqo.tensor_search.telemetry import RequestMetrics, RequestMetricsStore
+from marqo.s2_inference.configs import ModelCache
+from marqo.s2_inference.errors import InvalidModelPropertiesError
+from marqo.s2_inference.logger import get_logger
+from marqo.s2_inference.processing.custom_clip_utils import HFTokenizer, download_model
+from marqo.s2_inference.types import *
+from marqo.tensor_search.enums import ModelProperties, InferenceParams
+from marqo.tensor_search.models.private_models import ModelLocation
+from marqo.tensor_search.telemetry import RequestMetrics
 
 logger = get_logger(__name__)
 
@@ -114,7 +117,7 @@ def load_image_from_path(image_path: str, image_download_headers: dict, timeout=
                 metrics_obj.stop(f"image_download.{image_path}")
 
         except (requests.exceptions.ConnectTimeout, requests.exceptions.ConnectionError,
-                requests.exceptions.RequestException, ConnectionResetError
+                requests.exceptions.RequestException, ConnectionResetError, ProtocolError
                 ) as e:
             raise UnidentifiedImageError(
                 f"image url `{image_path}` is unreachable, perhaps due to timeout. "

--- a/src/marqo/s2_inference/clip_utils.py
+++ b/src/marqo/s2_inference/clip_utils.py
@@ -114,7 +114,7 @@ def load_image_from_path(image_path: str, image_download_headers: dict, timeout=
                 metrics_obj.stop(f"image_download.{image_path}")
 
         except (requests.exceptions.ConnectTimeout, requests.exceptions.ConnectionError,
-                requests.exceptions.RequestException
+                requests.exceptions.RequestException, ConnectionResetError
                 ) as e:
             raise UnidentifiedImageError(
                 f"image url `{image_path}` is unreachable, perhaps due to timeout. "

--- a/src/marqo/tensor_search/add_docs.py
+++ b/src/marqo/tensor_search/add_docs.py
@@ -5,6 +5,7 @@ import random
 import threading
 from contextlib import contextmanager
 from typing import List, Optional, Tuple, ContextManager, Union
+import concurrent
 
 import PIL
 from PIL.ImageFile import ImageFile
@@ -16,6 +17,7 @@ from marqo.tensor_search import constants
 import marqo.core.exceptions as core_exceptions
 import marqo.exceptions as base_exceptions
 from marqo.core.models.marqo_index import *
+from concurrent.futures import ThreadPoolExecutor
 
 
 def threaded_download_images(allocated_docs: List[dict], image_repo: dict, tensor_fields: List[str],
@@ -111,16 +113,15 @@ def download_images(docs: List[dict], thread_count: int, tensor_fields: List[str
     try:
         m = [RequestMetrics() for i in range(thread_count)]
         thread_allocated_docs = [copied[i: i + docs_per_thread] for i in range(len(copied))[::docs_per_thread]]
-        threads = [threading.Thread(target=threaded_download_images, args=(allocation, image_repo,
-                                                                           tensor_fields,
-                                                                           image_download_headers, m[i]))
-                   for i, allocation in enumerate(thread_allocated_docs)]
+        with ThreadPoolExecutor(max_workers=len(thread_allocated_docs)) as executor:
+            futures = [executor.submit(threaded_download_images, allocation, image_repo, tensor_fields,
+                                       image_download_headers, m[i])
+                       for i, allocation in enumerate(thread_allocated_docs)]
 
-        for th in threads:
-            th.start()
-
-        for th in threads:
-            th.join()
+            # Unhandled exceptions will be raised here.
+            # We only raise the first exception if there are multiple exceptions
+            for future in concurrent.futures.as_completed(futures):
+                _ = future.result()
 
         # Fix up metric_obj to make it not mention thread-ids
         metric_obj = RequestMetricsStore.for_request()

--- a/tests/tensor_search/integ_tests/test_add_documents_combined.py
+++ b/tests/tensor_search/integ_tests/test_add_documents_combined.py
@@ -108,7 +108,6 @@ class TestAddDocumentsStructured(MarqoTestCase):
 
     def test_connectionResetErrorHandled_successfully(self):
         """Ensure ConnectionResetError is not causing 500 error, but 400 for the document in add_documents."""
-        """Ensure vectorise does not receive enable_cache when calling add_documents."""
         documents = [
             {
                 "image_field_1": "https://raw.githubusercontent.com/marqo-ai/"

--- a/tests/tensor_search/integ_tests/test_add_documents_combined.py
+++ b/tests/tensor_search/integ_tests/test_add_documents_combined.py
@@ -107,7 +107,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
                                                                "vectorise for add_documents")
                 mock_vectorise.reset_mock()
 
-    def test_connectionResetErrorHandled_successfully(self):
+    def test_imageRepoHandleConnectionError_successfully(self):
         """Ensure ConnectionResetError is not causing 500 error, but 400 for the document in add_documents."""
         documents = [
             {
@@ -133,3 +133,27 @@ class TestAddDocumentsStructured(MarqoTestCase):
                     self.assertEqual(1, len(r["items"]))
                     self.assertEqual(400, r["items"][0]["status"])
                     self.assertIn(str(error.__name__), r["items"][0]["error"])
+
+    def test_imageRepoHandleThreadHandleError_successfully(self):
+        """Ensure image_repo can catch an unexpected error right in thread."""
+        documents = [
+            {
+                "image_field_1": "https://raw.githubusercontent.com/marqo-ai/"
+                                 "marqo-api-tests/mainline/assets/ai_hippo_realistic.png",
+                "_id": "1"
+            }
+        ]
+
+        for index_name in [self.unstructured_marqo_index_name, self.structured_marqo_index_name]:
+            error = Exception("Unexpected error during image download")
+            tensor_fields = ["image_field_1"] if index_name == self.unstructured_marqo_index_name \
+                else None
+            with (self.subTest(f"{index_name}-{error}")):
+                with patch("marqo.s2_inference.clip_utils.requests.get", side_effect=error) \
+                        as mock_requests_get:
+                    with self.assertRaises(Exception) as e:
+                        r = tensor_search.add_documents(config=self.config,
+                                                        add_docs_params=AddDocsParams(index_name=index_name,
+                                                                                      docs=documents,
+                                                                                      tensor_fields=tensor_fields))
+                        self.assertIn("Unexpected error during image download", str(e.exception))


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
if an `ConnectionResetError` is raised, we will have 500 errors

* **What is the new behavior (if this is a feature change)?**
we now catch it

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
running

* **Related Python client changes** (link commit/PR here)
no

* **Related documentation changes** (link commit/PR here)
no

* **Other information**:
no

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

