### PR TITLE
Enable Lexical score modifiers and change lexical from weakAND to OR

### DIFF
--- a/src/marqo/core/structured_vespa_index/structured_vespa_index.py
+++ b/src/marqo/core/structured_vespa_index/structured_vespa_index.py
@@ -462,9 +462,9 @@ class StructuredVespaIndex(VespaIndex):
         lexical_term = self._get_lexical_search_term(marqo_query) if fields_to_search else "False"
         filter_term = self._get_filter_term(marqo_query)
         if filter_term:
-            filter_term = f' AND {filter_term}'
+            search_term = f'({lexical_term}) AND ({filter_term})'
         else:
-            filter_term = ''
+            search_term = f'({lexical_term})'
 
         select_attributes = self._get_select_attributes(marqo_query)
         summary = common.SUMMARY_ALL_VECTOR if marqo_query.expose_facets else common.SUMMARY_ALL_NON_VECTOR
@@ -480,7 +480,7 @@ class StructuredVespaIndex(VespaIndex):
             query_inputs.update(score_modifiers)
 
         query = {
-            'yql': f'select {select_attributes} from {self._marqo_index.schema_name} where {lexical_term}{filter_term}',
+            'yql': f'select {select_attributes} from {self._marqo_index.schema_name} where {search_term}',
             'model_restrict': self._marqo_index.schema_name,
             'hits': marqo_query.limit,
             'offset': marqo_query.offset,

--- a/src/marqo/core/structured_vespa_index/structured_vespa_index.py
+++ b/src/marqo/core/structured_vespa_index/structured_vespa_index.py
@@ -666,12 +666,17 @@ class StructuredVespaIndex(VespaIndex):
         if marqo_query.or_phrases == ["*"] and not marqo_query.and_phrases:
             return 'true'
 
-        if marqo_query.or_phrases:
+        if marqo_query.or_phrases and marqo_query.score_modifiers:
             or_terms = ' OR '.join([
+                self._get_lexical_contains_term(phrase, marqo_query) for phrase in marqo_query.or_phrases
+            ])
+        elif marqo_query.or_phrases and not marqo_query.score_modifiers:
+            or_terms = 'weakAnd(%s)' % ', '.join([
                 self._get_lexical_contains_term(phrase, marqo_query) for phrase in marqo_query.or_phrases
             ])
         else:
             or_terms = ''
+
         if marqo_query.and_phrases:
             and_terms = ' AND '.join([
                 self._get_lexical_contains_term(phrase, marqo_query) for phrase in marqo_query.and_phrases

--- a/src/marqo/core/structured_vespa_index/structured_vespa_index.py
+++ b/src/marqo/core/structured_vespa_index/structured_vespa_index.py
@@ -667,7 +667,7 @@ class StructuredVespaIndex(VespaIndex):
             return 'true'
 
         if marqo_query.or_phrases:
-            or_terms = 'weakAnd(%s)' % ', '.join([
+            or_terms = ' OR '.join([
                 self._get_lexical_contains_term(phrase, marqo_query) for phrase in marqo_query.or_phrases
             ])
         else:
@@ -677,6 +677,7 @@ class StructuredVespaIndex(VespaIndex):
                 self._get_lexical_contains_term(phrase, marqo_query) for phrase in marqo_query.and_phrases
             ])
             if or_terms:
+                or_terms = f'({or_terms})'
                 and_terms = f' AND ({and_terms})'
         else:
             and_terms = ''

--- a/src/marqo/core/unstructured_vespa_index/unstructured_vespa_index.py
+++ b/src/marqo/core/unstructured_vespa_index/unstructured_vespa_index.py
@@ -259,10 +259,15 @@ class UnstructuredVespaIndex(VespaIndex):
 
         lexical_term = _get_lexical_search_term(marqo_query)
         filter_term = self._get_filter_term(marqo_query)
+
         if filter_term:
-            filter_term = f' AND {filter_term}'
+            search_term = f'({lexical_term}) AND ({filter_term})'
         else:
-            filter_term = ''
+            search_term = f'({lexical_term})'
+        #if filter_term:
+        #    filter_term = f' AND {filter_term}'
+        #else:
+        #    filter_term = ''
 
         summary = unstructured_common.SUMMARY_ALL_VECTOR if marqo_query.expose_facets \
             else unstructured_common.SUMMARY_ALL_NON_VECTOR
@@ -277,7 +282,7 @@ class UnstructuredVespaIndex(VespaIndex):
             query_inputs.update(score_modifiers)
 
         query = {
-            'yql': f'select * from {self._marqo_index.schema_name} where {lexical_term}{filter_term}',
+            'yql': f'select * from {self._marqo_index.schema_name} where {search_term}',
             'model_restrict': self._marqo_index.schema_name,
             'hits': marqo_query.limit,
             'offset': marqo_query.offset,

--- a/src/marqo/core/unstructured_vespa_index/unstructured_vespa_index.py
+++ b/src/marqo/core/unstructured_vespa_index/unstructured_vespa_index.py
@@ -239,12 +239,17 @@ class UnstructuredVespaIndex(VespaIndex):
             if marqo_query.or_phrases == ["*"] and not marqo_query.and_phrases:
                 return 'true'
             
-            if marqo_query.or_phrases:
+            if marqo_query.or_phrases and marqo_query.score_modifiers:
                 or_terms = ' OR '.join([
+                    f'default contains "{phrase}"' for phrase in marqo_query.or_phrases
+                ])
+            elif marqo_query.or_phrases and not marqo_query.score_modifiers:
+                or_terms = 'weakAnd(%s)' % ', '.join([
                     f'default contains "{phrase}"' for phrase in marqo_query.or_phrases
                 ])
             else:
                 or_terms = ''
+
             if marqo_query.and_phrases:
                 and_terms = ' AND '.join([
                     f'default contains "{phrase}"' for phrase in marqo_query.and_phrases

--- a/src/marqo/core/unstructured_vespa_index/unstructured_vespa_index.py
+++ b/src/marqo/core/unstructured_vespa_index/unstructured_vespa_index.py
@@ -264,10 +264,6 @@ class UnstructuredVespaIndex(VespaIndex):
             search_term = f'({lexical_term}) AND ({filter_term})'
         else:
             search_term = f'({lexical_term})'
-        #if filter_term:
-        #    filter_term = f' AND {filter_term}'
-        #else:
-        #    filter_term = ''
 
         summary = unstructured_common.SUMMARY_ALL_VECTOR if marqo_query.expose_facets \
             else unstructured_common.SUMMARY_ALL_NON_VECTOR

--- a/src/marqo/core/unstructured_vespa_index/unstructured_vespa_index.py
+++ b/src/marqo/core/unstructured_vespa_index/unstructured_vespa_index.py
@@ -240,7 +240,7 @@ class UnstructuredVespaIndex(VespaIndex):
                 return 'true'
             
             if marqo_query.or_phrases:
-                or_terms = 'weakAnd(%s)' % ', '.join([
+                or_terms = ' OR '.join([
                     f'default contains "{phrase}"' for phrase in marqo_query.or_phrases
                 ])
             else:
@@ -250,11 +250,11 @@ class UnstructuredVespaIndex(VespaIndex):
                     f'default contains "{phrase}"' for phrase in marqo_query.and_phrases
                 ])
                 if or_terms:
+                    or_terms = f'({or_terms})'
                     and_terms = f' AND ({and_terms})'
             else:
                 and_terms = ''
-
-
+            
             return f'{or_terms}{and_terms}'
 
         lexical_term = _get_lexical_search_term(marqo_query)

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -1329,15 +1329,16 @@ def search(config: Config, index_name: str, text: Optional[Union[str, dict]],
         if approximate is not None:
             raise errors.InvalidArgError(
                 f"approximate is not a valid argument for lexical search")
-        if score_modifiers is not None:
-            raise errors.InvalidArgError(
-                "Score modifiers is not supported for lexical search yet"
-            )
+        #if score_modifiers is not None:
+        #    raise errors.InvalidArgError(
+        #        "Score modifiers is not supported for lexical search yet"
+        #    )
 
         search_result = _lexical_search(
             config=config, index_name=index_name, text=text, result_count=result_count, offset=offset,
             searchable_attributes=searchable_attributes, verbose=verbose,
-            filter_string=filter, attributes_to_retrieve=attributes_to_retrieve, highlights=highlights
+            filter_string=filter, attributes_to_retrieve=attributes_to_retrieve, highlights=highlights,
+            score_modifiers=score_modifiers
         )
     else:
         raise api_exceptions.InvalidArgError(f"Search called with unknown search method: {search_method}")
@@ -1376,7 +1377,8 @@ def search(config: Config, index_name: str, text: Optional[Union[str, dict]],
 def _lexical_search(
         config: Config, index_name: str, text: str, result_count: int = 3, offset: int = 0,
         searchable_attributes: Sequence[str] = None, verbose: int = 0, filter_string: str = None,
-        highlights: bool = True, attributes_to_retrieve: Optional[List[str]] = None, expose_facets: bool = False):
+        highlights: bool = True, attributes_to_retrieve: Optional[List[str]] = None, expose_facets: bool = False,
+        score_modifiers: Optional[ScoreModifier] = None):
     """
 
     Args:
@@ -1419,6 +1421,7 @@ def _lexical_search(
         offset=offset,
         searchable_attributes=searchable_attributes,
         attributes_to_retrieve=attributes_to_retrieve,
+        score_modifiers=score_modifiers.to_marqo_score_modifiers() if score_modifiers else None
     )
 
     vespa_index = vespa_index_factory(marqo_index)

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -1329,10 +1329,6 @@ def search(config: Config, index_name: str, text: Optional[Union[str, dict]],
         if approximate is not None:
             raise errors.InvalidArgError(
                 f"approximate is not a valid argument for lexical search")
-        #if score_modifiers is not None:
-        #    raise errors.InvalidArgError(
-        #        "Score modifiers is not supported for lexical search yet"
-        #    )
 
         search_result = _lexical_search(
             config=config, index_name=index_name, text=text, result_count=result_count, offset=offset,

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.9.0"
+__version__ = "2.10.0"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/tests/core/index_management/test_index_validation.py
+++ b/tests/core/index_management/test_index_validation.py
@@ -119,8 +119,5 @@ class TestIndexValidateSettings(unittest.TestCase):
         with self.assertRaises(ValidationError) as context:
             IndexManagement.validate_index_settings("test_index", input_settings)
         self.assertIn("__root__", str(context.exception))
-        print(f"hello: ", str(context.exception))
-        self.assertIn("Invalid field name 'dependent_fields'. See Create Index "
-                      "API reference here "
-                      "https://docs.marqo.ai/2.9/API-Reference/Indexes/create_index/ (type=value_error)",
-                      str(context.exception))
+
+        self.assertIn("See Create Index API reference here ", str(context.exception))

--- a/tests/core/index_management/test_index_validation.py
+++ b/tests/core/index_management/test_index_validation.py
@@ -120,5 +120,5 @@ class TestIndexValidateSettings(unittest.TestCase):
             IndexManagement.validate_index_settings("test_index", input_settings)
         self.assertIn("__root__", str(context.exception))
 
-        self.assertIn("See Create Index API reference here. See Create Index ", 
+        self.assertIn("Invalid field name 'dependent_fields'. See Create Index", 
                       str(context.exception))

--- a/tests/core/index_management/test_index_validation.py
+++ b/tests/core/index_management/test_index_validation.py
@@ -120,4 +120,5 @@ class TestIndexValidateSettings(unittest.TestCase):
             IndexManagement.validate_index_settings("test_index", input_settings)
         self.assertIn("__root__", str(context.exception))
 
-        self.assertIn("See Create Index API reference here ", str(context.exception))
+        self.assertIn("See Create Index API reference here. See Create Index ", 
+                      str(context.exception))


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
- score modifiers are not supported in lexical search
- `weakAND` is used for constructing in `or_phrases` in constructing lexical search terms. This is for accellerated OR like search https://docs.vespa.ai/en/using-wand-with-vespa.html 

* **What is the new behavior (if this is a feature change)?**
- Enables support for score modifiers when conducting lexical search
- Use `OR` instead of `weakAND` in `or_phrases` in constructing lexical search terms. This is so that all documents are matched against the query during search.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
Yes

* **Related Python client changes** (link commit/PR here)
None

* **Related documentation changes** (link commit/PR here)
None

* **Other information**:


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

