### PR TITLE
Fix docs link tests

### DIFF
--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -17,4 +17,9 @@ class TestDocumentation(unittest.TestCase):
                 url = getattr(marqo_docs, func)()
                 response = httpx.get(url, follow_redirects=True)
                 response.raise_for_status()
-                self.assertFalse('404.html' in response.content.decode(), f"{func} URL returned a 404 response")
+                self.assertFalse(
+                    '404.html' in response.content.decode(), f"{func} URL returned a 404 response"
+                )
+                self.assertFalse(
+                    '<title>Redirecting</title>' in response.content.decode(), f"{func} URL is a redirect"
+                )


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fail docs tests

* **What is the current behavior?** (You can also link to an open issue here)
Docs tests pass even if the version doesn't have docs because the test looks for a 404 whereas our docs redirect to latest instead of 404

* **What is the new behavior (if this is a feature change)?**
Extra assert so if that version doesn't have docs published, the test fails

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)


* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

