### PR TITLE
Li/patch search method

### DIFF
--- a/src/marqo/api/exceptions.py
+++ b/src/marqo/api/exceptions.py
@@ -106,7 +106,7 @@ class __InvalidRequestError(MarqoWebError):
 
 
 class UnprocessableEntityError(__InvalidRequestError):
-    code = "un_processable_entity"
+    code = "unprocessable_entity"
     status_code = HTTPStatus.UNPROCESSABLE_ENTITY
 
 

--- a/src/marqo/api/exceptions.py
+++ b/src/marqo/api/exceptions.py
@@ -105,6 +105,11 @@ class __InvalidRequestError(MarqoWebError):
     error_type = "invalid_request"
 
 
+class UnprocessableEntityError(__InvalidRequestError):
+    code = "un_processable_entity"
+    status_code = HTTPStatus.UNPROCESSABLE_ENTITY
+
+
 class TooManyRequestsError(__InvalidRequestError):
     code = "too_many_requests"
     status_code = HTTPStatus.TOO_MANY_REQUESTS

--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -159,7 +159,7 @@ def marqo_api_exception_handler(request: Request, exc: api_exceptions.MarqoWebEr
 
 
 @app.exception_handler(RequestValidationError)
-async def validation_exception_handler(request: Request, exc: RequestValidationError):
+async def api_validation_exception_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
     """Catch FastAPI validation errors and return a 422 error with the error messages.
 
     Note: The Pydantic Validation error that happens at the API will be caught here and returned as a 422 error.

--- a/src/marqo/tensor_search/models/api_models.py
+++ b/src/marqo/tensor_search/models/api_models.py
@@ -79,11 +79,11 @@ class SearchQuery(BaseMarqoModel):
         query = values.get('q')
         context = values.get('context')
 
-        if search_method.upper() in {SearchMethod.TENSOR, SearchMethod.HYBRID}:
+        if search_method in {SearchMethod.TENSOR, SearchMethod.HYBRID}:
             if query is None and context is None:
                 raise ValueError(f"One of Query(q) or context is required for {search_method} "
                                  f"search but both are missing")
-        elif search_method.upper() == SearchMethod.LEXICAL:
+        elif search_method == SearchMethod.LEXICAL:
             if query is None:
                 raise ValueError("Query(q) is required for lexical search")
         else:

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.10.0"
+__version__ = "2.10.1"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/tests/tensor_search/integ_tests/test_search_combined.py
+++ b/tests/tensor_search/integ_tests/test_search_combined.py
@@ -850,8 +850,9 @@ class TestSearch(MarqoTestCase):
         ]
         for search_method, search_method_type in invalid_search_methods:
             with self.subTest(search_method_type=search_method_type):
-                with self.assertRaises(ValidationError):
+                with self.assertRaises(ValidationError) as cm:
                     _ = SearchQuery(q="test", search_method=search_method)
+                self.assertIn("search_method", str(cm.exception))
 
     def test_search_query_CanAcceptDifferentSearchMethods(self):
         """Test that the SearchQuery can accept different search methods."""

--- a/tests/tensor_search/integ_tests/test_search_combined.py
+++ b/tests/tensor_search/integ_tests/test_search_combined.py
@@ -839,7 +839,6 @@ class TestSearch(MarqoTestCase):
 
                     self.assertEqual(result, expected_result)
 
-
     def test_search_query_ExpectedErrorRaisedForInvalidSearchMethod(self):
         """Test that the ValidationError is raised when an incorrect search method is provided."""
         invalid_search_methods = [

--- a/tests/tensor_search/integ_tests/test_search_combined.py
+++ b/tests/tensor_search/integ_tests/test_search_combined.py
@@ -865,3 +865,7 @@ class TestSearch(MarqoTestCase):
             with self.subTest(search_method_type=search_method_type):
                 search_query = SearchQuery(q="test", searchMethod=search_method)
                 self.assertEqual(expected_search_method, search_query.searchMethod)
+
+        # A special case for no search method provided
+        search_query = SearchQuery(q="test")
+        self.assertEqual(SearchMethod.TENSOR, search_query.searchMethod)

--- a/tests/tensor_search/integ_tests/test_search_combined.py
+++ b/tests/tensor_search/integ_tests/test_search_combined.py
@@ -14,6 +14,8 @@ from marqo.core.models.marqo_query import MarqoLexicalQuery
 from marqo.core.models.score_modifier import ScoreModifierType, ScoreModifier
 from marqo.core.structured_vespa_index.structured_vespa_index import StructuredVespaIndex
 from marqo.core.unstructured_vespa_index.unstructured_vespa_index import UnstructuredVespaIndex
+from marqo.tensor_search.models.api_models import SearchQuery
+from pydantic import ValidationError
 
 
 class TestSearch(MarqoTestCase):
@@ -836,3 +838,30 @@ class TestSearch(MarqoTestCase):
                         result = full_query['yql'].split('where')[1].strip()
 
                     self.assertEqual(result, expected_result)
+
+
+    def test_search_query_ExpectedErrorRaisedForInvalidSearchMethod(self):
+        """Test that the ValidationError is raised when an incorrect search method is provided."""
+        invalid_search_methods = [
+            ("", "Empty string"),
+            (1, "Integer"),
+            ([], "List"),
+            ({"searchMethod": "LEXICAL"}, "Dictionary"),
+        ]
+        for search_method, search_method_type in invalid_search_methods:
+            with self.subTest(search_method_type=search_method_type):
+                with self.assertRaises(ValidationError):
+                    _ = SearchQuery(q="test", search_method=search_method)
+
+    def test_search_query_CanAcceptDifferentSearchMethods(self):
+        """Test that the SearchQuery can accept different search methods."""
+        valid_search_methods = [
+            ("lexical", SearchMethod.LEXICAL, "lowercase lexical"),
+            ("teNsor", SearchMethod.TENSOR, "mixed case tensor"),
+            ("hybrid", SearchMethod.HYBRID, "mixed case hybrid"),
+            (None, SearchMethod.TENSOR, "None"),
+        ]
+        for search_method, expected_search_method, search_method_type in valid_search_methods:
+            with self.subTest(search_method_type=search_method_type):
+                search_query = SearchQuery(q="test", searchMethod=search_method)
+                self.assertEqual(expected_search_method, search_query.searchMethod)

--- a/tests/tensor_search/test_api_exception_handler.py
+++ b/tests/tensor_search/test_api_exception_handler.py
@@ -107,10 +107,10 @@ class TestBaseExceptionHandler(MarqoTestCase):
         self.assertNotIn("This should not be propagated.", converted_error.message)
         self.assertIn("unexpected internal error", converted_error.message)
 
-    async def test_validation_exception_handler(self):
+    async def test_validation_exception_handler_CorrectResponseBody(self):
+        """Ensure that the validation exception handler returns the correct response body when 422 is raised."""
         # Create a mock request
         mock_request = MagicMock(spec=Request)
-
         # Manually create a RequestValidationError
         errors = [
             {
@@ -122,11 +122,8 @@ class TestBaseExceptionHandler(MarqoTestCase):
         ]
         validation_error = RequestValidationError(errors)
 
-        # Call the exception handler with the mock request and validation error
         response = await api_validation_exception_handler(mock_request, validation_error)
-        # Assert the response status code
         self.assertEqual(422, response.status_code)
-        # Assert the response content
         self.assertEqual(
             {
                 "detail": jsonable_encoder(validation_error.errors()),

--- a/tests/tensor_search/test_api_exception_handler.py
+++ b/tests/tensor_search/test_api_exception_handler.py
@@ -1,8 +1,15 @@
 from unittest import mock
+from unittest.mock import MagicMock
+
+from fastapi import Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
 
 from marqo import exceptions as base_exceptions
 from marqo.api import exceptions as api_exceptions
+from marqo.api.exceptions import UnprocessableEntityError
 from marqo.core import exceptions as core_exceptions
+from marqo.tensor_search.api import api_validation_exception_handler
 from marqo.tensor_search.api import marqo_base_exception_handler
 from marqo.vespa import exceptions as vespa_exceptions
 from tests.marqo_test import MarqoTestCase
@@ -100,3 +107,32 @@ class TestBaseExceptionHandler(MarqoTestCase):
         self.assertNotIn("This should not be propagated.", converted_error.message)
         self.assertIn("unexpected internal error", converted_error.message)
 
+    async def test_validation_exception_handler(self):
+        # Create a mock request
+        mock_request = MagicMock(spec=Request)
+
+        # Manually create a RequestValidationError
+        errors = [
+            {
+                "loc": ("body", "name"),
+                "msg": "ensure this value has at most 10 characters",
+                "type": "value_error.any_str.max_length",
+                "ctx": {"limit_value": 10}
+            }
+        ]
+        validation_error = RequestValidationError(errors)
+
+        # Call the exception handler with the mock request and validation error
+        response = await api_validation_exception_handler(mock_request, validation_error)
+        # Assert the response status code
+        self.assertEqual(422, response.status_code)
+        # Assert the response content
+        self.assertEqual(
+            {
+                "detail": jsonable_encoder(validation_error.errors()),
+                "code": UnprocessableEntityError.code,
+                "type": UnprocessableEntityError.error_type,
+                "link": UnprocessableEntityError.link
+            },
+            response.body
+        )


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
we fix two bugs in this PR:
1. When an invalid search_method is received, Marqo is returning a 500 error instead of a 400 error
2. The 422 error does not contain `code` and `type` inside the response body

* **What is the new behavior (if this is a feature change)?**
1. An invalid search_method will get a correct 400 error now
2. The 422 error now correctly contain `code` and `type` inside the response body

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
yes

* **Related Python client changes** (link commit/PR here)
no

* **Related documentation changes** (link commit/PR here)
no

* **Other information**:
no

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

