### PR TITLE
Fix permission issue when transferring state from older versions

### DIFF
--- a/run_marqo.sh
+++ b/run_marqo.sh
@@ -47,6 +47,7 @@ See https://docs.marqo.ai/2.0.0/Guides/Advanced-Usage/configuration/ for more in
 elif [ -z "$VESPA_QUERY_URL" ] && [ -z "$VESPA_DOCUMENT_URL" ] && [ -z "$VESPA_CONFIG_URL" ]; then
   # Start local vespa
   echo "External vector store not configured. Using local vector store"
+  chown -R vespa:vespa /opt/vespa/var/
   tmux new-session -d -s vespa "bash /usr/local/bin/start_vespa.sh"
 
   echo "Waiting for vector store to start"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
State transfer from <=2.11 to 2.12+ fails due to permission issue, most likely related to change of Linux distro in the base image

* **What is the new behavior (if this is a feature change)?**
Fix `/opt/vespa/var` permissions for 2.12 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)


* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

