### PR TITLE
Use the IN operator for recommender filter with structured indexes

### DIFF
--- a/src/marqo/core/search/recommender.py
+++ b/src/marqo/core/search/recommender.py
@@ -171,7 +171,7 @@ class Recommender:
 
         if exclude_input_documents:
             # Make sure to include zero-weight documents in this filter
-            recommend_filter = self._get_exclusion_filter(all_document_ids, filter)
+            recommend_filter = self._get_exclusion_filter(marqo_index, all_document_ids, filter)
         else:
             recommend_filter = filter
 
@@ -202,8 +202,11 @@ class Recommender:
         else:
             return InterpolationMethod.LERP
 
-    def _get_exclusion_filter(self, documents: List[str], user_filter: Optional[str]) -> str:
-        not_in = 'NOT (' + ' OR '.join([f'_id:({doc})' for doc in documents]) + ')'
+    def _get_exclusion_filter(self, marqo_index: MarqoIndex, documents: List[str], user_filter: Optional[str]) -> str:
+        if marqo_index.type == IndexType.Structured:
+            not_in = 'NOT _id IN (' + ', '.join([f'{doc}' for doc in documents]) + ')'
+        else:
+            not_in = 'NOT (' + ' OR '.join([f'_id:({doc})' for doc in documents]) + ')'
 
         if user_filter is not None and user_filter.strip() != '':
             return f'({user_filter}) AND {not_in}'


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
For structured indexes, use the IN operator for recommender input document exclusion

* **What is the current behavior?** (You can also link to an open issue here)
Conjunction of OR operators. From experience we know this is prone to SO errors in Vespa due to a Vespa bug

* **What is the new behavior (if this is a feature change)?**
Use the safer IN operator if index is structured

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)


* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

