### PR TITLE
Patch wrong Modality Error

### DIFF
--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -65,12 +65,6 @@ jobs:
           repository: marqo-ai/marqo-base
           path: marqo-base
 
-      - name: Install FFmpeg and libmagic
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ffmpeg libmagic1
-          ffmpeg -version  # Verify installation
-          file --version   # Verify libmagic installation and version
       - name: Install dependencies
         run: |
           pip install -r marqo-base/requirements.txt

--- a/src/marqo/tensor_search/add_docs.py
+++ b/src/marqo/tensor_search/add_docs.py
@@ -140,10 +140,12 @@ def threaded_download_and_preprocess_content(allocated_docs: List[dict],
 
                     elif (inferred_modality in [Modality.VIDEO, Modality.AUDIO] and is_unstructured_index) or (
                             is_structured_index and media_field_types_mapping[field] in [FieldType.AudioPointer, FieldType.VideoPointer] and inferred_modality in [Modality.AUDIO, Modality.VIDEO]):
-
-                        if marqo_index_model.properties.get('type') not in [
-                            ModelType.LanguageBind] and inferred_modality not in marqo_index_model.properties.get(
-                            'supported_modalities'):
+                        if marqo_index_model.properties.get('type') not in [ModelType.LanguageBind]:
+                            media_repo[doc[field]] = UnsupportedModalityError(
+                                f"Model {marqo_index_model.name} does not support {inferred_modality}")
+                            continue
+                        
+                        if inferred_modality not in marqo_index_model.properties.get('supported_modalities'):
                             media_repo[doc[field]] = UnsupportedModalityError(
                                 f"Model {marqo_index_model.name} does not support {inferred_modality}")
                             continue


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix for error catching

* **What is the current behavior?** (You can also link to an open issue here)
When user selects a languagebind model which does not support X modality, marqo gives a 500 error instead of being caught by the validator saying `Model LanguageBind/Video_V1.5_FT does not support audio`. Only non languagebind models which receive unsupported x modalities with be caught by the validator.

* **What is the new behavior (if this is a feature change)?**
Catches languagebind model unsupported modality error with `Model LanguageBind/Video_V1.5_FT does not support audio`

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)


* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

