### PR TITLE
Fix image download with invalid _id for 2.8.1 release

### DIFF
--- a/src/marqo/tensor_search/add_docs.py
+++ b/src/marqo/tensor_search/add_docs.py
@@ -2,10 +2,10 @@
 import concurrent
 import copy
 import math
-import random
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from typing import ContextManager
+import threading
 
 import PIL
 from PIL.ImageFile import ImageFile
@@ -49,11 +49,8 @@ def threaded_download_and_preprocess_images(allocated_docs: List[dict], image_re
         None
 
     """
-    # TODO - We may not be handling errors in threads properly. Test introducing errors (e.g., call a method
-    #  that doesn't exist) in this code and verify
     # Generate pseudo-unique ID for thread metrics.
-    _id = hash("".join([d.get("_id", str(random.getrandbits(64))) for d in allocated_docs])) % 1000
-    _id = f"image_download.{_id}"
+    _id = f'image_download.{threading.get_ident()}'
     TIMEOUT_SECONDS = 3
     if metric_obj is None:  # Occurs predominately in testing.
         metric_obj = RequestMetricsStore.for_request()

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.8.0"
+__version__ = "2.8.1"
 
 
 def get_version() -> str:


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix, and release 2.8.1

* **What is the current behavior?** (You can also link to an open issue here)
A 500 error is returned if a document with invalid `_id` is indexed to an image index.

E.g., creating an index with `treat_urls_and_pointers_as_image=True` and indexing this document
```{"_id": 123, "image_field": "https://a-url-to-image/image1.jpg"}```
with give you a 500 error.

* **What is the new behavior (if this is a feature change)?**
only 400 is returned for the document with an invalid id. The other documents in the batch will be indexed as expected.

We also update the version to 2.8.1

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
no

* **Related Python client changes** (link commit/PR here)
no

* **Related documentation changes** (link commit/PR here)
no

* **Other information**:
no

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

