### PR TITLE
Change highlights log message level to DEBUG

### DIFF
--- a/src/marqo/core/structured_vespa_index/structured_vespa_index.py
+++ b/src/marqo/core/structured_vespa_index/structured_vespa_index.py
@@ -56,7 +56,7 @@ class StructuredVespaIndex(VespaIndex):
     def get_vespa_id_field(self) -> str:
         return common.FIELD_ID
 
-    def to_vespa_partial_document(self, marqo_document: Dict[str,Any]) -> Dict[str, Any]:
+    def to_vespa_partial_document(self, marqo_document: Dict[str, Any]) -> Dict[str, Any]:
         vespa_id: Optional[str] = None
         vespa_fields: Dict[str, Any] = dict()
         score_modifiers: Dict[str, float] = dict()
@@ -744,9 +744,10 @@ class StructuredVespaIndex(VespaIndex):
             if chunk_field_name in vespa_document_fields:
                 chunk = vespa_document_fields[chunk_field_name][chunk_index]
             else:
-                logger.warn(f'Failed to extract highlights as Vespa document is missing chunk field '
-                            f'{chunk_field_name}. This can happen if attributes_to_retrieve does not include '
-                            f'all searchable tensor fields (searchable_attributes)')
+                # Note: WARN level will create verbose logs in production as this is per result
+                logger.debug(f'Failed to extract highlights as Vespa document is missing chunk field '
+                             f'{chunk_field_name}. This can happen if attributes_to_retrieve does not include '
+                             f'all searchable tensor fields (searchable_attributes)')
 
                 chunk = None
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Improvement

* **What is the current behavior?** (You can also link to an open issue here)
Where `attributes_to_retrieve` excludes a searchable attribute, Marqo prints a warning because retrieved fields aren't enough to generate highlights. This warning is per result, so for limit=1000 it's printed 1000 times. In production, this has led to high CPU util and 1s+ post-processing telemetry (i.e. result processing in Marqo). 

* **What is the new behavior (if this is a feature change)?**
Change log level to DEBUG for this message

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
NA

* **Related Python client changes** (link commit/PR here)
NA

* **Related documentation changes** (link commit/PR here)
NA

* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

