### PR TITLE
Fix the api tests by emptying the index cache after updating the index

### DIFF
--- a/src/marqo/core/embed/embed.py
+++ b/src/marqo/core/embed/embed.py
@@ -72,7 +72,7 @@ class Embed:
 
         # Generate input for the vectorise pipeline (Preprocessing)
         RequestMetricsStore.for_request().start("embed.query_preprocessing")
-        marqo_index = index_meta_cache.get_index(config=temp_config, index_name=index_name)
+        marqo_index = index_meta_cache.get_index(index_management=temp_config.index_management, index_name=index_name)
 
         # Transform content to list if it is not already
         if isinstance(content, List):

--- a/src/marqo/core/search/hybrid_search.py
+++ b/src/marqo/core/search/hybrid_search.py
@@ -82,7 +82,7 @@ class HybridSearch:
 
         RequestMetricsStore.for_request().start("search.hybrid.processing_before_vespa")
 
-        marqo_index = index_meta_cache.get_index(config=config, index_name=index_name)
+        marqo_index = index_meta_cache.get_index(index_management=config.index_management, index_name=index_name)
 
         # Version checks (different for structured and unstructured)
         marqo_index_version = marqo_index.parsed_marqo_version()

--- a/src/marqo/core/search/recommender.py
+++ b/src/marqo/core/search/recommender.py
@@ -80,7 +80,7 @@ class Recommender:
         if len(documents) == 0:
             raise InvalidArgumentError('No documents with non-zero weight provided')
 
-        marqo_index = index_meta_cache.get_index(config.Config(self.vespa_client), index_name=index_name)
+        marqo_index = index_meta_cache.get_index(index_management=self.index_management, index_name=index_name)
 
         if interpolation_method is None:
             interpolation_method = self._get_default_interpolation_method(marqo_index)

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_add_document_handler.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_add_document_handler.py
@@ -66,6 +66,11 @@ class SemiStructuredAddDocumentsHandler(UnstructuredAddDocumentsHandler):
         if self.should_update_index:
             with RequestMetricsStore.for_request().time("add_documents.update_index"):
                 self.index_management.update_index(self.marqo_index)
+            # Empty the index cache so the latest version can be loaded
+            # TODO this is temporary solution to fix the consistency issue for single instance Marqo (used extensively
+            #   in api-tests and integration tests). Find a better way to solve consistency issue for Marqo clusters
+            from marqo.tensor_search import index_meta_cache
+            index_meta_cache.empty_cache()
 
     def _add_lexical_field_to_index(self, field_name):
         if field_name in self.marqo_index.field_map:

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_add_document_handler.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_add_document_handler.py
@@ -66,11 +66,11 @@ class SemiStructuredAddDocumentsHandler(UnstructuredAddDocumentsHandler):
         if self.should_update_index:
             with RequestMetricsStore.for_request().time("add_documents.update_index"):
                 self.index_management.update_index(self.marqo_index)
-            # Empty the index cache so the latest version can be loaded
-            # TODO this is temporary solution to fix the consistency issue for single instance Marqo (used extensively
+            # Force fresh this index in the index cache to make sure the following search requests get the latest index
+            # TODO this is a temporary solution to fix the consistency issue for single instance Marqo (used extensively
             #   in api-tests and integration tests). Find a better way to solve consistency issue for Marqo clusters
             from marqo.tensor_search import index_meta_cache
-            index_meta_cache.empty_cache()
+            index_meta_cache.get_index(self.index_management, self.marqo_index.name, force_refresh=True)
 
     def _add_lexical_field_to_index(self, field_name):
         if field_name in self.marqo_index.field_map:

--- a/src/marqo/s2_inference/multimodal_model_load.py
+++ b/src/marqo/s2_inference/multimodal_model_load.py
@@ -126,7 +126,7 @@ class DefaultEncoder(ModelEncoder):
         self.model = model
 
     def encode(self, content, modality, **kwargs):
-        return self.model.encode(content)
+        return self.model.encode(content, **kwargs)
 
 
 @contextmanager

--- a/src/marqo/tensor_search/index_meta_cache.py
+++ b/src/marqo/tensor_search/index_meta_cache.py
@@ -5,7 +5,7 @@ index in the search DB via a plugin.
 """
 import threading
 import time
-from typing import Dict
+from typing import Dict, Optional
 
 from marqo import marqo_docs
 from marqo.api import exceptions
@@ -41,22 +41,27 @@ def get_cache() -> Dict[str, MarqoIndex]:
     return index_info_cache
 
 
-def get_index(config: Config, index_name: str, force_refresh=False) -> MarqoIndex:
+def get_index(index_management: IndexManagement, index_name: str, force_refresh=False) -> MarqoIndex:
     """
     Get an index.
 
     Args:
+        index_management: IndexManagement object to load the index if not found in cache
+        index_name (str): Name of the index to retrieve.
         force_refresh: Get index from Vespa even if already in cache. If False, Vespa is called only if index is not
         found in cache.
 
     Returns:
+        The latest index if the index is not found in cache or force_refresh flag is True. Otherwise, the cached index
 
+    Raises:
+        IndexNotFoundError: If index is not found in cache.
     """
     # Make sure refresh thread is running
-    _check_refresh_thread(config)
+    _check_refresh_thread(index_management)
 
     if force_refresh or index_name not in index_info_cache:
-        _refresh_index(config, index_name)
+        _refresh_index(index_management, index_name)
 
     if index_name in index_info_cache:
         return index_info_cache[index_name]
@@ -65,11 +70,10 @@ def get_index(config: Config, index_name: str, force_refresh=False) -> MarqoInde
     raise exceptions.IndexNotFoundError(f"Index {index_name} not found")
 
 
-def _refresh_index(config: Config, index_name: str) -> None:
+def _refresh_index(index_management: IndexManagement, index_name: str) -> None:
     """
     Refresh cache for a specific index
     """
-    index_management = IndexManagement(config.vespa_client)
     try:
         index = index_management.get_index(index_name)
     except IndexNotFoundError as e:
@@ -78,7 +82,7 @@ def _refresh_index(config: Config, index_name: str) -> None:
     index_info_cache[index_name] = index
 
 
-def _check_refresh_thread(config: Config):
+def _check_refresh_thread(index_management: IndexManagement):
     if refresh_lock.locked():
         # Another thread is running this function, skip as concurrent changes to the thread can error out
         logger.debug('Refresh thread is locked. Skipping')
@@ -98,7 +102,7 @@ def _check_refresh_thread(config: Config):
                     try:
                         global cache_refresh_last_logged_time
 
-                        populate_cache(config)
+                        populate_cache(index_management)
 
                         if time.time() - cache_refresh_last_logged_time > cache_refresh_log_interval:
                             cache_refresh_last_logged_time = time.time()
@@ -126,15 +130,14 @@ def _check_refresh_thread(config: Config):
 
 
 def start_refresh_thread(config: Config):
-    _check_refresh_thread(config)
+    _check_refresh_thread(config.index_management)
 
 
-def populate_cache(config: Config):
+def populate_cache(index_management: IndexManagement):
     """
     Refresh cache for all indexes
     """
     global index_info_cache
-    index_management = IndexManagement(config.vespa_client)
     indexes = index_management.get_all_indexes()
 
     # Enable caching and reset any existing model caches

--- a/src/marqo/tensor_search/index_meta_cache.py
+++ b/src/marqo/tensor_search/index_meta_cache.py
@@ -5,7 +5,7 @@ index in the search DB via a plugin.
 """
 import threading
 import time
-from typing import Dict, Optional
+from typing import Dict
 
 from marqo import marqo_docs
 from marqo.api import exceptions

--- a/src/marqo/tensor_search/index_meta_cache.py
+++ b/src/marqo/tensor_search/index_meta_cache.py
@@ -25,7 +25,7 @@ index_info_cache = dict()
 # Because it is non thread safe, there is a chance multiple threads push out
 # multiple refresh requests at the same. It isn't a critical problem if that
 # happens.
-cache_refresh_interval: int = 10  # seconds
+cache_refresh_interval: int = 1  # seconds
 cache_refresh_log_interval: int = 60
 cache_refresh_last_logged_time: float = 0
 refresh_thread = None

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -110,7 +110,7 @@ def add_documents(config: Config, add_docs_params: AddDocsParams) -> MarqoAddDoc
     """
     try:
         marqo_index = index_meta_cache.get_index(
-            config=config, index_name=add_docs_params.index_name, force_refresh=True
+            index_management=config.index_management, index_name=add_docs_params.index_name, force_refresh=True
         )
 
     # TODO: raise core_exceptions.IndexNotFoundError instead (fix associated tests)
@@ -1405,7 +1405,7 @@ def _get_latest_index(config: Config, index_name: str) -> MarqoIndex:
     never change. It also makes sure we always get the latest version of semi-structured index to guarantee the strong
     consistency.
     """
-    marqo_index = index_meta_cache.get_index(config=config, index_name=index_name)
+    marqo_index = index_meta_cache.get_index(index_management=config.index_management, index_name=index_name)
     if marqo_index.type == IndexType.SemiStructured:
         return config.index_management.get_index(index_name=index_name)
     return marqo_index
@@ -1677,7 +1677,7 @@ def _lexical_search(
             f"Query arg must be of type str! text arg is of type {type(text)}. "
             f"Query arg: {text}")
 
-    marqo_index = index_meta_cache.get_index(config=config, index_name=index_name)
+    marqo_index = index_meta_cache.get_index(index_management=config.index_management, index_name=index_name)
 
     # SEARCH TIMER-LOGGER (pre-processing)
     RequestMetricsStore.for_request().start("search.lexical.processing_before_vespa")
@@ -2136,7 +2136,7 @@ def _vector_text_search(
 
     RequestMetricsStore.for_request().start("search.vector.processing_before_vespa")
 
-    marqo_index = index_meta_cache.get_index(config=config, index_name=index_name)
+    marqo_index = index_meta_cache.get_index(index_management=config.index_management, index_name=index_name)
 
     # Determine the text query prefix
     text_query_prefix = marqo_index.model.get_text_query_prefix(text_query_prefix)
@@ -2699,7 +2699,7 @@ def vectorise_multimodal_combination_field_structured(
 def delete_documents(config: Config, index_name: str, doc_ids: List[str]):
     """Delete documents from the Marqo index with the given doc_ids """
     # Make sure the index exists
-    marqo_index = index_meta_cache.get_index(config=config, index_name=index_name)
+    marqo_index = index_meta_cache.get_index(index_management=config.index_management, index_name=index_name)
 
     return delete_docs.delete_documents(
         config=config,

--- a/tests/core/document/test_partial_document_update.py
+++ b/tests/core/document/test_partial_document_update.py
@@ -133,7 +133,7 @@ class TestUpdate(MarqoTestCase):
             "text_field_tensor": "text field tensor",
             "_id": "1"
         }
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.structured_index_name,
             docs=[original_doc]
         ))
@@ -149,7 +149,7 @@ class TestUpdate(MarqoTestCase):
             "text_field_tensor": "text field tensor",
             "_id": "1"
         }
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.structured_index_name,
             docs=[original_doc]
         ))
@@ -165,7 +165,7 @@ class TestUpdate(MarqoTestCase):
             "text_field_tensor": "text field tensor",
             "_id": "1"
         }
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.structured_index_name,
             docs=[original_doc]
         ))
@@ -369,7 +369,7 @@ class TestUpdate(MarqoTestCase):
             "text_field_tensor": "search me",
             "_id": "1"
         }
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.structured_index_name,
             docs=[original_doc]
         ))
@@ -402,7 +402,7 @@ class TestUpdate(MarqoTestCase):
             "text_field_tensor": "search me",
             "_id": "1"
         }
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.structured_index_name,
             docs=[original_doc]
         ))
@@ -455,7 +455,7 @@ class TestUpdate(MarqoTestCase):
                     mappings = None
 
                 # Add the original document
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index_name,
@@ -470,7 +470,7 @@ class TestUpdate(MarqoTestCase):
                     "_id": "1",
                     "image_field_1": updated_image_url
                 }
-                r = self.add_documents_and_refresh_index(
+                r = self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index_name,
@@ -506,7 +506,7 @@ class TestUpdate(MarqoTestCase):
             "dependent_field_2": "dependent field 2",
             "_id": "1"
         }
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.structured_index_name,
             docs=[original_doc]
         ))
@@ -529,7 +529,7 @@ class TestUpdate(MarqoTestCase):
             "text_field_tensor": "search me",
             "_id": "1"
         }
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.structured_index_name,
             docs=[original_doc]
         ))
@@ -657,7 +657,7 @@ class TestUpdate(MarqoTestCase):
             "_id": "1"
         }
 
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.structured_index_name,
             docs=[original_document]
         ))
@@ -733,7 +733,7 @@ class TestUpdate(MarqoTestCase):
         original_document["text_field_tensor"] = "text field tensor"
         original_document["_id"] = "1"
 
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.large_score_modifier_index_name,
             docs=[original_document]
         ))

--- a/tests/core/monitoring/test_monitoring.py
+++ b/tests/core/monitoring/test_monitoring.py
@@ -155,7 +155,7 @@ class TestMonitoring(MarqoTestCase):
         """
         for marqo_index in self.indexes_to_test:
             with self.subTest(f'{marqo_index.name} - {marqo_index.type.value}'):
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         docs=[{"title": "2"}, {"title": "2"}, {"title": "62"}],
                         index_name=marqo_index.name,
@@ -177,7 +177,7 @@ class TestMonitoring(MarqoTestCase):
         get_index_stats returns the correct stats for a multimodal index
         """
         marqo_index = self.structured_index_multimodal
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 docs=[
                     {"title": "2",
@@ -205,7 +205,7 @@ class TestMonitoring(MarqoTestCase):
         """
         for marqo_index in self.indexes_to_test:
             with self.subTest(f'{marqo_index.name} - {marqo_index.type.value}'):
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         docs=[{"desc": "2"}, {"desc": "2"}, {"desc": "62"}],
                         index_name=marqo_index.name,
@@ -228,7 +228,7 @@ class TestMonitoring(MarqoTestCase):
         """
         for marqo_index in self.indexes_to_test:
             with self.subTest(f'{marqo_index.name} - {marqo_index.type.value}'):
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         docs=[{"title": "2"}, {"title": "2"}, {"desc": "62"}],
                         index_name=marqo_index.name,
@@ -281,7 +281,7 @@ class TestMonitoring(MarqoTestCase):
             with self.subTest(f'{marqo_index.name} - {marqo_index.type.value}'):
                 for operation, docs, expected_stats in operations:
                     if operation == 'add':
-                        self.add_documents_and_refresh_index(
+                        self.add_documents(
                             config=self.config, add_docs_params=AddDocsParams(
                                 docs=docs,
                                 index_name=marqo_index.name,
@@ -309,7 +309,7 @@ class TestMonitoring(MarqoTestCase):
 
         for marqo_index in self.indexes_to_test:
             with self.subTest(f'{marqo_index.name} - {marqo_index.type.value}'):
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         docs=[{"title": "test " * number_of_words}, {"title": "2"}],  # 3 + 1 vectors expected
                         index_name=marqo_index.name,
@@ -332,7 +332,7 @@ class TestMonitoring(MarqoTestCase):
         """
         for marqo_index in self.indexes_to_test:
             with self.subTest(f'{marqo_index.name} - {marqo_index.type.value}'):
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         docs=[{"title": "2"}, {"title": "2"}, {"title": "62"}],
                         index_name=marqo_index.name,

--- a/tests/core/search/test_recommender.py
+++ b/tests/core/search/test_recommender.py
@@ -159,7 +159,7 @@ class TestRecommender(MarqoTestCase):
         else:
             tensor_fields = None
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             self.config,
             add_docs_params=AddDocsParams(
                 index_name=index.name,
@@ -354,7 +354,7 @@ class TestRecommender(MarqoTestCase):
             }
         ]
         index = self.unstructured_text_index
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             self.config,
             add_docs_params=AddDocsParams(
                 index_name=index.name,

--- a/tests/marqo_test.py
+++ b/tests/marqo_test.py
@@ -84,11 +84,9 @@ class MarqoTestCase(unittest.TestCase):
         return indexes
 
     @classmethod
-    def add_documents_and_refresh_index(cls, *args, **kwargs):
-        index_name = kwargs['add_docs_params'].index_name
-        result = tensor_search.add_documents(*args, **kwargs)
-        index_meta_cache.get_index(config=cls.config, index_name=index_name, force_refresh=True)
-        return result
+    def add_documents(cls, *args, **kwargs):
+        # TODO change to use config.document.add_documents when tensor_search.add_documents is removed
+        return tensor_search.add_documents(*args, **kwargs)
 
     def setUp(self) -> None:
         self.clear_indexes(self.indexes)

--- a/tests/s2_inference/test_generic_clip_model.py
+++ b/tests/s2_inference/test_generic_clip_model.py
@@ -72,9 +72,9 @@ class TestGenericModelSupport(MarqoTestCase):
                 "desc 2": "content 2. blah blah blah"
             }]
 
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_1, docs=docs, device="cpu")
-                                             )
+                           )
 
         # test if we can get the document by _id
         assert tensor_search.get_document_by_id(
@@ -93,7 +93,7 @@ class TestGenericModelSupport(MarqoTestCase):
                 "desc 2": "test again test again test again"
             }]
 
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_1, docs=docs2, device="cpu"))
 
         assert tensor_search.get_document_by_id(
@@ -138,7 +138,7 @@ class TestGenericModelSupport(MarqoTestCase):
                 "desc 2": "content 2. blah blah blah"
             }]
 
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_2, docs=docs, device="cpu"
         ))
 
@@ -157,7 +157,7 @@ class TestGenericModelSupport(MarqoTestCase):
                 "desc 2": "test again test again test again"
             }]
 
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_2, docs=docs2, device="cpu"))
 
         assert tensor_search.get_document_by_id(
@@ -205,7 +205,7 @@ class TestGenericModelSupport(MarqoTestCase):
                 "desc 2": "content 2. blah blah blah"
             }]
 
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_1, docs=docs, device="cpu"))
 
         assert tensor_search.get_document_by_id(
@@ -223,7 +223,7 @@ class TestGenericModelSupport(MarqoTestCase):
                 "desc 2": "test again test again test again"
             }]
 
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_1, docs=docs2, device="cpu"))
 
         assert tensor_search.get_document_by_id(
@@ -326,7 +326,7 @@ class TestGenericModelSupport(MarqoTestCase):
                 "image" : TestImageUrls.COCO.value
             }]
 
-        self.add_documents_and_refresh_index(config=config, add_docs_params=AddDocsParams(
+        self.add_documents(config=config, add_docs_params=AddDocsParams(
             index_name=index_name, docs=docs, device="cpu"))
 
 

--- a/tests/s2_inference/test_generic_model.py
+++ b/tests/s2_inference/test_generic_model.py
@@ -93,7 +93,7 @@ class TestGenericModelSupport(MarqoTestCase):
                 "desc 2": "content 2. blah blah blah"
             }]
 
-        self.add_documents_and_refresh_index(config=config, add_docs_params=AddDocsParams(
+        self.add_documents(config=config, add_docs_params=AddDocsParams(
             index_name=index_name, docs=docs, device="cpu"))
 
     def test_validate_model_properties_missing_required_keys(self):

--- a/tests/tensor_search/backwards_compat/test_search_regression.py
+++ b/tests/tensor_search/backwards_compat/test_search_regression.py
@@ -115,7 +115,7 @@ class TestSearchRegression(MarqoTestCase):
                     docs_with_same_bm25_score.append(("doc7", "doc11"))
 
                 # Add documents
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -163,7 +163,7 @@ class TestSearchRegression(MarqoTestCase):
         for index in [self.structured_text_index_score_modifiers, self.unstructured_text_index]:
             with self.subTest(index=index.name):
                 # Add documents
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,

--- a/tests/tensor_search/integ_tests/test_add_documents_combined.py
+++ b/tests/tensor_search/integ_tests/test_add_documents_combined.py
@@ -164,7 +164,7 @@ class TestAddDocumentsCombined(MarqoTestCase):
             tensor_fields = ["image_field_1", "text_field_1"] if index_name != self.structured_marqo_index_name \
                 else None
             with self.subTest(f"test add documents with truncated image for {index_name}"):
-                r = self.add_documents_and_refresh_index(
+                r = self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index_name,
@@ -193,7 +193,7 @@ class TestAddDocumentsCombined(MarqoTestCase):
                 else None
             with self.subTest(index_name):
                 with patch("marqo.s2_inference.s2_inference.vectorise", return_value=dummy_return) as mock_vectorise:
-                    r = self.add_documents_and_refresh_index(
+                    r = self.add_documents(
                         config=self.config,
                         add_docs_params=AddDocsParams(
                             index_name=index_name,
@@ -231,7 +231,7 @@ class TestAddDocumentsCombined(MarqoTestCase):
         for index_name in [self.structured_languagebind_index_name, self.semi_structured_languagebind_index_name,
                            self.unstructured_languagebind_index_name]:
             with self.subTest(index_name):
-                res = self.add_documents_and_refresh_index(
+                res = self.add_documents(
                     self.config,
                     add_docs_params=AddDocsParams(
                         docs=documents,
@@ -297,7 +297,7 @@ class TestAddDocumentsCombined(MarqoTestCase):
                     },
                 }
             } if "unstructured" in index_name else None
-            res = self.add_documents_and_refresh_index(
+            res = self.add_documents(
                 self.config,
                 add_docs_params=AddDocsParams(
                     docs=multimodal_document,
@@ -340,7 +340,7 @@ class TestAddDocumentsCombined(MarqoTestCase):
                 with patch("marqo.s2_inference.clip_utils.requests.get", side_effect=error) \
                         as mock_requests_get:
                     with self.assertRaises(Exception) as e:
-                        r = self.add_documents_and_refresh_index(
+                        r = self.add_documents(
                             config=self.config,
                             add_docs_params=AddDocsParams(
                                 index_name=index_name,
@@ -364,7 +364,7 @@ class TestAddDocumentsCombined(MarqoTestCase):
                 else None
             with self.subTest(index_name):
                 with patch("marqo.s2_inference.s2_inference.vectorise", return_value=dummy_return) as mock_vectorise:
-                    r = self.add_documents_and_refresh_index(
+                    r = self.add_documents(
                         config=self.config,
                         add_docs_params=AddDocsParams(
                             index_name=index_name,
@@ -398,7 +398,7 @@ class TestAddDocumentsCombined(MarqoTestCase):
                             add_docs, 'threaded_download_and_preprocess_content',
                             wraps=add_docs.threaded_download_and_preprocess_content
                     ) as mock_download_images:
-                        self.add_documents_and_refresh_index(
+                        self.add_documents(
                             config=self.config, add_docs_params=AddDocsParams(
                                 index_name=index_name, docs=docs, device="cpu",
                                 image_download_thread_count=thread_count,
@@ -422,7 +422,7 @@ class TestAddDocumentsCombined(MarqoTestCase):
             tensor_fields = ["image_field_1"] if index_name != self.structured_marqo_index_name \
                 else None
             with self.subTest(index_name):
-                res = self.add_documents_and_refresh_index(
+                res = self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index_name,
@@ -481,7 +481,7 @@ class TestAddDocumentsCombined(MarqoTestCase):
                     tensor_fields = None
                     mappings = None
 
-                res = self.add_documents_and_refresh_index(
+                res = self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index_name,
@@ -606,7 +606,7 @@ class TestAddDocumentsCombined(MarqoTestCase):
             with self.subTest(index_name):
                 for docs, expected_results in docs_results:
                     with self.subTest(f'{expected_results} - {index_name}'):
-                        add_res = self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+                        add_res = self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                             index_name=index_name, docs=docs, device="cpu", tensor_fields=tensor_fields)).dict(
                             exclude_none=True, by_alias=True)
                         self.assertEqual(len(expected_results), len(add_res['items']))
@@ -754,7 +754,7 @@ class TestAddDocumentsCombined(MarqoTestCase):
             tensor_fields = ["image_field_1", "text_field_1"] if index_name != self.structured_marqo_index_name \
                 else None
             with self.subTest(index_name):
-                r = self.add_documents_and_refresh_index(
+                r = self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index_name,
@@ -897,7 +897,7 @@ class TestAddDocumentsCombined(MarqoTestCase):
                 if isinstance(index, UnstructuredMarqoIndex) else None
 
             def add_docs(batch_vectorisation_mode: BatchVectorisationMode):
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,

--- a/tests/tensor_search/integ_tests/test_add_documents_semi_structured.py
+++ b/tests/tensor_search/integ_tests/test_add_documents_semi_structured.py
@@ -74,7 +74,7 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
         ]
         for index_name, desc in tests:
             with self.subTest(desc):
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=self.default_text_index,
                         docs=[{
@@ -103,7 +103,7 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
         """
 
         # Add once to get vectors
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index, docs=[{
@@ -117,7 +117,7 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
             config=self.config, index_name=self.default_text_index,
             document_id="1", show_vectors=True)['_tensor_facets']
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index, docs=[
@@ -129,7 +129,7 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
                 device="cpu", tensor_fields=["title"]
             )
         )
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index, docs=[
@@ -157,7 +157,7 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
         rand_index = 'a' + str(uuid.uuid4()).replace('-', '')
 
         with pytest.raises(IndexNotFoundError):
-            self.add_documents_and_refresh_index(
+            self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(
                     index_name=rand_index, docs=[{"abc": "def"}], device="cpu"
                 )
@@ -176,7 +176,7 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
             {"title": "\r\r"},
             {"title": "\r\t\n"},
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.default_text_index, docs=docs, device="cpu", tensor_fields=[]
             )
@@ -188,7 +188,7 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
         assert count == len(docs)
 
     def test_add_docs_response_format(self):
-        add_res = self.add_documents_and_refresh_index(
+        add_res = self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
                 docs=[
@@ -252,7 +252,7 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
         for use_existing_tensors_flag in (True, False):
             for bad_doc_arg in bad_doc_args:
                 with self.subTest(msg=f'{bad_doc_arg} - use_existing_tensors={use_existing_tensors_flag}'):
-                    add_res = self.add_documents_and_refresh_index(
+                    add_res = self.add_documents(
                         config=self.config, add_docs_params=AddDocsParams(
                             index_name=self.default_text_index, docs=bad_doc_arg,
                             use_existing_tensors=use_existing_tensors_flag, device="cpu",
@@ -285,7 +285,7 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
         for use_existing_tensors_flag in (True, False):
             for bad_doc_arg in bad_doc_args:
                 with self.subTest(f'{bad_doc_arg} - use_existing_tensors={use_existing_tensors_flag}'):
-                    add_res = self.add_documents_and_refresh_index(
+                    add_res = self.add_documents(
                         config=self.config, add_docs_params=AddDocsParams(
                             index_name=self.default_text_index, docs=bad_doc_arg[0],
                             use_existing_tensors=use_existing_tensors_flag, device="cpu", tensor_fields=["title"]
@@ -307,7 +307,7 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
             [{"_id": "to_fail_123", "tags": ["wow", "this", "is"]}]
         ]
         for bad_doc_arg in good_docs:
-            add_res = self.add_documents_and_refresh_index(
+            add_res = self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(
                     index_name=self.default_text_index,
                     docs=bad_doc_arg,
@@ -327,7 +327,7 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
         bad_doc_args = self.tags_
         for bad_doc_arg in bad_doc_args:
             with self.subTest(bad_doc_arg):
-                add_res = self.add_documents_and_refresh_index(
+                add_res = self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=self.default_text_index,
                         docs=bad_doc_arg,
@@ -347,7 +347,7 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
 
         @mock.patch("marqo.s2_inference.s2_inference.vectorise", mock_vectorise)
         def run():
-            self.add_documents_and_refresh_index(
+            self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(
                     index_name=self.default_text_index, device="cuda:22", docs=[{"title": "doc"}, {"title": "doc"}],
                     tensor_fields=["title"]
@@ -364,7 +364,7 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
         Adding empty documents raises BadRequestError
         """
         try:
-            self.add_documents_and_refresh_index(
+            self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(
                     index_name=self.default_text_index, docs=[],
                     device="cpu")
@@ -383,8 +383,8 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
         ]
 
         with mock.patch('PIL.Image.open') as mock_image_open:
-            self.add_documents_and_refresh_index(config=self.config,
-                                                 add_docs_params=AddDocsParams(
+            self.add_documents(config=self.config,
+                               add_docs_params=AddDocsParams(
                                             index_name=self.default_image_index, docs=docs,
                                             device="cpu", tensor_fields=["title"]
                                         ))
@@ -433,7 +433,7 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
         ]
         for docs, expected_results in docs_results:
             with self.subTest(f'{expected_results}'):
-                add_res = self.add_documents_and_refresh_index(
+                add_res = self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=self.default_text_index, docs=docs,
                         device="cpu", tensor_fields=[]
@@ -450,7 +450,7 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
     def test_add_document_with_tensor_fields(self):
         """Ensure tensor_fields only works for title but not desc"""
         docs_ = [{"_id": "789", "title": "Story of Alice Appleseed", "desc": "Alice grew up in Houston, Texas."}]
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.default_text_index, docs=docs_, device="cpu", tensor_fields=["title"]
         ))
         resp = tensor_search.get_document_by_id(config=self.config,
@@ -468,7 +468,7 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
 
         @mock.patch.dict(os.environ, {**os.environ, **mock_environ})
         def run():
-            update_res = self.add_documents_and_refresh_index(
+            update_res = self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(
                     index_name=self.default_text_index, docs=[
                         {"_id": "123", 'desc': "edf " * (max_size // 4)},
@@ -493,7 +493,7 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
 
         @mock.patch.dict(os.environ, {**os.environ, **mock_environ})
         def run():
-            update_res = self.add_documents_and_refresh_index(
+            update_res = self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(
                     index_name=self.default_text_index, docs=[
                         {"_id": "123", 'desc': "edf " * (max_size // 4)},
@@ -516,7 +516,7 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
         for env_dict in [dict()]:
             @mock.patch.dict(os.environ, {**os.environ, **env_dict})
             def run():
-                update_res = self.add_documents_and_refresh_index(
+                update_res = self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=self.default_text_index, docs=[
                             {"_id": "123", 'desc': "Some content"},
@@ -536,13 +536,13 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
         If a document is re-indexed with a tensor field removed, the vectors are removed
         """
         # test replace and update workflows
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             self.config, add_docs_params=AddDocsParams(
                 docs=[{"_id": "123", "title": "mydata", "desc": "mydata2"}],
                 index_name=self.default_text_index, device="cpu", tensor_fields=["title"]
             )
         )
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             self.config,
             add_docs_params=AddDocsParams(
                 docs=[{"_id": "123", "desc": "mydata"}],
@@ -572,7 +572,7 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
 
                 if error:
                     with self.assertRaises(BadRequestError):
-                        self.add_documents_and_refresh_index(
+                        self.add_documents(
                             config=self.config, add_docs_params=AddDocsParams(
                                 index_name=self.default_text_index,
                                 docs=[{
@@ -584,7 +584,7 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
                         )
                 else:
                     self.assertEqual(False,
-                                     self.add_documents_and_refresh_index(
+                                     self.add_documents(
                                          config=self.config, add_docs_params=AddDocsParams(
                                              index_name=self.default_text_index,
                                              docs=[{
@@ -600,7 +600,7 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
         """
         If a document is indexed with no tensor fields on an empty index, no vectors are added
         """
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             self.config, add_docs_params=AddDocsParams(
                 docs=[{"_id": "123", "desc": "mydata"}],
                 index_name=self.default_text_index,
@@ -616,7 +616,7 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
         """
         If a document is indexed with a tensor field vectors are added for the tensor field
         """
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             self.config, add_docs_params=AddDocsParams(
                 docs=[{"_id": "123", "title": "mydata", "desc": "mydata"}],
                 index_name=self.default_text_index, tensor_fields=["title"],
@@ -661,7 +661,7 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
         for c in doc_counts:
             self.clear_index_by_name(self.image_index_with_random_model)
 
-            res1 = self.add_documents_and_refresh_index(
+            res1 = self.add_documents(
                 self.config,
                 add_docs_params=AddDocsParams(
                     docs=[{"_id": str(doc_num),
@@ -690,7 +690,7 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
         for tensor_fields, error_message, msg in test_cases:
             with self.subTest(msg):
                 with self.assertRaises(BadRequestError) as e:
-                    self.add_documents_and_refresh_index(
+                    self.add_documents(
                         config=self.config,
                         add_docs_params=AddDocsParams(index_name=self.default_text_index,
                                                       docs=[{"some": "data"}], **tensor_fields))
@@ -715,7 +715,7 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
 
         for doc, error in test_case:
             with self.subTest():
-                res = self.add_documents_and_refresh_index(
+                res = self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=self.default_text_index, docs=[doc], device="cpu",
                         tensor_fields=[]
@@ -741,8 +741,8 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
         for documents, number_of_docs, msg in test_cases:
             self.clear_index_by_name(self.default_text_index)
             with self.subTest(msg):
-                r = self.add_documents_and_refresh_index(config=self.config,
-                                                         add_docs_params=AddDocsParams(
+                r = self.add_documents(config=self.config,
+                                       add_docs_params=AddDocsParams(
                                                     index_name=self.default_text_index, docs=documents,
                                                     device="cpu", tensor_fields=["text_field"]
                                                 )).dict(exclude_none=True, by_alias=True)

--- a/tests/tensor_search/integ_tests/test_add_documents_semi_structured_add_fields.py
+++ b/tests/tensor_search/integ_tests/test_add_documents_semi_structured_add_fields.py
@@ -63,7 +63,7 @@ class TestAddDocumentsSemiStructuredAddFields(MarqoTestCase):
         self.device_patcher.stop()
 
     def _add_and_get_doc(self, index_name: str, doc_id: str, tensor_fields: List[str], use_existing_tensors=False):
-        add_doc_result = self.add_documents_and_refresh_index(
+        add_doc_result = self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=index_name,
                 docs=[{
@@ -139,7 +139,7 @@ class TestAddDocumentsSemiStructuredAddFields(MarqoTestCase):
         self.assertEqual(1, len(res['hits']))
 
     def test_add_documents_should_add_custom_vector_field_content_as_lexical_fields(self):
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.text_index_3,
                 docs=[{
@@ -168,7 +168,7 @@ class TestAddDocumentsSemiStructuredAddFields(MarqoTestCase):
         self.assertIn('marqo__lexical_custom_vector_field', updated_index.lexical_field_map.keys())
 
     def test_add_documents_should_add_image_field_as_lexical_fields(self):
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.image_index_with_chunking,
                 docs=[{
@@ -193,7 +193,7 @@ class TestAddDocumentsSemiStructuredAddFields(MarqoTestCase):
         self.assertIn('marqo__lexical_image_field', updated_index.lexical_field_map.keys())
 
     def test_add_documents_should_add_multimodal_subfield_as_lexical_fields(self):
-        add_doc_result = self.add_documents_and_refresh_index(
+        add_doc_result = self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.text_index_4,
                 docs=[{
@@ -291,8 +291,6 @@ class TestAddDocumentsSemiStructuredAddFields(MarqoTestCase):
                 device="cpu", tensor_fields=["title"],
             )
         )
-
-        index_meta_cache.get_index(config=self.config, index_name=self.text_index_5, force_refresh=True)
 
         res = tensor_search.search(
             text="content", search_method=SearchMethod.TENSOR,

--- a/tests/tensor_search/integ_tests/test_add_documents_structured.py
+++ b/tests/tensor_search/integ_tests/test_add_documents_structured.py
@@ -196,7 +196,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
         ]
         for index_name, desc in tests:
             with self.subTest(desc):
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=index_name,
                         docs=[{
@@ -248,7 +248,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
         for index_name, desc in test_indexes:
             for test_case in test_cases:
                 with self.subTest(test_case[0] + ' - ' + desc):
-                    self.add_documents_and_refresh_index(
+                    self.add_documents(
                         config=self.config, add_docs_params=AddDocsParams(
                             index_name=index_name,
                             docs=[
@@ -271,7 +271,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
         """
 
         # Add once to get vectors
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.index_name_1, docs=[{
@@ -285,7 +285,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
             config=self.config, index_name=self.index_name_1,
             document_id="1", show_vectors=True)['_tensor_facets']
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.index_name_1, docs=[
@@ -297,7 +297,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
                 device="cpu"
             )
         )
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.index_name_1, docs=[
@@ -325,7 +325,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
         rand_index = 'a' + str(uuid.uuid4()).replace('-', '')
 
         with pytest.raises(IndexNotFoundError):
-            self.add_documents_and_refresh_index(
+            self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(
                     index_name=rand_index, docs=[{"abc": "def"}], auto_refresh=True, device="cpu"
                 )
@@ -344,7 +344,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
             {"title": "\r\r"},
             {"title": "\r\t\n"},
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_1, docs=docs, device="cpu"
             )
@@ -356,7 +356,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
         assert count == len(docs)
 
     def test_add_docs_response_format(self):
-        add_res = self.add_documents_and_refresh_index(
+        add_res = self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_1,
                 docs=[
@@ -421,7 +421,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
         for use_existing_tensors_flag in (True, False):
             for bad_doc_arg in bad_doc_args:
                 with self.subTest(f'{bad_doc_arg} - use_existing_tensors={use_existing_tensors_flag}'):
-                    add_res = self.add_documents_and_refresh_index(
+                    add_res = self.add_documents(
                         config=self.config, add_docs_params=AddDocsParams(
                             index_name=self.index_name_1, docs=bad_doc_arg,
                             use_existing_tensors=use_existing_tensors_flag, device="cpu"
@@ -453,7 +453,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
         for use_existing_tensors_flag in (True, False):
             for bad_doc_arg in bad_doc_args:
                 with self.subTest(f'{bad_doc_arg} - use_existing_tensors={use_existing_tensors_flag}'):
-                    add_res = self.add_documents_and_refresh_index(
+                    add_res = self.add_documents(
                         config=self.config, add_docs_params=AddDocsParams(
                             index_name=self.index_name_1, docs=bad_doc_arg[0],
                             use_existing_tensors=use_existing_tensors_flag, device="cpu"
@@ -474,7 +474,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
             [{"_id": "to_fail_123", "tags": ["wow", "this", "is"]}]
         ]
         for bad_doc_arg in good_docs:
-            add_res = self.add_documents_and_refresh_index(
+            add_res = self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(
                     index_name=self.index_name_1,
                     docs=bad_doc_arg,
@@ -492,7 +492,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
         ]
         for bad_doc_arg in bad_doc_args:
             with self.subTest(bad_doc_arg):
-                add_res = self.add_documents_and_refresh_index(
+                add_res = self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=self.index_name_1,
                         docs=bad_doc_arg,
@@ -511,7 +511,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
 
         @mock.patch("marqo.s2_inference.s2_inference.vectorise", mock_vectorise)
         def run():
-            self.add_documents_and_refresh_index(
+            self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(
                     index_name=self.index_name_1, device="cuda:22", docs=[{"title": "doc"}, {"title": "doc"}],
 
@@ -528,7 +528,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
         Adding empty documents raises BadRequestError
         """
         try:
-            self.add_documents_and_refresh_index(
+            self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(
                     index_name=self.index_name_1, docs=[],
                     device="cpu")
@@ -547,8 +547,8 @@ class TestAddDocumentsStructured(MarqoTestCase):
         ]
 
         with mock.patch('PIL.Image.open') as mock_image_open:
-            self.add_documents_and_refresh_index(config=self.config,
-                                                 add_docs_params=AddDocsParams(
+            self.add_documents(config=self.config,
+                               add_docs_params=AddDocsParams(
                                             index_name=self.index_name_img_no_chunking, docs=docs,
                                             device="cpu",
                                         ))
@@ -598,7 +598,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
         ]
         for docs, expected_results in docs_results:
             with self.subTest(f'{expected_results}'):
-                add_res = self.add_documents_and_refresh_index(
+                add_res = self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=self.index_name_1, docs=docs,
                         device="cpu"
@@ -614,7 +614,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
 
     def test_add_document_with_tensor_fields(self):
         docs_ = [{"_id": "789", "title": "Story of Alice Appleseed", "desc": "Alice grew up in Houston, Texas."}]
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_1, docs=docs_, device="cpu"
         ))
         resp = tensor_search.get_document_by_id(config=self.config, index_name=self.index_name_1, document_id="789",
@@ -631,7 +631,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
 
         @mock.patch.dict(os.environ, {**os.environ, **mock_environ})
         def run():
-            update_res = self.add_documents_and_refresh_index(
+            update_res = self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(
                     index_name=self.index_name_1, docs=[
                         {"_id": "123", 'desc': "edf " * (max_size // 4)},
@@ -656,7 +656,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
 
         @mock.patch.dict(os.environ, {**os.environ, **mock_environ})
         def run():
-            update_res = self.add_documents_and_refresh_index(
+            update_res = self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(
                     index_name=self.index_name_1, docs=[
                         {"_id": "123", 'desc': "edf " * (max_size // 4)},
@@ -679,7 +679,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
         for env_dict in [dict()]:
             @mock.patch.dict(os.environ, {**os.environ, **env_dict})
             def run():
-                update_res = self.add_documents_and_refresh_index(
+                update_res = self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=self.index_name_1, docs=[
                             {"_id": "123", 'desc': "Some content"},
@@ -710,7 +710,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
 
                 if error:
                     with self.assertRaises(BadRequestError):
-                        self.add_documents_and_refresh_index(
+                        self.add_documents(
                             config=self.config, add_docs_params=AddDocsParams(
                                 index_name=self.index_name_1,
                                 docs=[{
@@ -721,7 +721,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
                         )
                 else:
                     self.assertEqual(False,
-                                     self.add_documents_and_refresh_index(
+                                     self.add_documents(
                                          config=self.config, add_docs_params=AddDocsParams(
                                              index_name=self.index_name_1,
                                              docs=[{
@@ -737,13 +737,13 @@ class TestAddDocumentsStructured(MarqoTestCase):
         If a document is re-indexed with a tensor field removed, the vectors are removed
         """
         # test replace and update workflows
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             self.config, add_docs_params=AddDocsParams(
                 docs=[{"_id": "123", "title": "mydata", "desc": "mydata2"}],
                 index_name=self.index_name_1, device="cpu"
             )
         )
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             self.config,
             add_docs_params=AddDocsParams(
                 docs=[{"_id": "123", "desc": "mydata"}],
@@ -761,7 +761,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
         """
         If a document is indexed with no tensor fields on an empty index, no vectors are added
         """
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             self.config, add_docs_params=AddDocsParams(
                 docs=[{"_id": "123", "desc": "mydata"}],
                 index_name=self.index_name_1,
@@ -779,7 +779,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
         If a document is indexed with a tensor field and a non-tensor field on an empty index, vectors are added
         for the tensor field
         """
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             self.config, add_docs_params=AddDocsParams(
                 docs=[{"_id": "123", "title": "mydata", "desc": "mydata"}],
                 index_name=self.index_name_1,
@@ -825,7 +825,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
         for c in doc_counts:
             self.clear_index_by_name(self.index_name_img_random)
 
-            res1 = self.add_documents_and_refresh_index(
+            res1 = self.add_documents(
                 self.config,
                 add_docs_params=AddDocsParams(
                     docs=[{"_id": str(doc_num),
@@ -881,7 +881,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
 
         for doc, error, msg in test_case:
             with self.subTest(msg):
-                res = self.add_documents_and_refresh_index(
+                res = self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=self.index_name_1, docs=[doc], device="cpu",
                     )
@@ -910,7 +910,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
 
         for doc, expected_doc, msg in test_case:
             with self.subTest(msg):
-                res = self.add_documents_and_refresh_index(
+                res = self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=self.index_name_1, docs=[doc], device="cpu",
                     )
@@ -945,7 +945,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
 
         ]
 
-        r = self.add_documents_and_refresh_index(
+        r = self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_img_no_chunking, docs=documents
             )

--- a/tests/tensor_search/integ_tests/test_add_documents_unstructured.py
+++ b/tests/tensor_search/integ_tests/test_add_documents_unstructured.py
@@ -85,7 +85,7 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
         ]
         for index_name, desc in tests:
             with self.subTest(desc):
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=self.default_text_index,
                         docs=[{
@@ -114,7 +114,7 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
         """
 
         # Add once to get vectors
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index, docs=[{
@@ -128,7 +128,7 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
             config=self.config, index_name=self.default_text_index,
             document_id="1", show_vectors=True)['_tensor_facets']
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index, docs=[
@@ -140,7 +140,7 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
                 device="cpu", tensor_fields=["title"]
             )
         )
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index, docs=[
@@ -168,7 +168,7 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
         rand_index = 'a' + str(uuid.uuid4()).replace('-', '')
 
         with pytest.raises(IndexNotFoundError):
-            self.add_documents_and_refresh_index(
+            self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(
                     index_name=rand_index, docs=[{"abc": "def"}], device="cpu"
                 )
@@ -187,7 +187,7 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
             {"title": "\r\r"},
             {"title": "\r\t\n"},
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.default_text_index, docs=docs, device="cpu", tensor_fields=[]
             )
@@ -199,7 +199,7 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
         assert count == len(docs)
 
     def test_add_docs_response_format(self):
-        add_res = self.add_documents_and_refresh_index(
+        add_res = self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
                 docs=[
@@ -263,7 +263,7 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
         for use_existing_tensors_flag in (True, False):
             for bad_doc_arg in bad_doc_args:
                 with self.subTest(msg=f'{bad_doc_arg} - use_existing_tensors={use_existing_tensors_flag}'):
-                    add_res = self.add_documents_and_refresh_index(
+                    add_res = self.add_documents(
                         config=self.config, add_docs_params=AddDocsParams(
                             index_name=self.default_text_index, docs=bad_doc_arg,
                             use_existing_tensors=use_existing_tensors_flag, device="cpu",
@@ -296,7 +296,7 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
         for use_existing_tensors_flag in (True, False):
             for bad_doc_arg in bad_doc_args:
                 with self.subTest(f'{bad_doc_arg} - use_existing_tensors={use_existing_tensors_flag}'):
-                    add_res = self.add_documents_and_refresh_index(
+                    add_res = self.add_documents(
                         config=self.config, add_docs_params=AddDocsParams(
                             index_name=self.default_text_index, docs=bad_doc_arg[0],
                             use_existing_tensors=use_existing_tensors_flag, device="cpu", tensor_fields=["title"]
@@ -318,7 +318,7 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
             [{"_id": "to_fail_123", "tags": ["wow", "this", "is"]}]
         ]
         for bad_doc_arg in good_docs:
-            add_res = self.add_documents_and_refresh_index(
+            add_res = self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(
                     index_name=self.default_text_index,
                     docs=bad_doc_arg,
@@ -338,7 +338,7 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
         bad_doc_args = self.tags_
         for bad_doc_arg in bad_doc_args:
             with self.subTest(bad_doc_arg):
-                add_res = self.add_documents_and_refresh_index(
+                add_res = self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=self.default_text_index,
                         docs=bad_doc_arg,
@@ -358,7 +358,7 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
 
         @mock.patch("marqo.s2_inference.s2_inference.vectorise", mock_vectorise)
         def run():
-            self.add_documents_and_refresh_index(
+            self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(
                     index_name=self.default_text_index, device="cuda:22", docs=[{"title": "doc"}, {"title": "doc"}],
                     tensor_fields=["title"]
@@ -375,7 +375,7 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
         Adding empty documents raises BadRequestError
         """
         try:
-            self.add_documents_and_refresh_index(
+            self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(
                     index_name=self.default_text_index, docs=[],
                     device="cpu")
@@ -394,8 +394,8 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
         ]
 
         with mock.patch('PIL.Image.open') as mock_image_open:
-            self.add_documents_and_refresh_index(config=self.config,
-                                                 add_docs_params=AddDocsParams(
+            self.add_documents(config=self.config,
+                               add_docs_params=AddDocsParams(
                                             index_name=self.default_image_index, docs=docs,
                                             device="cpu", tensor_fields=["title"]
                                         ))
@@ -444,7 +444,7 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
         ]
         for docs, expected_results in docs_results:
             with self.subTest(f'{expected_results}'):
-                add_res = self.add_documents_and_refresh_index(
+                add_res = self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=self.default_text_index, docs=docs,
                         device="cpu", tensor_fields=[]
@@ -461,7 +461,7 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
     def test_add_document_with_tensor_fields(self):
         """Ensure tensor_fields only works for title but not desc"""
         docs_ = [{"_id": "789", "title": "Story of Alice Appleseed", "desc": "Alice grew up in Houston, Texas."}]
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.default_text_index, docs=docs_, device="cpu", tensor_fields=["title"]
         ))
         resp = tensor_search.get_document_by_id(config=self.config,
@@ -479,7 +479,7 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
 
         @mock.patch.dict(os.environ, {**os.environ, **mock_environ})
         def run():
-            update_res = self.add_documents_and_refresh_index(
+            update_res = self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(
                     index_name=self.default_text_index, docs=[
                         {"_id": "123", 'desc': "edf " * (max_size // 4)},
@@ -504,7 +504,7 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
 
         @mock.patch.dict(os.environ, {**os.environ, **mock_environ})
         def run():
-            update_res = self.add_documents_and_refresh_index(
+            update_res = self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(
                     index_name=self.default_text_index, docs=[
                         {"_id": "123", 'desc': "edf " * (max_size // 4)},
@@ -527,7 +527,7 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
         for env_dict in [dict()]:
             @mock.patch.dict(os.environ, {**os.environ, **env_dict})
             def run():
-                update_res = self.add_documents_and_refresh_index(
+                update_res = self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=self.default_text_index, docs=[
                             {"_id": "123", 'desc': "Some content"},
@@ -547,13 +547,13 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
         If a document is re-indexed with a tensor field removed, the vectors are removed
         """
         # test replace and update workflows
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             self.config, add_docs_params=AddDocsParams(
                 docs=[{"_id": "123", "title": "mydata", "desc": "mydata2"}],
                 index_name=self.default_text_index, device="cpu", tensor_fields=["title"]
             )
         )
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             self.config,
             add_docs_params=AddDocsParams(
                 docs=[{"_id": "123", "desc": "mydata"}],
@@ -583,7 +583,7 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
 
                 if error:
                     with self.assertRaises(BadRequestError):
-                        self.add_documents_and_refresh_index(
+                        self.add_documents(
                             config=self.config, add_docs_params=AddDocsParams(
                                 index_name=self.default_text_index,
                                 docs=[{
@@ -595,7 +595,7 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
                         )
                 else:
                     self.assertEqual(False,
-                                     self.add_documents_and_refresh_index(
+                                     self.add_documents(
                                          config=self.config, add_docs_params=AddDocsParams(
                                              index_name=self.default_text_index,
                                              docs=[{
@@ -611,7 +611,7 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
         """
         If a document is indexed with no tensor fields on an empty index, no vectors are added
         """
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             self.config, add_docs_params=AddDocsParams(
                 docs=[{"_id": "123", "desc": "mydata"}],
                 index_name=self.default_text_index,
@@ -627,7 +627,7 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
         """
         If a document is indexed with a tensor field vectors are added for the tensor field
         """
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             self.config, add_docs_params=AddDocsParams(
                 docs=[{"_id": "123", "title": "mydata", "desc": "mydata"}],
                 index_name=self.default_text_index, tensor_fields=["title"],
@@ -672,7 +672,7 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
         for c in doc_counts:
             self.clear_index_by_name(self.image_index_with_random_model)
 
-            res1 = self.add_documents_and_refresh_index(
+            res1 = self.add_documents(
                 self.config,
                 add_docs_params=AddDocsParams(
                     docs=[{"_id": str(doc_num),
@@ -701,7 +701,7 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
         for tensor_fields, error_message, msg in test_cases:
             with self.subTest(msg):
                 with self.assertRaises(BadRequestError) as e:
-                    self.add_documents_and_refresh_index(
+                    self.add_documents(
                         config=self.config,
                         add_docs_params=AddDocsParams(index_name=self.default_text_index,
                                                       docs=[{"some": "data"}], **tensor_fields))
@@ -726,7 +726,7 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
 
         for doc, error in test_case:
             with self.subTest():
-                res = self.add_documents_and_refresh_index(
+                res = self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=self.default_text_index, docs=[doc], device="cpu",
                         tensor_fields=[]
@@ -752,8 +752,8 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
         for documents, number_of_docs, msg in test_cases:
             self.clear_index_by_name(self.default_text_index)
             with self.subTest(msg):
-                r = self.add_documents_and_refresh_index(config=self.config,
-                                                         add_docs_params=AddDocsParams(
+                r = self.add_documents(config=self.config,
+                                       add_docs_params=AddDocsParams(
                                                     index_name=self.default_text_index, docs=documents,
                                                     device="cpu", tensor_fields=["text_field"]
                                                 )).dict(exclude_none=True, by_alias=True)

--- a/tests/tensor_search/integ_tests/test_custom_vector_field.py
+++ b/tests/tensor_search/integ_tests/test_custom_vector_field.py
@@ -141,7 +141,7 @@ class TestCustomVectorField(MarqoTestCase):
 
             @mock.patch("marqo.vespa.vespa_client.VespaClient.feed_batch", mock_feed_batch)
             def run():
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=index.name,
                         docs=[{
@@ -198,7 +198,7 @@ class TestCustomVectorField(MarqoTestCase):
 
             @mock.patch("marqo.vespa.vespa_client.VespaClient.feed_batch", mock_feed_batch)
             def run():
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=index.name,
                         docs=[{
@@ -267,7 +267,7 @@ class TestCustomVectorField(MarqoTestCase):
 
             @mock.patch("marqo.vespa.vespa_client.VespaClient.feed_batch", mock_feed_batch)
             def run():
-                add_docs_res = self.add_documents_and_refresh_index(
+                add_docs_res = self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=index.name,
                         docs=[{
@@ -328,7 +328,7 @@ class TestCustomVectorField(MarqoTestCase):
         for index in self.indexes:
             with self.subTest(f"Index: {index.name}, type: {index.type}"):
                 # If we change the custom vector, doc should change
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=index.name,
                         docs=[{
@@ -348,7 +348,7 @@ class TestCustomVectorField(MarqoTestCase):
                     config=self.config, index_name=index.name,
                     document_id="0", show_vectors=True)
 
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=index.name,
                         docs=[{
@@ -374,7 +374,7 @@ class TestCustomVectorField(MarqoTestCase):
                 assert get_doc_2[enums.TensorField.tensor_facets][0][enums.TensorField.embedding] == self.random_vector_2
 
                 # If we do not, it should remain the same, no errors
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=index.name,
                         docs=[{
@@ -404,7 +404,7 @@ class TestCustomVectorField(MarqoTestCase):
         """
         for index in self.indexes:
             with self.subTest(f"Index: {index.name}, type: {index.type}"):
-                res = self.add_documents_and_refresh_index(
+                res = self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=index.name,
                         docs=[{
@@ -441,7 +441,7 @@ class TestCustomVectorField(MarqoTestCase):
         """
         for index in self.indexes:
             with self.subTest(f"Index: {index.name}, type: {index.type}"):
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=index.name,
                         docs=[
@@ -534,7 +534,7 @@ class TestCustomVectorField(MarqoTestCase):
                 for case in test_cases:
                     with self.subTest(f"Case: {case}"):
                         with self.assertRaises(pydantic.ValidationError):
-                            res = self.add_documents_and_refresh_index(
+                            res = self.add_documents(
                                 config=self.config, add_docs_params=AddDocsParams(
                                     index_name=index.name,
                                     docs=[{
@@ -553,7 +553,7 @@ class TestCustomVectorField(MarqoTestCase):
         """
         for index in self.indexes:
             with self.subTest(f"Index: {index.name}, type: {index.type}"):
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=index.name,
                         docs=[
@@ -615,7 +615,7 @@ class TestCustomVectorField(MarqoTestCase):
         """
         for index in self.indexes:
             with self.subTest(f"Index: {index.name}, type: {index.type}"):
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=index.name,
                         docs=[
@@ -673,7 +673,7 @@ class TestCustomVectorField(MarqoTestCase):
         # Using another field as score modifier on a custom vector:
         for index in self.indexes:
             with self.subTest(f"Index: {index.name}, type: {index.type}"):
-                add_docs_res = self.add_documents_and_refresh_index(
+                add_docs_res = self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=index.name,
                         docs=[
@@ -740,7 +740,7 @@ class TestCustomVectorField(MarqoTestCase):
 
         for index in self.indexes:
             with self.subTest(f"Index: {index.name}, type: {index.type}"):
-                add_docs_res = self.add_documents_and_refresh_index(
+                add_docs_res = self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=index.name,
                         docs=[
@@ -852,7 +852,7 @@ class TestCustomVectorField(MarqoTestCase):
                 if isinstance(index, UnstructuredMarqoIndex):
                     break
 
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=index.name,
                         docs=[
@@ -919,7 +919,7 @@ class TestCustomVectorField(MarqoTestCase):
                 # Skip this test for unstructured indexes.
                 if isinstance(index, UnstructuredMarqoIndex):
                     break
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=index.name,
                         docs=[
@@ -1006,7 +1006,7 @@ class TestCustomVectorField(MarqoTestCase):
 
         for index in [self.unstructured_custom_index, self.unstructured_custom_index]:
             with self.subTest(f"Index: {index.name}, type: {index.type}"):
-                add_docs_res = self.add_documents_and_refresh_index(
+                add_docs_res = self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=self.unstructured_custom_index.name,
                         docs=[
@@ -1055,7 +1055,7 @@ class TestCustomVectorField(MarqoTestCase):
             },
         }
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_1,
                 docs=[
@@ -1246,7 +1246,7 @@ class TestCustomVectorFieldWithIndexNormalizeEmbeddingsTrue(MarqoTestCase):
 
             @mock.patch("marqo.vespa.vespa_client.VespaClient.feed_batch", mock_feed_batch)
             def run():
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=index.name,
                         docs=[{
@@ -1306,7 +1306,7 @@ class TestCustomVectorFieldWithIndexNormalizeEmbeddingsTrue(MarqoTestCase):
                 ],
                 errors=False)
 
-            add_documents_response = self.add_documents_and_refresh_index(
+            add_documents_response = self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=index.name,
                         docs=[{
@@ -1349,7 +1349,7 @@ class TestCustomVectorFieldWithIndexNormalizeEmbeddingsTrue(MarqoTestCase):
         """
         for index in [self.structured_custom_index, self.semi_structured_custom_index]:
             with self.subTest(f"Index: {index.name}, type: {index.type}"):
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=index.name,
                         docs=[

--- a/tests/tensor_search/integ_tests/test_delete_documents.py
+++ b/tests/tensor_search/integ_tests/test_delete_documents.py
@@ -52,7 +52,7 @@ class TestDeleteDocuments(MarqoTestCase):
     def test_delete_documents(self):
         for index in self.indexes:
             with self.subTest(f"Index type: {index.type}. Index name: {index.name}"):
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, 
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -67,7 +67,7 @@ class TestDeleteDocuments(MarqoTestCase):
 
                 count0_res = self.monitoring.get_index_stats_by_name(index.name).number_of_documents
 
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, 
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -92,7 +92,7 @@ class TestDeleteDocuments(MarqoTestCase):
     def test_delete_docs_format(self):
         for index in self.indexes:
             with self.subTest(f"Index type: {index.type}. Index name: {index.name}"):
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, 
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -118,7 +118,7 @@ class TestDeleteDocuments(MarqoTestCase):
     def test_only_specified_documents_are_deleted(self):
         for index in self.indexes:
             with self.subTest(f"Index type: {index.type}. Index name: {index.name}"):
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, 
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -152,7 +152,7 @@ class TestDeleteDocuments(MarqoTestCase):
     def test_delete_multiple_documents(self):
         for index in self.indexes:
             with self.subTest(f"Index type: {index.type}. Index name: {index.name}"):
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, 
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -184,7 +184,7 @@ class TestDeleteDocuments(MarqoTestCase):
     def test_document_is_actually_deleted(self):
         for index in self.indexes:
             with self.subTest(f"Index type: {index.type}. Index name: {index.name}"):
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, 
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -206,7 +206,7 @@ class TestDeleteDocuments(MarqoTestCase):
     def test_multiple_documents_are_actually_deleted(self):
         for index in self.indexes:
             with self.subTest(f"Index type: {index.type}. Index name: {index.name}"):
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, 
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -274,7 +274,7 @@ class TestDeleteDocuments(MarqoTestCase):
         for index in self.indexes:
             with self.subTest(f"Index type: {index.type}. Index name: {index.name}"):
                 # Add a document
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, 
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -308,7 +308,7 @@ class TestDeleteDocuments(MarqoTestCase):
         for index in self.indexes:
             with self.subTest(f"Index type: {index.type}. Index name: {index.name}"):
                 # Add a document
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, 
                     add_docs_params=AddDocsParams(
                         index_name=index.name,

--- a/tests/tensor_search/integ_tests/test_dict_score_modifiers.py
+++ b/tests/tensor_search/integ_tests/test_dict_score_modifiers.py
@@ -84,7 +84,7 @@ class TestDictScoreModifiers(MarqoTestCase):
         for index in [self.structured_default_text_index]:
             with self.subTest(index=index.type):
                 # Add documents
-                res = self.add_documents_and_refresh_index(
+                res = self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -118,7 +118,7 @@ class TestDictScoreModifiers(MarqoTestCase):
         for index in [self.structured_default_text_index]:
             with self.subTest(index=index.type):
                 # Add documents
-                res = self.add_documents_and_refresh_index(
+                res = self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -152,7 +152,7 @@ class TestDictScoreModifiers(MarqoTestCase):
         for index in [self.structured_default_text_index, self.unstructured_default_text_index]:
             with self.subTest(index=index.type):
                 # Add documents
-                res = self.add_documents_and_refresh_index(
+                res = self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -194,7 +194,7 @@ class TestDictScoreModifiers(MarqoTestCase):
         for index in [self.structured_default_text_index, self.unstructured_default_text_index]:
             with self.subTest(index=index.type):
                 # Add documents
-                res = self.add_documents_and_refresh_index(
+                res = self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -238,7 +238,7 @@ class TestDictScoreModifiers(MarqoTestCase):
         for index in [self.structured_default_text_index, self.unstructured_default_text_index]:
             with self.subTest(index=index.type):
                 # Add documents
-                res = self.add_documents_and_refresh_index(
+                res = self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -283,7 +283,7 @@ class TestDictScoreModifiers(MarqoTestCase):
         for index in [self.structured_default_text_index]:
             with self.subTest(index=index.type):
                 # Add documents
-                res = self.add_documents_and_refresh_index(
+                res = self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -345,7 +345,7 @@ class TestDictScoreModifiers(MarqoTestCase):
         for index in [self.structured_default_text_index, self.unstructured_default_text_index]:
             with self.subTest(index=index.type):
                 # Add documents
-                res = self.add_documents_and_refresh_index(
+                res = self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -391,7 +391,7 @@ class TestDictScoreModifiers(MarqoTestCase):
         for index in [self.unstructured_default_text_index]:
             with self.subTest(index=index.type):
                 # Add documents
-                res = self.add_documents_and_refresh_index(
+                res = self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -429,7 +429,7 @@ class TestDictScoreModifiers(MarqoTestCase):
         for index in [self.unstructured_default_text_index]:
             with self.subTest(index=index.type):
                 # Add documents
-                res = self.add_documents_and_refresh_index(
+                res = self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -496,7 +496,7 @@ class TestDictScoreModifiers(MarqoTestCase):
             with self.subTest(index=index.type):
                 # Add documents
                 with self.assertRaises(ValidationError):
-                    res = self.add_documents_and_refresh_index(
+                    res = self.add_documents(
                         config=self.config,
                         add_docs_params=AddDocsParams(
                             index_name=index.name,

--- a/tests/tensor_search/integ_tests/test_embed.py
+++ b/tests/tensor_search/integ_tests/test_embed.py
@@ -311,7 +311,7 @@ class TestEmbed(MarqoTestCase):
         """
         for index in [self.unstructured_default_text_index, self.structured_default_text_index]:
             with self.subTest(index=index.type):
-                add_docs_res = self.add_documents_and_refresh_index(
+                add_docs_res = self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=index.name,
                         docs=[
@@ -356,7 +356,7 @@ class TestEmbed(MarqoTestCase):
         """
         for index in [self.unstructured_default_text_index, self.structured_default_text_index]:
             with self.subTest(index=index.type):
-                add_docs_res = self.add_documents_and_refresh_index(
+                add_docs_res = self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=index.name,
                         docs=[

--- a/tests/tensor_search/integ_tests/test_get_document.py
+++ b/tests/tensor_search/integ_tests/test_get_document.py
@@ -47,7 +47,7 @@ class TestGetDocument(MarqoTestCase):
         """Also ensures that the _id is returned"""
         for index in self.indexes:
             with self.subTest(f"Index type: {index.type}. Index name: {index.name}"):
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(index_name=index.name, docs=[
                         {
                             "_id": "123",
@@ -101,11 +101,11 @@ class TestGetDocument(MarqoTestCase):
 
                 keys = ("title1", "desc2")
                 vals = ("content 1", "content 2. blah blah blah")
-                self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+                self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                     index_name=index.name, docs=[{"_id": "123", **dict(zip(keys, vals))}],
                     auto_refresh=True, device="cpu",
                     tensor_fields=["title1", "desc2"] if isinstance(index, UnstructuredMarqoIndex) else None)
-                                                     )
+                                   )
 
                 res = tensor_search.get_document_by_id(
                     config=self.config, index_name=index.name,

--- a/tests/tensor_search/integ_tests/test_get_documents_by_ids.py
+++ b/tests/tensor_search/integ_tests/test_get_documents_by_ids.py
@@ -59,7 +59,7 @@ class TestGetDocuments(MarqoTestCase):
                     {"_id": "1", "title1": "content 1"}, {"_id": "2", "title1": "content 2"},
                     {"_id": "3", "title1": "content 3"}
                 ]
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(index_name=index.name, docs=docs, device="cpu",
                     tensor_fields=["title1", "desc2"] if isinstance(index, UnstructuredMarqoIndex) else None)
@@ -83,7 +83,7 @@ class TestGetDocuments(MarqoTestCase):
         
         for index in self.indexes:
             with self.subTest(f"Index type: {index.type}. Index name: {index.name}"):
-                self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+                self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                     index_name=index.name, docs=[dict(zip(k, v)) for k, v in zip(keys, vals)],
                     device="cpu",
                     tensor_fields=["title1", "desc2"] if isinstance(index, UnstructuredMarqoIndex) else None))
@@ -126,13 +126,13 @@ class TestGetDocuments(MarqoTestCase):
     def test_get_document_vectors_resilient(self):
         for index in self.indexes:
             with self.subTest(f"Index type: {index.type}. Index name: {index.name}"):
-                self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+                self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                     index_name=index.name, docs=[
                         {"_id": '456', "title1": "alexandra"},
                         {'_id': '221', 'desc2': 'hello'}],
                     device="cpu",
                     tensor_fields=["title1", "desc2"] if isinstance(index, UnstructuredMarqoIndex) else None)
-                                                     )
+                                   )
                 id_reqs = [
                     (['123', '456'], [False, True]), ([['456', '789'], [True, False]]),
                     ([['456', '789', '221'], [True, False, True]]), ([['vkj', '456', '4891'], [False, True, False]])

--- a/tests/tensor_search/integ_tests/test_hybrid_search.py
+++ b/tests/tensor_search/integ_tests/test_hybrid_search.py
@@ -741,8 +741,8 @@ class TestHybridSearch(MarqoTestCase):
                     self.assertIn("hits", hybrid_res)
                     self.assertEqual(len(hybrid_res["hits"]), 3)    # Only 3 documents have text field 2. Tensor retrieval will get them all.
                     self.assertEqual(hybrid_res["hits"][0]["_id"], "doc12")
-                    self.assertEqual(hybrid_res["hits"][1]["_id"], "doc11")
-                    self.assertEqual(hybrid_res["hits"][2]["_id"], "doc13")
+                    # doc11 and doc13 has score 0, so their order is non-deterministic
+                    self.assertSetEqual({'doc11', 'doc13'}, {hit["_id"] for hit in hybrid_res["hits"][1:]})
 
     def test_hybrid_search_score_modifiers(self):
         """

--- a/tests/tensor_search/integ_tests/test_hybrid_search.py
+++ b/tests/tensor_search/integ_tests/test_hybrid_search.py
@@ -671,7 +671,6 @@ class TestHybridSearch(MarqoTestCase):
     def test_hybrid_search_searchable_attributes(self):
         """
         Tests that searchable attributes work as expected for all methods
-        TODO: Add unstructured index once searchable attributes are supported
         """
 
         for index in [self.structured_text_index_score_modifiers, self.semi_structured_default_text_index]:

--- a/tests/tensor_search/integ_tests/test_hybrid_search.py
+++ b/tests/tensor_search/integ_tests/test_hybrid_search.py
@@ -213,7 +213,7 @@ class TestHybridSearch(MarqoTestCase):
 
                 if isinstance(index, UnstructuredMarqoIndex):
                     # this is required to create the tensor fields in the semi-structured index
-                    self.add_documents_and_refresh_index(
+                    self.add_documents(
                         config=self.config,
                         add_docs_params=AddDocsParams(
                             index_name=index.name,
@@ -446,7 +446,7 @@ class TestHybridSearch(MarqoTestCase):
         mock_vespa_client_query = unittest.mock.MagicMock()
         mock_vespa_client_query.side_effect = pass_through_query
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.semi_structured_index_with_no_model.name,
@@ -579,7 +579,7 @@ class TestHybridSearch(MarqoTestCase):
                       self.unstructured_default_text_index]:
             with self.subTest(index=index.name):
                 # Add documents
-                add_docs_res = self.add_documents_and_refresh_index(
+                add_docs_res = self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -631,7 +631,7 @@ class TestHybridSearch(MarqoTestCase):
                       self.unstructured_default_text_index]:
             with self.subTest(index=index.name):
                 # Add documents
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -677,7 +677,7 @@ class TestHybridSearch(MarqoTestCase):
         for index in [self.structured_text_index_score_modifiers, self.semi_structured_default_text_index]:
             with self.subTest(index=index.name):
                 # Add documents
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -754,7 +754,7 @@ class TestHybridSearch(MarqoTestCase):
                       self.unstructured_default_text_index]:
             with self.subTest(index=index.name):
                 # Add documents
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -907,7 +907,7 @@ class TestHybridSearch(MarqoTestCase):
                       self.unstructured_default_text_index]:
             with self.subTest(index=type(index)):
                 # Add documents
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -974,7 +974,7 @@ class TestHybridSearch(MarqoTestCase):
                       self.unstructured_default_text_index]:
             with self.subTest(index=index.name):
                 # Add documents
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -1028,7 +1028,7 @@ class TestHybridSearch(MarqoTestCase):
                       self.unstructured_default_text_index]:
             with self.subTest(index=index.name):
                 # Add documents
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -1075,7 +1075,7 @@ class TestHybridSearch(MarqoTestCase):
                       self.unstructured_default_image_index]:
             with self.subTest(index=index.name):
                 # Add documents
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -1142,7 +1142,7 @@ class TestHybridSearch(MarqoTestCase):
         """
 
         # Add documents
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.structured_text_index_score_modifiers.name,
@@ -1254,7 +1254,7 @@ class TestHybridSearch(MarqoTestCase):
         """
 
         # Add documents
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.semi_structured_default_image_index.name,
@@ -1367,7 +1367,7 @@ class TestHybridSearch(MarqoTestCase):
             with self.subTest(msg=f'{index.type}', index=index):
 
                 # Add documents
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -1753,8 +1753,8 @@ class TestHybridSearch(MarqoTestCase):
                                                     if isinstance(index, UnstructuredMarqoIndex) else None,
                                                 mappings={"custom_field_1": {"type": "custom_vector"}} \
                                                     if isinstance(index, UnstructuredMarqoIndex) else None)
-                _ = self.add_documents_and_refresh_index(config=self.config,
-                                                         add_docs_params=add_docs_params)
+                _ = self.add_documents(config=self.config,
+                                       add_docs_params=add_docs_params)
 
                 r = tensor_search.search(config=self.config, index_name=index.name, text=None,
                                          search_method="hybrid",

--- a/tests/tensor_search/integ_tests/test_no_model.py
+++ b/tests/tensor_search/integ_tests/test_no_model.py
@@ -119,7 +119,7 @@ class TestNoModel(MarqoTestCase):
                     index_name == self.unstructured_index_with_no_model else None
                 mappings = {"custom_field_1": {"type": "custom_vector"}} if \
                     index_name == self.unstructured_index_with_no_model else None
-                r = self.add_documents_and_refresh_index(
+                r = self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index_name,
@@ -183,8 +183,8 @@ class TestNoModel(MarqoTestCase):
                                                 docs=docs,
                                                 tensor_fields=tensor_fields,
                                                 mappings=mappings)
-                _ = self.add_documents_and_refresh_index(config=self.config,
-                                                         add_docs_params=add_docs_params)
+                _ = self.add_documents(config=self.config,
+                                       add_docs_params=add_docs_params)
 
                 r = tensor_search.search(config=self.config, index_name=index_name, text=None,
                                          search_method="tensor",

--- a/tests/tensor_search/integ_tests/test_search_combined.py
+++ b/tests/tensor_search/integ_tests/test_search_combined.py
@@ -211,7 +211,7 @@ class TestSearch(MarqoTestCase):
         ]
         for index in [self.unstructured_languagebind_index, self.structured_languagebind_index]:
             with self.subTest(index=index.type):
-                response = self.add_documents_and_refresh_index(
+                response = self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -246,7 +246,7 @@ class TestSearch(MarqoTestCase):
         ]
         for index in [self.unstructured_languagebind_index, self.structured_languagebind_index]:
             with self.subTest(index=index.type):
-                response = self.add_documents_and_refresh_index(
+                response = self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -272,7 +272,7 @@ class TestSearch(MarqoTestCase):
     def test_filtering_list_case_tensor(self):
         for index in [self.unstructured_default_text_index, self.structured_default_text_index]:
             with self.subTest(type=index.type):
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -320,7 +320,7 @@ class TestSearch(MarqoTestCase):
     def test_filtering_list_case_lexical(self):
         for index in [self.unstructured_default_text_index, self.structured_default_text_index]:
             with self.subTest(index=index.type):
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -368,7 +368,7 @@ class TestSearch(MarqoTestCase):
         for index in [self.unstructured_default_image_index, self.structured_default_image_index]:
             with self.subTest(index=index):
                 hippo_img = TestImageUrls.HIPPO_REALISTIC.value
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -421,7 +421,7 @@ class TestSearch(MarqoTestCase):
         for index in [self.unstructured_default_text_index, self.structured_default_text_index]:
             with self.subTest(index=index.type):
                 # Add documents first
-                res = self.add_documents_and_refresh_index(
+                res = self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -554,7 +554,7 @@ class TestSearch(MarqoTestCase):
         """
         for index in [self.unstructured_default_text_index, self.structured_default_text_index]:
             with self.subTest(index=index.type):
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -606,7 +606,7 @@ class TestSearch(MarqoTestCase):
         for index in [self.unstructured_default_text_index, self.structured_default_text_index]:
             with self.subTest(index=index.type):
                 # Add documents
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -652,7 +652,7 @@ class TestSearch(MarqoTestCase):
         for index in [self.unstructured_default_text_index, self.structured_default_text_index]:
             with self.subTest(index=index):
                 # Adding documents
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -699,7 +699,7 @@ class TestSearch(MarqoTestCase):
         for index in [self.structured_default_text_index]:
             with self.subTest(index=index.type):
                 # Adding documents
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -754,7 +754,7 @@ class TestSearch(MarqoTestCase):
         """
         for index in [self.structured_default_text_index, self.unstructured_default_text_index]:
             with self.subTest(index=index.type):
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -784,7 +784,7 @@ class TestSearch(MarqoTestCase):
         """
         for index in [self.structured_default_text_index, self.unstructured_default_text_index]:
             with self.subTest(index=index.type):
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -839,7 +839,7 @@ class TestSearch(MarqoTestCase):
             with self.subTest(msg=index.type):
                 tensor_fields = ["text_field_1", "text_field_2"] \
                     if isinstance(index, UnstructuredMarqoIndex) else None
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,

--- a/tests/tensor_search/integ_tests/test_search_semi_structured.py
+++ b/tests/tensor_search/integ_tests/test_search_semi_structured.py
@@ -89,8 +89,8 @@ class TestSearchSemiStructured(MarqoTestCase):
         ]
         for index_name, desc in tests:
             with self.subTest(desc):
-                self.add_documents_and_refresh_index(config=self.config,
-                                                     add_docs_params=AddDocsParams(
+                self.add_documents(config=self.config,
+                                   add_docs_params=AddDocsParams(
                                                 index_name=index_name,
                                                 docs=[
                                                     {"abc": "Exact match hehehe efgh ", "other_field": "baaadd efgh ",
@@ -100,7 +100,7 @@ class TestSearchSemiStructured(MarqoTestCase):
                                                 ],
                                                 tensor_fields=["abc", "other_field", "finally"],
                                             )
-                                                     )
+                                   )
 
                 search_res = tensor_search._vector_text_search(
                     config=self.config, index_name=index_name,
@@ -178,7 +178,7 @@ class TestSearchSemiStructured(MarqoTestCase):
                     The editor-in-chief Katharine Viner succeeded Alan Rusbridger in 2015.[10][11] Since 2018, the paper's main newsprint sections have been published in tabloid format. As of July 2021, its print edition had a daily circulation of 105,134.[4] The newspaper has an online edition, TheGuardian.com, as well as two international websites, Guardian Australia (founded in 2013) and Guardian US (founded in 2011). The paper's readership is generally on the mainstream left of British political opinion,[12][13][14][15] and the term "Guardian reader" is used to imply a stereotype of liberal, left-wing or "politically correct" views.[3] Frequent typographical errors during the age of manual typesetting led Private Eye magazine to dub the paper the "Grauniad" in the 1960s, a nickname still used occasionally by the editors for self-mockery.[16]
                     """
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -199,7 +199,7 @@ class TestSearchSemiStructured(MarqoTestCase):
 
     def test_search_edge_case(self):
         """We ran into bugs with this doc"""
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index, docs=[
@@ -229,7 +229,7 @@ class TestSearchSemiStructured(MarqoTestCase):
         """Is the result formatted correctly?"""
         q = "Exact match hehehe"
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -282,7 +282,7 @@ class TestSearchSemiStructured(MarqoTestCase):
         assert search_res["limit"] > 0
 
     def test_result_count_validation(self):
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -326,7 +326,7 @@ class TestSearchSemiStructured(MarqoTestCase):
         assert len(search_res['hits']) >= 1
 
     def test_highlights_tensor(self):
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -351,7 +351,7 @@ class TestSearchSemiStructured(MarqoTestCase):
             assert "_highlights" not in hit
 
     def test_highlights_lexical(self):
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index, docs=[
@@ -377,7 +377,7 @@ class TestSearchSemiStructured(MarqoTestCase):
 
     def test_search_int_field(self):
         """doesn't error out if there is a random int field"""
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -396,7 +396,7 @@ class TestSearchSemiStructured(MarqoTestCase):
                 assert len(s_res["hits"]) > 0
 
     def test_filtering_list_case_tensor(self):
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -438,7 +438,7 @@ class TestSearchSemiStructured(MarqoTestCase):
         assert len(res_should_only_match_keyword_good["hits"]) == 1
 
     def test_filtering_list_case_lexical(self):
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -471,7 +471,7 @@ class TestSearchSemiStructured(MarqoTestCase):
     def test_filtering_list_case_image(self):
 
         hippo_img = TestImageUrls.HIPPO_REALISTIC.value
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_image_index,
@@ -504,7 +504,7 @@ class TestSearchSemiStructured(MarqoTestCase):
     def test_filtering(self):
         # TODO-Li Add support for filter on Bool
         # Add documents first (assuming add_docs_caller is a method to add documents)
-        res = self.add_documents_and_refresh_index(
+        res = self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -550,7 +550,7 @@ class TestSearchSemiStructured(MarqoTestCase):
              "bool_field_1": False, "bool_field_2": True, "text_field_3": "search me"},
         ]
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -589,7 +589,7 @@ class TestSearchSemiStructured(MarqoTestCase):
 
     def test_filter_spaced_fields(self):
         # Add documents
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -623,7 +623,7 @@ class TestSearchSemiStructured(MarqoTestCase):
 
     def test_filtering_bad_syntax(self):
         # Adding documents
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -673,7 +673,7 @@ class TestSearchSemiStructured(MarqoTestCase):
         assert kwargs["device"] == "cuda:123"
 
     def test_search_other_types_subsearch(self):
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -703,7 +703,7 @@ class TestSearchSemiStructured(MarqoTestCase):
             "some_str": "blah"
         }]
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -725,7 +725,7 @@ class TestSearchSemiStructured(MarqoTestCase):
 
     def test_lexical_filtering(self):
         # Adding documents
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -791,7 +791,7 @@ class TestSearchSemiStructured(MarqoTestCase):
     def test_filter_on_id_and_more(self):
         """Test various filtering scenarios including _id and other conditions"""
         # Adding documents
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -850,7 +850,7 @@ class TestSearchSemiStructured(MarqoTestCase):
             (None, {"field_1", "field_2", "random_field", "random_lala", "marqomarqo", "_id", "_score", "_highlights"}),
         )
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -879,7 +879,7 @@ class TestSearchSemiStructured(MarqoTestCase):
         batch_size_list = [50, 50, 28]
         # We add 128 documents to the index wth batch_size 50, 50, 28 to avoid timeout
         for batch_size in batch_size_list:
-            res = self.add_documents_and_refresh_index(
+            res = self.add_documents(
                 config=self.config,
                 add_docs_params=AddDocsParams(
                     index_name=self.default_text_index,
@@ -962,7 +962,7 @@ class TestSearchSemiStructured(MarqoTestCase):
             {"_id": "789",
              "image_field": url_2},
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_image_index,
@@ -987,7 +987,7 @@ class TestSearchSemiStructured(MarqoTestCase):
             {"field_a": "Construction and scaffolding equipment",
              "_id": 'irrelevant_doc'}
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -1025,7 +1025,7 @@ class TestSearchSemiStructured(MarqoTestCase):
                 "_id": 'artefact_hippo'
             }
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_image_index,
@@ -1071,7 +1071,7 @@ class TestSearchSemiStructured(MarqoTestCase):
             }
         ]
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_image_index,
@@ -1102,7 +1102,7 @@ class TestSearchSemiStructured(MarqoTestCase):
                 "_id": 'artefact_hippo'
             }
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_image_index,
@@ -1128,7 +1128,7 @@ class TestSearchSemiStructured(MarqoTestCase):
             {"field_a": "Some text about a weird forest",
              "_id": 'artefact_hippo'}
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -1163,7 +1163,7 @@ class TestSearchSemiStructured(MarqoTestCase):
 
         docs = list(doc_dict.values())
 
-        res = self.add_documents_and_refresh_index(
+        res = self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_image_index,
@@ -1192,7 +1192,7 @@ class TestSearchSemiStructured(MarqoTestCase):
             {"_id": "2", "text_field_1": "some code", "text_field_2": "match", "int_field_1": 2},
 
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -1218,7 +1218,7 @@ class TestSearchSemiStructured(MarqoTestCase):
             {"_id": "2", "text_field_1": "some code", "text_field_2": "match", "int_field_1": 2},
 
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -1256,7 +1256,7 @@ class TestSearchSemiStructured(MarqoTestCase):
             # large negative float
             {'double_field_1': -9999999999.87675, '_id': '7', "search_field": "some text"}
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -1288,7 +1288,7 @@ class TestSearchSemiStructured(MarqoTestCase):
         docs = [
             {"_id": "1", "text_field": "::my_text"} # This should work properly
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -1336,7 +1336,7 @@ class TestSearchSemiStructured(MarqoTestCase):
         for document, msg in [full_fields_document, partial_fields_document, no_field_documents]:
             with self.subTest(msg):
                 self.clear_index_by_name(self.default_text_index)
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=self.default_text_index,

--- a/tests/tensor_search/integ_tests/test_search_semi_structured.py
+++ b/tests/tensor_search/integ_tests/test_search_semi_structured.py
@@ -1081,7 +1081,7 @@ class TestSearchSemiStructured(MarqoTestCase):
         )
 
         invalid_queries = [{}, None, {123: 123}, {'123': None},
-                           {"https://marqo_not_real.com/image_1.png": 3}, set()]
+                           {"https://marqo-not-real.com/image_1.png": 3}, set()]
         for q in invalid_queries:
             with self.subTest(f"query={q}"):
                 with self.assertRaises((ValidationError, errors.InvalidArgError)) as e:

--- a/tests/tensor_search/integ_tests/test_search_structured.py
+++ b/tests/tensor_search/integ_tests/test_search_structured.py
@@ -909,7 +909,7 @@ class TestSearchStructured(MarqoTestCase):
         )
 
         invalid_queries = [{}, None, {123: 123}, {'123': None},
-                           {"https://marqo_not_real.com/image_1.png": 3}, set()]
+                           {"https://marqo-not-real.com/image_1.png": 3}, set()]
         for q in invalid_queries:
             with self.subTest(f"query={q}"):
                 with self.assertRaises((ValidationError, errors.InvalidArgError)) as e:

--- a/tests/tensor_search/integ_tests/test_search_structured.py
+++ b/tests/tensor_search/integ_tests/test_search_structured.py
@@ -157,7 +157,7 @@ class TestSearchStructured(MarqoTestCase):
         ]
         for index_name, desc in tests:
             with self.subTest(desc):
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index_name,
@@ -234,7 +234,7 @@ class TestSearchStructured(MarqoTestCase):
                     The editor-in-chief Katharine Viner succeeded Alan Rusbridger in 2015.[10][11] Since 2018, the paper's main newsprint sections have been published in tabloid format. As of July 2021, its print edition had a daily circulation of 105,134.[4] The newspaper has an online edition, TheGuardian.com, as well as two international websites, Guardian Australia (founded in 2013) and Guardian US (founded in 2011). The paper's readership is generally on the mainstream left of British political opinion,[12][13][14][15] and the term "Guardian reader" is used to imply a stereotype of liberal, left-wing or "politically correct" views.[3] Frequent typographical errors during the age of manual typesetting led Private Eye magazine to dub the paper the "Grauniad" in the 1960s, a nickname still used occasionally by the editors for self-mockery.[16]
                     """
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -256,7 +256,7 @@ class TestSearchStructured(MarqoTestCase):
 
     def test_search_edge_case(self):
         """We ran into bugs with this doc"""
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -286,7 +286,7 @@ class TestSearchStructured(MarqoTestCase):
         """Is the result formatted correctly?"""
         q = "Exact match hehehe"
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -340,7 +340,7 @@ class TestSearchStructured(MarqoTestCase):
         assert search_res["limit"] > 0
 
     def test_result_count_validation(self):
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -412,7 +412,7 @@ class TestSearchStructured(MarqoTestCase):
         assert len(search_res['hits']) >= 1
 
     def test_highlights_tensor(self):
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -437,7 +437,7 @@ class TestSearchStructured(MarqoTestCase):
             assert "_highlights" not in hit
 
     def test_highlights_lexical(self):
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -463,7 +463,7 @@ class TestSearchStructured(MarqoTestCase):
 
     def test_search_int_field(self):
         """doesn't error out if there is a random int field"""
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -515,7 +515,7 @@ class TestSearchStructured(MarqoTestCase):
         assert kwargs["device"] == "cuda:123"
 
     def test_search_other_types_subsearch(self):
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -544,7 +544,7 @@ class TestSearchStructured(MarqoTestCase):
             "text_field_1": "blah"
         }]
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -566,7 +566,7 @@ class TestSearchStructured(MarqoTestCase):
 
     def test_lexical_filtering(self):
         # Adding documents
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -684,7 +684,7 @@ class TestSearchStructured(MarqoTestCase):
             #         "_highlights"}),
         )
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -708,7 +708,7 @@ class TestSearchStructured(MarqoTestCase):
         vocab_source = "https://www.mit.edu/~ecprice/wordlist.10000"
         vocab = requests.get(vocab_source).text.splitlines()
 
-        res = self.add_documents_and_refresh_index(
+        res = self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.image_index_with_random_model,
@@ -795,7 +795,7 @@ class TestSearchStructured(MarqoTestCase):
             {"_id": "123", "image_field_1": url_1, "text_field_1": "irrelevant text"},
             {"_id": "789", "image_field_1": url_2},
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_image_index,
@@ -819,7 +819,7 @@ class TestSearchStructured(MarqoTestCase):
             {"text_field_1": "Construction and scaffolding equipment",
              "_id": 'irrelevant_doc'}
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -856,7 +856,7 @@ class TestSearchStructured(MarqoTestCase):
                 "image_field_2": TestImageUrls.HIPPO_STATUE.value
             }
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_image_index,
@@ -900,7 +900,7 @@ class TestSearchStructured(MarqoTestCase):
             }
         ]
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_image_index,
@@ -931,7 +931,7 @@ class TestSearchStructured(MarqoTestCase):
                 "text_field_1": "Some text about a weird forest"
             }
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_image_index,
@@ -955,7 +955,7 @@ class TestSearchStructured(MarqoTestCase):
             {"_id": 'realistic_hippo', "image_field_1": "124"},
             {"_id": 'artefact_hippo', "text_field_1": "Some text about a weird forest"}
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -983,7 +983,7 @@ class TestSearchStructured(MarqoTestCase):
 
         docs = list(doc_dict.values())
 
-        res = self.add_documents_and_refresh_index(
+        res = self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_image_index,
@@ -1012,7 +1012,7 @@ class TestSearchStructured(MarqoTestCase):
 
         ]
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -1039,7 +1039,7 @@ class TestSearchStructured(MarqoTestCase):
             {"_id": "2", "text_field_1": "some code", "text_field_2": "match", "int_field_1": 2},
 
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -1076,7 +1076,7 @@ class TestSearchStructured(MarqoTestCase):
             # large negative float
             {'double_field_1': -9999999999.87675, '_id': '7', "text_field_1": "some text"}
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -1135,7 +1135,7 @@ class TestSearchStructured(MarqoTestCase):
         docs = [
                    {"text_field_1": "some text", "text_field_2": "Close match hehehe", "int_field_1": 1},
                ] * 10
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,

--- a/tests/tensor_search/integ_tests/test_search_unstructured.py
+++ b/tests/tensor_search/integ_tests/test_search_unstructured.py
@@ -1096,7 +1096,7 @@ class TestSearchUnstructured(MarqoTestCase):
         )
 
         invalid_queries = [{}, None, {123: 123}, {'123': None},
-                           {"https://marqo_not_real.com/image_1.png": 3}, set()]
+                           {"https://marqo-not-real.com/image_1.png": 3}, set()]
         for q in invalid_queries:
             with self.subTest(f"query={q}"):
                 with self.assertRaises((ValidationError, errors.InvalidArgError)) as e:

--- a/tests/tensor_search/integ_tests/test_search_unstructured.py
+++ b/tests/tensor_search/integ_tests/test_search_unstructured.py
@@ -104,8 +104,8 @@ class TestSearchUnstructured(MarqoTestCase):
         ]
         for index_name, desc in tests:
             with self.subTest(desc):
-                self.add_documents_and_refresh_index(config=self.config,
-                                                     add_docs_params=AddDocsParams(
+                self.add_documents(config=self.config,
+                                   add_docs_params=AddDocsParams(
                                                 index_name=index_name,
                                                 docs=[
                                                     {"abc": "Exact match hehehe efgh ", "other_field": "baaadd efgh ",
@@ -115,7 +115,7 @@ class TestSearchUnstructured(MarqoTestCase):
                                                 ],
                                                 tensor_fields=["abc", "other_field", "finally"],
                                             )
-                                                     )
+                                   )
 
                 search_res = tensor_search._vector_text_search(
                     config=self.config, index_name=index_name,
@@ -193,7 +193,7 @@ class TestSearchUnstructured(MarqoTestCase):
                     The editor-in-chief Katharine Viner succeeded Alan Rusbridger in 2015.[10][11] Since 2018, the paper's main newsprint sections have been published in tabloid format. As of July 2021, its print edition had a daily circulation of 105,134.[4] The newspaper has an online edition, TheGuardian.com, as well as two international websites, Guardian Australia (founded in 2013) and Guardian US (founded in 2011). The paper's readership is generally on the mainstream left of British political opinion,[12][13][14][15] and the term "Guardian reader" is used to imply a stereotype of liberal, left-wing or "politically correct" views.[3] Frequent typographical errors during the age of manual typesetting led Private Eye magazine to dub the paper the "Grauniad" in the 1960s, a nickname still used occasionally by the editors for self-mockery.[16]
                     """
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -214,7 +214,7 @@ class TestSearchUnstructured(MarqoTestCase):
 
     def test_search_edge_case(self):
         """We ran into bugs with this doc"""
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index, docs=[
@@ -244,7 +244,7 @@ class TestSearchUnstructured(MarqoTestCase):
         """Is the result formatted correctly?"""
         q = "Exact match hehehe"
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -297,7 +297,7 @@ class TestSearchUnstructured(MarqoTestCase):
         assert search_res["limit"] > 0
 
     def test_result_count_validation(self):
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -341,7 +341,7 @@ class TestSearchUnstructured(MarqoTestCase):
         assert len(search_res['hits']) >= 1
 
     def test_highlights_tensor(self):
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -366,7 +366,7 @@ class TestSearchUnstructured(MarqoTestCase):
             assert "_highlights" not in hit
 
     def test_highlights_lexical(self):
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index, docs=[
@@ -392,7 +392,7 @@ class TestSearchUnstructured(MarqoTestCase):
 
     def test_search_int_field(self):
         """doesn't error out if there is a random int field"""
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -411,7 +411,7 @@ class TestSearchUnstructured(MarqoTestCase):
                 assert len(s_res["hits"]) > 0
 
     def test_filtering_list_case_tensor(self):
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -453,7 +453,7 @@ class TestSearchUnstructured(MarqoTestCase):
         assert len(res_should_only_match_keyword_good["hits"]) == 1
 
     def test_filtering_list_case_lexical(self):
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -486,7 +486,7 @@ class TestSearchUnstructured(MarqoTestCase):
     def test_filtering_list_case_image(self):
 
         hippo_img = TestImageUrls.HIPPO_REALISTIC.value
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_image_index,
@@ -519,7 +519,7 @@ class TestSearchUnstructured(MarqoTestCase):
     def test_filtering(self):
         # TODO-Li Add support for filter on Bool
         # Add documents first (assuming add_docs_caller is a method to add documents)
-        res = self.add_documents_and_refresh_index(
+        res = self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -565,7 +565,7 @@ class TestSearchUnstructured(MarqoTestCase):
              "bool_field_1": False, "bool_field_2": True, "text_field_3": "search me"},
         ]
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -604,7 +604,7 @@ class TestSearchUnstructured(MarqoTestCase):
 
     def test_filter_spaced_fields(self):
         # Add documents
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -638,7 +638,7 @@ class TestSearchUnstructured(MarqoTestCase):
 
     def test_filtering_bad_syntax(self):
         # Adding documents
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -688,7 +688,7 @@ class TestSearchUnstructured(MarqoTestCase):
         assert kwargs["device"] == "cuda:123"
 
     def test_search_other_types_subsearch(self):
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -718,7 +718,7 @@ class TestSearchUnstructured(MarqoTestCase):
             "some_str": "blah"
         }]
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -740,7 +740,7 @@ class TestSearchUnstructured(MarqoTestCase):
 
     def test_lexical_filtering(self):
         # Adding documents
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -806,7 +806,7 @@ class TestSearchUnstructured(MarqoTestCase):
     def test_filter_on_id_and_more(self):
         """Test various filtering scenarios including _id and other conditions"""
         # Adding documents
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -865,7 +865,7 @@ class TestSearchUnstructured(MarqoTestCase):
             (None, {"field_1", "field_2", "random_field", "random_lala", "marqomarqo", "_id", "_score", "_highlights"}),
         )
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -894,7 +894,7 @@ class TestSearchUnstructured(MarqoTestCase):
         batch_size_list = [50, 50, 28]
         # We add 128 documents to the index wth batch_size 50, 50, 28 to avoid timeout
         for batch_size in batch_size_list:
-            res = self.add_documents_and_refresh_index(
+            res = self.add_documents(
                 config=self.config,
                 add_docs_params=AddDocsParams(
                     index_name=self.default_text_index,
@@ -977,7 +977,7 @@ class TestSearchUnstructured(MarqoTestCase):
             {"_id": "789",
              "image_field": url_2},
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_image_index,
@@ -1002,7 +1002,7 @@ class TestSearchUnstructured(MarqoTestCase):
             {"field_a": "Construction and scaffolding equipment",
              "_id": 'irrelevant_doc'}
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -1040,7 +1040,7 @@ class TestSearchUnstructured(MarqoTestCase):
                 "_id": 'artefact_hippo'
             }
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_image_index,
@@ -1086,7 +1086,7 @@ class TestSearchUnstructured(MarqoTestCase):
             }
         ]
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_image_index,
@@ -1117,7 +1117,7 @@ class TestSearchUnstructured(MarqoTestCase):
                 "_id": 'artefact_hippo'
             }
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_image_index,
@@ -1143,7 +1143,7 @@ class TestSearchUnstructured(MarqoTestCase):
             {"field_a": "Some text about a weird forest",
              "_id": 'artefact_hippo'}
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -1178,7 +1178,7 @@ class TestSearchUnstructured(MarqoTestCase):
 
         docs = list(doc_dict.values())
 
-        res = self.add_documents_and_refresh_index(
+        res = self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_image_index,
@@ -1207,7 +1207,7 @@ class TestSearchUnstructured(MarqoTestCase):
             {"_id": "2", "text_field_1": "some code", "text_field_2": "match", "int_field_1": 2},
 
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -1233,7 +1233,7 @@ class TestSearchUnstructured(MarqoTestCase):
             {"_id": "2", "text_field_1": "some code", "text_field_2": "match", "int_field_1": 2},
 
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -1271,7 +1271,7 @@ class TestSearchUnstructured(MarqoTestCase):
             # large negative float
             {'double_field_1': -9999999999.87675, '_id': '7', "search_field": "some text"}
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -1303,7 +1303,7 @@ class TestSearchUnstructured(MarqoTestCase):
         docs = [
             {"_id": "1", "text_field": "::my_text"} # This should work properly
         ]
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
@@ -1351,7 +1351,7 @@ class TestSearchUnstructured(MarqoTestCase):
         for document, msg in [full_fields_document, partial_fields_document, no_field_documents]:
             with self.subTest(msg):
                 self.clear_index_by_name(self.default_text_index)
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=self.default_text_index,

--- a/tests/tensor_search/test_add_documents_use_existing_tensors.py
+++ b/tests/tensor_search/test_add_documents_use_existing_tensors.py
@@ -71,7 +71,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
                 with mock.patch.object(s2_inference,
                                        'vectorise',
                                        side_effect=original_vectorise) as mock_vectorise:
-                    self.add_documents_and_refresh_index(
+                    self.add_documents(
                         config=self.config,
                         add_docs_params=AddDocsParams(
                             index_name=index_name,
@@ -85,7 +85,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
                 with mock.patch.object(s2_inference,
                                        'vectorise',
                                        side_effect=original_vectorise) as mock_vectorise:
-                    self.add_documents_and_refresh_index(
+                    self.add_documents(
                         config=self.config,
                         add_docs_params=AddDocsParams(
                             index_name=index_name,
@@ -125,7 +125,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
                 with mock.patch.object(s2_inference,
                                        'vectorise',
                                        side_effect=original_vectorise) as mock_vectorise:
-                    self.add_documents_and_refresh_index(
+                    self.add_documents(
                         config=self.config,
                         add_docs_params=AddDocsParams(
                             index_name=index_name,
@@ -139,7 +139,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
                 with mock.patch.object(s2_inference,
                                        'vectorise',
                                        side_effect=original_vectorise) as mock_vectorise:
-                    self.add_documents_and_refresh_index(
+                    self.add_documents(
                         config=self.config,
                         add_docs_params=AddDocsParams(
                             index_name=index_name,
@@ -183,7 +183,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
                 with mock.patch.object(s2_inference,
                                        'vectorise',
                                        side_effect=original_vectorise) as mock_vectorise:
-                    self.add_documents_and_refresh_index(
+                    self.add_documents(
                         config=self.config,
                         add_docs_params=AddDocsParams(
                             index_name=index_name,
@@ -198,7 +198,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
                 with mock.patch.object(s2_inference,
                                        'vectorise',
                                        side_effect=original_vectorise) as mock_vectorise:
-                    self.add_documents_and_refresh_index(
+                    self.add_documents(
                         config=self.config,
                         add_docs_params=AddDocsParams(
                             index_name=index_name,
@@ -249,7 +249,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
                 with mock.patch.object(s2_inference,
                                        'vectorise',
                                        side_effect=original_vectorise) as mock_vectorise:
-                    self.add_documents_and_refresh_index(
+                    self.add_documents(
                         config=self.config,
                         add_docs_params=AddDocsParams(
                             index_name=index_name,
@@ -262,7 +262,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
                 with mock.patch.object(s2_inference,
                                        'vectorise',
                                        side_effect=original_vectorise) as mock_vectorise:
-                    self.add_documents_and_refresh_index(
+                    self.add_documents(
                         config=self.config,
                         add_docs_params=AddDocsParams(
                             index_name=index_name,
@@ -314,7 +314,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
                 with mock.patch.object(s2_inference,
                                        'vectorise',
                                        side_effect=original_vectorise) as mock_vectorise:
-                    self.add_documents_and_refresh_index(
+                    self.add_documents(
                         config=self.config,
                         add_docs_params=AddDocsParams(
                             index_name=index_name,
@@ -329,7 +329,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
                 with mock.patch.object(s2_inference,
                                        'vectorise',
                                        side_effect=original_vectorise) as mock_vectorise:
-                    self.add_documents_and_refresh_index(
+                    self.add_documents(
                         config=self.config,
                         add_docs_params=AddDocsParams(
                             index_name=index_name,
@@ -361,7 +361,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
             "desc 2": "content 2. blah blah blah"
         }
         # 1 valid ID doc:
-        res = self.add_documents_and_refresh_index(
+        res = self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(index_name=self.index_name_1,
                                                               docs=[d1, {'_id': 1224}, {"_id": "fork", "abc": "123"}],
                                                               auto_refresh=True, use_existing_tensors=True,
@@ -369,7 +369,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
         assert [item['status'] for item in res['items']] == [201, 400, 201]
 
         # no valid IDs
-        res_no_valid_id = self.add_documents_and_refresh_index(
+        res_no_valid_id = self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(index_name=self.index_name_1, docs=[d1, {'_id': 1224}, d1],
                                           auto_refresh=True, use_existing_tensors=True, device="cpu"))
@@ -384,11 +384,11 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
             "title 1": "content 1",
             "desc 2": "content 2. blah blah blah"
         }
-        r1 = self.add_documents_and_refresh_index(
+        r1 = self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(index_name=self.index_name_1, docs=[d1],
                                                               auto_refresh=True, use_existing_tensors=True,
                                                               device="cpu"))
-        r2 = self.add_documents_and_refresh_index(
+        r2 = self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(index_name=self.index_name_1, docs=[d1, d1],
                                                               auto_refresh=True, use_existing_tensors=True,
                                                               device="cpu"))
@@ -403,7 +403,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
         """check parity between a doc created with and without use_existing_tensors, then overwritten,
         for a newly created doc.
         """
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_1, docs=[
                 {
                     "_id": "123",
@@ -418,7 +418,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
         tensor_search.delete_index(config=self.config, index_name=self.index_name_1)
         tensor_search.create_vector_index(config=self.config, index_name=self.index_name_1)
 
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_1, docs=[
                 {
                     "_id": "123",
@@ -430,7 +430,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
             document_id="123", show_vectors=True)
         self.assertEqual(use_existing_tensors_doc, regular_doc)
 
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_1, docs=[
                 {
                     "_id": "123",
@@ -449,7 +449,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
         Should only use the latest inserted ID. Make sure it doesn't get the first/middle one
         """
 
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_1, docs=[
                 {
                     "_id": "3",
@@ -464,7 +464,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
 
         tensor_search.delete_index(config=self.config, index_name=self.index_name_1)
         tensor_search.create_vector_index(config=self.config, index_name=self.index_name_1)
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_1, docs=[
                 {
                     "_id": "1",
@@ -490,7 +490,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
 
         self.assertEqual(doc_3_solo, doc_3_duped)
 
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_1, docs=[
                 {
                     "_id": "1",
@@ -526,7 +526,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
         They should still have no tensors.
         """
 
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_1, docs=[
                 {
                     "_id": "123",
@@ -541,7 +541,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
             document_id="123", show_vectors=True)
         assert len(d1["_tensor_facets"]) == 0
 
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_1, docs=[
                 {
                     "_id": "123",
@@ -563,7 +563,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
         When we insert the doc again, with use_existing_tensors, because the content
         hasn't changed, we use the existing (non-existent) vectors
         """
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_1, docs=[
                 {
                     "_id": "123",
@@ -576,7 +576,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
         assert len(d1["_tensor_facets"]) == 1
         assert "title 1" in d1["_tensor_facets"][0]
 
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_1, docs=[
                 {
                     "_id": "123",
@@ -589,7 +589,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
         self.assertEqual(d1["_tensor_facets"], d2["_tensor_facets"])
 
         # The only field is a non-tensor field. This makes a chunkless doc.
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_1, docs=[
                 {
                     "_id": "999",
@@ -600,7 +600,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
             document_id="999", show_vectors=True)
         assert len(d1["_tensor_facets"]) == 0
 
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_1, docs=[
                 {
                     "_id": "999",
@@ -615,7 +615,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
     def test_use_existing_tensors_check_updates(self):
         """ Check to see if the document has been appropriately updated
         """
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_1, docs=[
                 {
                     "_id": "123",
@@ -635,7 +635,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
 
         @unittest.mock.patch("marqo.s2_inference.s2_inference.vectorise", mock_vectorise)
         def run():
-            self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+            self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_1, docs=[
                     {
                         "_id": "123",
@@ -661,7 +661,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
         Checks chunk meta data and vectors are as expected
 
         """
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_1, docs=[
                 {
                     "_id": "123",
@@ -685,7 +685,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
             "fl": 101.3,
             "new_bool": False
         }
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_1, docs=[{"_id": "123", **use_existing_tensor_doc}],
                 auto_refresh=True, non_tensor_fields=["2nd-non-tensor-field", "field_to_be_list", 'new_field_list'],
@@ -714,7 +714,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
 
     @unittest.skip
     def test_use_existing_tensors_check_meta_data_mappings(self):
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_1, docs=[
                 {
                     "_id": "123",
@@ -738,7 +738,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
             "fl": 101.3,
             "new_bool": False
         }
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(index_name=self.index_name_1,
                                                               docs=[{"_id": "123", **use_existing_tensor_doc}],
                                                               auto_refresh=True,
@@ -781,7 +781,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
             index_name=self.index_name_2, index_settings=index_settings, config=self.config)
         hippo_img = TestImageUrls.HIPPO_REALISTIC.value
         artefact_hippo_img = TestImageUrls.HIPPO_STATUE.value
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_2, docs=[
                 {
                     "_id": "123",
@@ -820,7 +820,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
                 "fl": 3.5,
                 "non-tensor-field": ["it", "is", "9", "o clock"]
             }
-            self.add_documents_and_refresh_index(
+            self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(index_name=self.index_name_2,
                                                                   docs=[{"_id": "123", **use_existing_tensor_doc}],
                                                                   auto_refresh=True,
@@ -900,7 +900,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
 
         for doc_arg in doc_args:
             # Add doc normally without use_existing_tensors
-            add_res = self.add_documents_and_refresh_index(
+            add_res = self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(index_name=self.index_name_1,
                                                                   docs=doc_arg, auto_refresh=True, device="cpu"))
 
@@ -909,7 +909,7 @@ class TestAddDocumentsUseExistingTensors(MarqoTestCase):
                 document_ids=[doc["_id"] for doc in doc_arg], show_vectors=True)
 
             # Then replace doc with use_existing_tensors
-            add_res = self.add_documents_and_refresh_index(
+            add_res = self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(index_name=self.index_name_1,
                                                                   docs=doc_arg, auto_refresh=True,
                                                                   use_existing_tensors=True, device="cpu"))

--- a/tests/tensor_search/test_context_vectors_search.py
+++ b/tests/tensor_search/test_context_vectors_search.py
@@ -90,12 +90,12 @@ class TestContextVectors(MarqoTestCase):
         """Test to ensure that the score is the same for the same query with different context vectors combinations."""
         for index_name in [self.structured_index_with_random_model, self.unstructured_index_with_random_model]:
             tensor_fields = ["text_field_1"] if index_name == self.unstructured_index_with_random_model else None
-            self.add_documents_and_refresh_index(config=self.config, add_docs_params=
+            self.add_documents(config=self.config, add_docs_params=
                                         AddDocsParams(index_name=index_name,
                                                       docs=[{"text_field_1": "A rider", "_id": "1"}],
                                                       tensor_fields=tensor_fields
                                                       )
-                                                 )
+                               )
             with self.subTest(msg=index_name):
                 query = {
                     "A rider is riding a horse jumping over the barrier": 1,

--- a/tests/tensor_search/test_default_device.py
+++ b/tests/tensor_search/test_default_device.py
@@ -98,7 +98,7 @@ class TestDefaultDevice(MarqoTestCase):
                 with patch.dict("marqo.tensor_search.utils.os.environ", {EnvVars.MARQO_BEST_AVAILABLE_DEVICE: best_available_device}),\
                      patch("marqo.tensor_search.utils.check_device_is_available", return_value=True) as mock_check_device_is_available,\
                      patch("marqo.s2_inference.s2_inference.vectorise", return_value=dummy_vector) as mock_vectorise:
-                        self.add_documents_and_refresh_index(
+                        self.add_documents(
                         config=self.config,
                         add_docs_params=AddDocsParams(**AddDocsParams_kwargs)
                         )
@@ -119,7 +119,7 @@ class TestDefaultDevice(MarqoTestCase):
 
         for AddDocsParams_kwargs in AddDocsParams_kwargs_list:
             try:
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                 config=self.config,
                 add_docs_params=AddDocsParams(**AddDocsParams_kwargs)
                 )
@@ -139,7 +139,7 @@ class TestDefaultDevice(MarqoTestCase):
         for explicitly_set_device in devices_list:
             with patch("marqo.s2_inference.s2_inference.vectorise", return_value=dummy_vector) as mock_vectorise,\
                  patch("marqo.tensor_search.models.add_docs_objects.get_best_available_device") as mock_get_best_available_device:
-                    self.add_documents_and_refresh_index(
+                    self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(index_name=self.index_name_1,
                                     docs=[{"Title": "blah"} for _ in range(5)],
@@ -171,9 +171,9 @@ class TestDefaultDevice(MarqoTestCase):
                 mocks = [patcher.start() for patcher in patchers]
 
                 # Add docs
-                self.add_documents_and_refresh_index(config=self.config, add_docs_params = AddDocsParams(
+                self.add_documents(config=self.config, add_docs_params = AddDocsParams(
                     auto_refresh=True, device="cpu", index_name=self.index_name_1, docs=[{"test": "blah"}])
-                                                     )
+                                   )
 
                 # Call search
                 tensor_search.search(
@@ -215,9 +215,9 @@ class TestDefaultDevice(MarqoTestCase):
                 mocks = [patcher.start() for patcher in patchers]
 
                 # Add docs
-                self.add_documents_and_refresh_index(config=self.config, add_docs_params = AddDocsParams(
+                self.add_documents(config=self.config, add_docs_params = AddDocsParams(
                     auto_refresh=True, device="cpu", index_name=self.index_name_1, docs=[{"test": "blah"}])
-                                                     )
+                                   )
 
                 # Call search
                 tensor_search.search(
@@ -246,9 +246,9 @@ class TestDefaultDevice(MarqoTestCase):
         """
         self.assertNotIn("MARQO_BEST_AVAILABLE_DEVICE", os.environ)
         # Add docs
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params = AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params = AddDocsParams(
             auto_refresh=True, device="cpu", index_name=self.index_name_1, docs=[{"test": "blah"}])
-                                             )
+                           )
 
         try:
             # Call search
@@ -287,12 +287,12 @@ class TestDefaultDevice(MarqoTestCase):
                         mock_obj.return_value = self.mock_bulk_vector_text_search_results
 
                 # Add docs
-                self.add_documents_and_refresh_index(config=self.config, add_docs_params = AddDocsParams(
+                self.add_documents(config=self.config, add_docs_params = AddDocsParams(
                     auto_refresh=True, device="cpu", index_name=self.index_name_1, docs=[
                         {"abc": "Exact match hehehe", "other field": "baaadd", "_id": "id1-first"},
                         {"abc": "random text", "other field": "Close match hehehe", "_id": "id1-second"}
                     ])
-                                                     )
+                                   )
 
                 # Call bulk search
                 tensor_search.bulk_search(
@@ -351,12 +351,12 @@ class TestDefaultDevice(MarqoTestCase):
                         mock_obj.return_value = self.mock_bulk_vector_text_search_results
 
                 # Add docs
-                self.add_documents_and_refresh_index(config=self.config, add_docs_params = AddDocsParams(
+                self.add_documents(config=self.config, add_docs_params = AddDocsParams(
                     auto_refresh=True, device="cpu", index_name=self.index_name_1, docs=[
                         {"abc": "Exact match hehehe", "other field": "baaadd", "_id": "id1-first"},
                         {"abc": "random text", "other field": "Close match hehehe", "_id": "id1-second"}
                     ])
-                                                     )
+                                   )
 
                 # Call bulk search
                 tensor_search.bulk_search(
@@ -398,9 +398,9 @@ class TestDefaultDevice(MarqoTestCase):
         """
         self.assertNotIn("MARQO_BEST_AVAILABLE_DEVICE", os.environ)
         # Add docs
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params = AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params = AddDocsParams(
             auto_refresh=True, device="cpu", index_name=self.index_name_1, docs=[{"test": "blah"}])
-                                             )
+                           )
 
         try:
             # Call bulk search

--- a/tests/tensor_search/test_image_download_headers.py
+++ b/tests/tensor_search/test_image_download_headers.py
@@ -63,7 +63,7 @@ class TestImageDownloadHeaders(MarqoTestCase):
             config=self.config, index_name=self.index_name_1, index_settings=self.image_index_settings()
         )
         image_download_headers = {"Authorization": "some secret key blah"}
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_1, docs=[
                 {"_id": "1", "image": self.real_img_url}],
             auto_refresh=True, image_download_headers=image_download_headers, device="cpu"))
@@ -105,7 +105,7 @@ class TestImageDownloadHeaders(MarqoTestCase):
             image_download_headers = {"Authorization": "some secret key blah"}
 
             # Add a document with an image URL
-            self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+            self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_1, docs=[
                     {"_id": "1", "image": self.real_img_url}
                 ], auto_refresh=True, image_download_headers=image_download_headers, device="cpu"
@@ -138,7 +138,7 @@ class TestImageDownloadHeaders(MarqoTestCase):
         mock_load_image_from_path.side_effect = pass_through_load_image_from_path
 
         with unittest.mock.patch("marqo.s2_inference.clip_utils.load_image_from_path", mock_load_image_from_path):
-            self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+            self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_1, docs=[
                     {
                         "_id": "1",

--- a/tests/tensor_search/test_image_preprocessing.py
+++ b/tests/tensor_search/test_image_preprocessing.py
@@ -52,8 +52,8 @@ class TestImagePreprocessing(MarqoTestCase):
             tensor_fields = None if index_name == self.structured_image_index else ["image_field_1"]
 
             with self.subTest(f"index_name = {index_name}"):
-                self.add_documents_and_refresh_index(config=self.config,
-                                                     add_docs_params=AddDocsParams(index_name=index_name,
+                self.add_documents(config=self.config,
+                                   add_docs_params=AddDocsParams(index_name=index_name,
                                                                           docs=documents,
                                                                           tensor_fields=tensor_fields))
                 search_result = tensor_search.search(config=self.config,
@@ -74,8 +74,8 @@ class TestImagePreprocessing(MarqoTestCase):
             tensor_fields = None if index_name == self.structured_image_index else ["image_field_1"]
 
             with self.subTest(f"index_name = {index_name}"):
-                self.add_documents_and_refresh_index(config=self.config,
-                                                     add_docs_params=AddDocsParams(index_name=index_name,
+                self.add_documents(config=self.config,
+                                   add_docs_params=AddDocsParams(index_name=index_name,
                                                                           docs=documents,
                                                                           tensor_fields=tensor_fields))
                 get_doc_result = tensor_search.get_document_by_id(config=self.config,

--- a/tests/tensor_search/test_index_meta_cache.py
+++ b/tests/tensor_search/test_index_meta_cache.py
@@ -87,11 +87,11 @@ class TestIndexMetaCache(MarqoTestCase):
         assert self.index_name_3 in index_meta_cache.get_cache()
 
     def test_add_new_fields_preserves_index_cache(self):
-        add_doc_res_1 = self.add_documents_and_refresh_index(
+        add_doc_res_1 = self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(index_name=self.index_name_1, docs=[{"abc": "def"}], auto_refresh=True, device="cpu")
         )
-        add_doc_res_2 = self.add_documents_and_refresh_index(
+        add_doc_res_2 = self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_1, docs=[{"cool field": "yep yep", "haha": "heheh"}],
                 auto_refresh=True, device="cpu"
@@ -100,7 +100,7 @@ class TestIndexMetaCache(MarqoTestCase):
         index_info_t0 = index_meta_cache.get_cache()[self.index_name_1]
         # reset cache:
         index_meta_cache.empty_cache()
-        add_doc_res_3 = self.add_documents_and_refresh_index(
+        add_doc_res_3 = self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_1, docs=[{"newer field": "ndewr content",
                                                                      "goblin": "paradise"}],
@@ -119,12 +119,12 @@ class TestIndexMetaCache(MarqoTestCase):
 
     def test_delete_removes_index_from_cache(self):
         """note the implicit index creation"""
-        add_doc_res_1 = self.add_documents_and_refresh_index(
+        add_doc_res_1 = self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_1, docs=[{"abc": "def"}], auto_refresh=True, device="cpu"
             )
         )
-        add_doc_res_2 = self.add_documents_and_refresh_index(
+        add_doc_res_2 = self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_2, docs=[{"abc": "def"}], auto_refresh=True, device="cpu"
             )
@@ -147,7 +147,7 @@ class TestIndexMetaCache(MarqoTestCase):
         }
         d1 = {"some doc 1": "some 2 marqo", "field abc": "robodog is not a cat", "_id": "Jupyter_12"}
         d2 = {"exclude me": "marqo"}
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_1, auto_refresh=True, docs=[d0, d1, d2], device="cpu")
         )
@@ -167,7 +167,7 @@ class TestIndexMetaCache(MarqoTestCase):
         }
         d1 = {"some doc 1": "some 2 marqo", "field abc": "robodog is not a cat", "_id": "Jupyter_12"}
         d2 = {"exclude me": "marqo"}
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_1, auto_refresh=True,
                 docs=[d0, d1, d2 ], device="cpu")
@@ -201,7 +201,7 @@ class TestIndexMetaCache(MarqoTestCase):
         # save the state of the cache:
         cache_t0 = copy.deepcopy(index_meta_cache.get_cache())
         # mock external party indexing something:
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(index_name=index_name,
                 docs=docs, auto_refresh=True, device="cpu"))
 
@@ -227,7 +227,7 @@ class TestIndexMetaCache(MarqoTestCase):
         """ search (search_method=SearchMethod.lexical)
         after the first cache hit is empty, it should be updated.
         """
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(index_name=self.index_name_1,
                 docs=[{"some field": "Plane 1"}], auto_refresh=True, device="cpu"))
         self._simulate_externally_added_docs(
@@ -246,7 +246,7 @@ class TestIndexMetaCache(MarqoTestCase):
     def test_search_vectors_externally_created_field(self):
         """ search (search_method=SearchMethod.chunk_embeddings)
         """
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_1, docs=[{"some field": "Plane 1"}], auto_refresh=True, device="cpu"))
         self._simulate_externally_added_docs(
@@ -263,7 +263,7 @@ class TestIndexMetaCache(MarqoTestCase):
         assert result_2["hits"][0]["_id"] == "1234"
 
     def test_search_vectors_externally_created_field_attributes(self):
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(index_name=self.index_name_1,
                 docs=[{"some field": "Plane 1"}], auto_refresh=True, device="cpu"))
         self._simulate_externally_added_docs(
@@ -281,7 +281,7 @@ class TestIndexMetaCache(MarqoTestCase):
         index_meta_cache.empty_cache()
         tensor_search.create_vector_index(
             config=self.config, index_name=self.index_name_3)
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(index_name=self.index_name_1,
                 docs=[{"some field": "Plane 1"}], auto_refresh=True, device="cpu"))
         self._simulate_externally_added_docs(
@@ -299,7 +299,7 @@ class TestIndexMetaCache(MarqoTestCase):
         assert result_2["hits"][0]["_id"] == "1234"
 
     def test_vector_search_non_existent_field(self):
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(index_name=self.index_name_1,
                 docs=[{"some field": "Plane 1"}], auto_refresh=True, device="cpu"))
         assert "brand new field" not in index_meta_cache.get_cache()[self.index_name_1].properties
@@ -311,7 +311,7 @@ class TestIndexMetaCache(MarqoTestCase):
 
     def test_lexical_search_non_existent_field(self):
         """"""
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(index_name=self.index_name_1,
                 docs=[{"some field": "Plane 1"}], auto_refresh=True, device="cpu"))
         assert "brand new field" not in index_meta_cache.get_cache()[self.index_name_1].properties
@@ -326,7 +326,7 @@ class TestIndexMetaCache(MarqoTestCase):
         The cache should update after search
         With single KNN field, doc should be found even if field is not in cache
         """
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(index_name=self.index_name_1,
                 docs=[{"some field": "Plane 1"}], auto_refresh=True, device="cpu"))
         time.sleep(2.5)
@@ -560,7 +560,7 @@ class TestIndexMetaCache(MarqoTestCase):
         # we need to search it once, to get something in the cache, otherwise
         # the threads will see an empty cache and try to fill it
         try:
-            self.add_documents_and_refresh_index(
+            self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(
                     index_name=self.index_name_1, docs=[{"hi": "hello"}],
                     auto_refresh=False, device="cpu"))
@@ -632,7 +632,7 @@ class TestIndexMetaCache(MarqoTestCase):
                                               index_settings={"index_defaults": {"model": "random"}})
             clear_cache_thread = threading.Thread(target=clear_cache)
             clear_cache_thread.start()
-            self.add_documents_and_refresh_index(
+            self.add_documents(
                 config=self.config,
                 add_docs_params=AddDocsParams(
                     **{
@@ -672,7 +672,7 @@ class TestIndexMetaCache(MarqoTestCase):
             clear_cache_thread = threading.Thread(target=delete_index)
             clear_cache_thread.start()
             try:
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     **{"config": self.config},
                     add_docs_params=AddDocsParams(
                         **{

--- a/tests/tensor_search/test_lexical_search.py
+++ b/tests/tensor_search/test_lexical_search.py
@@ -44,7 +44,7 @@ class TestLexicalSearch(MarqoTestCase):
 
     
     def test_lexical_search_empty_text(self):
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(index_name=self.index_name_1,
                 docs=[{"some doc 1": "some field 2", "some doc 2": "some other thing"}], auto_refresh=True, device="cpu")
         )
@@ -53,7 +53,7 @@ class TestLexicalSearch(MarqoTestCase):
         assert res["hits"] == []
 
     def test_lexical_search_bad_text_type(self):
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(index_name=self.index_name_1,
                 docs=[{"some doc 1": "some field 2", "some doc 2": "some other thing"}], auto_refresh=True, device="cpu"))
         bad_args = [None, 1234, 1.0]
@@ -76,7 +76,7 @@ class TestLexicalSearch(MarqoTestCase):
             "the big field": "very unlikely theory. marqo is pretty awesom, in the field"
         }
         d1 = {"title": "Marqo", "some doc 2": "some other thing", "_id": "abcdef"}
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_1, auto_refresh=True,
                 docs=[d1,
@@ -101,10 +101,10 @@ class TestLexicalSearch(MarqoTestCase):
               "_id": "122"}
         d4 = {"Lucy": "Travis", "field lambda": "there is a whole bunch of text here. "
                                                 "Just a slight mention of a field", "_id": "123"}
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(index_name=self.index_name_1, auto_refresh=True,
                 docs=[d0, d4, d1 ], device="cpu"))
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(index_name=self.index_name_1, auto_refresh=True,
                 docs=[d3, d2], device="cpu"))
         res = tensor_search._lexical_search(
@@ -127,11 +127,11 @@ class TestLexicalSearch(MarqoTestCase):
               "field lambda": "some prop called marqo. This actually has a lot more content than you thought." }
         d4 = {"Lucy": "Travis", "field lambda": "there is a whole bunch of text here. "
                                                 "Just a slight mention of a field", "_id": "123"}
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_1, auto_refresh=True,
                 docs=[d0, d4, d1], device="cpu"))
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_1, auto_refresh=True, docs=[d3, d2], device="cpu")
         )
@@ -157,7 +157,7 @@ class TestLexicalSearch(MarqoTestCase):
                                                 "Another bunch of words that may mean something. "
                                                 "Just a slight mention of a field"}
         d5 = {"some completely irrelevant": "document hehehe"}
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(index_name=self.index_name_1, auto_refresh=True,
                 docs=[d0, d4, d1, d3, d2], device="cpu"))
         r1 = tensor_search._lexical_search(
@@ -191,7 +191,7 @@ class TestLexicalSearch(MarqoTestCase):
         d4 = {"Lucy": "Travis", "field lambda": "there is a whole bunch of text here. "
                                                 "Just a slight mention of a field"}
         d5 = {"some completely irrelevant": "document hehehe"}
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(index_name=self.index_name_1, auto_refresh=True,
                 docs=[d0, d4, d1, d3, d2], device="cpu"))
         res_lexical_search = tensor_search._lexical_search(
@@ -225,7 +225,7 @@ class TestLexicalSearch(MarqoTestCase):
             "the big field": "just your average doc...",
             "Cool field": "Marqo is the best!"
         }
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(index_name=self.index_name_1, auto_refresh=True,
                 docs=[d0], device="cpu"))
         assert [] == tensor_search._lexical_search(
@@ -235,7 +235,7 @@ class TestLexicalSearch(MarqoTestCase):
         assert len (grey_query["hits"]) == 1
         assert grey_query["hits"][0]["_id"] == a_consistent_id
         # update doc so it does indeed get returned
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(index_name=self.index_name_1, auto_refresh=True,
                 docs=[d1], device="cpu"))
         cool_query = tensor_search._lexical_search(
@@ -257,10 +257,10 @@ class TestLexicalSearch(MarqoTestCase):
         d4 = {"Lucy": "Travis", "field lambda": "there is a whole bunch of text here. "
                                                 "Just a slight mention of a field", "day": 190,
               "_id": "123"}
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(index_name=self.index_name_1, auto_refresh=True,
                 docs=[d0, d4, d1 ], device="cpu"))
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(index_name=self.index_name_1, auto_refresh=True,
                 docs=[d3, d2], device="cpu"))
         res = tensor_search._lexical_search(
@@ -280,7 +280,7 @@ class TestLexicalSearch(MarqoTestCase):
         d1 = {"title": "Marqo", "some doc 2": "some other thing", "_id": "abcdef"}
         d2 = {"some doc 1": "some 2 jnkerkbj", "field abc": "extravagant robodog is not a cat", "_id": "Jupyter_12"}
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_1, auto_refresh=True,
                 docs=[d0, d1, d2], device="cpu")
@@ -344,7 +344,7 @@ class TestLexicalSearch(MarqoTestCase):
         ]
         fields = ["Field 1", "Field 2", "Field 3"]
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_1, docs=docs, auto_refresh=False, device="cpu")
         )
@@ -405,7 +405,7 @@ class TestLexicalSearch(MarqoTestCase):
                 assert len(id_only_hits) == 0
 
     def test_lexical_search_list(self):
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_1, docs=[
                     {"abc": "some text", "other field": "baaadd", "_id": "5678", "my_string": "b"},
@@ -440,7 +440,7 @@ class TestLexicalSearch(MarqoTestCase):
         assert res_filtered_other_list['hits'][0]['_id'] == '1001'
 
     def test_lexical_search_list_searchable_attr(self):
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_1, docs=[
                     {"abc": "some text", "other field": "baaadd", "_id": "5678", "my_string": "b"},
@@ -463,7 +463,7 @@ class TestLexicalSearch(MarqoTestCase):
         assert len(res_wrong_attr['hits']) == 0
 
     def test_lexical_search_filter_with_dot(self):
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(index_name=self.index_name_1, docs=[
                 {"content": "a man on a horse", "filename" : "Important_File_1.pdf", "_id":"123"},
                 {"content": "the horse is eating grass", "filename": "Important_File_2.pdf", "_id": "456"},

--- a/tests/tensor_search/test_model_auth.py
+++ b/tests/tensor_search/test_model_auth.py
@@ -123,7 +123,7 @@ class TestModelAuthLoadedS3(MarqoTestCase):
 
         with unittest.mock.patch('boto3.client', return_value=mock_s3_client) as mock_boto3_client:
             # Call the function that uses the generate_presigned_url method
-            res = cls.add_documents_and_refresh_index(config=cls.config, add_docs_params=AddDocsParams(
+            res = cls.add_documents(config=cls.config, add_docs_params=AddDocsParams(
                 index_name=cls.index_name_1, docs=[{'a': 'b'}],
                 model_auth=ModelAuth(
                     s3=S3Auth(aws_access_key_id=cls.fake_access_key_id, aws_secret_access_key=cls.fake_secret_key)),
@@ -161,7 +161,7 @@ class TestModelAuthLoadedS3(MarqoTestCase):
 
     def test_after_downloading_auth_doesnt_matter(self):
         """on this instance, at least"""
-        res = self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        res = self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_1, docs=[{'c': 'd'}], device="cpu"
         ))
         assert not res['errors']
@@ -173,7 +173,7 @@ class TestModelAuthLoadedS3(MarqoTestCase):
         assert not any([m['model_name'] == 'my_model' for m in mods])
         mock_req = mock.MagicMock()
         with mock.patch('urllib.request.urlopen', mock_req):
-            res = self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+            res = self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_1, auto_refresh=True, docs=[{'c': 'd'}], device="cpu"
             ))
             assert not res['errors']
@@ -255,7 +255,7 @@ class TestModelAuthOpenCLIP(MarqoTestCase):
         with unittest.mock.patch('open_clip.create_model_and_transforms', mock_open_clip_creat_model):
             with unittest.mock.patch('marqo.s2_inference.model_downloading.from_hf.hf_hub_download', mock_hf_hub_download):
                 try:
-                    self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+                    self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                         index_name=self.index_name_1, auto_refresh=True, docs=[{'a': 'b'}],
                         model_auth=ModelAuth(hf=HfAuth(token=hf_token)), device="cpu"))
                 except BadRequestError as e:
@@ -478,7 +478,7 @@ class TestModelAuthOpenCLIP(MarqoTestCase):
                 with unittest.mock.patch(
                     'marqo.s2_inference.processing.custom_clip_utils.download_pretrained_from_url'
                 ) as mock_download_pretrained_from_url:
-                    self.add_documents_and_refresh_index(
+                    self.add_documents(
                         config=self.config,
                         add_docs_params=AddDocsParams(
                             index_name=self.index_name_1,
@@ -614,7 +614,7 @@ class TestModelAuthOpenCLIP(MarqoTestCase):
                 aws_access_key_id=fake_access_key_id,
                 aws_secret_access_key=fake_secret_key)
             )
-            res = self.add_documents_and_refresh_index(
+            res = self.add_documents(
                 config=self.config,
                 add_docs_params=AddDocsParams(
                     index_name=self.index_name_1,
@@ -691,7 +691,7 @@ class TestModelAuthOpenCLIP(MarqoTestCase):
 
         with unittest.mock.patch('boto3.client', return_value=mock_s3_client):
             with self.assertRaises(BadRequestError) as cm2:
-                res = self.add_documents_and_refresh_index(
+                res = self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=self.index_name_1, auto_refresh=True,
                         docs=[{'title': 'blah blah'}], device="cpu"
@@ -738,7 +738,7 @@ class TestModelAuthOpenCLIP(MarqoTestCase):
         self.assertIn("403 error when trying to retrieve model from s3", str(cm.exception))
 
         with self.assertRaises(BadRequestError) as cm2:
-            res = self.add_documents_and_refresh_index(
+            res = self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(
                     index_name=self.index_name_1, auto_refresh=True,
                     docs=[{'title': 'blah blah'}], model_auth=model_auth, device="cpu"
@@ -780,7 +780,7 @@ class TestModelAuthOpenCLIP(MarqoTestCase):
         self.assertIn("Could not find the specified Hugging Face model repository.", str(cm.exception))
 
         with self.assertRaises(BadRequestError) as cm2:
-            res = self.add_documents_and_refresh_index(
+            res = self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(
                     index_name=self.index_name_1, auto_refresh=True,
                     docs=[{'title': 'blah blah'}], model_auth=model_auth, device="cpu"
@@ -823,7 +823,7 @@ class TestModelAuthOpenCLIP(MarqoTestCase):
         self.assertIn("Could not find the specified Hugging Face model repository.", str(cm.exception))
 
         with self.assertRaises(BadRequestError) as cm2:
-            res = self.add_documents_and_refresh_index(
+            res = self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(
                     index_name=self.index_name_1, auto_refresh=True,
                     docs=[{'title': 'blah blah'}], model_auth=model_auth, device="cpu"
@@ -1122,7 +1122,7 @@ class TestModelAuthDownloadAndExtractS3HFModel(MarqoTestCase):
 
     def test_after_downloading_auth_doesnt_matter(self):
         """on this instance, at least"""
-        res = self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        res = self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_1, auto_refresh=True, docs=[{'c': 'd'}], device="cpu"
         ))
         assert not res['errors']
@@ -1134,7 +1134,7 @@ class TestModelAuthDownloadAndExtractS3HFModel(MarqoTestCase):
         assert not any([m['model_name'] == 'my_model' for m in mods])
         mock_req = mock.MagicMock()
         with mock.patch('urllib.request.urlopen', mock_req):
-            res = self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+            res = self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_1, auto_refresh=True, docs=[{'c': 'd'}], device="cpu"
             ))
             assert not res['errors']
@@ -1570,7 +1570,7 @@ class TestModelAuthlLoadForHFModelBasic(MarqoTestCase):
                 with unittest.mock.patch('marqo.s2_inference.model_downloading.from_hf.hf_hub_download', mock_hf_hub_download):
                     with unittest.mock.patch("marqo.s2_inference.hf_utils.extract_huggingface_archive", mock_extract_huggingface_archive):
                         try:
-                            self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+                            self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                                 index_name=self.index_name_1, auto_refresh=True, docs=[{'a': 'b'}],
                                 model_auth=ModelAuth(hf=HfAuth(token=hf_token)), device="cpu"))
                         except KeyError as e:
@@ -1630,7 +1630,7 @@ class TestModelAuthlLoadForHFModelBasic(MarqoTestCase):
                 with unittest.mock.patch('marqo.s2_inference.model_downloading.from_hf.hf_hub_download', mock_hf_hub_download):
                     with unittest.mock.patch("marqo.s2_inference.hf_utils.extract_huggingface_archive", mock_extract_huggingface_archive):
                         try:
-                            self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+                            self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                                 index_name=self.index_name_1, auto_refresh=True, docs=[{'a': 'b'}], device="cpu"))
                         except KeyError as e:
                             # KeyError as this is not a real model. It does not have an attention_mask
@@ -1702,7 +1702,7 @@ class TestModelAuthlLoadForHFModelBasic(MarqoTestCase):
                         with unittest.mock.patch("marqo.s2_inference.hf_utils.extract_huggingface_archive",
                                                  mock_extract_huggingface_archive):
                             try:
-                                self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+                                self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                                     index_name=self.index_name_1, auto_refresh=True, docs=[{'a': 'b'}],
                                     model_auth=ModelAuth(s3=S3Auth(aws_access_key_id=fake_access_key_id,
                                                                    aws_secret_access_key=fake_secret_key)),
@@ -1757,7 +1757,7 @@ class TestModelAuthlLoadForHFModelBasic(MarqoTestCase):
         with mock.patch('transformers.AutoModel.from_pretrained', new=mock_automodel_from_pretrained):
             with mock.patch('marqo.s2_inference.processing.custom_clip_utils.download_pretrained_from_url', new=mock_download):
                 with mock.patch("marqo.s2_inference.hf_utils.extract_huggingface_archive", new=mock_extract_huggingface_archive):
-                    self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+                    self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                         index_name=self.index_name_1, auto_refresh=True, docs=[{'a': 'b'}], device="cpu"))
 
         assert len(mock_extract_huggingface_archive.call_args_list) == 1
@@ -1797,7 +1797,7 @@ class TestModelAuthlLoadForHFModelBasic(MarqoTestCase):
 
         with unittest.mock.patch("transformers.AutoModel.from_pretrained",  mock_automodel_from_pretrained):
             with unittest.mock.patch("transformers.AutoTokenizer.from_pretrained", mock_autotokenizer_from_pretrained):
-                self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+                self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                     index_name=self.index_name_1, auto_refresh=True, docs=[{'a': 'b'}], model_auth=ModelAuth(hf=HfAuth(token=hf_token)),
                     device="cpu"))
 
@@ -1868,7 +1868,7 @@ class TestModelAuthlLoadForHFModelBasic(MarqoTestCase):
         mock_automodel_from_pretrained = mock.MagicMock(side_effect=AutoModel.from_pretrained)
 
         with mock.patch('transformers.AutoModel.from_pretrained', new=mock_automodel_from_pretrained):
-            self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+            self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_1, auto_refresh=True, docs=[{'a': 'b'}], device="cpu"))
 
         mock_automodel_from_pretrained.assert_called_once_with(
@@ -2073,7 +2073,7 @@ class TestS3ModelAuthlLoadForHFModelVariants(MarqoTestCase):
                 with unittest.mock.patch(
                     'marqo.s2_inference.processing.custom_clip_utils.download_pretrained_from_url'
                 ) as mock_download_pretrained_from_url:
-                    self.add_documents_and_refresh_index(
+                    self.add_documents(
                         config=self.config,
                         add_docs_params=AddDocsParams(
                             index_name=self.index_name_1,
@@ -2195,7 +2195,7 @@ class TestS3ModelAuthlLoadForHFModelVariants(MarqoTestCase):
                 aws_access_key_id=fake_access_key_id,
                 aws_secret_access_key=fake_secret_key)
             )
-            res = self.add_documents_and_refresh_index(
+            res = self.add_documents(
                 config=self.config,
                 add_docs_params=AddDocsParams(
                     index_name=self.index_name_1,
@@ -2268,7 +2268,7 @@ class TestS3ModelAuthlLoadForHFModelVariants(MarqoTestCase):
 
         with unittest.mock.patch('boto3.client', return_value=mock_s3_client):
             with self.assertRaises(BadRequestError) as cm2:
-                res = self.add_documents_and_refresh_index(
+                res = self.add_documents(
                     config=self.config, add_docs_params=AddDocsParams(
                         index_name=self.index_name_1, auto_refresh=True,
                         docs=[{'title': 'blah blah'}], device="cpu"
@@ -2313,7 +2313,7 @@ class TestS3ModelAuthlLoadForHFModelVariants(MarqoTestCase):
         self.assertIn("403 error when trying to retrieve model from s3", str(cm.exception))
 
         with self.assertRaises(BadRequestError) as cm2:
-            res = self.add_documents_and_refresh_index(
+            res = self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(
                     index_name=self.index_name_1, auto_refresh=True,
                     docs=[{'title': 'blah blah'}], model_auth=model_auth, device="cpu"
@@ -2354,7 +2354,7 @@ class TestS3ModelAuthlLoadForHFModelVariants(MarqoTestCase):
         self.assertIn("Could not find the specified Hugging Face model repository.", str(cm.exception))
 
         with self.assertRaises(BadRequestError) as cm2:
-            res = self.add_documents_and_refresh_index(
+            res = self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(
                     index_name=self.index_name_1, auto_refresh=True,
                     docs=[{'title': 'blah blah'}], model_auth=model_auth, device="cpu"
@@ -2396,7 +2396,7 @@ class TestS3ModelAuthlLoadForHFModelVariants(MarqoTestCase):
         self.assertIn("Could not find the specified Hugging Face model repository.", str(cm.exception))
 
         with self.assertRaises(BadRequestError) as cm2:
-            res = self.add_documents_and_refresh_index(
+            res = self.add_documents(
                 config=self.config, add_docs_params=AddDocsParams(
                     index_name=self.index_name_1, auto_refresh=True,
                     docs=[{'title': 'blah blah'}], model_auth=model_auth, device="cpu"

--- a/tests/tensor_search/test_model_auth_cuda.py
+++ b/tests/tensor_search/test_model_auth_cuda.py
@@ -113,7 +113,7 @@ class TestModelAuthLoadedS3(MarqoTestCase):
 
     def test_after_downloading_auth_doesnt_matter(self):
         """on this instance, at least"""
-        res = self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        res = self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.index_name_1, auto_refresh=True, docs=[{'c': 'd'}], device=self.device
         ))
         assert not res['errors']
@@ -123,7 +123,7 @@ class TestModelAuthLoadedS3(MarqoTestCase):
         tensor_search.eject_model(model_name=self.custom_model_name, device=self.device)
         mock_req = mock.MagicMock()
         with mock.patch('urllib.request.urlopen', mock_req):
-            res = self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+            res = self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_1, auto_refresh=True, docs=[{'c': 'd'}],
                 device=self.device
             ))

--- a/tests/tensor_search/test_multimodal_tensor_combination.py
+++ b/tests/tensor_search/test_multimodal_tensor_combination.py
@@ -226,12 +226,12 @@ class TestMultimodalTensorCombination(MarqoTestCase):
                         }
                 }
 
-                self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+                self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                     index_name=index.name, docs=[doc, ],
                     mappings=mappings if isinstance(index, UnstructuredMarqoIndex) else None,
                     device="cpu",
                     tensor_fields=["combo_text_image"] if isinstance(index, UnstructuredMarqoIndex) else None),
-                                                     )
+                                   )
                 added_doc = tensor_search.get_document_by_id(config=self.config, index_name=index.name,
                                                              document_id="1", show_vectors=True)
                 for key, value in doc.items():
@@ -279,7 +279,7 @@ class TestMultimodalTensorCombination(MarqoTestCase):
                         }
                 }
 
-                self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+                self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                     index_name=index.name, docs=[doc, ],
                     mappings=mappings if isinstance(index, UnstructuredMarqoIndex) else None,
                     device="cpu",
@@ -319,7 +319,7 @@ class TestMultimodalTensorCombination(MarqoTestCase):
                         }
                 }
 
-                self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+                self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                     index_name=index.name, docs=[doc, ],
                     mappings=mappings if isinstance(index, UnstructuredMarqoIndex) else None,
                     device="cpu",
@@ -389,12 +389,12 @@ class TestMultimodalTensorCombination(MarqoTestCase):
 
         for mappings, tensor_fields, number_of_documents, number_of_vectors in test_cases:
             with self.subTest(f"{mappings}, {tensor_fields}"):
-                self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+                self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                     index_name=self.unstructured_random_multimodal_index.name, docs=doc,
                     mappings=mappings,
                     device="cpu",
                     tensor_fields=tensor_fields),
-                                                     )
+                                   )
 
                 res = self.monitoring.get_index_stats_by_name(index_name=self.unstructured_random_multimodal_index.name)
                 self.assertEqual(number_of_documents, res.number_of_documents)
@@ -431,7 +431,7 @@ class TestMultimodalTensorCombination(MarqoTestCase):
                     error_msg = error_msg_unstructured if isinstance(index, UnstructuredMarqoIndex) else error_msg_structured
                     with self.subTest(error_msg):
                         with mock.patch("marqo.s2_inference.s2_inference.vectorise") as mock_vectorise:
-                            res = self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+                            res = self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                                 index_name=index.name, docs=[document, ],
                                 mappings=mappings if isinstance(index, UnstructuredMarqoIndex) else None,
                                 device="cpu",
@@ -450,7 +450,7 @@ class TestMultimodalTensorCombination(MarqoTestCase):
             with self.subTest(f"Index type: {index.type}. Index name: {index.name}"):
                 def get_score(document):
                     self.clear_indexes(self.indexes)
-                    res = self.add_documents_and_refresh_index(
+                    res = self.add_documents(
                         config=self.config, add_docs_params=AddDocsParams(
                             index_name=index.name, docs=[document],
                             mappings={"combo_text_image": {"type": "multimodal_combination",
@@ -486,7 +486,7 @@ class TestMultimodalTensorCombination(MarqoTestCase):
     def test_multimodal_tensor_combination_tensor_value(self):
         for index in [self.unstructured_unnormalized_multimodal_index, self.structured_unnormalized_multimodal_index]:
             with self.subTest(f"Index type: {index.type}. Index name: {index.name}"):
-                res = self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+                res = self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                     index_name=index.name, docs=[
                         {
                             "text_field_1": "A rider is riding a horse jumping over the barrier.",
@@ -527,7 +527,7 @@ class TestMultimodalTensorCombination(MarqoTestCase):
                     } if isinstance(index, UnstructuredMarqoIndex) else None
                 ))
 
-                self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+                self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                     index_name=index.name, docs=[
                         {
                             "text_field_3": "A rider is riding a horse jumping over the barrier.",
@@ -573,7 +573,7 @@ class TestMultimodalTensorCombination(MarqoTestCase):
             with self.subTest(f"Index type: {index.type}. Index name: {index.name}"):
                 def get_score(document):
                     self.clear_indexes(self.indexes)
-                    self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+                    self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                         index_name=index.name, docs=[document], device="cpu", mappings={
                             "zero_weight_combo_text_image": {
                                 "type": "multimodal_combination",
@@ -612,7 +612,7 @@ class TestMultimodalTensorCombination(MarqoTestCase):
         @mock.patch("marqo.tensor_search.tensor_search.vectorise_multimodal_combination_field_unstructured",
                     mock_multimodal_combination)
         def run():
-            self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+            self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.unstructured_random_multimodal_index.name, docs=[
                     {
                         "text_field": "A rider is riding a horse jumping over the barrier.",
@@ -634,7 +634,7 @@ class TestMultimodalTensorCombination(MarqoTestCase):
                         "weights": {"image_field": 0.5, "text_field": 0.5}}}, device="cpu",
                 tensor_fields=["combo_text_image"]
             )
-                                                 )
+                               )
 
             # first multimodal-doc
             real_field_0, field_content_0 = [call_args for call_args, call_kwargs
@@ -677,7 +677,7 @@ class TestMultimodalTensorCombination(MarqoTestCase):
         @mock.patch("marqo.tensor_search.tensor_search.vectorise_multimodal_combination_field_structured",
                     mock_multimodal_combination)
         def run():
-            self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+            self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.structured_random_multimodal_index.name, docs=[
                     {
                         "text_field": "A rider is riding a horse jumping over the barrier.",
@@ -694,7 +694,7 @@ class TestMultimodalTensorCombination(MarqoTestCase):
                         "_id": "534",
                     }],
             )
-                                                 )
+                               )
 
             # TODO: Create function to extract args corresponding to "combo_text_image" only, as there are other fields in the args list.
             # first multimodal-doc
@@ -734,7 +734,7 @@ class TestMultimodalTensorCombination(MarqoTestCase):
 
                 @mock.patch("marqo.s2_inference.s2_inference.vectorise", mock_vectorise)
                 def run():
-                    res = self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+                    res = self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                         index_name=index.name, docs=[
                             {
                                 "text_field_1": "A rider is riding a horse jumping over the barrier_1.",
@@ -793,7 +793,7 @@ class TestMultimodalTensorCombination(MarqoTestCase):
 
                 @mock.patch("marqo.s2_inference.s2_inference.vectorise", mock_vectorise)
                 def run():
-                    res = self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+                    res = self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                         index_name=index.name, docs=[
                             {
                                 "text_field_1": "A rider is riding a horse jumping over the barrier_1.",
@@ -847,7 +847,7 @@ class TestMultimodalTensorCombination(MarqoTestCase):
 
         @mock.patch("marqo.s2_inference.clip_utils.load_image_from_path", mock_load_image_from_path)
         def run():
-            res = self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+            res = self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.unstructured_random_multimodal_index.name, docs=[
                     {
                         "text_0": "A rider is riding a horse jumping over the barrier_0.",
@@ -877,7 +877,7 @@ class TestMultimodalTensorCombination(MarqoTestCase):
 
     def test_lexical_search_on_multimodal_combination(self):
         # TODO: Make structured index
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.unstructured_multimodal_index.name, docs=[
                 {
                     "Title": "Extravehicular Mobility Unit (EMU)",
@@ -901,7 +901,7 @@ class TestMultimodalTensorCombination(MarqoTestCase):
                 }}, device="cpu", tensor_fields=["my_combination_field"]
         ))
 
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.unstructured_multimodal_index.name, docs=[
                 {
                     "Title": "text",
@@ -923,7 +923,7 @@ class TestMultimodalTensorCombination(MarqoTestCase):
                         "additional_field_1": 0.2,
                     }
                 }}, device="cpu", tensor_fields=["my_combination_field"])
-                                             )
+                           )
         res = tensor_search.search(config=self.config, index_name=self.unstructured_multimodal_index.name,
                                    text="search me please", search_method="LEXICAL")
         assert res["hits"][0]["_id"] == "article_591"
@@ -934,7 +934,7 @@ class TestMultimodalTensorCombination(MarqoTestCase):
 
     def test_search_with_filtering_and_infer_image_false(self):
         # TODO: Make structured index
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.unstructured_random_multimodal_index.name, docs=[
                     {
@@ -994,7 +994,7 @@ class TestMultimodalTensorCombination(MarqoTestCase):
                     "_id": "123",
                 }
 
-                res = self.add_documents_and_refresh_index(
+                res = self.add_documents(
                     self.config,
                     add_docs_params=AddDocsParams(
                         docs=[test_doc], index_name=index.name, device="cpu",

--- a/tests/tensor_search/test_pagination.py
+++ b/tests/tensor_search/test_pagination.py
@@ -113,7 +113,7 @@ class TestPagination(MarqoTestCase):
                            'desc': 'my description'}
                     docs.append(doc)
 
-                r = self.add_documents_and_refresh_index(
+                r = self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(index_name=index.name,
                                                   # Add docs with increasing title word count, so each will have unique tensor and lexical scores
@@ -171,7 +171,7 @@ class TestPagination(MarqoTestCase):
                            "title": title,
                            'desc': 'my description'}
                     docs.append(doc)
-                r = self.add_documents_and_refresh_index(
+                r = self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(index_name=index.name,
                                                   docs=docs,
@@ -235,7 +235,7 @@ class TestPagination(MarqoTestCase):
         for index in [self.index_structured, self.index_unstructured]:
             with self.subTest(index=type(index)):
                 # Add documents
-                add_docs_res = self.add_documents_and_refresh_index(
+                add_docs_res = self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -340,7 +340,7 @@ class TestPagination(MarqoTestCase):
         with mock.patch.object(utils, 'read_env_vars_and_defaults', new=read_var):
             for index in [self.index_structured, self.index_unstructured]:
                 for _ in range(0, num_docs, batch_size):
-                    r = self.add_documents_and_refresh_index(
+                    r = self.add_documents(
                         config=self.config,
                         add_docs_params=AddDocsParams(index_name=index.name,
                                                       docs=[{"title": 'my title', 'desc': 'my title'} for i in
@@ -561,7 +561,7 @@ class TestPagination(MarqoTestCase):
         d1 = {"title": "Marqo", "some doc 2": "some other thing", "_id": "abcdef"}
         d2 = {"some doc 1": "some 2 jnkerkbj", "field abc": "extravagant robodog is not a cat", "_id": "Jupyter_12"}
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(
                 index_name=self.index_name_1, auto_refresh=True,
                 docs=[d0, d1, d2], device="cpu")

--- a/tests/tensor_search/test_prefix.py
+++ b/tests/tensor_search/test_prefix.py
@@ -129,21 +129,21 @@ class TestPrefix(MarqoTestCase):
         for index in [self.unstructured_index_1, self.structured_text_index]:
             with self.subTest(index=index.type):
                 # A) Add normal text document (1 chunk)
-                self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+                self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                     index_name=index.name, docs=[{"_id": "doc_a", "text": "hello"}], auto_refresh=True,
                     device=self.config.default_device,
                     tensor_fields=["text"] if isinstance(index, UnstructuredMarqoIndex) else None
                 ))
 
                 # B) Add same text document but WITH PREFIX (1 chunk)
-                self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+                self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                     index_name=index.name, docs=[{"_id": "doc_b", "text": "hello"}], auto_refresh=True,
                     device=self.config.default_device, text_chunk_prefix="PREFIX: ",
                     tensor_fields=["text"] if isinstance(index, UnstructuredMarqoIndex) else None
                 ))
 
                 # C) Add document with prefix built into text itself (1 chunk)
-                self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+                self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                     index_name=index.name, docs=[{"_id": "doc_c", "text": "PREFIX: hello"}], auto_refresh=True,
                     device=self.config.default_device,
                     tensor_fields=["text"] if isinstance(index, UnstructuredMarqoIndex) else None
@@ -189,21 +189,21 @@ class TestPrefix(MarqoTestCase):
         for index in [self.unstructured_index_e5]:
             with self.subTest(index=index.type):
                 # A) prefix should default to "passage: " with the e5-small model
-                self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+                self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                     index_name=index.name, docs=[{"_id": "doc_a", "text": "hello"}], auto_refresh=True,
                     device=self.config.default_device,
                     tensor_fields=["text"] if isinstance(index, UnstructuredMarqoIndex) else None
                 ))
 
                 # B) manually set prefix at the request level
-                self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+                self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                     index_name=index.name, docs=[{"_id": "doc_b", "text": "hello"}], auto_refresh=True,
                     device=self.config.default_device, text_chunk_prefix="passage: ",
                     tensor_fields=["text"] if isinstance(index, UnstructuredMarqoIndex) else None
                 ))
 
                 # C) Set no prefix 
-                self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+                self.add_documents(config=self.config, add_docs_params=AddDocsParams(
                     index_name=index.name, docs=[{"_id": "doc_c", "text": "hello"}], auto_refresh=True,
                     device=self.config.default_device, text_chunk_prefix="custom_prefix: ",
                     tensor_fields=["text"] if isinstance(index, UnstructuredMarqoIndex) else None
@@ -252,7 +252,7 @@ class TestPrefix(MarqoTestCase):
         for index in [self.unstructured_index_multimodal]:
             with self.subTest(index=index.type):
                 # Add a multimodal doc with a text and image field
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -274,7 +274,7 @@ class TestPrefix(MarqoTestCase):
                     )
                 )
 
-                self.add_documents_and_refresh_index(
+                self.add_documents(
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name,
@@ -364,7 +364,7 @@ class TestPrefix(MarqoTestCase):
             self.assertEqual(result, "test passage: ")
 
         # doc_a should default to the override prefix
-        self.add_documents_and_refresh_index(config=self.config, add_docs_params=AddDocsParams(
+        self.add_documents(config=self.config, add_docs_params=AddDocsParams(
             index_name=self.unstructured_index_with_override.name, docs=[{"_id": "doc_a", "text": "hello"}], auto_refresh=True,
             device=self.config.default_device,
             tensor_fields=["text"] if isinstance(self.unstructured_index_with_override, UnstructuredMarqoIndex) else None

--- a/tests/tensor_search/test_search.py
+++ b/tests/tensor_search/test_search.py
@@ -1170,7 +1170,7 @@ class TestVectorSearch(MarqoTestCase):
             docs=docs, auto_refresh=True
         )
         invalid_queries = [{}, None, {123: 123}, {'123': None},
-                           {"https://marqo_not_real.com/image_1.png": 3}, set()]
+                           {"https://marqo-not-real.com/image_1.png": 3}, set()]
         for q in invalid_queries:
             try:
                 tensor_search.search(

--- a/tests/tensor_search/test_search.py
+++ b/tests/tensor_search/test_search.py
@@ -901,7 +901,7 @@ class TestVectorSearch(MarqoTestCase):
 
         vocab = requests.get(vocab_source).text.splitlines()
 
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config, add_docs_params=AddDocsParams(index_name=self.index_name_1,
                                                               docs=[{"Title": "a " + (
                                                                   " ".join(random.choices(population=vocab, k=25)))}

--- a/tests/tensor_search/test_searchable_attributes.py
+++ b/tests/tensor_search/test_searchable_attributes.py
@@ -51,7 +51,7 @@ class TestSearchableAttributes(MarqoTestCase):
         self.device_patcher.stop()
 
     def _add_documents(self, index_name):
-        self.add_documents_and_refresh_index(
+        self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=index_name,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix, fix tests


* **What is the current behavior?** (You can also link to an open issue here)
After updating an index, the local index cache won't refresh

* **What is the new behavior (if this is a feature change)?**
Force reload the local index cache (for one index) after it is updated

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
Yes, all the integration tests, and api tests

* **Related Python client changes** (link commit/PR here)
No

* **Related documentation changes** (link commit/PR here)
N/A

* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

