### PR TITLE
Lexical parser modification - best effort double quote parsing

### DIFF
--- a/src/marqo/core/exceptions.py
+++ b/src/marqo/core/exceptions.py
@@ -102,6 +102,9 @@ class AddDocumentsError(Exception):
         self.error_message = error_message
         self.status_code = int(status_code)
 
+    def __str__(self) -> str:
+        return f'{self.error_code}: {self.error_message}'
+
 
 class DuplicateDocumentError(AddDocumentsError):
     pass

--- a/src/marqo/core/inference/tensor_fields_container.py
+++ b/src/marqo/core/inference/tensor_fields_container.py
@@ -159,6 +159,7 @@ class Vectoriser(ABC):
             # Fail the whole batch due to a malfunctioning embedding model
             raise ModelError(f'Problem vectorising query. Reason: {str(model_error)}')
         except s2_inference_errors.S2InferenceError as e:
+            # TODO find a better error code, the existing one is 'invalid_argument'
             raise AddDocumentsError(e.message) from e
 
     @classmethod

--- a/src/marqo/core/vespa_index/add_documents_handler.py
+++ b/src/marqo/core/vespa_index/add_documents_handler.py
@@ -365,7 +365,7 @@ class AddDocumentsHandler(ABC):
             except AddDocumentsError as err:
                 logger.error('Encountered problem when vectorising batch of documents. Reason: %s', err)
                 raise InternalError(
-                    message=f'Encountered problem when vectorising batch of documents. Reason: {str(err)}'
+                    message=f'Encountered problem when vectorising batch of documents. Reason: {err.error_message}'
                 )
 
             for doc_id, field_name, tensor_field_content in (

--- a/src/marqo/tensor_search/utils.py
+++ b/src/marqo/tensor_search/utils.py
@@ -234,7 +234,7 @@ def parse_lexical_query(text: str) -> Tuple[List[str], List[str]]:
         if text[i] == '"':
             # Check if ESCAPED
             if i > 0 and text[i - 1] == '\\':
-                # Read quote literally. Backslash should be ignored (both blob and required)
+                # Read quote literally. Backslash should be passed directly to Vespa.
                 pass
 
             # OPENING QUOTE
@@ -252,7 +252,8 @@ def parse_lexical_query(text: str) -> Tuple[List[str], List[str]]:
                 if (i == len(text) - 1 or text[i + 1] == " ") and not current_quote_pair_is_faulty:
                     # Add everything in between the quotes as a required term
                     new_required_term = text[opening_quote_idx + 1:i]
-                    required_terms.append(new_required_term)
+                    if new_required_term:                           # Do not add empty strings as required terms
+                        required_terms.append(new_required_term)
 
                     # Remove this required term from the blob
                     blob = blob[:-(len(new_required_term) + 2)]

--- a/src/marqo/tensor_search/utils.py
+++ b/src/marqo/tensor_search/utils.py
@@ -199,17 +199,20 @@ def parse_lexical_query(text: str) -> Tuple[List[str], List[str]]:
     """
     Find required terms enclosed within double quotes.
 
-    All other terms go into optional_terms, split by whitespace.
+    All other terms go into blob, split by whitespace. blob starts as a string then splits into
+    a list by space.
 
     Syntax:
         Required strings must be enclosed by quotes. These quotes must be enclosed by spaces or the start
-        or end of the text
+        or end of the text. Quotes always come in pairs.
 
+        Bad syntax rules:
+        - If 1 or both of the quotes in a pair has bad syntax (e.g. no space before opening quote or after closing
+          quote), both will be treated as whitespace.
+        - Incomplete quotes will be treated as whitespace.
     Notes:
-        Double quote can be either opening, closing, or escaped.
-        Escaped double quotes are interpreted literally.
-        If any double quotes exist that are neither opening, closing, nor escaped,
-        interpret entire string literally instead.
+        - Correct double quote can be either opening, closing, or escaped.
+        - Escaped double quotes are interpreted literally.
 
     Users need to escape the backslash itself. (Single \ get ignored) -> q='dwayne \\"the rock\\" johnson'
 
@@ -217,15 +220,16 @@ def parse_lexical_query(text: str) -> Tuple[List[str], List[str]]:
         2-tuple of <required terms> (for "must" clause) <optional terms> (for "should" clause)
     """
     required_terms = []
-    optional_terms = ""
+    blob = ""
     opening_quote_idx = None
+    current_quote_pair_is_faulty = False
 
     if not isinstance(text, str):
         raise TypeError("parse_lexical_query must have string as input")
 
     for i in range(len(text)):
-        # Add all characters to blob initially
-        optional_terms += text[i]
+        # Add every character to blob initially
+        blob += text[i]
 
         if text[i] == '"':
             # Check if ESCAPED
@@ -233,38 +237,47 @@ def parse_lexical_query(text: str) -> Tuple[List[str], List[str]]:
                 # Read quote literally. Backslash should be ignored (both blob and required)
                 pass
 
-            # Check if CLOSING QUOTE
-            # Closing " must have space on the right (or is last character) while opening exists.
-            elif (opening_quote_idx is not None) and (i == len(text) - 1 or text[i + 1] == " "):
-                # Add everything in between the quotes as a required term
-                new_required_term = text[opening_quote_idx + 1:i]
-                required_terms.append(new_required_term)
-
-                # Remove this required term from the optional blob
-                optional_terms = optional_terms[:-(len(new_required_term) + 2)]
-                opening_quote_idx = None
-
-            # Check if OPENING QUOTE
-            # Opening " must have space on the left (or is first character).
-            elif i == 0 or text[i - 1] == " ":
+            # OPENING QUOTE
+            elif (opening_quote_idx is None):
                 opening_quote_idx = i
+                blob_opening_quote_idx = len(blob) - 1 # Opening quote index in blob is different from text
 
-            # None of the above: Syntax error. Interpret text literally instead.
+                # Bad syntax opening quote: flag it, replace quote with whitespace
+                if not (i == 0 or text[i - 1] == " "):
+                    current_quote_pair_is_faulty = True
+                    blob = blob[:-1] + " "
+            # CLOSING QUOTE
             else:
-                return [], text.split()
+                # Good syntax closing: must have space on the right (or is last character) while opening exists.
+                if (i == len(text) - 1 or text[i + 1] == " ") and not current_quote_pair_is_faulty:
+                    # Add everything in between the quotes as a required term
+                    new_required_term = text[opening_quote_idx + 1:i]
+                    required_terms.append(new_required_term)
 
+                    # Remove this required term from the blob
+                    blob = blob[:-(len(new_required_term) + 2)]
+
+                else:
+                    # Bad syntax closing: treat this and opening quote as whitespace
+                    blob = blob[:blob_opening_quote_idx] + " " + \
+                                     blob[blob_opening_quote_idx + 1:-1] + " "
+
+                # Clean up flags
+                opening_quote_idx = None
+                current_quote_pair_is_faulty = False
+
+    # Unpaired quote will be turned to whitespace
     if opening_quote_idx is not None:
-        # string parsing finished with a quote still open: syntax error.
-        return [], text.split()
+        blob = blob[:blob_opening_quote_idx] + " " + blob[blob_opening_quote_idx + 1:]
 
     # Remove double/leading white spaces
-    optional_terms = optional_terms.split()
+    blob = blob.split()
 
     # Remove escape character. `\"` becomes just `"`
     required_terms = [term.replace('\\"', '"') for term in required_terms]
-    optional_terms = [term.replace('\\"', '"') for term in optional_terms]
+    blob = [term.replace('\\"', '"') for term in blob]
 
-    return required_terms, optional_terms
+    return required_terms, blob
 
 
 def get_marqo_root_from_env() -> str:

--- a/src/marqo/tensor_search/utils.py
+++ b/src/marqo/tensor_search/utils.py
@@ -271,13 +271,9 @@ def parse_lexical_query(text: str) -> Tuple[List[str], List[str]]:
         blob = blob[:blob_opening_quote_idx] + " " + blob[blob_opening_quote_idx + 1:]
 
     # Remove double/leading white spaces
-    blob = blob.split()
+    optional_terms = blob.split()
 
-    # Remove escape character. `\"` becomes just `"`
-    required_terms = [term.replace('\\"', '"') for term in required_terms]
-    blob = [term.replace('\\"', '"') for term in blob]
-
-    return required_terms, blob
+    return required_terms, optional_terms
 
 
 def get_marqo_root_from_env() -> str:

--- a/tests/core/vespa_index/test_add_documents_handler.py
+++ b/tests/core/vespa_index/test_add_documents_handler.py
@@ -315,7 +315,7 @@ class TestAddDocumentHandler(MarqoTestCase):
                 ])
         )
 
-        with self.assertRaises(InternalError) as context:
+        with self.assertRaisesStrict(InternalError) as context:
             handler.add_documents()
 
         self.assertEquals('Encountered problem when vectorising batch of documents. Reason: vectorise error',

--- a/tests/tensor_search/integ_tests/test_search_combined.py
+++ b/tests/tensor_search/integ_tests/test_search_combined.py
@@ -984,7 +984,7 @@ class TestSearch(MarqoTestCase):
             {"_id": "red_herring_3", "text_field_1": 'wrong"'}
         ]
         test_cases = [
-            ('1\\"2', ['doc1']),                        # Match off of '12"'
+            ('1\\"2', ['doc1']),                        # Match off of '1"2'
             ('"exact match"', ['doc2']),                # Match off of 'exact match'
             ('\\"escaped\\"', ['doc4', 'red_herring_2']),        # Match off of 'escaped' or '"escaped"'
             ('"exacto" wrong"', ['doc3']),       # Match properly off of 'wrong'

--- a/tests/tensor_search/integ_tests/test_search_combined.py
+++ b/tests/tensor_search/integ_tests/test_search_combined.py
@@ -988,6 +988,9 @@ class TestSearch(MarqoTestCase):
             ('"exact match"', ['doc2']),                # Match off of 'exact match'
             ('\\"escaped\\"', ['doc4', 'red_herring_2']),        # Match off of 'escaped' or '"escaped"'
             ('"exacto" wrong"', ['doc3']),       # Match properly off of 'wrong'
+            ('""', []),                          # Single quote should return no results (treated as whitespace)
+            ('"', []),                           # Double quote should return no results (treated as whitespace)
+            ('', [])                            # Empty string should return no results
         ]
 
         for index in [self.unstructured_default_text_index, self.structured_default_text_index]:

--- a/tests/tensor_search/integ_tests/test_search_combined.py
+++ b/tests/tensor_search/integ_tests/test_search_combined.py
@@ -966,3 +966,46 @@ class TestSearch(MarqoTestCase):
         # A special case for no search method provided
         search_query = SearchQuery(q="test")
         self.assertEqual(SearchMethod.TENSOR, search_query.searchMethod)
+
+    def test_lexical_search_DoesNotErrorWithEscapedQuotes(self):
+        """
+        Ensure that lexical search handles double quotes properly, both escaped and wrong quotes.
+        Expected behavior: escaped quotes are passed to vespa. Incorrect quotes are treated like whitespace.
+        """
+
+        docs_list = [
+            {"_id": "doc1", "text_field_1": '1"2'},
+            {"_id": "doc2", "text_field_1": 'exact match'},
+            {"_id": "doc3", "text_field_1": 'exacto wrong syntax'},
+            {"_id": "doc4", "text_field_1": '"escaped"'},
+
+            {"_id": "red_herring_1", "text_field_1": '12'},
+            {"_id": "red_herring_2", "text_field_1": 'escaped'},
+            {"_id": "red_herring_3", "text_field_1": 'wrong"'}
+        ]
+        test_cases = [
+            ('1\\"2', ['doc1']),                        # Match off of '12"'
+            ('"exact match"', ['doc2']),                # Match off of 'exact match'
+            ('\\"escaped\\"', ['doc4', 'red_herring_2']),        # Match off of 'escaped' or '"escaped"'
+            ('"exacto" wrong"', ['doc3']),       # Match properly off of 'wrong'
+        ]
+
+        for index in [self.unstructured_default_text_index, self.structured_default_text_index]:
+            with self.subTest(index=index.type):
+                tensor_search.add_documents(
+                    config=self.config,
+                    add_docs_params=AddDocsParams(
+                        index_name=index.name,
+                        docs=docs_list,
+                        tensor_fields=["text_field_1"] if isinstance(index, UnstructuredMarqoIndex) else None
+                    )
+                )
+
+                for query, expected_ids in test_cases:
+                    with self.subTest(query=query):
+                        res = tensor_search.search(
+                            text=query, config=self.config, index_name=index.name,
+                            search_method=SearchMethod.LEXICAL
+                        )
+                        self.assertEqual(len(expected_ids), len(res['hits']))
+                        self.assertEqual(set(expected_ids), {hit['_id'] for hit in res['hits']})

--- a/tests/tensor_search/test_utils.py
+++ b/tests/tensor_search/test_utils.py
@@ -234,9 +234,12 @@ class TestUtils(unittest.TestCase):
             ('', ([], [])),
             ('"cookie"', (["cookie"], [])),
             ('"朋友"', (["朋友"], [])),
-            ('"', ([], ['"'])),
-            ('"""hello', ([], ['"""hello'])),
-            ('""" python docstring appeared"""', ([], ['"""', 'python', 'docstring', 'appeared"""'])),
+
+            # Badly formatted double quotes.
+            # Treat every 2 as a pair, bad/unpaired quotes become whitespace.
+            ('"', ([], [])),
+            ('"""hello', ([], ['hello'])),
+            ('""" python docstring appeared"""', ([], ['python', 'docstring', 'appeared'])),
             ('""', ([''], [])),
             ('what about backticks `?', ([], ['what', 'about', 'backticks', '`?'])),
             (
@@ -245,19 +248,25 @@ class TestUtils(unittest.TestCase):
             ),
             ('\\"朋友\\"', ([], ['"朋友"'])),
             ('double  spaces  get  removed', ([], ['double', 'spaces', 'get', 'removed'])),
-            ('"go"od"', ([], ['"go"od"'])),
-            ('"ter"m1" term2', ([], ['"ter"m1"', 'term2'])),
-            ('"term1" "term2" "term3', ([], ['"term1"', '"term2"', '"term3'])),
-            ('"good', ([], ['"good'])),
-            ('"朋友', ([], ['"朋友'])),
+            ('"go"od"', ([], ['go', 'od'])),
+            ('"ter"m1" term2', ([], ['ter','m1', 'term2'])),
+            ('"term1" "term2" "term3', (['term1', 'term2'], ['term3'])),
+            ('"term1" "term2" "ter"m3', (['term1', 'term2'], ['ter', 'm3'])),
+            ('"term 1" "term "2 "term 3"', (['term 1', 'term 3'], ['term', '2'])),  # good syntax in between bad syntax
+            ('"good', ([], ['good'])),      # Unpaired quotes
+            ('"朋友', ([], ['朋友'])),
+            # Combination: good terms, bad terms (opening and closing), escaped quotes, spaces.
+            ('hello "term1" " term 2 " space b"adterm" "badte"rm "term \\"3" "unfinished',
+             (['term1', ' term 2 ', 'term "3'], ['hello', 'space', 'b', 'adterm', 'badte', 'rm', 'unfinished'])),
 
             # on Lucene, these unusual structures seem to get passed straight through as well.
             # The quotes seem to be completely ignored (with and without quotes yields identical results,
             # including scores):
-            ('"go"od" a"', ([], ['"go"od"', 'a"'])),
-            ('"sam"a', ([], ['"sam"a'])),
-            ('"sam"?', ([], ['"sam"?'])),
-            ('"朋友"你好', ([], ['"朋友"你好'])),
+            ('"go"od" a"', ([], ['go', 'od', 'a'])),
+            ('"sam"a', ([], ['sam', 'a'])),     # Good opening, bad closing
+            ('sa"ma" hello!', ([], ['sa', 'ma', 'hello!'])),    # Bad opening, good closing
+            ('"sam"?', ([], ['sam', '?'])),
+            ('"朋友"你好', ([], ['朋友', '你好'])),
 
         ]
         for input, expected_output in cases:

--- a/tests/tensor_search/test_utils.py
+++ b/tests/tensor_search/test_utils.py
@@ -223,7 +223,7 @@ class TestUtils(unittest.TestCase):
             ('just "a long long " string', (["a long long "], ['just', 'string'])),
             ('"required 1 " not required " required2" again',
              (["required 1 ", " required2"], ['not', 'required', 'again'])),
-            ('"just" "just" "" a string', (["just", "just", ""], ['a', 'string'])),
+            ('"just" "just" "" a string', (["just", "just"], ['a', 'string'])),
 
             ('朋友你好', ([], ['朋友你好'])),
             ('朋友 "你好"', (["你好"], ['朋友'])),
@@ -240,13 +240,13 @@ class TestUtils(unittest.TestCase):
             ('"', ([], [])),
             ('"""hello', ([], ['hello'])),
             ('""" python docstring appeared"""', ([], ['python', 'docstring', 'appeared'])),
-            ('""', ([''], [])),
+            ('""', ([], [])),
             ('what about backticks `?', ([], ['what', 'about', 'backticks', '`?'])),
             (
                 '\\" escaped quotes\\"  what happens here?',
-                ([], ['"', 'escaped', 'quotes"', 'what', 'happens', 'here?'])
+                ([], ['\\"', 'escaped', 'quotes\\"', 'what', 'happens', 'here?'])
             ),
-            ('\\"朋友\\"', ([], ['"朋友"'])),
+            ('\\"朋友\\"', ([], ['\\"朋友\\"'])),
             ('double  spaces  get  removed', ([], ['double', 'spaces', 'get', 'removed'])),
             ('"go"od"', ([], ['go', 'od'])),
             ('"ter"m1" term2', ([], ['ter','m1', 'term2'])),
@@ -257,7 +257,7 @@ class TestUtils(unittest.TestCase):
             ('"朋友', ([], ['朋友'])),
             # Combination: good terms, bad terms (opening and closing), escaped quotes, spaces.
             ('hello "term1" " term 2 " space b"adterm" "badte"rm "term \\"3" "unfinished',
-             (['term1', ' term 2 ', 'term "3'], ['hello', 'space', 'b', 'adterm', 'badte', 'rm', 'unfinished'])),
+             (['term1', ' term 2 ', 'term \\"3'], ['hello', 'space', 'b', 'adterm', 'badte', 'rm', 'unfinished'])),
 
             # on Lucene, these unusual structures seem to get passed straight through as well.
             # The quotes seem to be completely ignored (with and without quotes yields identical results,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
Any bad syntax with "" results in lexical search query being interpreted literally. The unescaped double quotes then cause a 400 from Vespa, resulting in a 500.

* **What is the new behavior (if this is a feature change)?**
Parser logic updated: Badly formatted double quotes are treated as whitespace, terms split by this will be optional. Always tries to interpret double quotes in pairs, from left to right.
```
'"term one" "term tw"o' --> required_terms = ['term one'], optional_terms = ['term', 'tw', 'o']
'"term one" "term two" "term three' --> required_terms = ['term one', 'term two'], optional_terms = ['term', 'three']
'"term on"e "term two" "term three" --> required_terms = ['term two', 'term three'], optional_terms = ['term', 'on', 'e']
'"ter"m on"e "term two" "term three" --> required_terms = [], optional_terms = ['ter', 'm', 'on', 'e', 'term', 'two', 'three']
```

Ecape character (`\\`) is no longer removed from optional and required terms, thus no longer cause a 400 from Vespa. 
* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No, these queries used to 500 anyway.

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
In progress

* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

