### PR TITLE
Fix hybrid search RRF duplicate results bug

### DIFF
--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -7,9 +7,11 @@ on:
   push:
     branches:
       - mainline
+      - releases/*
   pull_request:
     branches:
       - mainline
+      - releases/*
 
 permissions:
   contents: read

--- a/vespa/src/test/java/ai/marqo/search/HybridSearcherTest.java
+++ b/vespa/src/test/java/ai/marqo/search/HybridSearcherTest.java
@@ -1,10 +1,12 @@
 package ai.marqo.search;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.sun.jdi.InternalException;
 import com.yahoo.component.chain.Chain;
 import com.yahoo.search.*;
 import com.yahoo.search.query.ranking.RankFeatures;
@@ -47,11 +49,11 @@ class HybridSearcherTest {
         Query query = getHybridQuery(k, alpha, "test", "disjunction", "rrf");
 
         HitGroup hitsTensor = new HitGroup();
-        hitsTensor.add(new Hit("tensor1", 1.0));
-        hitsTensor.add(new Hit("both", 0.4));
+        hitsTensor.add(new Hit("index:test/0/tensor1", 1.0));
+        hitsTensor.add(new Hit("index:test/0/both", 0.4));
 
         HitGroup hitsLexical = new HitGroup();
-        hitsLexical.add(new Hit("both", 0.45));
+        hitsLexical.add(new Hit("index:test/0/both", 0.45));
 
         ArgumentCaptor<Query> queryArgumentCaptor = ArgumentCaptor.forClass(Query.class);
 
@@ -63,7 +65,10 @@ class HybridSearcherTest {
         // verify the result is the fused hit group
         assertThat(result).isNotNull();
         assertThat(result.hits().get(0))
-                .isEqualTo(new Hit("both", alpha * (1.0 / (5 + k)) + alpha * (1.0 / (4 + k))));
+                .isEqualTo(
+                        new Hit(
+                                "index:test/0/both",
+                                alpha * (1.0 / (5 + k)) + alpha * (1.0 / (4 + k))));
         assertThat(result.hits().get(0).fields())
                 .containsAllEntriesOf(
                         Map.of("marqo__raw_tensor_score", 0.4, "marqo__raw_lexical_score", 0.45));
@@ -75,83 +80,226 @@ class HybridSearcherTest {
         assertThat(allQueries.get(1).properties().get("yql")).isEqualTo("tensor yql");
     }
 
-    @Test
-    void testRRF() {
-        // Create Hybrid Searcher
-        HybridSearcher testSearcher = new HybridSearcher();
+    @Nested
+    class RRFTest {
+        @Test
+        void shouldFuseWithDefaultParameters() {
+            // Cases
+            // With tied scores
+            // No overlap
+            // With overlap
+            // More tensor hits
+            // More lexical hits
+            // 0 Tensor hits
+            // 0 Lexical hits
+            // 0 hits both
+            // Higher alpha (break ties)
+            // Lower alpha (stack results)
+            // invalid alpha (should throw exception) < 0 or > 1
+            // alpha is 0, alpha is 1
 
-        // Cases
-        // With tied scores
-        // No overlap
-        // With overlap
-        // More tensor hits
-        // More lexical hits
-        // 0 Tensor hits
-        // 0 Lexical hits
-        // 0 hits both
-        // Higher alpha (break ties)
-        // Lower alpha (stack results)
-        // invalid alpha (should throw exception) < 0 or > 1
-        // alpha is 0, alpha is 1
+            // Use nested classes to group tests (eg testAlpha)
+            // Each case is 1 method
 
-        // Use nested classes to group tests (eg testAlpha)
-        // Each case is 1 method
+            // Create tensor hits
+            HitGroup hitsTensor = new HitGroup();
+            hitsTensor.add(new Hit("index:test/0/tensor1", 1.0));
+            hitsTensor.add(new Hit("index:test/0/tensor2", 0.8));
+            hitsTensor.add(new Hit("index:test/0/tensor3", 0.6));
+            hitsTensor.add(new Hit("index:test/0/tensor4", 0.5));
+            hitsTensor.add(new Hit("index:test/0/both1", 0.4));
+            hitsTensor.add(new Hit("index:test/0/both2", 0.3));
 
-        // Create tensor hits
-        HitGroup hitsTensor = new HitGroup();
-        hitsTensor.add(new Hit("tensor1", 1.0));
-        hitsTensor.add(new Hit("tensor2", 0.8));
-        hitsTensor.add(new Hit("tensor3", 0.6));
-        hitsTensor.add(new Hit("tensor4", 0.5));
-        hitsTensor.add(new Hit("both1", 0.4));
-        hitsTensor.add(new Hit("both2", 0.3));
+            // Create lexical hits
+            HitGroup hitsLexical = new HitGroup();
+            hitsLexical.add(new Hit("index:test/0/lexical1", 1.0));
+            hitsLexical.add(new Hit("index:test/0/lexical2", 0.7));
+            hitsLexical.add(new Hit("index:test/0/lexical3", 0.5));
+            hitsLexical.add(new Hit("index:test/0/both1", 0.45));
+            hitsLexical.add(new Hit("index:test/0/both2", 0.44));
 
-        // Create lexical hits
-        HitGroup hitsLexical = new HitGroup();
-        hitsLexical.add(new Hit("lexical1", 1.0));
-        hitsLexical.add(new Hit("lexical2", 0.7));
-        hitsLexical.add(new Hit("lexical3", 0.5));
-        hitsLexical.add(new Hit("both1", 0.45));
-        hitsLexical.add(new Hit("both2", 0.44));
+            // Set parameters
+            int k = 60;
+            double alpha = 0.5;
+            boolean verbose = false;
 
-        // Set parameters
-        int k = 60;
-        double alpha = 0.5;
-        boolean verbose = false;
+            // Call the rrf function
+            HitGroup result = hybridSearcher.rrf(hitsTensor, hitsLexical, k, alpha, verbose);
 
-        // Call the rrf function
-        HitGroup result = testSearcher.rrf(hitsTensor, hitsLexical, k, alpha, verbose);
+            // Check that the result size is correct
+            assertThat(result.asList()).hasSize(6);
 
-        // Check that the result size is correct
-        assertThat(result.asList()).hasSize(6);
+            // Check that result order and scores are correct
+            assertThat(result.asList())
+                    .containsExactly(
+                            // Score should be a sum (tensor rank and lexical rank)
+                            new Hit(
+                                    "index:test/0/both1",
+                                    alpha * (1.0 / (5 + k)) + alpha * (1.0 / (4 + k))),
+                            // Score should be a sum (tensor rank and lexical rank)
+                            new Hit(
+                                    "index:test/0/both2",
+                                    alpha * (1.0 / (6 + k)) + alpha * (1.0 / (5 + k))),
+                            // Since tie, lexical was put first. Likely due to alphabetical ID.
+                            new Hit("index:test/0/lexical1", alpha * (1.0 / (1 + k))),
+                            new Hit("index:test/0/tensor1", alpha * (1.0 / (1 + k))),
+                            new Hit("index:test/0/lexical2", alpha * (1.0 / (2 + k))),
+                            new Hit("index:test/0/tensor2", alpha * (1.0 / (2 + k))));
 
-        // Check that result order and scores are correct
-        assertThat(result.asList())
-                .containsExactly(
-                        // Score should be a sum (tensor rank and lexical rank)
-                        new Hit("both1", alpha * (1.0 / (5 + k)) + alpha * (1.0 / (4 + k))),
-                        // Score should be a sum (tensor rank and lexical rank)
-                        new Hit("both2", alpha * (1.0 / (6 + k)) + alpha * (1.0 / (5 + k))),
-                        // Since tie, lexical was put first. Likely due to alphabetical ID.
-                        new Hit("lexical1", alpha * (1.0 / (1 + k))),
-                        new Hit("tensor1", alpha * (1.0 / (1 + k))),
-                        new Hit("lexical2", alpha * (1.0 / (2 + k))),
-                        new Hit("tensor2", alpha * (1.0 / (2 + k))));
+            assertThat(result.get(0).fields())
+                    .containsAllEntriesOf(
+                            Map.of(
+                                    "marqo__raw_tensor_score",
+                                    0.4,
+                                    "marqo__raw_lexical_score",
+                                    0.45));
+            assertThat(result.get(1).fields())
+                    .containsAllEntriesOf(
+                            Map.of(
+                                    "marqo__raw_tensor_score",
+                                    0.3,
+                                    "marqo__raw_lexical_score",
+                                    0.44));
+            assertThat(result.get(2).fields())
+                    .containsAllEntriesOf(Map.of("marqo__raw_lexical_score", 1.0));
+            assertThat(result.get(3).fields())
+                    .containsAllEntriesOf(Map.of("marqo__raw_tensor_score", 1.0));
+            assertThat(result.get(4).fields())
+                    .containsAllEntriesOf(Map.of("marqo__raw_lexical_score", 0.7));
+            assertThat(result.get(5).fields())
+                    .containsAllEntriesOf(Map.of("marqo__raw_tensor_score", 0.8));
+        }
 
-        assertThat(result.get(0).fields())
-                .containsAllEntriesOf(
-                        Map.of("marqo__raw_tensor_score", 0.4, "marqo__raw_lexical_score", 0.45));
-        assertThat(result.get(1).fields())
-                .containsAllEntriesOf(
-                        Map.of("marqo__raw_tensor_score", 0.3, "marqo__raw_lexical_score", 0.44));
-        assertThat(result.get(2).fields())
-                .containsAllEntriesOf(Map.of("marqo__raw_lexical_score", 1.0));
-        assertThat(result.get(3).fields())
-                .containsAllEntriesOf(Map.of("marqo__raw_tensor_score", 1.0));
-        assertThat(result.get(4).fields())
-                .containsAllEntriesOf(Map.of("marqo__raw_lexical_score", 0.7));
-        assertThat(result.get(5).fields())
-                .containsAllEntriesOf(Map.of("marqo__raw_tensor_score", 0.8));
+        @Test
+        void shouldFuseWithMismatchedGroups() {
+            // Create tensor hits
+            HitGroup hitsTensor = new HitGroup();
+            hitsTensor.add(new Hit("index:test/5/tensor1", 1.0));
+            hitsTensor.add(new Hit("index:test/6/tensor2", 0.8));
+            hitsTensor.add(new Hit("index:test/7/tensor3", 0.6));
+            hitsTensor.add(new Hit("index:test/8/tensor4", 0.5));
+            hitsTensor.add(new Hit("index:test/9/both1", 0.4));
+            hitsTensor.add(new Hit("index:test/10/both2", 0.3));
+
+            // Create lexical hits
+            HitGroup hitsLexical = new HitGroup();
+            hitsLexical.add(new Hit("index:test/0/lexical1", 1.0));
+            hitsLexical.add(new Hit("index:test/1/lexical2", 0.7));
+            hitsLexical.add(new Hit("index:test/2/lexical3", 0.5));
+            hitsLexical.add(new Hit("index:test/3/both1", 0.45));
+            hitsLexical.add(new Hit("index:test/4/both2", 0.44));
+
+            // Set parameters
+            int k = 60;
+            double alpha = 0.5;
+            boolean verbose = false;
+
+            // Call the rrf function
+            HitGroup result = hybridSearcher.rrf(hitsTensor, hitsLexical, k, alpha, verbose);
+
+            // Check that the result size is correct
+            assertThat(result.asList()).hasSize(6);
+
+            // Check that result order and scores are correct
+            // If results have the same score, they will be sorted by alphabetical hit ID.
+            // Results in TENSOR list will be prioritized, because they are evaluated first in RRF.
+            assertThat(result.asList())
+                    .containsExactly(
+                            // Score should be a sum (tensor rank and lexical rank)
+                            new Hit(
+                                    "index:test/9/both1",
+                                    alpha * (1.0 / (5 + k)) + alpha * (1.0 / (4 + k))),
+                            // Score should be a sum (tensor rank and lexical rank)
+                            new Hit(
+                                    "index:test/10/both2",
+                                    alpha * (1.0 / (6 + k)) + alpha * (1.0 / (5 + k))),
+                            // Since tie, lexical was put first. Likely due to alphabetical ID.
+                            new Hit("index:test/0/lexical1", alpha * (1.0 / (1 + k))),
+                            new Hit("index:test/5/tensor1", alpha * (1.0 / (1 + k))),
+                            new Hit("index:test/1/lexical2", alpha * (1.0 / (2 + k))),
+                            new Hit("index:test/6/tensor2", alpha * (1.0 / (2 + k))));
+
+            assertThat(result.get(0).fields())
+                    .containsAllEntriesOf(
+                            Map.of(
+                                    "marqo__raw_tensor_score",
+                                    0.4,
+                                    "marqo__raw_lexical_score",
+                                    0.45));
+            assertThat(result.get(1).fields())
+                    .containsAllEntriesOf(
+                            Map.of(
+                                    "marqo__raw_tensor_score",
+                                    0.3,
+                                    "marqo__raw_lexical_score",
+                                    0.44));
+            assertThat(result.get(2).fields())
+                    .containsAllEntriesOf(Map.of("marqo__raw_lexical_score", 1.0));
+            assertThat(result.get(3).fields())
+                    .containsAllEntriesOf(Map.of("marqo__raw_tensor_score", 1.0));
+            assertThat(result.get(4).fields())
+                    .containsAllEntriesOf(Map.of("marqo__raw_lexical_score", 0.7));
+            assertThat(result.get(5).fields())
+                    .containsAllEntriesOf(Map.of("marqo__raw_tensor_score", 0.8));
+        }
+    }
+
+    @Nested
+    class IdExtractorTest {
+        @ParameterizedTest
+        @CsvSource(
+                value = {
+                    "index:vespa-content-dummy_index/0/e0a1c64b0c20b56741834b5,"
+                            + " e0a1c64b0c20b56741834b5", // Base case
+                    "index:vespa-content-dummy_index/0/e0a1c64b0/c20b56741834b5,"
+                            + " e0a1c64b0/c20b56741834b5", // Slash in doc ID
+                    "index:vespa-content-dummy_index/0/e0a1c64b0//c20b56741834b5,"
+                            + " e0a1c64b0//c20b56741834b5", // Double slash in doc ID
+                    "index:vespa-content-dummy_index/0//e0a1c64b0c20b56741834b5,"
+                            + " /e0a1c64b0c20b56741834b5", // Slash at start of doc ID
+                    "index:vespa-content-dummy_index/0/e0a1c64b0c/2/0b56741834b5,"
+                            + " e0a1c64b0c/2/0b56741834b5", // Multiple slashes in doc ID
+                })
+        void shouldExtractIdFromHit(String vespaId, String expectedId) {
+            String id = HybridSearcher.extractDocIdFromHitId(vespaId);
+            assertThat(id).isEqualTo(expectedId);
+        }
+
+        // Negative test cases
+        @ParameterizedTest
+        @CsvSource({
+            "invalidformat/0/e0a1c64b0c20b56741834b5", // Missing 'index:'
+            "index:/0/e0a1c64b0c20b56741834b5", // Missing content after 'index:'
+            "index:vespa-content-dummy_index//e0a1c64b0c20b56741834b5", // Missing digit part
+            "index:vespa-content-dummy_index/123/", // Missing doc ID part after last slash
+            "someotherformat:vespa-content-dummy_index/0/e0a1c64b0c20b56741834b5", // Incorrect
+            // prefix
+            "index:vespa content dummy_index/0/e0a1c64b0c20b56741834b5", // Whitespace in index name
+            "index:vespa-content/dummy_index/0/e0a1c64b0c20b56741834b5", // Slash in index name
+            "index:vespa-content-dummy_index/abc/e0a1c64b0c20b56741834b5", // Non-numeric value in
+            // the 2nd group
+            "index:vespa-content-dummy_index/1abc/e0a1c64b0c20b56741834b5", // Partially numeric
+            // value in 2nd group
+            "index:vespa-content-dummy_index/-123/e0a1c64b0c20b56741834b5", // Negative number in
+            // the 2nd group
+            "index:vespa-content-dummy_index/0 ", // Whitespace after last slash, missing document
+            // ID
+        })
+        void shouldThrowExceptionForInvalidFormat(String invalidVespaId) {
+            // Ensure IllegalStateException is thrown when the regex does not match
+            InternalException exception =
+                    assertThrows(
+                            InternalException.class,
+                            () -> {
+                                HybridSearcher.extractDocIdFromHitId(invalidVespaId);
+                            });
+
+            // Assert the exception message contains the invalid hit ID
+            assertThat(exception.getMessage())
+                    .contains(
+                            "Vespa doc ID could not be extracted from the full hit ID: "
+                                    + invalidVespaId);
+        }
     }
 
     @Nested


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
Some results in RRF hybrid search are duplicated. This was fixed in released in 2.11: https://github.com/marqo-ai/marqo/commit/c605243dc84d7883b4e6b5ab008395ad9e260ed8

* **What is the new behavior (if this is a feature change)?**
Group name is now ignored for hit IDs in hybrid search

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
In progress

* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

