### PR TITLE
fix backwards compatibility error with get_settings

### DIFF
--- a/src/marqo/tensor_search/models/index_settings.py
+++ b/src/marqo/tensor_search/models/index_settings.py
@@ -36,11 +36,11 @@ class IndexSettings(StrictBaseModel):
     imagePreprocessing: core.ImagePreProcessing = core.ImagePreProcessing(
         patchMethod=None
     )
-    videoPreprocessing: core.VideoPreProcessing = core.VideoPreProcessing(
+    videoPreprocessing: Optional[core.VideoPreProcessing] = core.VideoPreProcessing(
         splitLength=20,
         splitOverlap=3,
     )
-    audioPreprocessing: core.AudioPreProcessing = core.AudioPreProcessing(
+    audioPreprocessing: Optional[core.AudioPreProcessing] = core.AudioPreProcessing(
         splitLength=10,
         splitOverlap=3,
     )

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.12.2"
+__version__ = "2.12.3"
 
 def get_version() -> str:
     return f"{__version__}"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
users switching from 2.11 to 2.12 and using the `get_settings` api endpoint will get an error 
```
{
  "message": "[{\"loc\": [\"videoPreprocessing\"], \"msg\": \"none is not an allowed value\", \"type\": \"type_error.none.not_allowed\"}, {\"loc\": [\"audioPreprocessing\"], \"msg\": \"none is not an allowed value\", \"type\": \"type_error.none.not_allowed\"}]",
  "code": "invalid_argument",
  "type": "invalid_request",
  "link": ""
}
```
other api endpoints unaffected

* **What is the new behavior (if this is a feature change)?**
2.11 indexes upgraded to 2.12 will no longer get this error

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)


* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

