### PR TITLE
Catch the timeout error when waiting for Vespa converge

### DIFF
--- a/src/marqo/vespa/vespa_client.py
+++ b/src/marqo/vespa/vespa_client.py
@@ -169,7 +169,10 @@ class VespaClient:
                 else:
                     logger.debug('Waiting for Vespa application to converge')
                     time.sleep(1)
+            # TODO Find out what exceptions is raised here
             except (httpx.TimeoutException, httpcore.TimeoutException):
+                logger.debug("Marqo timed out waiting for Vespa application to converge. Will retry.")
+                time.sleep(1)
                 pass
 
         raise VespaError(f"Vespa application did not converge within {timeout} seconds")

--- a/src/marqo/vespa/vespa_client.py
+++ b/src/marqo/vespa/vespa_client.py
@@ -10,6 +10,7 @@ from typing import Dict, Any, List, Optional
 from urllib.parse import urlparse
 
 import httpx
+import httpcore
 
 import marqo.logging
 import marqo.vespa.concurrency as conc
@@ -168,7 +169,7 @@ class VespaClient:
                 else:
                     logger.debug('Waiting for Vespa application to converge')
                     time.sleep(1)
-            except httpx._exceptions.TimeoutException:
+            except (httpx.TimeoutException, httpcore.TimeoutException):
                 pass
 
         raise VespaError(f"Vespa application did not converge within {timeout} seconds")

--- a/src/marqo/vespa/vespa_client.py
+++ b/src/marqo/vespa/vespa_client.py
@@ -162,11 +162,14 @@ class VespaClient:
         """
         start_time = time.time()
         while time.time() - start_time < timeout:
-            if self.get_application_has_converged():
-                return
-            else:
-                logger.debug('Waiting for Vespa application to converge')
-                time.sleep(1)
+            try:
+                if self.get_application_has_converged():
+                    return
+                else:
+                    logger.debug('Waiting for Vespa application to converge')
+                    time.sleep(1)
+            except httpx._exceptions.TimeoutException:
+                pass
 
         raise VespaError(f"Vespa application did not converge within {timeout} seconds")
 

--- a/src/marqo/vespa/vespa_client.py
+++ b/src/marqo/vespa/vespa_client.py
@@ -171,8 +171,7 @@ class VespaClient:
                     time.sleep(1)
             # TODO Find out what exceptions is raised here
             except (httpx.TimeoutException, httpcore.TimeoutException):
-                logger.debug("Marqo timed out waiting for Vespa application to converge. Will retry.")
-                time.sleep(1)
+                logger.error("Marqo timed out waiting for Vespa application to converge. Will retry.")
                 pass
 
         raise VespaError(f"Vespa application did not converge within {timeout} seconds")

--- a/src/marqo/vespa/vespa_client.py
+++ b/src/marqo/vespa/vespa_client.py
@@ -9,8 +9,8 @@ from json import JSONDecodeError
 from typing import Dict, Any, List, Optional
 from urllib.parse import urlparse
 
-import httpx
 import httpcore
+import httpx
 
 import marqo.logging
 import marqo.vespa.concurrency as conc

--- a/tests/vespa/test_vespa_client.py
+++ b/tests/vespa/test_vespa_client.py
@@ -13,6 +13,7 @@ from marqo.vespa.models.query_result import Error
 from marqo.vespa.vespa_client import VespaClient
 from tests.marqo_test import AsyncMarqoTestCase
 
+import httpcore
 
 class TestFeedDocumentAsync(AsyncMarqoTestCase):
     TEST_SCHEMA = "test_vespa_client"
@@ -427,14 +428,19 @@ class TestFeedDocumentAsync(AsyncMarqoTestCase):
     @patch.object(VespaClient, 'get_application_has_converged')
     def test_vespa_client_timeout_exception_handled(self, mock_get_application_has_converged):
         """If a timeout exception is raised, the method should retry until the total wait time is reached"""
-        mock_get_application_has_converged.side_effect = httpx._exceptions.ReadTimeout("Read Timeout")
-        vespa_client = VespaClient("http://localhost:19071", "http://localhost:8080",
-                                   "http://localhost:8080", "content_default")
-
-        with self.assertRaises(VespaError) as e:
-            vespa_client.wait_for_application_convergence(10)
-        self.assertGreaterEqual(mock_get_application_has_converged.call_count, 5)
-        self.assertIn("Vespa application did not converge", str(e.exception))
+        side_effects = [
+            httpx._exceptions.ReadTimeout("Read Timeout"),
+            httpcore._exceptions.ReadTimeout("Read Timeout")
+        ]
+        for side_effect in side_effects:
+            with self.subTest(side_effect=side_effect):
+                mock_get_application_has_converged.side_effect = httpx._exceptions.ReadTimeout("Read Timeout")
+                vespa_client = VespaClient("http://localhost:19071", "http://localhost:8080",
+                                           "http://localhost:8080", "content_default")
+                with self.assertRaises(VespaError) as e:
+                    vespa_client.wait_for_application_convergence(10)
+                self.assertGreaterEqual(mock_get_application_has_converged.call_count, 5)
+                self.assertIn("Vespa application did not converge", str(e.exception))
 
     @patch.object(VespaClient, 'get_application_has_converged')
     def test_wait_for_application_timeout(self, mock_get_application_has_converged):

--- a/tests/vespa/test_vespa_client.py
+++ b/tests/vespa/test_vespa_client.py
@@ -3,6 +3,7 @@ import os
 import unittest
 from unittest.mock import patch
 
+import httpcore
 import httpx
 import vespa.application as pyvespa
 
@@ -13,7 +14,6 @@ from marqo.vespa.models.query_result import Error
 from marqo.vespa.vespa_client import VespaClient
 from tests.marqo_test import AsyncMarqoTestCase
 
-import httpcore
 
 class TestFeedDocumentAsync(AsyncMarqoTestCase):
     TEST_SCHEMA = "test_vespa_client"

--- a/tests/vespa/test_vespa_client.py
+++ b/tests/vespa/test_vespa_client.py
@@ -444,7 +444,7 @@ class TestFeedDocumentAsync(AsyncMarqoTestCase):
 
     @patch.object(VespaClient, 'get_application_has_converged')
     def test_wait_for_application_timeout(self, mock_get_application_has_converged):
-        """If the total wait time is reached, the method should raise a VespaTimeoutError"""
+        """If the total wait time is reached, the method should raise a VespaError"""
         mock_get_application_has_converged.return_value = False
         vespa_client = VespaClient("http://localhost:19071", "http://localhost:8080",
                                    "http://localhost:8080", "content_default")


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
we are not catching timeout error when waiting for vespa converge. If Vespa is slow and does not respond in 5 seconds, we will see a 500 error.

* **What is the new behavior (if this is a feature change)?**
we now catch the timeout error when waiting for Vespa's converge.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
yes

* **Related Python client changes** (link commit/PR here)
no

* **Related documentation changes** (link commit/PR here)
no

* **Other information**:
no

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

