### PR TITLE
Patch zookeeper client

### DIFF
--- a/run_marqo.sh
+++ b/run_marqo.sh
@@ -104,6 +104,7 @@ elif [ -z "$VESPA_QUERY_URL" ] && [ -z "$VESPA_DOCUMENT_URL" ] && [ -z "$VESPA_C
   export VESPA_QUERY_URL="http://localhost:8080"
   export VESPA_DOCUMENT_URL="http://localhost:8080"
   export VESPA_CONFIG_URL="http://localhost:19071"
+  export ZOOKEEPER_HOSTS="localhost:2181"
   export VESPA_IS_INTERNAL=True
 
 else

--- a/src/marqo/api/configs.py
+++ b/src/marqo/api/configs.py
@@ -10,7 +10,7 @@ def default_env_vars() -> dict:
         EnvVars.VESPA_CONFIG_URL: "http://localhost:19071",
         EnvVars.VESPA_QUERY_URL: "http://localhost:8080",
         EnvVars.VESPA_DOCUMENT_URL: "http://localhost:8080",
-        EnvVars.ZOOKEEPER_HOSTS: "localhost:2181",
+        EnvVars.ZOOKEEPER_HOSTS: None,
         EnvVars.VESPA_CONTENT_CLUSTER_NAME: "content_default",
         EnvVars.VESPA_POOL_SIZE: 10,
         EnvVars.VESPA_FEED_POOL_SIZE: 10,

--- a/src/marqo/config.py
+++ b/src/marqo/config.py
@@ -43,7 +43,7 @@ class Config:
             utils.read_env_vars_and_defaults(EnvVars.MARQO_BEST_AVAILABLE_DEVICE))
 
         # Initialize Core layer dependencies
-        self.index_management = IndexManagement(vespa_client, zookeeper_client)
+        self.index_management = IndexManagement(vespa_client, zookeeper_client, enable_index_operations=True)
         self.monitoring = Monitoring(vespa_client, self.index_management)
         self.document = Document(vespa_client, self.index_management)
         self.recommender = Recommender(vespa_client, self.index_management)

--- a/src/marqo/core/index_management/index_management.py
+++ b/src/marqo/core/index_management/index_management.py
@@ -66,7 +66,8 @@ class IndexManagement:
         Args:
             vespa_client: VespaClient object
             zookeeper_client: ZookeeperClient object
-            enable_index_operations: Flag to enable index operations
+            enable_index_operations: A flag to enable index operations. If set to True,
+                the object can create/delete indexes, otherwise, it raises an InternalError during index operations.
         """
         self.vespa_client = vespa_client
         self._zookeeper_client = zookeeper_client
@@ -566,11 +567,8 @@ class IndexManagement:
         """
         if self._enable_index_operations:
             if self._zookeeper_deployment_lock is None:
-                logger.warning(f"You are trying to perform an index operation without setting a Zookeeper client. "
-                               f"Your operation will proceed without locking. "
-                               f"This may lead to conflicts if multiple operations are performed simultaneously. "
-                               f"Please set a Zookeeper client to enable locking "
-                               f"by setting the '{EnvVars.ZOOKEEPER_HOSTS}' environment variable")
+                logger.warning(f"No Zookeeper client provided. "
+                               f"Concurrent index operations may result in race conditions. ")
                 yield  # No lock, proceed without locking
             else:
                 try:

--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -53,10 +53,11 @@ def generate_config() -> config.Config:
         partial_update_pool_size=utils.read_env_vars_and_defaults_ints(EnvVars.VESPA_PARTIAL_UPDATE_POOL_SIZE),
     )
 
+    # Zookeeper is only instantiated if the hosts are provided
     zookeeper_client = ZookeeperClient(
         zookeeper_connection_timeout=utils.read_env_vars_and_defaults_ints(EnvVars.ZOOKEEPER_CONNECTION_TIMEOUT),
         hosts=utils.read_env_vars_and_defaults(EnvVars.ZOOKEEPER_HOSTS)
-    )
+    ) if utils.read_env_vars_and_defaults(EnvVars.ZOOKEEPER_HOSTS) else None
 
     # Determine default device
     default_device = utils.read_env_vars_and_defaults(EnvVars.MARQO_BEST_AVAILABLE_DEVICE)

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.7.0"
+__version__ = "2.7.1"
 
 
 def get_version() -> str:

--- a/tests/marqo_test.py
+++ b/tests/marqo_test.py
@@ -47,7 +47,7 @@ class MarqoTestCase(unittest.TestCase):
         cls.configure_request_metrics()
         cls.vespa_client = vespa_client
         cls.zookeeper_client = zookeeper_client
-        cls.index_management = IndexManagement(cls.vespa_client, cls.zookeeper_client)
+        cls.index_management = IndexManagement(cls.vespa_client, cls.zookeeper_client, enable_index_operations=True)
         cls.monitoring = Monitoring(cls.vespa_client, cls.index_management)
         cls.config = config.Config(vespa_client=vespa_client, default_device="cpu",
                                    zookeeper_client=cls.zookeeper_client)


### PR DESCRIPTION
… the environment variable is no set

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
the index operations will be blocked if marqo fails to connect to Zookeeper

* **What is the new behavior (if this is a feature change)?**
If the `ZOOKEEPER_HOSTS` environment variable is not set, we still allow users to conduct index operations without concurrency protection.

If the `ZOOKEEPER_HOSTS` environment variable is set, Marqo will block the index operations if it fails to connect the target zookeeper server.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
no

* **Related Python client changes** (link commit/PR here)
no

* **Related documentation changes** (link commit/PR here)

no
* **Other information**:
no

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

