### PR TITLE
Improve index deletion resilience 

### DIFF
--- a/src/marqo/core/index_management/index_management.py
+++ b/src/marqo/core/index_management/index_management.py
@@ -464,8 +464,9 @@ class IndexManagement:
         schema_path = os.path.join(app, 'schemas', f'{name}.sd')
         if not os.path.exists(schema_path):
             logger.warn(f"Schema {name} does not exist in application package, nothing to remove")
-
-        os.remove(schema_path)
+            return None
+        else:
+            os.remove(schema_path)
 
     def _add_schema_to_services(self, app: str, name: str) -> None:
         services_path = os.path.join(app, 'services.xml')

--- a/tests/tensor_search/integ_tests/test_create_index_resilience.py
+++ b/tests/tensor_search/integ_tests/test_create_index_resilience.py
@@ -1,0 +1,196 @@
+from unittest.mock import patch
+
+from marqo.core.exceptions import IndexNotFoundError
+from tests.marqo_test import MarqoTestCase
+
+from marqo.tensor_search import tensor_search
+from marqo.tensor_search.models.add_docs_objects import AddDocsParams
+
+
+class TestCreateIndexResilience(MarqoTestCase):
+    """A test to check the resilience of the create index operation.
+
+    Index creation in Marqo is not atomic. We need to ensure that the create index operation is resilient to failures.
+    Users should at least be able to bring Marqo to a consistent state by repeating the call to create index and get a
+    200 response code.
+
+    The index creation operation consists of the following steps:
+    1. Download the application package.
+    2. Check the configuration of the index from the marqo__config index.
+    3. Check the existence of the index in the schema.
+    3.5 Optional: Add the marqo__config index if it does not exist.
+    4. Generate the schema.
+    5. Add new schema .sd file
+    6. Add the new schema to the service
+    7. Deploy the new application package
+    8. Add the index settings to marqo__settings index
+    9. Add the Marqo version to the marqo__config index
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.index_management.bootstrap_vespa()
+
+    def setUp(self) -> None:
+        self.index_name = "test_index_creation_resilience"
+        try:
+            # Clear up the index before test
+            tensor_search.delete_index(self.config, self.index_name)
+        except IndexNotFoundError:
+            pass
+        self.index_request = self.unstructured_marqo_index_request(name=self.index_name)
+
+    def tearDown(self) -> None:
+        try:
+            # Clear up the index after test
+            tensor_search.delete_index(self.config, self.index_name)
+        except IndexNotFoundError:
+            pass
+
+    def check_resilience(self):
+        # Ensure the index can be created again by repeating the create index operation
+        self.index_management.create_index(self.index_request)
+
+        # Add documents to the index
+        r = tensor_search.add_documents(
+            config=self.config,
+            add_docs_params=AddDocsParams(
+                index_name=self.index_name,
+                tensor_fields=[],
+                docs=[{"test": "test", "_id": "1"}]
+            )
+        )
+        self.assertEqual(r["errors"], False)
+
+        # Test search
+        r = tensor_search.search(
+            config=self.config,
+            index_name=self.index_name,
+            text="test",
+            search_method="LEXICAL"
+        )
+        self.assertEqual(1, len(r["hits"]))
+
+        # Ensure the index can be deleted successfully
+        tensor_search.delete_index(self.config, self.index_name)
+
+    def test_downloadApplicationPackageFail(self):
+        """Test that the create index operation is resilient to failures in downloading the application package."""
+        error = Exception("Failed to download the application package")
+        with patch("marqo.vespa.vespa_client.VespaClient.download_application", side_effect=error) \
+                as mock_create_index_by_name:
+            with self.assertRaises(Exception) as e:
+                self.index_management.create_index(self.index_request)
+            self.assertEqual(e.exception, error)
+
+        self.check_resilience()
+
+    def test_checkIndexConfigurationFail(self):
+        """Test that the create index operation is resilient to failures in checking the configuration of the index."""
+        error = Exception("Failed to check the configuration of the index")
+        with patch("marqo.core.index_management.index_management.IndexManagement._marqo_config_exists",
+                   side_effect=error) as mock_create_index_by_name:
+            with self.assertRaises(Exception) as e:
+                self.index_management.create_index(self.index_request)
+            self.assertEqual(e.exception, error)
+
+        self.check_resilience()
+
+    def test_checkIndexExistsFail(self):
+        """Test that the create index operation is resilient to failures in checking the existence of the index in the
+        schema.
+        """
+        error = Exception("Failed to check the existence of the index in the schema")
+        with patch("marqo.core.index_management.index_management.IndexManagement.index_exists",
+                   side_effect=error) as mock_create_index_by_name:
+            with self.assertRaises(Exception) as e:
+                self.index_management.create_index(self.index_request)
+            self.assertEqual(e.exception, error)
+
+        self.check_resilience()
+
+    def test_addMarqoConfigIndexFail(self):
+        """Test that the create index operation is resilient to failures in adding the marqo__config index."""
+        error = Exception("Failed to add the marqo__config index")
+        with patch("marqo.core.index_management.index_management.IndexManagement._marqo_config_exists",
+                   return_value=False):
+            with patch("marqo.core.index_management.index_management.IndexManagement._add_marqo_config",
+                       side_effect=error) as mock_create_index_by_name:
+                with self.assertRaises(Exception) as e:
+                    self.index_management.create_index(self.index_request)
+                self.assertEqual(e.exception, error)
+
+        self.check_resilience()
+
+    def test_generateSchemaFail(self):
+        """Test that the create index operation is resilient to failures in generating the schema."""
+        error = Exception("Failed to generate the schema")
+        with patch("marqo.core.unstructured_vespa_index.unstructured_vespa_schema.UnstructuredVespaSchema."
+                   "generate_schema", side_effect=error) as mock_create_index_by_name:
+            with self.assertRaises(Exception) as e:
+                self.index_management.create_index(self.index_request)
+            self.assertEqual(e.exception, error)
+
+        self.check_resilience()
+
+    def test_addNewSchemaSdFileFail(self):
+        """Test that the create index operation is resilient to failures in add new schema .sd file."""
+        error = Exception("Failed to add the new schema .sd file")
+        with patch("marqo.core.index_management.index_management.IndexManagement._add_schema",
+                   side_effect=error) as mock_create_index_by_name:
+            with self.assertRaises(Exception) as e:
+                self.index_management.create_index(self.index_request)
+            self.assertEqual(e.exception, error)
+
+        self.check_resilience()
+
+    def test_addNewSchemaToServiceFail(self):
+        """Test that the create index operation is resilient to failures in adding the new schema to the service."""
+        error = Exception("Failed to add the new schema to the service")
+        with patch("marqo.core.index_management.index_management.IndexManagement._add_schema_to_services",
+                   side_effect=error) as mock_create_index_by_name:
+            with self.assertRaises(Exception) as e:
+                self.index_management.create_index(self.index_request)
+            self.assertEqual(e.exception, error)
+
+        self.check_resilience()
+
+    def test_deployApplicationPackageFail(self):
+        """Test that the create index operation is resilient to failures in deploying the new application package."""
+        error = Exception("Failed to deploy the new application package")
+        with patch("marqo.vespa.vespa_client.VespaClient.deploy_application",
+                   side_effect=error) as mock_create_index_by_name:
+            with self.assertRaises(Exception) as e:
+                self.index_management.create_index(self.index_request)
+            self.assertEqual(e.exception, error)
+
+        self.check_resilience()
+
+    def test_addTheIndexSettingsToMarqoSettingsIndexFail(self):
+        """Test that the create index operation is resilient to failures in adding the index settings to the
+        marqo__settings index.
+        """
+        error = Exception("Failed to add the index settings to the marqo__settings index")
+        with patch("marqo.core.index_management.index_management.IndexManagement._save_index_settings",
+                   side_effect=error) as mock_create_index_by_name:
+            with self.assertRaises(Exception) as e:
+                self.index_management.create_index(self.index_request)
+            self.assertEqual(e.exception, error)
+
+        self.check_resilience()
+
+    def test_saveMarqoVersionFail(self):
+        """Test that the create index operation is resilient to failures in saving the Marqo version."""
+        error = Exception("Failed to save the Marqo version")
+        with patch("marqo.core.index_management.index_management.IndexManagement._marqo_config_exists",
+                   return_value=False):
+            with patch("marqo.core.index_management.index_management.IndexManagement._save_marqo_version",
+                       side_effect=error) as mock_create_index_by_name:
+                with self.assertRaises(Exception) as e:
+                    self.index_management.create_index(self.index_request)
+                self.assertEqual(e.exception, error)
+
+        with patch("marqo.core.index_management.index_management.IndexManagement._marqo_config_exists",
+                   return_value=False):
+            self.check_resilience()

--- a/tests/tensor_search/integ_tests/test_delete_index_resilience.py
+++ b/tests/tensor_search/integ_tests/test_delete_index_resilience.py
@@ -1,0 +1,141 @@
+from unittest.mock import patch
+
+from marqo.core.exceptions import IndexNotFoundError
+from tests.marqo_test import MarqoTestCase
+
+from marqo.tensor_search import tensor_search
+from marqo.tensor_search.models.add_docs_objects import AddDocsParams
+
+
+class TestDeleteIndexResilience(MarqoTestCase):
+    """ This is a test class for testing the resilience of the delete index operation.
+
+    Index deletion is not atomic in Marqo. We need to ensure that the delete index operation is resilient to failures.
+    Users should at least be able to bring Marqo to a consistent state by repeating the call to delete index and get
+    a 200 response code.
+
+    I divide the delete index operation into the following steps:
+    1. Fetch the index object by name from the marqo__settings schema. Raise 400 index_not_found error if the index
+    does not exist.
+    2. Download the application package.
+    3. Remove the index in the schema. Raise os error (Internal Error 500) if the schema file path does not exist
+    4. Deploy the new application package
+    5. Delete the document in the Vespa marqo__settings schema
+    6. Delete the index cache
+
+    We will simulate failures in each of these steps and ensure that the delete index operation is resilient to these.
+    """
+
+    def setUp(self) -> None:
+        self.index_name = "test_index_deletion"
+        test_index_request = self.unstructured_marqo_index_request(
+            name=self.index_name
+        )
+        self.index_management.create_index(test_index_request)
+
+    def tearDown(self) -> None:
+        try:
+            # Clear up the index after test
+            tensor_search.delete_index(self.config, self.index_name)
+        except IndexNotFoundError:
+            pass
+
+    def check_resilience(self):
+        try:
+            # Repeat the delete index operation, it is OK to raise IndexNotFoundError
+            tensor_search.delete_index(self.config, self.index_name)
+        except IndexNotFoundError:
+            pass
+        self.create_indexes([self.unstructured_marqo_index_request(name=self.index_name)])
+
+        # Add documents to the index
+        r = tensor_search.add_documents(
+            config=self.config,
+            add_docs_params=AddDocsParams(
+                index_name=self.index_name,
+                tensor_fields=[],
+                docs=[{"test": "test", "_id": "1"}]
+            )
+        )
+        self.assertEqual(r["errors"], False)
+
+        # Test search
+        r = tensor_search.search(
+            config=self.config,
+            index_name=self.index_name,
+            text="test",
+            search_method="LEXICAL"
+        )
+        self.assertEqual(1, len(r["hits"]))
+
+    def test_fetchIndexObjectFail(self):
+        """Test that the delete index operation is resilient to failures in fetching the index object by name from the
+        marqo__settings schema.
+        """
+
+        error = Exception("Failed to fetch index object")
+        with patch("marqo.core.index_management.index_management.IndexManagement.get_index", side_effect=error) \
+                as mock_delete_index_by_name:
+            with self.assertRaises(Exception) as e:
+                tensor_search.delete_index(self.config, self.index_name)
+            self.assertEqual(e.exception, error)
+
+        self.check_resilience()
+
+    def test_downloadApplicationPackageFail(self):
+        """Test that the delete index operation is resilient to failures in downloading the application package."""
+        error = Exception("Failed to download the application package")
+        with patch("marqo.vespa.vespa_client.VespaClient.download_application", side_effect=error) \
+                as mock_delete_index_by_name:
+            with self.assertRaises(Exception) as e:
+                tensor_search.delete_index(self.config, self.index_name)
+            self.assertEqual(e.exception, error)
+
+        self.check_resilience()
+
+    def test_removeIndexInSchemaFail(self):
+        """Test that the delete index operation is resilient to failures in removing the index in the schema."""
+        error = Exception("Failed to remove the index in the schema")
+        with patch("marqo.core.index_management.index_management.IndexManagement._remove_schema_from_services",
+                   side_effect=error) as mock_delete_index_by_name:
+            with self.assertRaises(Exception) as e:
+                tensor_search.delete_index(self.config, self.index_name)
+            self.assertEqual(e.exception, error)
+
+        self.check_resilience()
+
+    def test_deployApplicationPackage(self):
+        """Test that the delete index operation is resilient to failures in deploying the new application package."""
+        error = Exception("Failed to remove the index in the schema")
+        with patch("marqo.vespa.vespa_client.VespaClient.deploy_application",
+                   side_effect=error) as mock_delete_index_by_name:
+            with self.assertRaises(Exception) as e:
+                tensor_search.delete_index(self.config, self.index_name)
+            self.assertEqual(e.exception, error)
+
+        self.check_resilience()
+
+    def test_deleteDocumentInVespaSchemaFail(self):
+        """Test that the delete index operation is resilient to failures in deleting the document in the Vespa
+        marqo__settings schema.
+        """
+        error = Exception("Failed to delete the document in the Vespa marqo__settings schema")
+        with patch("marqo.core.index_management.index_management.IndexManagement._delete_index_settings_by_name",
+                   side_effect=error) \
+                as mock_delete_index_by_name:
+            with self.assertRaises(Exception) as e:
+                tensor_search.delete_index(self.config, self.index_name)
+            self.assertEqual(e.exception, error)
+
+        self.check_resilience()
+
+    def test_deleteCacheFail(self):
+        """Test that the delete index operation is resilient to failures in deleting index_name cache."""
+        error = Exception("Failed to get cache")
+        with patch("marqo.tensor_search.tensor_search.get_cache", side_effect=error) \
+                as mock_delete_index_by_name:
+            with self.assertRaises(Exception) as e:
+                tensor_search.delete_index(self.config, self.index_name)
+            self.assertEqual(e.exception, error)
+
+        self.check_resilience()

--- a/tests/tensor_search/integ_tests/test_delete_index_resilience.py
+++ b/tests/tensor_search/integ_tests/test_delete_index_resilience.py
@@ -14,7 +14,7 @@ class TestDeleteIndexResilience(MarqoTestCase):
     Users should at least be able to bring Marqo to a consistent state by repeating the call to delete index and get
     a 200 response code.
 
-    I divide the delete index operation into the following steps:
+    The index deletion operation consists of the following steps:
     1. Fetch the index object by name from the marqo__settings schema. Raise 400 index_not_found error if the index
     does not exist.
     2. Download the application package.
@@ -25,6 +25,11 @@ class TestDeleteIndexResilience(MarqoTestCase):
 
     We will simulate failures in each of these steps and ensure that the delete index operation is resilient to these.
     """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.index_management.bootstrap_vespa()
 
     def setUp(self) -> None:
         self.index_name = "test_index_deletion"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
Deleting the index in Marqo is not atomic. It may lead Marqo to an intermediate state and break the index deletion and creation process. 

* **What is the new behavior (if this is a feature change)?**
Users can call delete_index again to bring Marqo into a consistent state and get a 200 response. Tests regarding the index deletion resilience have been added.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
yes

* **Related Python client changes** (link commit/PR here)
no

* **Related documentation changes** (link commit/PR here)
no

* **Other information**:
no

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

