### PR TITLE
Pin Vespa version in the build and in integration tests

### DIFF
--- a/scripts/vespa_local/vespa_local.py
+++ b/scripts/vespa_local/vespa_local.py
@@ -1,10 +1,8 @@
 import argparse
-import json
 
 import os
-import shutil
-import re
-import subprocess
+
+VESPA_SERVER_VERSION='8.396.18'  # version baked into marqo-base:29
 
 
 def start(args):
@@ -14,7 +12,7 @@ def start(args):
               "--name vespa "
               "--hostname vespa-container "
               "--publish 8080:8080 --publish 19071:19071 --publish 2181:2181 --publish 127.0.0.1:5005:5005 "
-              "vespaengine/vespa:8.367.14")
+              f"vespaengine/vespa:{VESPA_SERVER_VERSION}")
 
 
 def restart(args):

--- a/vespa/pom.xml
+++ b/vespa/pom.xml
@@ -128,7 +128,13 @@
     <parent>
         <groupId>com.yahoo.vespa</groupId>
         <artifactId>cloud-tenant-base</artifactId>
-        <version>[8,9)</version>  <!-- Use the latest Vespa release on each build -->
+        <!--
+        Vespa 8.332.5 is baked in the Marqo docker image for Marqo 2.5.0 to 2.11.4. This customer searcher feature
+        is first introduced in Marqo 2.10.0. Vespa minor versions are backward compatible, but not forward compatible.
+        Pin to this version to make sure we don't accidentally bring in dependencies that are missing in this version
+        of Vespa.
+        -->
+        <version>8.332.5</version>
         <relativePath/>
     </parent>
     


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Dependency management

* **What is the current behavior?** (You can also link to an open issue here)
- The custom searcher component jar is built using the latest version of vespa `cloud-tenant-base`, which might introduce dependency versions that are not supported by the Vespa version running in Marqo Cloud or older version of Marqo OS. 
- The integration tests are running against a randomly picked Vespa version `8.367.14`

* **What is the new behavior (if this is a feature change)?**
- The custom searcher are now built with vespa `cloud-tenant-base` 8.332.5, which is the server version we bake in to marqo-base:20, which is used when this component jar file was firstly introduced. This make sure the dependency versions are also pinned to work with Vespa server from 8.332.5 onwards. 
- The integration tests are now running against the latest vespa version we built into Marqo 2.12.0, which is 8.396.18

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)


* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

