### PR TITLE
Increase filterStringMaxLength

### DIFF
--- a/src/marqo/tensor_search/models/index_settings.py
+++ b/src/marqo/tensor_search/models/index_settings.py
@@ -126,7 +126,7 @@ class IndexSettings(StrictBaseModel):
             if self.filterStringMaxLength is None:
                 # Default value for filter_string_max_length is 20, but we can't set it in the model
                 # as it is not a valid parameter for structured indexes
-                self.filterStringMaxLength = 20
+                self.filterStringMaxLength = 50
 
             return UnstructuredMarqoIndexRequest(
                 name=index_name,

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.9.0"
+__version__ = "2.10.0"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/tests/core/index_management/test_get_settings.py
+++ b/tests/core/index_management/test_get_settings.py
@@ -88,7 +88,7 @@ class TestGetSettings(MarqoTestCase):
                         'parameters': {'efConstruction': 512, 'm': 16},
                         'spaceType': DistanceMetric.PrenormalizedAngular
                     },
-                    'filterStringMaxLength': 20,
+                    'filterStringMaxLength': 50,
                     'imagePreprocessing': {},
                     'model': 'hf/e5-base-v2',
                     'normalizeEmbeddings': True,
@@ -153,7 +153,7 @@ class TestGetSettings(MarqoTestCase):
                         'parameters': {'efConstruction': 512, 'm': 16},
                         'spaceType': DistanceMetric.PrenormalizedAngular
                     },
-                    'filterStringMaxLength': 20,
+                    'filterStringMaxLength': 50,
                     'imagePreprocessing': {},
                     'model': 'ViT-B/32',
                     'normalizeEmbeddings': False,

--- a/tests/core/index_management/test_index_validation.py
+++ b/tests/core/index_management/test_index_validation.py
@@ -119,8 +119,6 @@ class TestIndexValidateSettings(unittest.TestCase):
         with self.assertRaises(ValidationError) as context:
             IndexManagement.validate_index_settings("test_index", input_settings)
         self.assertIn("__root__", str(context.exception))
-        print(f"hello: ", str(context.exception))
-        self.assertIn("Invalid field name 'dependent_fields'. See Create Index "
-                      "API reference here "
-                      "https://docs.marqo.ai/2.9/API-Reference/Indexes/create_index/ (type=value_error)",
+
+        self.assertIn("Invalid field name 'dependent_fields'. See Create Index ",
                       str(context.exception))


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
default `filterStringMaxLength` is set to `20`

* **What is the new behavior (if this is a feature change)?**
default `filterStringMaxLength` is increased to `50`

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
Yes

* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

