### PR TITLE
Use the lower case for field parse error translation

### DIFF
--- a/src/marqo/core/document/document.py
+++ b/src/marqo/core/document/document.py
@@ -233,7 +233,7 @@ class Document:
         elif status == 507:
             return 400, "Marqo vector store is out of memory or disk space"
         # TODO Block the invalid special characters before sending to Vespa
-        elif status == 400 and isinstance(message, str) and "could not parse field" in message:
+        elif status == 400 and isinstance(message, str) and "could not parse field" in message.lower():
             return 400, f"The document contains invalid characters in the fields. Original error: {message} "
         else:
             logger.error(f"An unexpected error occurred from the Vespa document response. "


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
We check if `"could not parse field"` in the raw returned message from Vespa and convert it to a 400 error.

* **What is the new behavior (if this is a feature change)?**
We check if `"could not parse field"` in the returned message in lower case from Vespa and convert it to a 400 error.
Latest vespa change `could` to `Could` so we also need to modify our string matching method.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Have unit tests been run against this PR?** (Has there also been any additional testing?)


* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

