### PR TITLE
Change np.ndarray types to list type to fix model serialization to fix OpenAPISpec and SwaggerUI

### DIFF
--- a/src/marqo/tensor_search/models/add_docs_objects.py
+++ b/src/marqo/tensor_search/models/add_docs_objects.py
@@ -1,7 +1,5 @@
-from typing import List
-from typing import Optional, Union, Any, Sequence
+from typing import Optional, Any, Sequence, List, Dict
 
-import numpy as np
 from pydantic import BaseModel, validator, root_validator
 from pydantic import Field
 
@@ -29,7 +27,7 @@ class AddDocsBodyParams(BaseModel):
     imageDownloadHeaders: dict = Field(default_factory=dict)
     modelAuth: Optional[ModelAuth] = None
     mappings: Optional[dict] = None
-    documents: Union[Sequence[Union[dict, Any]], list]
+    documents: Sequence[Dict[str, Any]]
     imageDownloadThreadCount: int = Field(default_factory=lambda: read_env_vars_and_defaults_ints(EnvVars.MARQO_IMAGE_DOWNLOAD_THREAD_COUNT_PER_REQUEST))
     mediaDownloadThreadCount: Optional[int]
     textChunkPrefix: Optional[str] = None
@@ -65,7 +63,7 @@ class AddDocsParams(BaseModel):
         allow_mutation = False
 
     # this should only accept Sequences of dicts, but currently validation lies elsewhere
-    docs: Union[Sequence[Union[dict, Any]], list]
+    docs: Sequence[Dict[str, Any]]
 
     index_name: str
     device: Optional[str]

--- a/src/marqo/tensor_search/models/add_docs_objects.py
+++ b/src/marqo/tensor_search/models/add_docs_objects.py
@@ -29,7 +29,7 @@ class AddDocsBodyParams(BaseModel):
     imageDownloadHeaders: dict = Field(default_factory=dict)
     modelAuth: Optional[ModelAuth] = None
     mappings: Optional[dict] = None
-    documents: Union[Sequence[Union[dict, Any]], np.ndarray]
+    documents: Union[Sequence[Union[dict, Any]], list]
     imageDownloadThreadCount: int = Field(default_factory=lambda: read_env_vars_and_defaults_ints(EnvVars.MARQO_IMAGE_DOWNLOAD_THREAD_COUNT_PER_REQUEST))
     mediaDownloadThreadCount: Optional[int]
     textChunkPrefix: Optional[str] = None
@@ -65,7 +65,7 @@ class AddDocsParams(BaseModel):
         allow_mutation = False
 
     # this should only accept Sequences of dicts, but currently validation lies elsewhere
-    docs: Union[Sequence[Union[dict, Any]], np.ndarray]
+    docs: Union[Sequence[Union[dict, Any]], list]
 
     index_name: str
     device: Optional[str]

--- a/tests/tensor_search/test_openapi.py
+++ b/tests/tensor_search/test_openapi.py
@@ -1,0 +1,18 @@
+from fastapi.testclient import TestClient
+from marqo.tensor_search.api import app
+from tests.marqo_test import MarqoTestCase
+
+
+class OpenApiTests(MarqoTestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+
+    def test_docs_endpoint(self):
+        """Test if the /docs endpoint is accessible and returns status code 200."""
+        response = self.client.get("/docs")
+        self.assertEqual(response.status_code, 200, "The /docs endpoint should be accessible.")
+
+    def test_openapi_json_endpoint(self):
+        """Test if the /openapi.json endpoint is accessible and returns status code 200."""
+        response = self.client.get("/openapi.json")
+        self.assertEqual(response.status_code, 200, "The /openapi.json endpoint should be accessible.")


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
In Marqo 2.x, OpenAPI spec generation is not functional. Attempting to access `/openapi.json` or `/docs` results in errors, making it impossible to retrieve the API specifications and documentation. This issue is documented in [Issue #778](https://github.com/marqo-ai/marqo/issues/778).

* **What is the new behavior (if this is a feature change)?**
This PR restores OpenAPI spec generation and resolves the issues with the `/openapi.json` and `/docs` endpoints. The root cause was identified in `src/marqo/tensor_search/models/add_docs_objects.py`, where the documents field included a union type that couldn't be serialized due to the presence of np.ndarray.

By replacing np.ndarray with the standard Python list type in the union, the serialization issue is resolved, allowing OpenAPI specs and Swagger UI to function as expected.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No, this PR does not introduce any breaking changes. Existing functionalities remain unaffected, and users do not need to make any changes to their applications.

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
No, unit tests haven't been executed. I locally confirmed that the OpenAPI specification and Swagger UI are now accessible and operational.

* **Related Python client changes** (link commit/PR here)
No related changes in the Python client.

* **Related documentation changes** (link commit/PR here)
No changes needed as the fix restores a functionality already documented.

* **Other information**:
The issue was addressed by considering three potential solutions:

1. Implementing a custom OpenAPI function in FastAPI to exclude np.ndarray fields from the schema.
2. Creating a custom JSON encoder for models containing np.ndarray.
3. Replacing np.ndarray with a standard Python list type.

The third option was chosen for its simplicity and effectiveness.



* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)