### PR TITLE
fix invalid image error message and return False if not image

### DIFF
--- a/src/marqo/marqo_docs.py
+++ b/src/marqo/marqo_docs.py
@@ -54,4 +54,8 @@ def bring_your_own_model():
 
 
 def query_reference():
-    return _build_url('API-Reference/search/#query-q')
+    return _build_url('API-Reference/Search/search/#query-q')
+
+
+def indexing_images():
+    return _build_url('Guides/Advanced-Usage/images/')

--- a/src/marqo/s2_inference/clip_utils.py
+++ b/src/marqo/s2_inference/clip_utils.py
@@ -116,11 +116,13 @@ def load_image_from_path(image_path: str, image_download_headers: dict, timeout_
             if metrics_obj is not None:
                 metrics_obj.stop(f"image_download.{image_path}")
     else:
-        raise UnidentifiedImageError(f"input str of `{image_path}` is not a local file or a valid url. "
+        raise UnidentifiedImageError(f"Input str of `{image_path}` is not a local file or a valid url. "
                                      f"If you are using Marqo Cloud, please note that images can only be downloaded "
                                      f"from a URL and local files are not supported. "
                                      f"If you are running Marqo in a Docker container, you will need to use a Docker "
-                                     f"volume so that your container can access host files.")
+                                     f"volume so that your container can access host files. "
+                                     f"For more information, please refer to: "
+                                     f"https://docs.marqo.ai/latest/Guides/Advanced-Usage/images/")
 
     return img
 

--- a/src/marqo/s2_inference/clip_utils.py
+++ b/src/marqo/s2_inference/clip_utils.py
@@ -116,7 +116,7 @@ def load_image_from_path(image_path: str, image_download_headers: dict, timeout_
             if metrics_obj is not None:
                 metrics_obj.stop(f"image_download.{image_path}")
     else:
-        raise UnidentifiedImageError(f"Input str of `{image_path}` is not a local file or a valid url. "
+        raise UnidentifiedImageError(f"Input str of {image_path} is not a local file or a valid url. "
                                      f"If you are using Marqo Cloud, please note that images can only be downloaded "
                                      f"from a URL and local files are not supported. "
                                      f"If you are running Marqo in a Docker container, you will need to use a Docker "

--- a/src/marqo/s2_inference/clip_utils.py
+++ b/src/marqo/s2_inference/clip_utils.py
@@ -25,6 +25,7 @@ from marqo.s2_inference.types import *
 from marqo.tensor_search.enums import ModelProperties, InferenceParams
 from marqo.tensor_search.models.private_models import ModelLocation
 from marqo.tensor_search.telemetry import RequestMetrics
+from marqo import marqo_docs
 
 logger = get_logger(__name__)
 
@@ -122,7 +123,7 @@ def load_image_from_path(image_path: str, image_download_headers: dict, timeout_
                                      f"If you are running Marqo in a Docker container, you will need to use a Docker "
                                      f"volume so that your container can access host files. "
                                      f"For more information, please refer to: "
-                                     f"https://docs.marqo.ai/latest/Guides/Advanced-Usage/images/")
+                                     f"{marqo_docs.indexing_images()}")
 
     return img
 

--- a/src/marqo/s2_inference/clip_utils.py
+++ b/src/marqo/s2_inference/clip_utils.py
@@ -116,7 +116,11 @@ def load_image_from_path(image_path: str, image_download_headers: dict, timeout_
             if metrics_obj is not None:
                 metrics_obj.stop(f"image_download.{image_path}")
     else:
-        raise UnidentifiedImageError(f"input str of `{image_path}` is not a local file or a valid url")
+        raise UnidentifiedImageError(f"input str of `{image_path}` is not a local file or a valid url. "
+                                     f"If you are using Marqo Cloud, please note that images can only be downloaded "
+                                     f"from a URL and local files are not supported. "
+                                     f"If you are running Marqo in a Docker container, you will need to use a Docker "
+                                     f"volume so that your container can access host files.")
 
     return img
 
@@ -228,7 +232,7 @@ def _is_image(inputs: Union[str, List[Union[str, ImageType, ndarray]]]) -> bool:
             if validators.url(thing):
                 return True
             else:
-                False
+                return False
 
     # if it is an array, then it is an image
     elif isinstance(thing, (ImageType, ndarray, Tensor)):

--- a/tests/s2_inference/test_clip_utils.py
+++ b/tests/s2_inference/test_clip_utils.py
@@ -56,42 +56,45 @@ class TestImageDownloading(unittest.TestCase):
         # Check if c.close() was called
         mock_curl_instance.close.assert_called_once()
 
+class TestIsImage(unittest.TestCase):
     def test_is_image(self):
-        # Test with valid image file extensions
-        self.assertTrue(clip_utils._is_image('image.jpg'))
-        self.assertTrue(clip_utils._is_image('image.png'))
-        self.assertTrue(clip_utils._is_image('image.jpeg'))
-        self.assertTrue(clip_utils._is_image('image.bmp'))
+        test_cases = [
+            ("Valid JPG", 'image.jpg', True),
+            ("Valid PNG", 'image.png', True),
+            ("Valid JPEG", 'image.jpeg', True),
+            ("Valid BMP", 'image.bmp', True),
+            ("Uppercase JPG", 'image.JPG', True),
+            ("Uppercase PNG", 'image.PNG', True),
+            ("Valid URL", 'https://example.com/image.jpg', True),
+            ("Invalid PDF", 'document.pdf', False),
+            ("Invalid TXT", 'text.txt', False),
+            ("No extension", 'imagewithoutextension', False),
+        ]
 
-        # Test with uppercase extensions
-        self.assertTrue(clip_utils._is_image('image.JPG'))
-        self.assertTrue(clip_utils._is_image('image.PNG'))
-
-        # Test with valid URL
-        self.assertTrue(clip_utils._is_image('https://example.com/image.jpg'))
-
-        # Test with invalid file extensions
-        self.assertFalse(clip_utils._is_image('document.pdf'))
-        self.assertFalse(clip_utils._is_image('text.txt'))
-
-        # Test with no file extension
-        self.assertFalse(clip_utils._is_image('imagewithoutextension'))
+        for description, input_value, expected in test_cases:
+            with self.subTest(description=description, input=input_value):
+                self.assertEqual(clip_utils._is_image(input_value), expected,
+                                f"Failed for {description}: input '{input_value}' expected {expected}")
 
         # Test with PIL Image
-        pil_image = PIL.Image.new('RGB', (100, 100))
-        self.assertTrue(clip_utils._is_image(pil_image))
+        with self.subTest("PIL Image"):
+            pil_image = PIL.Image.new('RGB', (100, 100))
+            self.assertTrue(clip_utils._is_image(pil_image))
 
         # Test with list of images
-        image_list = ['image1.jpg', 'image2.png', 'https://example.com/image3.jpeg']
-        self.assertTrue(clip_utils._is_image(image_list))
+        with self.subTest("List of images"):
+            image_list = ['image1.jpg', 'image2.png', 'https://example.com/image3.jpeg']
+            self.assertTrue(clip_utils._is_image(image_list))
 
         # Test with empty list
-        with self.assertRaises(clip_utils.UnidentifiedImageError):
-            clip_utils._is_image([])
+        with self.subTest("Empty list"):
+            with self.assertRaises(clip_utils.UnidentifiedImageError):
+                clip_utils._is_image([])
 
         # Test with invalid type
-        with self.assertRaises(clip_utils.UnidentifiedImageError):
-            clip_utils._is_image(123)
+        with self.subTest("Invalid type"):
+            with self.assertRaises(clip_utils.UnidentifiedImageError):
+                clip_utils._is_image(123)
 
 
 class TestDownloadFromRepo(unittest.TestCase):

--- a/tests/s2_inference/test_clip_utils.py
+++ b/tests/s2_inference/test_clip_utils.py
@@ -56,6 +56,43 @@ class TestImageDownloading(unittest.TestCase):
         # Check if c.close() was called
         mock_curl_instance.close.assert_called_once()
 
+    def test_is_image(self):
+        # Test with valid image file extensions
+        self.assertTrue(clip_utils._is_image('image.jpg'))
+        self.assertTrue(clip_utils._is_image('image.png'))
+        self.assertTrue(clip_utils._is_image('image.jpeg'))
+        self.assertTrue(clip_utils._is_image('image.bmp'))
+
+        # Test with uppercase extensions
+        self.assertTrue(clip_utils._is_image('image.JPG'))
+        self.assertTrue(clip_utils._is_image('image.PNG'))
+
+        # Test with valid URL
+        self.assertTrue(clip_utils._is_image('https://example.com/image.jpg'))
+
+        # Test with invalid file extensions
+        self.assertFalse(clip_utils._is_image('document.pdf'))
+        self.assertFalse(clip_utils._is_image('text.txt'))
+
+        # Test with no file extension
+        self.assertFalse(clip_utils._is_image('imagewithoutextension'))
+
+        # Test with PIL Image
+        pil_image = PIL.Image.new('RGB', (100, 100))
+        self.assertTrue(clip_utils._is_image(pil_image))
+
+        # Test with list of images
+        image_list = ['image1.jpg', 'image2.png', 'https://example.com/image3.jpeg']
+        self.assertTrue(clip_utils._is_image(image_list))
+
+        # Test with empty list
+        with self.assertRaises(clip_utils.UnidentifiedImageError):
+            clip_utils._is_image([])
+
+        # Test with invalid type
+        with self.assertRaises(clip_utils.UnidentifiedImageError):
+            clip_utils._is_image(123)
+
 
 class TestDownloadFromRepo(unittest.TestCase):
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Error message change

* **What is the current behavior?** (You can also link to an open issue here)
When an invalid image is processed, marqo gives an error: `input str of `{image_path}` is not a local file or a valid url`
which might confuse users.

* **What is the new behavior (if this is a feature change)?**
The error message is changed to:
```
input str of `{image_path}` is not a local file or a valid url. 
If you are using Marqo Cloud, please note that images can only be downloaded "
from a URL and local files are not supported. "
If you are running Marqo in a Docker container, you will need to use a Docker "
volume so that your container can access host files."
```
for clarity

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)


* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

