### PR TITLE
Patch errors made for when user enters wrong modality into a structured pointer field

### DIFF
--- a/src/marqo/s2_inference/errors.py
+++ b/src/marqo/s2_inference/errors.py
@@ -7,6 +7,8 @@ class S2InferenceError(Exception):
             self.message = message
             super().__init__(self.message)
 
+class MediaMismatchError(S2InferenceError):
+    pass
 
 class ChunkerError(S2InferenceError):
     pass
@@ -64,6 +66,8 @@ class BatchInferenceSizeNotMatchError(S2InferenceError):
 class ImageDownloadError(S2InferenceError):
     pass
 
+class MediaDownloadError(S2InferenceError):
+    pass
 
 class UnsupportedModalityError(S2InferenceError):
     pass

--- a/src/marqo/s2_inference/multimodal_model_load.py
+++ b/src/marqo/s2_inference/multimodal_model_load.py
@@ -152,13 +152,10 @@ def infer_modality(content: Union[str, List[str], bytes]) -> Modality:
 
         extension = encoded_url.split('.')[-1].lower()
         if extension in ['jpg', 'jpeg', 'png', 'gif', 'webp']:
-            print(f"inferred image")
             return Modality.IMAGE
         elif extension in ['mp4', 'avi', 'mov']:
-            print(f"inferred video")
             return Modality.VIDEO
         elif extension in ['mp3', 'wav', 'ogg']:
-            print(f"inferred audio")
             return Modality.AUDIO
 
         if validate_url(encoded_url):
@@ -167,13 +164,10 @@ def infer_modality(content: Union[str, List[str], bytes]) -> Modality:
                 with fetch_content_sample(encoded_url) as sample:
                     mime = magic.from_buffer(sample.read(), mime=True)
                     if mime.startswith('image/'):
-                        print(f"inferred image from url")
                         return Modality.IMAGE
                     elif mime.startswith('video/'):
-                        print(f"inferred video from url")
                         return Modality.VIDEO
                     elif mime.startswith('audio/'):
-                        print(f"inferred audio from url")
                         return Modality.AUDIO
             except requests.exceptions.RequestException as e:
                 pass

--- a/src/marqo/s2_inference/multimodal_model_load.py
+++ b/src/marqo/s2_inference/multimodal_model_load.py
@@ -176,9 +176,7 @@ def infer_modality(content: Union[str, List[str], bytes]) -> Modality:
                 raise MediaDownloadError(f"Error determining MIME type for {encoded_url}: {e}") from e
             except IOError as e:
                 raise MediaDownloadError(f"IO error while processing {encoded_url}: {e}") from e
-            except Exception as e:
-                raise MediaDownloadError(f"Unexpected error while processing {encoded_url}: {e}") from e
-
+            
         return Modality.TEXT
 
     elif isinstance(content, bytes):

--- a/src/marqo/s2_inference/multimodal_model_load.py
+++ b/src/marqo/s2_inference/multimodal_model_load.py
@@ -171,7 +171,13 @@ def infer_modality(content: Union[str, List[str], bytes]) -> Modality:
                     elif mime.startswith('audio/'):
                         return Modality.AUDIO
             except requests.exceptions.RequestException as e:
-                raise MediaDownloadError(f"Error downloading media file {content}: {e}")
+                raise MediaDownloadError(f"Error downloading media file {content}: {e}") from e
+            except magic.MagicException as e:
+                raise MediaDownloadError(f"Error determining MIME type for {encoded_url}: {e}") from e
+            except IOError as e:
+                raise MediaDownloadError(f"IO error while processing {encoded_url}: {e}") from e
+            except Exception as e:
+                raise MediaDownloadError(f"Unexpected error while processing {encoded_url}: {e}") from e
 
         return Modality.TEXT
 

--- a/src/marqo/s2_inference/multimodal_model_load.py
+++ b/src/marqo/s2_inference/multimodal_model_load.py
@@ -23,6 +23,7 @@ from marqo.s2_inference.languagebind import (
     LanguageBindVideoProcessor, LanguageBindAudioProcessor, LanguageBindImageProcessor,
     to_device
 )
+from marqo.s2_inference.errors import MediaDownloadError
 from marqo.core.inference.image_download import encode_url
 from marqo.s2_inference.clip_utils import download_image_from_url, validate_url
 from marqo.s2_inference.languagebind.image.tokenization_image import LanguageBindImageTokenizer
@@ -170,7 +171,7 @@ def infer_modality(content: Union[str, List[str], bytes]) -> Modality:
                     elif mime.startswith('audio/'):
                         return Modality.AUDIO
             except requests.exceptions.RequestException as e:
-                pass
+                raise MediaDownloadError(f"Error downloading media file {content}: {e}")
 
         return Modality.TEXT
 
@@ -188,8 +189,7 @@ def infer_modality(content: Union[str, List[str], bytes]) -> Modality:
 
     else:
         return Modality.TEXT
-        # raise ValueError(f"Unsupported content type: {type(content)}.
-        # It is neither a string, list of strings, nor bytes.")
+
 
 
 class LanguageBindEncoder(ModelEncoder):

--- a/src/marqo/tensor_search/add_docs.py
+++ b/src/marqo/tensor_search/add_docs.py
@@ -138,14 +138,15 @@ def threaded_download_and_preprocess_content(allocated_docs: List[dict],
                                 f"Model {marqo_index.model.name} does not support {modality}")
                             continue
 
-                        if is_structured_index and modality is Modality.VIDEO and media_field_types_mapping[
+                        if is_structured_index:
+                            if modality is Modality.VIDEO and media_field_types_mapping[
                             field] is not FieldType.VideoPointer:
-                            media_repo[doc[field]] = S2InferenceError(
-                                f"Invalid audio file. Error processing media file {doc}, detected as video, but field type is not VideoPointer")
-                        elif is_structured_index and modality is Modality.AUDIO and media_field_types_mapping[
+                                media_repo[doc[field]] = S2InferenceError(
+                                    f"Invalid audio file. Error processing media file {doc}, detected as video, but field type is not VideoPointer")
+                            if modality is Modality.AUDIO and media_field_types_mapping[
                             field] is not FieldType.AudioPointer:
-                            media_repo[doc[field]] = S2InferenceError(
-                                f"Invalid video file. Error processing media file {doc}, detected as audio, but field type is not AudioPointer")
+                                media_repo[doc[field]] = S2InferenceError(
+                                    f"Invalid video file. Error processing media file {doc}, detected as audio, but field type is not AudioPointer")
                         else:
                             try:
                                 processed_chunks = download_and_chunk_media(doc[field], device, download_headers, modality,

--- a/src/marqo/tensor_search/add_docs.py
+++ b/src/marqo/tensor_search/add_docs.py
@@ -93,8 +93,12 @@ def threaded_download_and_preprocess_content(allocated_docs: List[dict],
                     try:    
                         inferred_modality = infer_modality(doc[field])
                     except MediaDownloadError as e:
-                        media_repo[doc[field]] = MediaDownloadError(f"Error inferring modality of media file {doc[field]}: {e}")
-                        continue
+                        if is_structured_index and media_field_types_mapping[field] == FieldType.ImagePointer:
+                            # Continue processing for structured indexes with image fields
+                            inferred_modality = Modality.IMAGE
+                        else:
+                            media_repo[doc[field]] = MediaDownloadError(f"Error inferring modality of media file {doc[field]}: {e}")
+                            continue
 
                     if (inferred_modality == Modality.IMAGE and is_unstructured_index) or (
                         is_structured_index and media_field_types_mapping[field] == FieldType.ImagePointer): # Don't use infer modality in structured image pointers

--- a/src/marqo/tensor_search/add_docs.py
+++ b/src/marqo/tensor_search/add_docs.py
@@ -22,7 +22,7 @@ from marqo.core.models.marqo_index import *
 from marqo.s2_inference import clip_utils
 from marqo.s2_inference.s2_inference import is_preprocess_image_model, load_multimodal_model_and_get_preprocessors, \
     infer_modality, Modality
-from marqo.s2_inference.errors import UnsupportedModalityError, S2InferenceError
+from marqo.s2_inference.errors import UnsupportedModalityError, S2InferenceError, MediaMismatchError, MediaDownloadError
 from marqo.tensor_search.streaming_media_processor import StreamingMediaProcessor
 from marqo.tensor_search import enums
 from marqo.tensor_search.models.private_models import ModelAuth
@@ -43,7 +43,10 @@ def threaded_download_and_preprocess_content(allocated_docs: List[dict],
                                              download_headers: Optional[Dict] = None,  # Optional for now
                                              metric_obj: Optional[RequestMetrics] = None,
                                              preprocessors: Optional[Dict[str, Compose]] = None,
-                                             marqo_index: Optional[MarqoIndex] = None,
+                                             marqo_index_type: Optional[IndexType] = None,
+                                             marqo_index_model: Optional[Model] = None,
+                                             audio_preprocessing: Optional[AudioPreProcessing] = None,
+                                             video_preprocessing: Optional[VideoPreProcessing] = None,
                                              force_download: bool = False) -> None:
     """A thread calls this function to download images for its allocated documents
 
@@ -71,9 +74,9 @@ def threaded_download_and_preprocess_content(allocated_docs: List[dict],
 
     """
     # Determine index type
-    is_no_index = marqo_index is None
-    is_structured_index = marqo_index.type == IndexType.Structured if not is_no_index else False
-    is_unstructured_index = marqo_index.type == IndexType.Unstructured if not is_no_index else False
+    #is_no_index = marqo_index is None
+    is_structured_index = marqo_index_type == IndexType.Structured
+    is_unstructured_index = marqo_index_type == IndexType.Unstructured
 
     # Generate pseudo-unique ID for thread metrics.
     _id = f'image_download.{threading.get_ident()}'
@@ -88,18 +91,23 @@ def threaded_download_and_preprocess_content(allocated_docs: List[dict],
                 if field not in tensor_fields:
                     continue
                 if isinstance(doc[field], str) or force_download:
-                    inferred_modality = infer_modality(doc[field])
-                    if (inferred_modality == Modality.IMAGE and is_no_index) or (
-                        inferred_modality == Modality.IMAGE and is_unstructured_index) or (
-                        is_structured_index and media_field_types_mapping[field] == FieldType.ImagePointer and inferred_modality not in [Modality.TEXT, Modality.AUDIO, Modality.VIDEO]):
+                    try:    
+                        inferred_modality = infer_modality(doc[field])
+                    except MediaDownloadError as e:
+                        media_repo[doc[field]] = MediaDownloadError(f"Error inferring modality of media file {doc[field]}: {e}")
+                        continue
 
-                        if (marqo_index is not None
-                                and marqo_index.model.properties.get('type') in [ModelType.LanguageBind]
-                                and marqo_index.model.properties.get('supported_modalities') is not None
-                                and Modality.IMAGE not in marqo_index.model.properties.get('supported_modalities')):
+                    if (inferred_modality == Modality.IMAGE and is_unstructured_index) or (
+                        is_structured_index and media_field_types_mapping[field] == FieldType.ImagePointer): # Don't use infer modality in structured image pointers
+
+                        if marqo_index_model.properties.get('type') in [ModelType.LanguageBind] \
+                            and marqo_index_model.properties.get('supported_modalities') is not None \
+                            and Modality.IMAGE not in marqo_index_model.properties.get('supported_modalities'):
+
                             media_repo[doc[field]] = UnsupportedModalityError(
-                                f"Model {marqo_index.model.name} does not support {inferred_modality}")
+                                f"Model {marqo_index_model.name} does not support {inferred_modality}")
                             continue
+
                         # Existing logic
                         if doc[field] in media_repo:
                             continue
@@ -127,40 +135,41 @@ def threaded_download_and_preprocess_content(allocated_docs: List[dict],
                                 else:
                                     raise e
 
-                    elif (inferred_modality in [Modality.VIDEO, Modality.AUDIO] and is_no_index) or (
+                    elif (
                             inferred_modality in [Modality.VIDEO, Modality.AUDIO] and is_unstructured_index) or (
-                            is_structured_index and media_field_types_mapping[field] in [FieldType.AudioPointer, FieldType.VideoPointer] and inferred_modality not in [Modality.TEXT, Modality.IMAGE]):
+                            is_structured_index and media_field_types_mapping[field] in [FieldType.AudioPointer, FieldType.VideoPointer] and inferred_modality in [Modality.AUDIO, Modality.VIDEO]):
 
-                        if marqo_index.model.properties.get('type') not in [
-                            ModelType.LanguageBind] and inferred_modality not in marqo_index.model.properties.get(
+                        if marqo_index_model.properties.get('type') not in [
+                            ModelType.LanguageBind] and inferred_modality not in marqo_index_model.properties.get(
                             'supported_modalities'):
                             media_repo[doc[field]] = UnsupportedModalityError(
-                                f"Model {marqo_index.model.name} does not support {inferred_modality}")
+                                f"Model {marqo_index_model.name} does not support {inferred_modality}")
                             continue
 
                         if is_structured_index:
                             if inferred_modality is Modality.VIDEO and media_field_types_mapping[
-                            field] is not FieldType.VideoPointer:
-                                media_repo[doc[field]] = S2InferenceError(
+                            field] is FieldType.AudioPointer:
+                                media_repo[doc[field]] = MediaMismatchError(
                                     f"Invalid audio file. Error processing media file {doc}, detected as video, but field type is not VideoPointer")
                                 continue
 
                             if inferred_modality is Modality.AUDIO and media_field_types_mapping[
-                            field] is not FieldType.AudioPointer:
-                                media_repo[doc[field]] = S2InferenceError(
+                            field] is FieldType.VideoPointer:
+                                media_repo[doc[field]] = MediaMismatchError(
                                     f"Invalid video file. Error processing media file {doc}, detected as audio, but field type is not AudioPointer")
                                 continue
 
                         try:
                             processed_chunks = download_and_chunk_media(doc[field], device, download_headers, inferred_modality,
-                                                                    marqo_index, preprocessors)
+                                                                    marqo_index_type, marqo_index_model, preprocessors,
+                                                                    audio_preprocessing, video_preprocessing)
                             media_repo[doc[field]] = processed_chunks
                         except (ffmpeg.Error, S2InferenceError) as e:
                             logger.error(f"Error processing {inferred_modality} file: {str(e)}")
                             media_repo[doc[field]] = S2InferenceError(f"Error processing {inferred_modality} file: {str(e)}")
                     
                     elif inferred_modality is Modality.TEXT and is_structured_index and media_field_types_mapping[field] in [FieldType.AudioPointer, FieldType.VideoPointer, FieldType.ImagePointer]:
-                        media_repo[doc[field]] = S2InferenceError(f"Error processing media file {doc}, detected as text or failed to determine modality")
+                        media_repo[doc[field]] = S2InferenceError(f"Error processing media file {doc}, detected as text, expected a {media_field_types_mapping[field]} pointer")
                     else:
                         pass
 
@@ -183,11 +192,13 @@ def threaded_download_and_preprocess_content(allocated_docs: List[dict],
                                 continue
 
 
-def download_and_chunk_media(url: str, device: str, headers: dict, modality: Modality, marqo_index: MarqoIndex,
-                             preprocessors: Preprocessors) -> List[Dict[str, torch.Tensor]]:
+def download_and_chunk_media(url: str, device: str, headers: dict, modality: Modality, marqo_index_type: IndexType, marqo_index_model: Model,
+                             preprocessors: Preprocessors, audio_preprocessing: AudioPreProcessing = None,
+                             video_preprocessing: VideoPreProcessing = None) -> List[Dict[str, torch.Tensor]]:
     MAX_FILE_SIZE = 100 * 1024 * 1024  # 100 MB in bytes
 
-    processor = StreamingMediaProcessor(url, device, headers, modality, marqo_index, preprocessors)
+    processor = StreamingMediaProcessor(url, device, headers, modality, marqo_index_type, marqo_index_model, preprocessors,
+                                        audio_preprocessing, video_preprocessing)
 
     if processor.total_size > MAX_FILE_SIZE:
         raise ValueError(
@@ -207,14 +218,18 @@ def download_and_preprocess_content(docs: List[dict], thread_count: int, tensor_
                                     model_auth: Optional[ModelAuth] = None,
                                     device: Optional[str] = None,
                                     patch_method_exists: bool = False,
-                                    marqo_index: Optional[MarqoIndex] = None,
+                                    marqo_index_type: Optional[IndexType] = None,
+                                    marqo_index_model: Optional[Model] = None,
+                                    audio_preprocessing: Optional[AudioPreProcessing] = None,
+                                    video_preprocessing: Optional[VideoPreProcessing] = None,
                                     force_download: bool = False
                                     ) -> ContextManager[dict]:
     media_repo = {}  # for image/video/audio
     media_repo = process_batch(docs, thread_count, tensor_fields, image_download_headers,
                                model_name, normalize_embeddings, force_download,
                                media_field_types_mapping, download_headers, model_properties, model_auth,
-                               device, patch_method_exists, marqo_index)
+                               device, patch_method_exists, marqo_index_type, marqo_index_model,
+                               audio_preprocessing, video_preprocessing)
 
     try:
         yield media_repo
@@ -232,7 +247,9 @@ def process_batch(docs: List[dict], thread_count: int, tensor_fields: List[str],
                   force_download: bool, media_field_types_mapping: Optional[Dict[str, FieldType]],
                   download_headers: Optional[Dict], model_properties: Optional[Dict],
                   model_auth: Optional[ModelAuth], device: Optional[str],
-                  patch_method_exists: bool, marqo_index: Optional[MarqoIndex]) -> dict:
+                  patch_method_exists: bool, marqo_index_type: Optional[IndexType], marqo_index_model: Optional[Model],
+                  audio_preprocessing: Optional[AudioPreProcessing] = None,
+                  video_preprocessing: Optional[VideoPreProcessing] = None) -> dict:
     docs_per_thread = math.ceil(len(docs) / thread_count)
     copied = copy.deepcopy(docs)
 
@@ -265,7 +282,10 @@ def process_batch(docs: List[dict], thread_count: int, tensor_fields: List[str],
                                    download_headers,
                                    m[i],
                                    preprocessors,
-                                   marqo_index,
+                                   marqo_index_type,
+                                   marqo_index_model,
+                                   audio_preprocessing,
+                                   video_preprocessing,
                                    force_download)
                    for i, allocation in enumerate(thread_allocated_docs)]
 

--- a/src/marqo/tensor_search/add_docs.py
+++ b/src/marqo/tensor_search/add_docs.py
@@ -92,7 +92,7 @@ def threaded_download_and_preprocess_content(allocated_docs: List[dict],
                     if (modality == Modality.IMAGE and is_no_index) or (
                         modality == Modality.IMAGE and is_unstructured_index) or (
                         is_structured_index and media_field_types_mapping[field] == FieldType.ImagePointer and modality not in [Modality.TEXT, Modality.AUDIO, Modality.VIDEO]):
-
+                        
                         if (marqo_index is not None
                                 and marqo_index.model.properties.get('type') in [ModelType.LanguageBind]
                                 and marqo_index.model.properties.get('supported_modalities') is not None
@@ -138,11 +138,11 @@ def threaded_download_and_preprocess_content(allocated_docs: List[dict],
                                 f"Model {marqo_index.model.name} does not support {modality}")
                             continue
 
-                        if modality is Modality.VIDEO and media_field_types_mapping[
+                        if is_structured_index and modality is Modality.VIDEO and media_field_types_mapping[
                             field] is not FieldType.VideoPointer:
                             media_repo[doc[field]] = S2InferenceError(
                                 f"Invalid audio file. Error processing media file {doc}, detected as video, but field type is not VideoPointer")
-                        elif modality is Modality.AUDIO and media_field_types_mapping[
+                        elif is_structured_index and modality is Modality.AUDIO and media_field_types_mapping[
                             field] is not FieldType.AudioPointer:
                             media_repo[doc[field]] = S2InferenceError(
                                 f"Invalid video file. Error processing media file {doc}, detected as audio, but field type is not AudioPointer")

--- a/src/marqo/tensor_search/add_docs.py
+++ b/src/marqo/tensor_search/add_docs.py
@@ -92,7 +92,7 @@ def threaded_download_and_preprocess_content(allocated_docs: List[dict],
                     if (modality == Modality.IMAGE and is_no_index) or (
                         modality == Modality.IMAGE and is_unstructured_index) or (
                         is_structured_index and media_field_types_mapping[field] == FieldType.ImagePointer and modality not in [Modality.TEXT, Modality.AUDIO, Modality.VIDEO]):
-                        
+
                         if (marqo_index is not None
                                 and marqo_index.model.properties.get('type') in [ModelType.LanguageBind]
                                 and marqo_index.model.properties.get('supported_modalities') is not None
@@ -130,7 +130,7 @@ def threaded_download_and_preprocess_content(allocated_docs: List[dict],
                     elif (modality in [Modality.VIDEO, Modality.AUDIO] and is_no_index) or (
                             modality in [Modality.VIDEO, Modality.AUDIO] and is_unstructured_index) or (
                             is_structured_index and media_field_types_mapping[field] in [FieldType.AudioPointer, FieldType.VideoPointer] and modality not in [Modality.TEXT, Modality.IMAGE]):
-                        
+
                         if marqo_index.model.properties.get('type') not in [
                             ModelType.LanguageBind] and modality not in marqo_index.model.properties.get(
                             'supported_modalities'):
@@ -143,18 +143,21 @@ def threaded_download_and_preprocess_content(allocated_docs: List[dict],
                             field] is not FieldType.VideoPointer:
                                 media_repo[doc[field]] = S2InferenceError(
                                     f"Invalid audio file. Error processing media file {doc}, detected as video, but field type is not VideoPointer")
+                                continue
+
                             if modality is Modality.AUDIO and media_field_types_mapping[
                             field] is not FieldType.AudioPointer:
                                 media_repo[doc[field]] = S2InferenceError(
                                     f"Invalid video file. Error processing media file {doc}, detected as audio, but field type is not AudioPointer")
-                        else:
-                            try:
-                                processed_chunks = download_and_chunk_media(doc[field], device, download_headers, modality,
-                                                                        marqo_index, preprocessors)
-                                media_repo[doc[field]] = processed_chunks
-                            except (ffmpeg.Error, S2InferenceError) as e:
-                                logger.error(f"Error processing {modality} file: {str(e)}")
-                                media_repo[doc[field]] = S2InferenceError(f"Error processing {modality} file: {str(e)}")
+                                continue
+
+                        try:
+                            processed_chunks = download_and_chunk_media(doc[field], device, download_headers, modality,
+                                                                    marqo_index, preprocessors)
+                            media_repo[doc[field]] = processed_chunks
+                        except (ffmpeg.Error, S2InferenceError) as e:
+                            logger.error(f"Error processing {modality} file: {str(e)}")
+                            media_repo[doc[field]] = S2InferenceError(f"Error processing {modality} file: {str(e)}")
                     elif modality is Modality.TEXT:
                         media_repo[doc[field]] = S2InferenceError(f"Error processing media file {doc}, detected as text")
                     else:

--- a/src/marqo/tensor_search/add_docs.py
+++ b/src/marqo/tensor_search/add_docs.py
@@ -158,7 +158,8 @@ def threaded_download_and_preprocess_content(allocated_docs: List[dict],
                         except (ffmpeg.Error, S2InferenceError) as e:
                             logger.error(f"Error processing {modality} file: {str(e)}")
                             media_repo[doc[field]] = S2InferenceError(f"Error processing {modality} file: {str(e)}")
-                    elif modality is Modality.TEXT:
+                    
+                    elif modality is Modality.TEXT and is_structured_index and media_field_types_mapping[field] in [FieldType.AudioPointer, FieldType.VideoPointer]:
                         media_repo[doc[field]] = S2InferenceError(f"Error processing media file {doc}, detected as text")
                     else:
                         pass

--- a/src/marqo/tensor_search/add_docs.py
+++ b/src/marqo/tensor_search/add_docs.py
@@ -159,8 +159,8 @@ def threaded_download_and_preprocess_content(allocated_docs: List[dict],
                             logger.error(f"Error processing {modality} file: {str(e)}")
                             media_repo[doc[field]] = S2InferenceError(f"Error processing {modality} file: {str(e)}")
                     
-                    elif modality is Modality.TEXT and is_structured_index and media_field_types_mapping[field] in [FieldType.AudioPointer, FieldType.VideoPointer]:
-                        media_repo[doc[field]] = S2InferenceError(f"Error processing media file {doc}, detected as text")
+                    elif modality is Modality.TEXT and is_structured_index and media_field_types_mapping[field] in [FieldType.AudioPointer, FieldType.VideoPointer, FieldType.ImagePointer]:
+                        media_repo[doc[field]] = S2InferenceError(f"Error processing media file {doc}, detected as text or failed to determine modality")
                     else:
                         pass
 

--- a/src/marqo/tensor_search/add_docs.py
+++ b/src/marqo/tensor_search/add_docs.py
@@ -91,14 +91,14 @@ def threaded_download_and_preprocess_content(allocated_docs: List[dict],
                     inferred_modality = infer_modality(doc[field])
                     if (inferred_modality == Modality.IMAGE and is_no_index) or (
                         inferred_modality == Modality.IMAGE and is_unstructured_index) or (
-                        is_structured_index and media_field_types_mapping[field] == FieldType.ImagePointer and modality not in [Modality.TEXT, Modality.AUDIO, Modality.VIDEO]):
+                        is_structured_index and media_field_types_mapping[field] == FieldType.ImagePointer and inferred_modality not in [Modality.TEXT, Modality.AUDIO, Modality.VIDEO]):
 
                         if (marqo_index is not None
                                 and marqo_index.model.properties.get('type') in [ModelType.LanguageBind]
                                 and marqo_index.model.properties.get('supported_modalities') is not None
                                 and Modality.IMAGE not in marqo_index.model.properties.get('supported_modalities')):
                             media_repo[doc[field]] = UnsupportedModalityError(
-                                f"Model {marqo_index.model.name} does not support {modality}")
+                                f"Model {marqo_index.model.name} does not support {inferred_modality}")
                             continue
                         # Existing logic
                         if doc[field] in media_repo:

--- a/src/marqo/tensor_search/add_docs.py
+++ b/src/marqo/tensor_search/add_docs.py
@@ -74,7 +74,6 @@ def threaded_download_and_preprocess_content(allocated_docs: List[dict],
 
     """
     # Determine index type
-    #is_no_index = marqo_index is None
     is_structured_index = marqo_index_type == IndexType.Structured
     is_unstructured_index = marqo_index_type == IndexType.Unstructured
 

--- a/src/marqo/tensor_search/add_docs.py
+++ b/src/marqo/tensor_search/add_docs.py
@@ -135,8 +135,7 @@ def threaded_download_and_preprocess_content(allocated_docs: List[dict],
                                 else:
                                     raise e
 
-                    elif (
-                            inferred_modality in [Modality.VIDEO, Modality.AUDIO] and is_unstructured_index) or (
+                    elif (inferred_modality in [Modality.VIDEO, Modality.AUDIO] and is_unstructured_index) or (
                             is_structured_index and media_field_types_mapping[field] in [FieldType.AudioPointer, FieldType.VideoPointer] and inferred_modality in [Modality.AUDIO, Modality.VIDEO]):
 
                         if marqo_index_model.properties.get('type') not in [

--- a/src/marqo/tensor_search/streaming_media_processor.py
+++ b/src/marqo/tensor_search/streaming_media_processor.py
@@ -18,13 +18,17 @@ from marqo.tensor_search.models.preprocessors_model import Preprocessors
 
 
 class StreamingMediaProcessor:
-    def __init__(self, url: str, device: str, headers: Dict[str, str], modality: Modality, marqo_index: MarqoIndex,
-                 preprocessors: Preprocessors):
+    def __init__(self, url: str, device: str, headers: Dict[str, str], modality: Modality, marqo_index_type: IndexType,
+                 marqo_index_model: Model, preprocessors: Preprocessors, audio_preprocessing: AudioPreProcessing = None,
+                 video_preprocessing: VideoPreProcessing = None):
         self.url = url
         self.device = device
         self.headers = headers
         self.modality = modality
-        self.marqo_index = marqo_index
+        self.marqo_index_type = marqo_index_type
+        self.marqo_index_model = marqo_index_model
+        self.audio_preprocessing = audio_preprocessing
+        self.video_preprocessing = video_preprocessing
         self.preprocessors = preprocessors
         self.preprocessor = self.preprocessors[modality]
         self.total_size, self.duration = self._fetch_file_metadata()
@@ -33,7 +37,7 @@ class StreamingMediaProcessor:
         self._log_initialization_details()
 
     def _set_split_parameters(self, modality):
-        preprocessing = self.marqo_index.video_preprocessing if modality == Modality.VIDEO else self.marqo_index.audio_preprocessing
+        preprocessing = self.video_preprocessing if modality == Modality.VIDEO else self.audio_preprocessing
 
         if preprocessing is not None:
             self.split_length = preprocessing.split_length

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -847,7 +847,7 @@ def _add_documents_structured(config: Config, add_docs_params: AddDocsParams, ma
                                 chunk_start = media_chunk['start_time']
                                 chunk_end = media_chunk['end_time']
                                 chunk_time = [chunk_start, chunk_end]
-                                chunk_id = f"{field}::{chunk_time}"
+                                chunk_id = f"{chunk_time}"
                                 chunks.append(chunk_id)
 
                                 vector = s2_inference.vectorise(

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -186,7 +186,10 @@ def _add_documents_unstructured(config: Config, add_docs_params: AddDocsParams, 
                         device=add_docs_params.device,
                         model_auth=add_docs_params.model_auth,
                         patch_method_exists=marqo_index.image_preprocessing.patch_method is not None,
-                        marqo_index=marqo_index
+                        marqo_index_type=marqo_index.type,
+                        marqo_index_model=marqo_index.model,
+                        audio_preprocessing=marqo_index.audio_preprocessing,
+                        video_preprocessing=marqo_index.video_preprocessing,
                     )
                 )
 
@@ -684,7 +687,10 @@ def _add_documents_structured(config: Config, add_docs_params: AddDocsParams, ma
                         device=add_docs_params.device,
                         model_auth=add_docs_params.model_auth,
                         patch_method_exists=marqo_index.image_preprocessing.patch_method is not None,
-                        marqo_index=marqo_index,
+                        marqo_index_type=marqo_index.type,
+                        marqo_index_model=marqo_index.model,
+                        audio_preprocessing=marqo_index.audio_preprocessing,
+                        video_preprocessing=marqo_index.video_preprocessing,
                         force_download=True
                     )
                 )

--- a/tests/tensor_search/integ_tests/test_add_documents_combined.py
+++ b/tests/tensor_search/integ_tests/test_add_documents_combined.py
@@ -485,6 +485,8 @@ class TestAddDocumentsCombined(MarqoTestCase):
             media_repo=media_repo,
             tensor_fields=['field_1', 'field_2'],
             image_download_headers={},
+            marqo_index_type=IndexType.Unstructured,
+            marqo_index_model=Model(name="test", properties={}),
         )
         assert len(media_repo) == 2
         assert isinstance(media_repo['https://google.com/my_dog.png'], PIL.UnidentifiedImageError)
@@ -504,7 +506,9 @@ class TestAddDocumentsCombined(MarqoTestCase):
             tensor_fields=['field_1', 'field_2'],
             image_download_headers={},
             preprocessors={'image': lambda x: torch.randn(3, 224, 224)},
-            device='cpu'
+            device='cpu',
+            marqo_index_type=IndexType.Unstructured,
+            marqo_index_model=Model(name="test", properties={}),
         )
         assert len(media_repo) == 2
         assert isinstance(media_repo['https://google.com/my_dog.png'], PIL.UnidentifiedImageError)
@@ -523,27 +527,6 @@ class TestAddDocumentsCombined(MarqoTestCase):
                 media_repo=media_repo,
                 tensor_fields=['Title', 'Desc', 'Loc'],
                 image_download_headers={},
-                marqo_index = UnstructuredMarqoIndex(
-                    name="test", 
-                    schema_name="test", 
-                    type=IndexType.Unstructured, 
-                    model=Model(name="test", properties={}), 
-                    normalize_embeddings=True, 
-                    text_preprocessing=TextPreProcessing(splitLength=1, splitMethod=TextSplitMethod.Sentence, splitOverlap=0), 
-                    image_preprocessing=ImagePreProcessing(patchMethod=None), 
-                    distance_metric=DistanceMetric.PrenormalizedAngular, 
-                    vector_numeric_type=VectorNumericType.Float, 
-                    treat_urls_and_pointers_as_images=True,
-                    filter_string_max_length=100,
-                    hnsw_config=HnswConfig(
-                        m=16, 
-                        efConstruction=512, 
-                    ), 
-                    marqo_version="0.1.0", 
-                    created_at=1, 
-                    updated_at=1, 
-                    _cache={}
-                )
             )
             assert list(media_repo.keys()) == ['https://google.com/my_dog.png']
             assert isinstance(media_repo['https://google.com/my_dog.png'], PIL.UnidentifiedImageError)
@@ -629,7 +612,9 @@ class TestAddDocumentsCombined(MarqoTestCase):
                 allocated_docs=docs,
                 media_repo=media_repo,
                 tensor_fields=['field_1', 'field_2'],
-                image_download_headers={}
+                image_download_headers={},
+                marqo_index_type=IndexType.Unstructured,
+                marqo_index_model=Model(name="test", properties={}),
             )
             assert len(expected_repo_structure) == len(media_repo)
             for k in expected_repo_structure:
@@ -684,7 +669,9 @@ class TestAddDocumentsCombined(MarqoTestCase):
                     normalize_embeddings=True,
                     model_properties=model_properties,
                     media_field_types_mapping=None,
-                    device="cpu"
+                    device="cpu",
+                    marqo_index_type=IndexType.Unstructured,
+                    marqo_index_model=Model(name="test", properties={}),
                 ) as media_repo:
                     self.assertEqual(len(expected_repo_structure), len(media_repo))
                     for k in expected_repo_structure:
@@ -764,7 +751,10 @@ class TestAddDocumentsCombined(MarqoTestCase):
             device='cpu',
             headers={},
             modality=streaming_media_processor.Modality.VIDEO,
-            marqo_index=mock_index,
+            marqo_index_type=IndexType.Unstructured,
+            marqo_index_model=Model(name="test", properties={}),
+            audio_preprocessing=unittest.mock.Mock(),
+            video_preprocessing=unittest.mock.Mock(),
             preprocessors={'video': unittest.mock.Mock()}
         )
 

--- a/tests/tensor_search/integ_tests/test_add_documents_combined.py
+++ b/tests/tensor_search/integ_tests/test_add_documents_combined.py
@@ -527,6 +527,8 @@ class TestAddDocumentsCombined(MarqoTestCase):
                 media_repo=media_repo,
                 tensor_fields=['Title', 'Desc', 'Loc'],
                 image_download_headers={},
+                marqo_index_type=IndexType.Unstructured,
+                marqo_index_model=Model(name="test", properties={}),
             )
             assert list(media_repo.keys()) == ['https://google.com/my_dog.png']
             assert isinstance(media_repo['https://google.com/my_dog.png'], PIL.UnidentifiedImageError)

--- a/tests/tensor_search/integ_tests/test_add_documents_structured.py
+++ b/tests/tensor_search/integ_tests/test_add_documents_structured.py
@@ -950,7 +950,6 @@ class TestAddDocumentsStructured(MarqoTestCase):
                 index_name=self.index_name_img_no_chunking, docs=documents
             )
         )
-        print(r)
 
         self.assertEqual(True, r.errors)
         self.assertEqual(3, r._batch_response_stats.failure_count)

--- a/tests/tensor_search/integ_tests/test_add_documents_structured.py
+++ b/tests/tensor_search/integ_tests/test_add_documents_structured.py
@@ -950,6 +950,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
                 index_name=self.index_name_img_no_chunking, docs=documents
             )
         )
+        print(r)
 
         self.assertEqual(True, r.errors)
         self.assertEqual(3, r._batch_response_stats.failure_count)

--- a/tests/tensor_search/test_modalities_download.py
+++ b/tests/tensor_search/test_modalities_download.py
@@ -8,6 +8,7 @@ from marqo.core.models.marqo_index import IndexType, MarqoIndex, FieldType
 from marqo.s2_inference.s2_inference import Modality
 from marqo.s2_inference.models.model_type import ModelType
 from marqo.tensor_search.telemetry import RequestMetricsStore, RequestMetrics
+from marqo.s2_inference.errors import MediaDownloadError
 import ffmpeg
 
 
@@ -62,7 +63,8 @@ class TestThreadedDownloadAndPreprocess(unittest.TestCase):
         
         threaded_download_and_preprocess_content(
             docs, media_repo, tensor_fields, {}, device="cpu",
-            marqo_index=self.mock_marqo_index
+            marqo_index_type=self.mock_marqo_index.type,
+            marqo_index_model=self.mock_marqo_index.model,
         )
 
         self.assertIn(self.mock_image_url, media_repo)
@@ -82,7 +84,8 @@ class TestThreadedDownloadAndPreprocess(unittest.TestCase):
         
         threaded_download_and_preprocess_content(
             docs, media_repo, tensor_fields, {}, device="cpu",
-            marqo_index=self.mock_marqo_index,
+            marqo_index_type=self.mock_marqo_index.type,
+            marqo_index_model=self.mock_marqo_index.model,
             media_field_types_mapping=media_field_types_mapping
         )
 
@@ -104,7 +107,8 @@ class TestThreadedDownloadAndPreprocess(unittest.TestCase):
         
         threaded_download_and_preprocess_content(
             docs, media_repo, tensor_fields, {}, device="cpu",
-            marqo_index=self.mock_marqo_index
+            marqo_index_type=self.mock_marqo_index.type,
+            marqo_index_model=self.mock_marqo_index.model,
         )
 
         self.assertIn(self.mock_video_url, media_repo)
@@ -127,7 +131,8 @@ class TestThreadedDownloadAndPreprocess(unittest.TestCase):
         
         threaded_download_and_preprocess_content(
             docs, media_repo, tensor_fields, {}, device="cpu",
-            marqo_index=self.mock_marqo_index,
+            marqo_index_type=self.mock_marqo_index.type,
+            marqo_index_model=self.mock_marqo_index.model,
             media_field_types_mapping=media_field_types_mapping
         )
 
@@ -144,7 +149,8 @@ class TestThreadedDownloadAndPreprocess(unittest.TestCase):
         
         threaded_download_and_preprocess_content(
             docs, media_repo, tensor_fields, {}, device="cpu",
-            marqo_index=self.mock_marqo_index
+            marqo_index_type=self.mock_marqo_index.type,
+            marqo_index_model=self.mock_marqo_index.model,
         )
 
         self.assertIn(self.mock_video_url, media_repo)
@@ -162,7 +168,8 @@ class TestThreadedDownloadAndPreprocess(unittest.TestCase):
         
         threaded_download_and_preprocess_content(
             docs, media_repo, tensor_fields, {}, device="cpu",
-            marqo_index=self.mock_marqo_index
+            marqo_index_type=self.mock_marqo_index.type,
+            marqo_index_model=self.mock_marqo_index.model,
         )
 
         self.assertIn(self.mock_image_url, media_repo)
@@ -183,7 +190,8 @@ class TestThreadedDownloadAndPreprocess(unittest.TestCase):
         
         threaded_download_and_preprocess_content(
             docs, media_repo, tensor_fields, {}, device="cpu",
-            marqo_index=self.mock_marqo_index
+            marqo_index_type=self.mock_marqo_index.type,
+            marqo_index_model=self.mock_marqo_index.model,
         )
         self.assertIn(self.mock_video_url, media_repo)
         self.assertIsInstance(media_repo[self.mock_video_url], S2InferenceError)
@@ -210,7 +218,8 @@ class TestThreadedDownloadAndPreprocess(unittest.TestCase):
         # Call the function
         threaded_download_and_preprocess_content(
             docs, media_repo, tensor_fields, {}, device="cpu",
-            marqo_index=self.mock_marqo_index
+            marqo_index_type=self.mock_marqo_index.type,
+            marqo_index_model=self.mock_marqo_index.model,
         )
 
         # Assertions
@@ -224,10 +233,10 @@ class TestThreadedDownloadAndPreprocess(unittest.TestCase):
 
         # Verify the calls to download_and_chunk_media
         mock_download_and_chunk.assert_any_call(
-            self.mock_video_url, "cpu", None, Modality.VIDEO, self.mock_marqo_index, None
+            self.mock_video_url, "cpu", None, Modality.VIDEO, self.mock_marqo_index.type, self.mock_marqo_index.model, None, None, None
         )
         mock_download_and_chunk.assert_any_call(
-            self.mock_audio_url, "cpu", None, Modality.AUDIO, self.mock_marqo_index, None
+            self.mock_audio_url, "cpu", None, Modality.AUDIO, self.mock_marqo_index.type, self.mock_marqo_index.model, None, None, None
         )
 
     @patch("marqo.tensor_search.add_docs.download_and_chunk_media")
@@ -253,7 +262,8 @@ class TestThreadedDownloadAndPreprocess(unittest.TestCase):
 
         threaded_download_and_preprocess_content(
             docs, media_repo, tensor_fields, {}, device="cpu",
-            marqo_index=self.mock_marqo_index,
+            marqo_index_type=self.mock_marqo_index.type,
+            marqo_index_model=self.mock_marqo_index.model,
             media_field_types_mapping=media_field_types_mapping
         )
 
@@ -282,7 +292,8 @@ class TestThreadedDownloadAndPreprocess(unittest.TestCase):
 
         threaded_download_and_preprocess_content(
             docs, media_repo, tensor_fields, {}, device="cpu",
-            marqo_index=self.mock_marqo_index,
+            marqo_index_type=self.mock_marqo_index.type,
+            marqo_index_model=self.mock_marqo_index.model,
             media_field_types_mapping=media_field_types_mapping
         )
 
@@ -311,7 +322,8 @@ class TestThreadedDownloadAndPreprocess(unittest.TestCase):
 
         threaded_download_and_preprocess_content(
             docs, media_repo, tensor_fields, {}, device="cpu",
-            marqo_index=self.mock_marqo_index,
+            marqo_index_type=self.mock_marqo_index.type,
+            marqo_index_model=self.mock_marqo_index.model,
             media_field_types_mapping=media_field_types_mapping
         )
 
@@ -336,9 +348,28 @@ class TestThreadedDownloadAndPreprocess(unittest.TestCase):
 
         threaded_download_and_preprocess_content(
             docs, media_repo, tensor_fields, {}, device="cpu",
-            marqo_index=self.mock_marqo_index,
+            marqo_index_type=self.mock_marqo_index.type,
+            marqo_index_model=self.mock_marqo_index.model,
             media_field_types_mapping=media_field_types_mapping
         )
 
         self.assertIn("https://example.com/valid_image.jpg", media_repo)
         self.assertEqual(media_repo["https://example.com/valid_image.jpg"], self.mock_image)
+
+    @patch("marqo.tensor_search.add_docs.infer_modality")
+    def test_media_download_error(self, mock_infer_modality):
+        mock_infer_modality.side_effect = MediaDownloadError("Network error while inferring modality")
+
+        docs = [{"field1": self.mock_video_url}]
+        media_repo = {}
+        tensor_fields = ["field1"]
+        
+        threaded_download_and_preprocess_content(
+            docs, media_repo, tensor_fields, {}, device="cpu",
+            marqo_index_type=self.mock_marqo_index.type,
+            marqo_index_model=self.mock_marqo_index.model,
+        )
+
+        self.assertIn(self.mock_video_url, media_repo)
+        self.assertIsInstance(media_repo[self.mock_video_url], MediaDownloadError)
+        self.assertIn("Network error while inferring modality", str(media_repo[self.mock_video_url]))


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
Generic Internal error when user 
- adds text to a video/audio pointer field in structured
- adds video link to audio pointer and vice version in structured

* **What is the new behavior (if this is a feature change)?**
Only the specific document is failed to 400, but the batch is not.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)


* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

