### PR TITLE
Change MarqoIndex model to allow extra fields

### DIFF
--- a/src/marqo/core/models/marqo_index.py
+++ b/src/marqo/core/models/marqo_index.py
@@ -10,7 +10,7 @@ from pydantic import ValidationError, validator
 from pydantic.error_wrappers import ErrorWrapper
 from pydantic.utils import ROOT_KEY
 
-from marqo.base_model import ImmutableStrictBaseModel, StrictBaseModel
+from marqo.base_model import ImmutableStrictBaseModel, ImmutableBaseModel, StrictBaseModel
 from marqo.core import constants
 from marqo.exceptions import InvalidArgumentError
 from marqo.logging import get_logger
@@ -235,9 +235,12 @@ class Model(StrictBaseModel):
         return default_prefix
 
 
-class MarqoIndex(ImmutableStrictBaseModel, ABC):
+class MarqoIndex(ImmutableBaseModel, ABC):
     """
     Base class for a Marqo index.
+    We inherit from ImmutableBaseModel deliberately to ignore extra fields during deserialization.
+    We will be adding multiple fields to this class in the future. This change will make MarqoIndex forward
+    compatible to these changes and allow us to roll back Marqo without breaking the Pydantic validation.
     """
     name: str
     schema_name: str

--- a/src/marqo/core/models/marqo_index.py
+++ b/src/marqo/core/models/marqo_index.py
@@ -238,9 +238,10 @@ class Model(StrictBaseModel):
 class MarqoIndex(ImmutableBaseModel, ABC):
     """
     Base class for a Marqo index.
-    We inherit from ImmutableBaseModel deliberately to ignore extra fields during deserialization.
+    We inherit from ImmutableBaseModel and add the extra = "allow" config to allow extra fields during deserialization.
     We will be adding multiple fields to this class in the future. This change will make MarqoIndex forward
-    compatible to these changes and allow us to roll back Marqo without breaking the Pydantic validation.
+    compatible to these changes and allow us to rollback Marqo without breaking the Pydantic validation or dropping
+    the added fields.
     """
     name: str
     schema_name: str

--- a/src/marqo/core/models/marqo_index.py
+++ b/src/marqo/core/models/marqo_index.py
@@ -257,8 +257,8 @@ class MarqoIndex(ImmutableBaseModel, ABC):
     updated_at: int = pydantic.Field(gt=0)
     _cache: Dict[str, Any] = PrivateAttr()
 
-    class Config:
-        allow_mutation = False
+    class Config(ImmutableBaseModel.Config):
+        extra = "allow"
 
     def __init__(self, **data: Any):
         super().__init__(**data)

--- a/tests/core/models/test_marqo_index.py
+++ b/tests/core/models/test_marqo_index.py
@@ -1,7 +1,13 @@
-from marqo.core.models.marqo_index import FieldType, FieldFeature, Field
+import pytest
+import json
+
+import pydantic
+
+from marqo.core.models.marqo_index import FieldType, FieldFeature, Field, MarqoIndex
 from tests.marqo_test import MarqoTestCase
 
 
+@pytest.mark.unittest
 class TestStructuredMarqoIndex(MarqoTestCase):
     def test_filterable_field_names_pre220(self):
         """
@@ -34,33 +40,56 @@ class TestStructuredMarqoIndex(MarqoTestCase):
                     {'price', 'tags'}
                 )
 
-        def test_filterable_field_names_post220(self):
-            """
-            Test that filterable_field_names returns the correct fields for a structured index when
-            index Marqo version >=2.2.0.
-            """
-            versions = [
-                '2.2.0',
-                '2.2.1',
-                '2.3.0',
-                '2.5.5'
-            ]
-            for version in versions:
-                with self.subTest(version=version):
-                    marqo_index = self.structured_marqo_index(
-                        name='my_index',
-                        schema_name='my_index',
-                        fields=[
-                            Field(name='title', type=FieldType.Text),
-                            Field(name='price', type=FieldType.Float, features=[FieldFeature.Filter],
-                                  filter_field_name='price_filter'),
-                            Field(name='tags', type=FieldType.Text, features=[FieldFeature.Filter],
-                                  filter_field_name='tags_filter')
-                        ],
-                        tensor_fields=[],
-                        marqo_version=version
-                    )
-                    self.assertEqual(
-                        marqo_index.filterable_fields_names,
-                        {'_id', 'price', 'tags'}
-                    )
+    def test_filterable_field_names_post220(self):
+        """
+        Test that filterable_field_names returns the correct fields for a structured index when
+        index Marqo version >=2.2.0.
+        """
+        versions = [
+            '2.2.0',
+            '2.2.1',
+            '2.3.0',
+            '2.5.5'
+        ]
+        for version in versions:
+            with self.subTest(version=version):
+                marqo_index = self.structured_marqo_index(
+                    name='my_index',
+                    schema_name='my_index',
+                    fields=[
+                        Field(name='title', type=FieldType.Text),
+                        Field(name='price', type=FieldType.Float, features=[FieldFeature.Filter],
+                              filter_field_name='price_filter'),
+                        Field(name='tags', type=FieldType.Text, features=[FieldFeature.Filter],
+                              filter_field_name='tags_filter')
+                    ],
+                    tensor_fields=[],
+                    marqo_version=version
+                )
+                self.assertEqual(
+                    marqo_index.filterable_fields_names,
+                    {'_id', 'price', 'tags'}
+                )
+
+    def test_deserialization_with_extra_fields(self):
+        """
+        Test Pydantic allows deserialization of MarqoIndex with extra fields
+        """
+        marqo_index = self.structured_marqo_index(
+            name='my_index',
+            schema_name='my_index',
+            fields=[
+                Field(name='title', type=FieldType.Text)
+            ],
+            tensor_fields=[],
+            marqo_version="2.12.0"
+        )
+        index_setting_json = json.loads(marqo_index.json())
+        index_setting_json["random_field"] = "value"
+
+        try:
+            parsed_index = MarqoIndex.parse_raw(json.dumps(index_setting_json))
+            # assert that extra fields are ignored
+            self.assertTrue("random_field" not in parsed_index)
+        except pydantic.error_wrappers.ValidationError as e:
+            self.fail(f"Pydantic validation failed: {e}")

--- a/tests/core/models/test_marqo_index.py
+++ b/tests/core/models/test_marqo_index.py
@@ -75,21 +75,31 @@ class TestStructuredMarqoIndex(MarqoTestCase):
         """
         Test Pydantic allows deserialization of MarqoIndex with extra fields
         """
-        marqo_index = self.structured_marqo_index(
-            name='my_index',
-            schema_name='my_index',
-            fields=[
-                Field(name='title', type=FieldType.Text)
-            ],
-            tensor_fields=[],
-            marqo_version="2.12.0"
-        )
-        index_setting_json = json.loads(marqo_index.json())
-        index_setting_json["random_field"] = "value"
+        indexes = [
+            self.structured_marqo_index(
+                name='my_index',
+                schema_name='my_index',
+                fields=[
+                    Field(name='title', type=FieldType.Text)
+                ],
+                tensor_fields=[],
+                marqo_version="2.12.0"
+            ),
+            self.unstructured_marqo_index(
+                name='my_index_2',
+                schema_name='my_index_2',
+                marqo_version="2.12.0"
+            )
+        ]
 
-        try:
-            parsed_index = MarqoIndex.parse_raw(json.dumps(index_setting_json))
-            # assert that extra fields are ignored
-            self.assertTrue("random_field" not in parsed_index)
-        except pydantic.error_wrappers.ValidationError as e:
-            self.fail(f"Pydantic validation failed: {e}")
+        for index in indexes:
+            with self.subTest(index=index):
+                index_setting_json = json.loads(index.json())
+                index_setting_json["random_field"] = "value"
+
+                try:
+                    parsed_index = MarqoIndex.parse_raw(json.dumps(index_setting_json))
+                    # assert that extra fields are ignored
+                    self.assertTrue("random_field" not in parsed_index)
+                except pydantic.error_wrappers.ValidationError as e:
+                    self.fail(f"Pydantic validation failed: {e}")

--- a/tests/core/models/test_marqo_index.py
+++ b/tests/core/models/test_marqo_index.py
@@ -83,12 +83,12 @@ class TestStructuredMarqoIndex(MarqoTestCase):
                     Field(name='title', type=FieldType.Text)
                 ],
                 tensor_fields=[],
-                marqo_version="2.12.0"
+                marqo_version='2.12.0'
             ),
             self.unstructured_marqo_index(
                 name='my_index_2',
                 schema_name='my_index_2',
-                marqo_version="2.12.0"
+                marqo_version='2.12.0'
             )
         ]
 
@@ -99,7 +99,9 @@ class TestStructuredMarqoIndex(MarqoTestCase):
 
                 try:
                     parsed_index = MarqoIndex.parse_raw(json.dumps(index_setting_json))
-                    # assert that extra fields are ignored
-                    self.assertTrue("random_field" not in parsed_index)
+                    # assert that the extra field is deserialized
+                    self.assertEqual("value", parsed_index.random_field)
+                    # assert that the extra field is kept after serialization
+                    self.assertTrue("random_field" in parsed_index.json())
                 except pydantic.error_wrappers.ValidationError as e:
                     self.fail(f"Pydantic validation failed: {e}")

--- a/tests/marqo_test.py
+++ b/tests/marqo_test.py
@@ -123,6 +123,57 @@ class MarqoTestCase(unittest.TestCase):
         )
 
     @classmethod
+    def unstructured_marqo_index(
+            cls,
+            name: str,
+            schema_name: str,
+            fields: List[Field] = None,
+            tensor_fields: List[TensorField] = None,
+            model: Model = Model(name='hf/all_datasets_v4_MiniLM-L6'),
+            normalize_embeddings: bool = True,
+            text_preprocessing: TextPreProcessing = TextPreProcessing(
+                split_length=2,
+                split_overlap=0,
+                split_method=TextSplitMethod.Sentence
+            ),
+            image_preprocessing: ImagePreProcessing = ImagePreProcessing(
+                patch_method=None
+            ),
+            distance_metric: DistanceMetric = DistanceMetric.Angular,
+            vector_numeric_type: VectorNumericType = VectorNumericType.Float,
+            hnsw_config: HnswConfig = HnswConfig(
+                ef_construction=128,
+                m=16
+            ),
+            marqo_version=version.get_version(),
+            created_at=time.time(),
+            updated_at=time.time(),
+            treat_urls_and_pointers_as_images=True,
+            filter_string_max_length=100
+    ) -> UnstructuredMarqoIndex:
+        """
+        Helper method that provides reasonable defaults for StructuredMarqoIndex.
+        """
+        return UnstructuredMarqoIndex(
+            name=name,
+            schema_name=schema_name,
+            model=model,
+            normalize_embeddings=normalize_embeddings,
+            text_preprocessing=text_preprocessing,
+            image_preprocessing=image_preprocessing,
+            distance_metric=distance_metric,
+            vector_numeric_type=vector_numeric_type,
+            hnsw_config=hnsw_config,
+            fields=fields,
+            tensor_fields=tensor_fields,
+            marqo_version=marqo_version,
+            created_at=created_at,
+            updated_at=updated_at,
+            treat_urls_and_pointers_as_images=treat_urls_and_pointers_as_images,
+            filter_string_max_length=filter_string_max_length
+        )
+
+    @classmethod
     def structured_marqo_index_request(
             cls,
             fields: List[FieldRequest],

--- a/tests/marqo_test.py
+++ b/tests/marqo_test.py
@@ -152,7 +152,7 @@ class MarqoTestCase(unittest.TestCase):
             filter_string_max_length=100
     ) -> UnstructuredMarqoIndex:
         """
-        Helper method that provides reasonable defaults for StructuredMarqoIndex.
+        Helper method that provides reasonable defaults for UnstructuredMarqoIndex.
         """
         return UnstructuredMarqoIndex(
             name=name,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Preparation for feature search model update

* **What is the current behavior?** (You can also link to an open issue here)
MarqoIndex will fail on Pydantic validation when deserialised from a source with extra fields

* **What is the new behavior (if this is a feature change)?**
MarqoIndex will ignore the extra fields

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
Yes

* **Related Python client changes** (link commit/PR here)
N/A

* **Related documentation changes** (link commit/PR here)
N/A

* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

