### PR TITLE
Change unstructured vespa score modifier expression

### DIFF
--- a/src/marqo/core/unstructured_vespa_index/unstructured_vespa_schema.py
+++ b/src/marqo/core/unstructured_vespa_index/unstructured_vespa_schema.py
@@ -75,6 +75,14 @@ class UnstructuredVespaSchema(VespaSchema):
             f'+ reduce(query(marqo__add_weights) ' 
             f'* attribute(marqo__score_modifiers), sum)'
         )
+        _score_modifier_expression = (
+            f'if (count(query(marqo__mult_weights)) == 0, 1, '
+            f'if (count(query(marqo__mult_weights) * attribute(marqo__score_modifiers)) == 0, '
+            f'1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod))) '
+            f'* score '
+            f'+ if (count(query(marqo__add_weights)) == 0, 0, '
+            f'reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum))'
+        )
 
         return textwrap.dedent(
             f"""

--- a/src/marqo/core/unstructured_vespa_index/unstructured_vespa_schema.py
+++ b/src/marqo/core/unstructured_vespa_index/unstructured_vespa_schema.py
@@ -69,12 +69,10 @@ class UnstructuredVespaSchema(VespaSchema):
         dimension = str(marqo_index.model.get_dimension())
 
         _score_modifier_expression = (
-            f'if (count(query(marqo__mult_weights)) == 0, 1, '
             f'if (count(query(marqo__mult_weights) * attribute(marqo__score_modifiers)) == 0, '
-            f'1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod))) '
+            f'  1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod)) '
             f'* score '
-            f'+ if (count(query(marqo__add_weights)) == 0, 0, '
-            f'reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum))'
+            f'+ reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum)'
         )
 
         return textwrap.dedent(

--- a/src/marqo/core/unstructured_vespa_index/unstructured_vespa_schema.py
+++ b/src/marqo/core/unstructured_vespa_index/unstructured_vespa_schema.py
@@ -69,13 +69,6 @@ class UnstructuredVespaSchema(VespaSchema):
         dimension = str(marqo_index.model.get_dimension())
 
         _score_modifier_expression = (
-            f'if (count(query(marqo__mult_weights)) == 0, 1, ' 
-            f'reduce(query(marqo__mult_weights) ' 
-            f'* attribute(marqo__score_modifiers), prod)) * score ' 
-            f'+ reduce(query(marqo__add_weights) ' 
-            f'* attribute(marqo__score_modifiers), sum)'
-        )
-        _score_modifier_expression = (
             f'if (count(query(marqo__mult_weights)) == 0, 1, '
             f'if (count(query(marqo__mult_weights) * attribute(marqo__score_modifiers)) == 0, '
             f'1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod))) '

--- a/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema.sd
+++ b/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema.sd
@@ -118,7 +118,7 @@ schema marqo__test_00unstructured_00schema {
             query(marqo__add_weights) tensor<double>(p{})
         }
         function modify(score) {
-            expression: if (count(query(marqo__mult_weights)) == 0, 1, if (count(query(marqo__mult_weights) * attribute(marqo__score_modifiers)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod))) * score + if (count(query(marqo__add_weights)) == 0, 0, reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum))
+            expression: if (count(query(marqo__mult_weights) * attribute(marqo__score_modifiers)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod)) * score + reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum)
         }
     }
 

--- a/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema.sd
+++ b/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema.sd
@@ -118,8 +118,8 @@ schema marqo__test_00unstructured_00schema {
             query(marqo__add_weights) tensor<double>(p{})
         }
         function modify(score) {
-            expression: if (count(query(marqo__mult_weights)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod)) * score + reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum)
-       }
+            expression: if (count(query(marqo__mult_weights)) == 0, 1, if (count(query(marqo__mult_weights) * attribute(marqo__score_modifiers)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod))) * score + if (count(query(marqo__add_weights)) == 0, 0, reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum))
+        }
     }
 
     rank-profile bm25_modifiers inherits modifiers {

--- a/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema_distance_metric_angular.sd
+++ b/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema_distance_metric_angular.sd
@@ -118,7 +118,7 @@ schema marqo__test_00unstructured_00schema_00distance_00metric {
             query(marqo__add_weights) tensor<double>(p{})
         }
         function modify(score) {
-            expression: if (count(query(marqo__mult_weights)) == 0, 1, if (count(query(marqo__mult_weights) * attribute(marqo__score_modifiers)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod))) * score + if (count(query(marqo__add_weights)) == 0, 0, reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum))
+            expression: if (count(query(marqo__mult_weights) * attribute(marqo__score_modifiers)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod)) * score + reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum)
        }
     }
 

--- a/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema_distance_metric_angular.sd
+++ b/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema_distance_metric_angular.sd
@@ -118,7 +118,7 @@ schema marqo__test_00unstructured_00schema_00distance_00metric {
             query(marqo__add_weights) tensor<double>(p{})
         }
         function modify(score) {
-            expression: if (count(query(marqo__mult_weights)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod)) * score + reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum)
+            expression: if (count(query(marqo__mult_weights)) == 0, 1, if (count(query(marqo__mult_weights) * attribute(marqo__score_modifiers)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod))) * score + if (count(query(marqo__add_weights)) == 0, 0, reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum))
        }
     }
 

--- a/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema_distance_metric_dotproduct.sd
+++ b/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema_distance_metric_dotproduct.sd
@@ -118,7 +118,7 @@ schema marqo__test_00unstructured_00schema_00distance_00metric {
             query(marqo__add_weights) tensor<double>(p{})
         }
         function modify(score) {
-            expression: if (count(query(marqo__mult_weights)) == 0, 1, if (count(query(marqo__mult_weights) * attribute(marqo__score_modifiers)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod))) * score + if (count(query(marqo__add_weights)) == 0, 0, reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum))
+            expression: if (count(query(marqo__mult_weights) * attribute(marqo__score_modifiers)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod)) * score + reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum)
        }
     }
 

--- a/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema_distance_metric_dotproduct.sd
+++ b/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema_distance_metric_dotproduct.sd
@@ -118,7 +118,7 @@ schema marqo__test_00unstructured_00schema_00distance_00metric {
             query(marqo__add_weights) tensor<double>(p{})
         }
         function modify(score) {
-            expression: if (count(query(marqo__mult_weights)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod)) * score + reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum)
+            expression: if (count(query(marqo__mult_weights)) == 0, 1, if (count(query(marqo__mult_weights) * attribute(marqo__score_modifiers)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod))) * score + if (count(query(marqo__add_weights)) == 0, 0, reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum))
        }
     }
 

--- a/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema_distance_metric_euclidean.sd
+++ b/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema_distance_metric_euclidean.sd
@@ -118,7 +118,7 @@ schema marqo__test_00unstructured_00schema_00distance_00metric {
             query(marqo__add_weights) tensor<double>(p{})
         }
         function modify(score) {
-            expression: if (count(query(marqo__mult_weights)) == 0, 1, if (count(query(marqo__mult_weights) * attribute(marqo__score_modifiers)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod))) * score + if (count(query(marqo__add_weights)) == 0, 0, reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum))
+            expression: if (count(query(marqo__mult_weights) * attribute(marqo__score_modifiers)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod)) * score + reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum)
        }
     }
 

--- a/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema_distance_metric_euclidean.sd
+++ b/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema_distance_metric_euclidean.sd
@@ -118,7 +118,7 @@ schema marqo__test_00unstructured_00schema_00distance_00metric {
             query(marqo__add_weights) tensor<double>(p{})
         }
         function modify(score) {
-            expression: if (count(query(marqo__mult_weights)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod)) * score + reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum)
+            expression: if (count(query(marqo__mult_weights)) == 0, 1, if (count(query(marqo__mult_weights) * attribute(marqo__score_modifiers)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod))) * score + if (count(query(marqo__add_weights)) == 0, 0, reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum))
        }
     }
 

--- a/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema_distance_metric_geodegrees.sd
+++ b/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema_distance_metric_geodegrees.sd
@@ -118,7 +118,7 @@ schema marqo__test_00unstructured_00schema_00distance_00metric {
             query(marqo__add_weights) tensor<double>(p{})
         }
         function modify(score) {
-            expression: if (count(query(marqo__mult_weights)) == 0, 1, if (count(query(marqo__mult_weights) * attribute(marqo__score_modifiers)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod))) * score + if (count(query(marqo__add_weights)) == 0, 0, reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum))
+            expression: if (count(query(marqo__mult_weights) * attribute(marqo__score_modifiers)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod)) * score + reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum)
        }
     }
 

--- a/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema_distance_metric_geodegrees.sd
+++ b/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema_distance_metric_geodegrees.sd
@@ -118,7 +118,7 @@ schema marqo__test_00unstructured_00schema_00distance_00metric {
             query(marqo__add_weights) tensor<double>(p{})
         }
         function modify(score) {
-            expression: if (count(query(marqo__mult_weights)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod)) * score + reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum)
+            expression: if (count(query(marqo__mult_weights)) == 0, 1, if (count(query(marqo__mult_weights) * attribute(marqo__score_modifiers)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod))) * score + if (count(query(marqo__add_weights)) == 0, 0, reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum))
        }
     }
 

--- a/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema_distance_metric_hamming.sd
+++ b/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema_distance_metric_hamming.sd
@@ -118,7 +118,7 @@ schema marqo__test_00unstructured_00schema_00distance_00metric {
             query(marqo__add_weights) tensor<double>(p{})
         }
         function modify(score) {
-            expression: if (count(query(marqo__mult_weights)) == 0, 1, if (count(query(marqo__mult_weights) * attribute(marqo__score_modifiers)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod))) * score + if (count(query(marqo__add_weights)) == 0, 0, reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum))
+            expression: if (count(query(marqo__mult_weights) * attribute(marqo__score_modifiers)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod)) * score + reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum)
        }
     }
 

--- a/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema_distance_metric_hamming.sd
+++ b/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema_distance_metric_hamming.sd
@@ -118,7 +118,7 @@ schema marqo__test_00unstructured_00schema_00distance_00metric {
             query(marqo__add_weights) tensor<double>(p{})
         }
         function modify(score) {
-            expression: if (count(query(marqo__mult_weights)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod)) * score + reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum)
+            expression: if (count(query(marqo__mult_weights)) == 0, 1, if (count(query(marqo__mult_weights) * attribute(marqo__score_modifiers)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod))) * score + if (count(query(marqo__add_weights)) == 0, 0, reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum))
        }
     }
 

--- a/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema_distance_metric_prenormalized-angular.sd
+++ b/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema_distance_metric_prenormalized-angular.sd
@@ -118,7 +118,7 @@ schema marqo__test_00unstructured_00schema_00distance_00metric {
             query(marqo__add_weights) tensor<double>(p{})
         }
         function modify(score) {
-            expression: if (count(query(marqo__mult_weights)) == 0, 1, if (count(query(marqo__mult_weights) * attribute(marqo__score_modifiers)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod))) * score + if (count(query(marqo__add_weights)) == 0, 0, reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum))
+            expression: if (count(query(marqo__mult_weights) * attribute(marqo__score_modifiers)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod)) * score + reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum)
        }
     }
 

--- a/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema_distance_metric_prenormalized-angular.sd
+++ b/tests/core/unstructured_vespa_index/test_schemas/unstructured_vespa_index_schema_distance_metric_prenormalized-angular.sd
@@ -118,7 +118,7 @@ schema marqo__test_00unstructured_00schema_00distance_00metric {
             query(marqo__add_weights) tensor<double>(p{})
         }
         function modify(score) {
-            expression: if (count(query(marqo__mult_weights)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod)) * score + reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum)
+            expression: if (count(query(marqo__mult_weights)) == 0, 1, if (count(query(marqo__mult_weights) * attribute(marqo__score_modifiers)) == 0, 1, reduce(query(marqo__mult_weights) * attribute(marqo__score_modifiers), prod))) * score + if (count(query(marqo__add_weights)) == 0, 0, reduce(query(marqo__add_weights) * attribute(marqo__score_modifiers), sum))
        }
     }
 

--- a/tests/tensor_search/integ_tests/test_dict_score_modifiers.py
+++ b/tests/tensor_search/integ_tests/test_dict_score_modifiers.py
@@ -2,7 +2,6 @@ import os
 from unittest import mock
 
 from marqo.api.models.update_documents import UpdateDocumentsBodyParams
-from marqo.core.exceptions import UnsupportedFeatureError
 from marqo.core.models.marqo_index import *
 from marqo.core.models.marqo_index_request import FieldRequest
 from marqo.core.structured_vespa_index.structured_vespa_index import StructuredVespaIndex

--- a/tests/tensor_search/integ_tests/test_dict_score_modifiers.py
+++ b/tests/tensor_search/integ_tests/test_dict_score_modifiers.py
@@ -216,7 +216,9 @@ class TestDictScoreModifiers(MarqoTestCase):
                 # Search with score modifier
                 # 0.5 * 0.5 * 4 = 1 (1 and 7)
                 score_modifier = ScoreModifier(
-                    **{"multiply_score_by": [{"field_name": "map_score_mods.a", "weight": 4}]})
+                    **{"multiply_score_by": [{"field_name": "map_score_mods.a", "weight": 4},
+                                             {"field_name": "map_score_mods.d", "weight": 4}]}) # Nonexistent field.
+                                            # Nonexistent field should not zero out the whole score
                 res = tensor_search.search(
                     index_name=index.name, config=self.config, text="",
                     score_modifiers=score_modifier,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
When a score modifier doesn't exist in document but is specified in the query, the score is multiplied by 0.

* **What is the new behavior (if this is a feature change)?**
When a score modifier doesn't exist in document but is specified in the query, the score is multiplied by 1.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Users who might have depended on the `0` behavior of `multiply_score_by` in score modifiers will be affected. As per team discussion, this change is acceptable.

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
Yes

* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:
marqo api tests: https://github.com/marqo-ai/marqo-api-tests/pull/86

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

