### PR TITLE
Patch the structured index lexical search always return 0 score bug

### DIFF
--- a/src/marqo/core/models/marqo_index.py
+++ b/src/marqo/core/models/marqo_index.py
@@ -349,6 +349,10 @@ class StructuredMarqoIndex(MarqoIndex):
 
     @property
     def lexical_field_map(self) -> Dict[str, Field]:
+        """Return a map from lexical field name to the field object.
+
+        The field.lexical_field_name is not the same as the field.name. It is the name of the field that is used in the
+        index schema with Marqo prefix."""
         return self._cache_or_get('lexical_field_map',
                                   lambda: {field.lexical_field_name: field for field in self.fields if
                                            FieldFeature.LexicalSearch in field.features}
@@ -363,6 +367,13 @@ class StructuredMarqoIndex(MarqoIndex):
 
     @property
     def lexically_searchable_fields_names(self) -> Set[str]:
+        """Return a set of field names (str) that are lexically searchable.
+
+        These are the original field names without any Marqo prefix. You should use this to generate
+        the searchable fields in your lexical search query.
+
+        Note that field.name is not identical to field.lexical_field_name. The latter is the name of the field
+        that is used in the index schema"""
         return self._cache_or_get('lexically_searchable_fields_names',
                                   lambda: {field.name for field in self.fields if
                                            FieldFeature.LexicalSearch in field.features}

--- a/src/marqo/core/structured_vespa_index/structured_vespa_index.py
+++ b/src/marqo/core/structured_vespa_index/structured_vespa_index.py
@@ -382,7 +382,7 @@ class StructuredVespaIndex(VespaIndex):
                     )
             fields_to_search = marqo_query.searchable_attributes
         else:
-            fields_to_search = self._marqo_index.lexical_field_map.keys()
+            fields_to_search = self._marqo_index.lexically_searchable_fields_names
 
         lexical_term = self._get_lexical_search_term(marqo_query) if fields_to_search else "False"
         filter_term = self._get_filter_term(marqo_query)

--- a/tests/tensor_search/integ_tests/test_search_combined.py
+++ b/tests/tensor_search/integ_tests/test_search_combined.py
@@ -723,7 +723,8 @@ class TestSearch(MarqoTestCase):
                         self.assertIn("hits", res)
                         self.assertEqual(expected_count, len(res['hits']))
 
-    def test_LexicalSearchResults(self):
+    def test_LexicalSearchResultsScore(self):
+        """A test to ensure that the score is returned for lexical search results and the scores are greater than 0."""
         docs = [
             {"_id": "11", "text_field_1": "field_1_document_1"},
             {"_id": "12", "text_field_1": "field_1_document_2"},


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
For a structured index, the lexical search results always have 0 scores

* **What is the new behavior (if this is a feature change)?**
The correct score can be returned now

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
running

* **Related Python client changes** (link commit/PR here)
no

* **Related documentation changes** (link commit/PR here)
no

* **Other information**:
no

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

