### PR TITLE
Add encode for url check

### DIFF
--- a/src/marqo/s2_inference/clip_utils.py
+++ b/src/marqo/s2_inference/clip_utils.py
@@ -106,7 +106,7 @@ def load_image_from_path(image_path: str, image_download_headers: dict, timeout_
     """
     if os.path.isfile(image_path):
         img = Image.open(image_path)
-    elif validators.url(image_path):
+    elif validators.url(image_path) or validators.url(encode_url(image_path)):
         if metrics_obj is not None:
             metrics_obj.start(f"image_download.{image_path}")
         try:

--- a/src/marqo/s2_inference/clip_utils.py
+++ b/src/marqo/s2_inference/clip_utils.py
@@ -106,7 +106,7 @@ def load_image_from_path(image_path: str, image_download_headers: dict, timeout_
     """
     if os.path.isfile(image_path):
         img = Image.open(image_path)
-    elif validators.url(image_path) or validators.url(encode_url(image_path)):
+    elif validate_url(image_path):
         if metrics_obj is not None:
             metrics_obj.start(f"image_download.{image_path}")
         try:
@@ -127,6 +127,21 @@ def load_image_from_path(image_path: str, image_download_headers: dict, timeout_
                                      f"{marqo_docs.indexing_images()}")
 
     return img
+
+
+def validate_url(url: str) -> bool:
+    """Validate a URL to ensure it is a valid URL. Returns True if the URL is valid or the encoded URL is valid.
+
+    Args:
+        url (str): URL to validate.
+
+    Returns:
+        bool: True if the URL is valid, False otherwise.
+    """
+    if isinstance(url, str):
+        return validators.url(url) or validators.url(encode_url(url))
+    else:
+        return False
 
 
 def download_image_from_url(image_path: str, image_download_headers: dict, timeout_ms: int = 3000) -> BytesIO:
@@ -262,7 +277,7 @@ def _is_image(inputs: Union[str, List[Union[str, ImageType, ndarray]]]) -> bool:
         else:
             # if it is not a local file and does not have an extension
             # check if url
-            if validators.url(thing) or validators.url(encode_url(thing)):
+            if validate_url(thing):
                 return True
             else:
                 return False
@@ -348,7 +363,7 @@ class CLIP:
                 self.model_path = self._download_from_repo()
             elif os.path.isfile(path):
                 self.model_path = path
-            elif validators.url(path):
+            elif validate_url(path):
                 self.model_path = download_model(url=path)
             else:
                 raise InvalidModelPropertiesError(f"Marqo can not load the custom clip model."
@@ -529,7 +544,7 @@ class OPEN_CLIP(CLIP):
                 self.model_path = self._download_from_repo()
             elif os.path.isfile(path):
                 self.model_path = path
-            elif validators.url(path):
+            elif validate_url(path):
                 self.model_path = download_model(url=path)
             else:
                 raise InvalidModelPropertiesError(

--- a/src/marqo/s2_inference/clip_utils.py
+++ b/src/marqo/s2_inference/clip_utils.py
@@ -262,7 +262,7 @@ def _is_image(inputs: Union[str, List[Union[str, ImageType, ndarray]]]) -> bool:
         else:
             # if it is not a local file and does not have an extension
             # check if url
-            if validators.url(thing):
+            if validators.url(thing) or validators.url(encode_url(thing)):
                 return True
             else:
                 return False

--- a/tests/s2_inference/test_clip_utils.py
+++ b/tests/s2_inference/test_clip_utils.py
@@ -69,6 +69,8 @@ class TestIsImage(unittest.TestCase):
             ("Invalid PDF", 'document.pdf', False),
             ("Invalid TXT", 'text.txt', False),
             ("No extension", 'imagewithoutextension', False),
+            ("Valid URL with unencoded characters",
+             "http://dummy.dummy.com/is/image/dummy/dummy (1)?wid=123&hei=321&qlt=123&fmt=png-alpha", True),
         ]
 
         for description, input_value, expected in test_cases:


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
We currently use validators.url to check the validity of a provided URL. However, when the URL contains unencoded characters, the function returns False.

* **What is the new behavior (if this is a feature change)?**
The function has been updated to return True if the URL is valid after encoding.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
running

* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

