### PR TITLE
add backwards compatibility for unstructured tensor search

### DIFF
--- a/src/marqo/core/unstructured_vespa_index/common.py
+++ b/src/marqo/core/unstructured_vespa_index/common.py
@@ -39,7 +39,7 @@ RANK_PROFILE_BM25_MODIFIERS_2_9 = 'bm25_modifiers'
 RANK_PROFILE_EMBEDDING_SIMILARITY_MODIFIERS_2_9 = 'embedding_similarity_modifiers'
 
 # Note field names are also used as query inputs, so make sure these reserved names have a marqo__ prefix
-# QUERY_INPUT_EMBEDDING = 'embedding_query'
+QUERY_INPUT_EMBEDDING_2_10 = 'embedding_query'      # Keep for backwards compatibility
 QUERY_INPUT_EMBEDDING = "marqo__query_embedding"    # TODO: see if this change from 'embedding_query' to 'embedding_query' changes anything
 QUERY_INPUT_BM25_AGGREGATOR = 'marqo__bm25_aggregator'
 

--- a/src/marqo/core/unstructured_vespa_index/unstructured_vespa_index.py
+++ b/src/marqo/core/unstructured_vespa_index/unstructured_vespa_index.py
@@ -12,7 +12,7 @@ from marqo.core.unstructured_vespa_index import common as unstructured_common
 from marqo.core.unstructured_vespa_index.unstructured_document import UnstructuredVespaDocument
 from marqo.core.vespa_index import VespaIndex
 from marqo.core import constants
-
+from marqo.exceptions import InternalError, InvalidArgumentError
 import semver
 
 

--- a/src/marqo/core/unstructured_vespa_index/unstructured_vespa_index.py
+++ b/src/marqo/core/unstructured_vespa_index/unstructured_vespa_index.py
@@ -107,8 +107,7 @@ class UnstructuredVespaIndex(VespaIndex):
 
         return query
 
-    @staticmethod
-    def _get_tensor_search_term(marqo_query: MarqoTensorQuery) -> str:
+    def _get_tensor_search_term(self, marqo_query: MarqoTensorQuery) -> str:
         field_to_search = unstructured_common.VESPA_DOC_EMBEDDINGS
 
         if marqo_query.ef_search is not None:

--- a/src/marqo/core/unstructured_vespa_index/unstructured_vespa_index.py
+++ b/src/marqo/core/unstructured_vespa_index/unstructured_vespa_index.py
@@ -12,7 +12,7 @@ from marqo.core.unstructured_vespa_index import common as unstructured_common
 from marqo.core.unstructured_vespa_index.unstructured_document import UnstructuredVespaDocument
 from marqo.core.vespa_index import VespaIndex
 from marqo.core import constants
-from marqo.exceptions import InternalError, InvalidArgumentError
+
 import semver
 
 
@@ -113,6 +113,11 @@ class UnstructuredVespaIndex(VespaIndex):
             target_hits = marqo_query.limit + marqo_query.offset
             additional_hits = 0
 
+        if self._marqo_index_version >= self._HYBRID_SEARCH_MINIMUM_VERSION:
+            query_input_embedding_parameter = unstructured_common.QUERY_INPUT_EMBEDDING
+        else:
+            query_input_embedding_parameter = unstructured_common.QUERY_INPUT_EMBEDDING_2_10
+
         return (
             f"("
             f"{{"
@@ -120,7 +125,7 @@ class UnstructuredVespaIndex(VespaIndex):
             f"approximate:{str(marqo_query.approximate)}, "
             f'hnsw.exploreAdditionalHits:{additional_hits}'
             f"}}"
-            f"nearestNeighbor({field_to_search}, {unstructured_common.QUERY_INPUT_EMBEDDING})"
+            f"nearestNeighbor({field_to_search}, {query_input_embedding_parameter})"
             f")"
         )
 
@@ -318,9 +323,14 @@ class UnstructuredVespaIndex(VespaIndex):
         summary = unstructured_common.SUMMARY_ALL_VECTOR if marqo_query.expose_facets \
             else unstructured_common.SUMMARY_ALL_NON_VECTOR
 
+        if self._marqo_index_version >= self._HYBRID_SEARCH_MINIMUM_VERSION:
+            query_input_embedding_parameter = unstructured_common.QUERY_INPUT_EMBEDDING
+        else:
+            query_input_embedding_parameter = unstructured_common.QUERY_INPUT_EMBEDDING_2_10
+
         # Assign parameters to query
         query_inputs = {
-            unstructured_common.QUERY_INPUT_EMBEDDING: marqo_query.vector_query,
+            query_input_embedding_parameter: marqo_query.vector_query,
             unstructured_common.QUERY_INPUT_HYBRID_FIELDS_TO_RANK_LEXICAL: {},
             unstructured_common.QUERY_INPUT_HYBRID_FIELDS_TO_RANK_TENSOR: {}
         }

--- a/src/marqo/core/unstructured_vespa_index/unstructured_vespa_index.py
+++ b/src/marqo/core/unstructured_vespa_index/unstructured_vespa_index.py
@@ -78,8 +78,13 @@ class UnstructuredVespaIndex(VespaIndex):
         else:
             ranking = unstructured_common.RANK_PROFILE_EMBEDDING_SIMILARITY
 
+        if self._marqo_index_version >= self._HYBRID_SEARCH_MINIMUM_VERSION:
+            query_input_embedding_parameter = unstructured_common.QUERY_INPUT_EMBEDDING
+        else:
+            query_input_embedding_parameter = unstructured_common.QUERY_INPUT_EMBEDDING_2_10
+
         query_inputs = {
-            unstructured_common.QUERY_INPUT_EMBEDDING: marqo_query.vector_query
+            query_input_embedding_parameter: marqo_query.vector_query
         }
 
         if score_modifiers:
@@ -323,14 +328,9 @@ class UnstructuredVespaIndex(VespaIndex):
         summary = unstructured_common.SUMMARY_ALL_VECTOR if marqo_query.expose_facets \
             else unstructured_common.SUMMARY_ALL_NON_VECTOR
 
-        if self._marqo_index_version >= self._HYBRID_SEARCH_MINIMUM_VERSION:
-            query_input_embedding_parameter = unstructured_common.QUERY_INPUT_EMBEDDING
-        else:
-            query_input_embedding_parameter = unstructured_common.QUERY_INPUT_EMBEDDING_2_10
-
         # Assign parameters to query
         query_inputs = {
-            query_input_embedding_parameter: marqo_query.vector_query,
+            unstructured_common.QUERY_INPUT_EMBEDDING: marqo_query.vector_query,
             unstructured_common.QUERY_INPUT_HYBRID_FIELDS_TO_RANK_LEXICAL: {},
             unstructured_common.QUERY_INPUT_HYBRID_FIELDS_TO_RANK_TENSOR: {}
         }

--- a/src/marqo/core/vespa_index.py
+++ b/src/marqo/core/vespa_index.py
@@ -6,6 +6,7 @@ from marqo.core.models import MarqoQuery, MarqoHybridQuery, MarqoTensorQuery, Ma
 from marqo.core.models.marqo_index import StructuredMarqoIndex, UnstructuredMarqoIndex
 from marqo.core.models.score_modifier import ScoreModifier, ScoreModifierType
 from marqo.core.models.marqo_index import *
+from marqo.exceptions import InternalError
 
 
 class VespaIndex(ABC):


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
tensor search backwards compatibility is broken in unstructured indexes.

* **What is the new behavior (if this is a feature change)?**
fixed query input parameter used for embedding

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
in progress

* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

