### PR TITLE
Expose vespa var and log folder as volume and skip the upgrade check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
 FROM marqoai/marqo-base:20 as base_image
-VOLUME /opt/vespa/
+
+# Allow mounting volume containing data and configs for vespa
+VOLUME /opt/vespa/var
+# Allow mounting volume to expose vespa logs
+VOLUME /opt/vespa/logs
+# This is required when mounting var folder from an older version of vespa (>30 minor version gap)
+# See https://docs.vespa.ai/en/operations-selfhosted/live-upgrade.html for details
+ENV VESPA_SKIP_UPGRADE_CHECK true
+
 ARG TARGETPLATFORM
 ARG COMMITHASH
 WORKDIR /app


### PR DESCRIPTION
Context:
- We used to expose the /opt/vespa folder as a volume. This is problematic since the vespa binaries are in this folder. When user use a newer version of marqo and mount a volume from an older version, it could end up with broken dependencies and make the process stuck. See https://github.com/marqo-ai/marqo/issues/867 for an example of this issue.
- Instead, we should only expose following folders as volumes. /opt/vespa/var for config and data, and /opt/vespa/logs for logs.
- VESPA_SKIP_UPGRADE_CHECK is also set to make the upgrade process smoother. By default, vespa only allows upgrade within 30 minor version changes, which blocks the upgrade of marqo image version if gaps are too large.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix: https://github.com/marqo-ai/marqo/issues/867

* **What is the current behavior?** (You can also link to an open issue here)
In the current docker file, /opt/vespa folder exposed as a volume

* **What is the new behavior (if this is a feature change)?**
/opt/vespa/var and /opt/vespa/logs will be exposed as separate volumes

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
This is a breaking change only if user runs marqo on a local vespa (embedded in marqo container) and does volume mapping in there docker run command. See docs for details for the detailed solution. 

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
It did not break any unit test

* **Related Python client changes** (link commit/PR here)
N/A

* **Related documentation changes** (link commit/PR here)
https://github.com/marqo-ai/marqodocs/pull/237

* **Other information**:


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

