### PR TITLE
Fix LanguageBind models normalization parameters parse

### DIFF
--- a/src/marqo/s2_inference/multimodal_model_load.py
+++ b/src/marqo/s2_inference/multimodal_model_load.py
@@ -278,7 +278,7 @@ class LanguageBindEncoder(ModelEncoder):
                 elif isinstance(content, str) and "http" in content:
                     self._download_content(content, temp_filename, media_download_headers)
                 else:
-                    return self.encode([content], modality=Modality.TEXT)
+                    return self.encode([content], normalize=normalize, media_download_headers=media_download_headers, modality=Modality.TEXT)
 
                 preprocessed_image = self.preprocessor(Modality.IMAGE)([temp_filename], return_tensors='pt')
                 inputs['image'] = to_device(preprocessed_image, self.model.device)['pixel_values']
@@ -295,7 +295,7 @@ class LanguageBindEncoder(ModelEncoder):
                 # If media has already been preprocessed
                 inputs[modality.value] = to_device(content[0], self.model.device)['pixel_values']
             elif isinstance(content[0], str) and 'http' in content[0]:
-                return self.encode(content[0], modality=modality, media_download_headers=media_download_headers)
+                return self.encode(content[0], modality=modality, normalize=normalize, media_download_headers=media_download_headers)
             else:
                 raise ValueError(f"Unsupported {modality.value} content type: {type(content)}, content: {content}")
 

--- a/src/marqo/s2_inference/multimodal_model_load.py
+++ b/src/marqo/s2_inference/multimodal_model_load.py
@@ -113,6 +113,7 @@ class MultimodalModel:
     def encode(self, content, modality, media_download_headers: Optional[Dict]=None, **kwargs):
         if self.encoder is None:
             raise ValueError("Model has not been loaded yet. Call _load_model() first.")
+        print(**kwargs)
         return self.encoder.encode(content, modality, media_download_headers, **kwargs)
 
 

--- a/src/marqo/s2_inference/multimodal_model_load.py
+++ b/src/marqo/s2_inference/multimodal_model_load.py
@@ -278,7 +278,7 @@ class LanguageBindEncoder(ModelEncoder):
                 elif isinstance(content, str) and "http" in content:
                     self._download_content(content, temp_filename, media_download_headers)
                 else:
-                    return self.encode([content], normalize=normalize, media_download_headers=media_download_headers, modality=Modality.TEXT)
+                    return self.encode([content], modality=Modality.TEXT)
 
                 preprocessed_image = self.preprocessor(Modality.IMAGE)([temp_filename], return_tensors='pt')
                 inputs['image'] = to_device(preprocessed_image, self.model.device)['pixel_values']
@@ -295,7 +295,7 @@ class LanguageBindEncoder(ModelEncoder):
                 # If media has already been preprocessed
                 inputs[modality.value] = to_device(content[0], self.model.device)['pixel_values']
             elif isinstance(content[0], str) and 'http' in content[0]:
-                return self.encode(content[0], modality=modality, normalize=normalize, media_download_headers=media_download_headers)
+                return self.encode(content[0], modality=modality, media_download_headers=media_download_headers)
             else:
                 raise ValueError(f"Unsupported {modality.value} content type: {type(content)}, content: {content}")
 

--- a/src/marqo/s2_inference/multimodal_model_load.py
+++ b/src/marqo/s2_inference/multimodal_model_load.py
@@ -114,7 +114,8 @@ class MultimodalModel:
         if self.encoder is None:
             raise ValueError("Model has not been loaded yet. Call _load_model() first.")
         return self.encoder.encode(
-            content=content, modality=modality, media_download_headers=media_download_headers, normalize=True, **kwargs
+            content=content, modality=modality, media_download_headers=media_download_headers,
+            normalize=normalize, **kwargs
         )
 
 

--- a/src/marqo/s2_inference/multimodal_model_load.py
+++ b/src/marqo/s2_inference/multimodal_model_load.py
@@ -278,7 +278,7 @@ class LanguageBindEncoder(ModelEncoder):
                 elif isinstance(content, str) and "http" in content:
                     self._download_content(content, temp_filename, media_download_headers)
                 else:
-                    return self.encode([content], normalize=normalize, media_download_headers=media_download_headers, modality=Modality.TEXT)
+                    return self.encode([content], normalize=normalize, modality=Modality.TEXT)
 
                 preprocessed_image = self.preprocessor(Modality.IMAGE)([temp_filename], return_tensors='pt')
                 inputs['image'] = to_device(preprocessed_image, self.model.device)['pixel_values']

--- a/src/marqo/s2_inference/multimodal_model_load.py
+++ b/src/marqo/s2_inference/multimodal_model_load.py
@@ -110,11 +110,12 @@ class MultimodalModel:
             raise ValueError("Model has not been loaded yet. Call _load_model() first.")
         return self.encoder.preprocessor(modality)
 
-    def encode(self, content, modality, media_download_headers: Optional[Dict]=None, **kwargs):
+    def encode(self, content, modality, media_download_headers: Optional[Dict]=None, normalize=True, **kwargs):
         if self.encoder is None:
             raise ValueError("Model has not been loaded yet. Call _load_model() first.")
-        print(**kwargs)
-        return self.encoder.encode(content, modality, media_download_headers, **kwargs)
+        return self.encoder.encode(
+            content=content, modality=modality, media_download_headers=media_download_headers, normalize=True, **kwargs
+        )
 
 
 class ModelEncoder(ABC):
@@ -256,7 +257,7 @@ class LanguageBindEncoder(ModelEncoder):
 
         return self._preprocessors.get(modality)
 
-    def encode(self, content, modality, normalize=True, media_download_headers: Optional[Dict]=None, **kwargs):
+    def encode(self, content, modality, media_download_headers: Optional[Dict]=None, normalize=True, **kwargs):
         inputs = {}
 
         if modality == Modality.TEXT:

--- a/src/marqo/tensor_search/on_start_script.py
+++ b/src/marqo/tensor_search/on_start_script.py
@@ -270,11 +270,6 @@ def _preload_model(model, content, device):
     """
     if isinstance(model, str):
         # For models IN REGISTRY
-        print(
-            f"model_name: {model}, "
-            f"content: {content}, "
-            f"device: {device}"
-        )
         _ = vectorise(
             model_name=model,
             content=content,

--- a/src/marqo/tensor_search/on_start_script.py
+++ b/src/marqo/tensor_search/on_start_script.py
@@ -270,6 +270,11 @@ def _preload_model(model, content, device):
     """
     if isinstance(model, str):
         # For models IN REGISTRY
+        print(
+            f"model_name: {model}, "
+            f"content: {content}, "
+            f"device: {device}"
+        )
         _ = vectorise(
             model_name=model,
             content=content,

--- a/tests/s2_inference/test_large_model_encoding.py
+++ b/tests/s2_inference/test_large_model_encoding.py
@@ -393,7 +393,7 @@ class TestLanguageBindModels(unittest.TestCase):
 
     def setUp(self):
         self.models = ["LanguageBind/Video_V1.5_FT_Audio_FT_Image"]
-        self.device="cpu"
+        self.device="cuda"
 
     def _help_test_vectorise(self, model_name, modality, test_content_list):
         for content in test_content_list:

--- a/tests/s2_inference/test_large_model_encoding.py
+++ b/tests/s2_inference/test_large_model_encoding.py
@@ -1,4 +1,6 @@
 import os
+from locale import normalize
+
 import torch
 import pytest
 from marqo.s2_inference.types import FloatTensor
@@ -367,10 +369,46 @@ class TestMultilingualE5Models(unittest.TestCase):
                     assert np.allclose(english_feature, other_language_feature, atol=e)
 
     def test_cuda_encode_type(self):
-        run_test_cuda_encode_type(self.models + ["fp16/ViT-B/32", "open_clip/convnext_base_w/laion2b_s13b_b82k",
-                                                 "open_clip/convnext_base_w_320/laion_aesthetic_s13b_b82k_augreg",
-                                                 "all-MiniLM-L6-v1", "all_datasets_v4_MiniLM-L6", "hf/all-MiniLM-L6-v1",
-                                                 "hf/all_datasets_v4_MiniLM-L6"])
+        run_test_cuda_encode_type(
+            self.models + ["fp16/ViT-B/32", "open_clip/convnext_base_w/laion2b_s13b_b82k",
+                           "open_clip/convnext_base_w_320/laion_aesthetic_s13b_b82k_augreg",
+                           "all-MiniLM-L6-v1", "all_datasets_v4_MiniLM-L6", "hf/all-MiniLM-L6-v1",
+                           "hf/all_datasets_v4_MiniLM-L6",]
+        )
+
+
+@pytest.mark.largemodel
+@pytest.mark.skipif(torch.cuda.is_available() is False,
+                    reason="We skip the large model test if we don't have cuda support")
+class TestLanguageBindModels(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        remove_cached_model_files()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        clear_loaded_models()
+        remove_cached_model_files()
+
+    def setUp(self):
+        self.models = ["LanguageBind/Video_V1.5_FT_Audio_FT_Image"]
+
+    def help_test_vectorise(self, model_name):
+        for content in ["test", ["test2", "test3"]]:
+            normalized_embeddings_list = vectorise(model_name=model_name,
+                                                   content=content, device="cuda", normalize_embeddings=True)
+            for embeddings in normalized_embeddings_list:
+                self.assertTrue(np.linalg.norm(np.array(embeddings)) - 1 < 1e-6)
+
+            unnormalized_embeddings_list = vectorise(model_name=model_name,
+                                                   content=content, device="cuda", normalize_embeddings=True)
+            for embeddings in unnormalized_embeddings_list:
+                self.assertTrue(np.linalg.norm(np.array(embeddings)) - 1 > 1e-2)
+
+    def test_models(self):
+        for model_name in self.models:
+            self.help_test_vectorise(model_name)
 
 
 @pytest.mark.largemodel

--- a/tests/s2_inference/test_large_model_encoding.py
+++ b/tests/s2_inference/test_large_model_encoding.py
@@ -385,22 +385,24 @@ class TestLanguageBindModels(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        remove_cached_model_files()
+        import os
+        os.environ["MARQO_MAX_CPU_MODEL_MEMORY"] = "10"
+        clear_loaded_models()
 
     @classmethod
     def tearDownClass(cls) -> None:
         clear_loaded_models()
-        remove_cached_model_files()
 
     def setUp(self):
         self.models = ["LanguageBind/Video_V1.5_FT_Audio_FT_Image"]
+        self.device="cpu"
 
     def _help_test_vectorise(self, model_name, modality, test_content_list):
         for content in test_content_list:
             with self.subTest(model=model_name, content=content, normalized=True):
                 normalized_embeddings_list = vectorise(
                     model_name=model_name,
-                    content=content, device="cuda", normalize_embeddings=True,
+                    content=content, device=self.device, normalize_embeddings=True,
                     modality=modality
                 )
                 for embeddings in normalized_embeddings_list:
@@ -409,7 +411,7 @@ class TestLanguageBindModels(unittest.TestCase):
             with self.subTest(model=model_name, content=content, normalized=False):
                 unnormalized_embeddings_list = vectorise(
                     model_name=model_name,
-                    content=content, device="cuda", normalize_embeddings=False,
+                    content=content, device=self.device, normalize_embeddings=False,
                     modality=modality
                 )
                 for embeddings in unnormalized_embeddings_list:

--- a/tests/s2_inference/test_large_model_encoding.py
+++ b/tests/s2_inference/test_large_model_encoding.py
@@ -1,20 +1,20 @@
+import functools
 import os
-from locale import normalize
-
-import torch
-import pytest
-from marqo.s2_inference.types import FloatTensor
-from marqo.s2_inference.s2_inference import clear_loaded_models, get_model_properties_from_registry, \
-    _convert_tensor_to_numpy
-from unittest.mock import patch
-import numpy as np
 import unittest
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+import torch
+
 from marqo.s2_inference.s2_inference import (
     _check_output_type, vectorise,
     _convert_vectorized_output,
 )
-import functools
 from marqo.s2_inference.s2_inference import _load_model as og_load_model
+from marqo.s2_inference.s2_inference import clear_loaded_models, get_model_properties_from_registry, \
+    _convert_tensor_to_numpy
+from marqo.s2_inference.types import FloatTensor
 from tests.marqo_test import TestImageUrls
 
 _load_model = functools.partial(og_load_model, calling_func="unit_test")

--- a/tests/s2_inference/test_large_model_encoding.py
+++ b/tests/s2_inference/test_large_model_encoding.py
@@ -16,10 +16,11 @@ from marqo.s2_inference.s2_inference import clear_loaded_models, get_model_prope
     _convert_tensor_to_numpy
 from marqo.s2_inference.types import FloatTensor
 from tests.marqo_test import TestImageUrls
-
-_load_model = functools.partial(og_load_model, calling_func="unit_test")
+from marqo.s2_inference.multimodal_model_load import Modality
 from marqo.s2_inference.configs import ModelCache
 import shutil
+
+_load_model = functools.partial(og_load_model, calling_func="unit_test")
 
 
 def remove_cached_model_files():
@@ -394,21 +395,56 @@ class TestLanguageBindModels(unittest.TestCase):
     def setUp(self):
         self.models = ["LanguageBind/Video_V1.5_FT_Audio_FT_Image"]
 
-    def help_test_vectorise(self, model_name):
-        for content in ["test", ["test2", "test3"]]:
-            normalized_embeddings_list = vectorise(model_name=model_name,
-                                                   content=content, device="cuda", normalize_embeddings=True)
-            for embeddings in normalized_embeddings_list:
-                self.assertTrue(np.linalg.norm(np.array(embeddings)) - 1 < 1e-6)
+    def _help_test_vectorise(self, model_name, modality, test_content_list):
+        for content in test_content_list:
+            with self.subTest(model=model_name, content=content, normalized=True):
+                normalized_embeddings_list = vectorise(
+                    model_name=model_name,
+                    content=content, device="cuda", normalize_embeddings=True,
+                    modality=modality
+                )
+                for embeddings in normalized_embeddings_list:
+                    self.assertTrue(np.linalg.norm(np.array(embeddings)) - 1 < 1e-6)
 
-            unnormalized_embeddings_list = vectorise(model_name=model_name,
-                                                   content=content, device="cuda", normalize_embeddings=False)
-            for embeddings in unnormalized_embeddings_list:
-                self.assertTrue(np.linalg.norm(np.array(embeddings)) - 1 > 1e-2)
+            with self.subTest(model=model_name, content=content, normalized=False):
+                unnormalized_embeddings_list = vectorise(
+                    model_name=model_name,
+                    content=content, device="cuda", normalize_embeddings=False,
+                    modality=modality
+                )
+                for embeddings in unnormalized_embeddings_list:
+                    self.assertTrue(np.linalg.norm(np.array(embeddings)) - 1 > 1e-2)
 
     def test_models(self):
+        test_cases = {
+            Modality.TEXT: ["test", ["test2", "test3"]],
+            Modality.AUDIO: [
+                "https://marqo-ecs-50-audio-test-dataset.s3.amazonaws.com/audios/4-145081-A-9.wav",
+                [
+                    "https://marqo-ecs-50-audio-test-dataset.s3.us-east-1.amazonaws.com/audios/1-115920-A-22.wav",
+                    "https://marqo-ecs-50-audio-test-dataset.s3.us-east-1.amazonaws.com/audios/1-115920-A-22.wav"
+                ]
+            ],
+            Modality.IMAGE: [
+                'https://raw.githubusercontent.com/marqo-ai/marqo/mainline/examples/ImageSearchGuide/data/image0.jpg',
+                [
+                    'https://raw.githubusercontent.com/marqo-ai/marqo/mainline/examples/ImageSearchGuide/data/image1.jpg',
+                    'https://raw.githubusercontent.com/marqo-ai/marqo/mainline/examples/ImageSearchGuide/data/image2.jpg'
+                ]
+            ],
+            Modality.VIDEO: [
+                'https://marqo-k400-video-test-dataset.s3.us-east-1.amazonaws.com/videos/--bO6XwZ9HI_000041_000051.mp4',
+                [
+                    'https://marqo-k400-video-test-dataset.s3.us-east-1.amazonaws.com/videos/-0MVWb7nJLY_000008_000018.mp4',
+                    'https://marqo-k400-video-test-dataset.s3.us-east-1.amazonaws.com/videos/-0oMsq-9b6c_000095_000105.mp4'
+                ]
+            ]
+        }
+
         for model_name in self.models:
-            self.help_test_vectorise(model_name)
+            for modality, test_content_list in test_cases.items():
+                with self.subTest(model=model_name, modality=modality):
+                    self._help_test_vectorise(model_name, modality, test_content_list)
 
 
 @pytest.mark.largemodel

--- a/tests/s2_inference/test_large_model_encoding.py
+++ b/tests/s2_inference/test_large_model_encoding.py
@@ -402,7 +402,7 @@ class TestLanguageBindModels(unittest.TestCase):
                 self.assertTrue(np.linalg.norm(np.array(embeddings)) - 1 < 1e-6)
 
             unnormalized_embeddings_list = vectorise(model_name=model_name,
-                                                   content=content, device="cuda", normalize_embeddings=True)
+                                                   content=content, device="cuda", normalize_embeddings=False)
             for embeddings in unnormalized_embeddings_list:
                 self.assertTrue(np.linalg.norm(np.array(embeddings)) - 1 > 1e-2)
 

--- a/tests/s2_inference/test_large_model_encoding.py
+++ b/tests/s2_inference/test_large_model_encoding.py
@@ -385,8 +385,6 @@ class TestLanguageBindModels(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        import os
-        os.environ["MARQO_MAX_CPU_MODEL_MEMORY"] = "10"
         clear_loaded_models()
 
     @classmethod
@@ -408,14 +406,15 @@ class TestLanguageBindModels(unittest.TestCase):
                 for embeddings in normalized_embeddings_list:
                     self.assertTrue(np.linalg.norm(np.array(embeddings)) - 1 < 1e-6)
 
-            with self.subTest(model=model_name, content=content, normalized=False):
-                unnormalized_embeddings_list = vectorise(
-                    model_name=model_name,
-                    content=content, device=self.device, normalize_embeddings=False,
-                    modality=modality
-                )
-                for embeddings in unnormalized_embeddings_list:
-                    self.assertTrue(np.linalg.norm(np.array(embeddings)) - 1 > 1e-2)
+            if modality != Modality.TEXT: # Text embeddings are always normalized
+                with self.subTest(model=model_name, content=content, normalized=False):
+                    unnormalized_embeddings_list = vectorise(
+                        model_name=model_name,
+                        content=content, device=self.device, normalize_embeddings=False,
+                        modality=modality
+                    )
+                    for embeddings in unnormalized_embeddings_list:
+                        self.assertTrue(np.linalg.norm(np.array(embeddings)) - 1 > 1e-2)
 
     def test_models(self):
         test_cases = {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
we are having an issue if we call vectorise on a language bind model. we see:
```
    on_start(_config)
  File "/app/src/marqo/tensor_search/on_start_script.py", line 45, in on_start
    thing_to_start.run()
  File "/app/src/marqo/tensor_search/on_start_script.py", line 180, in run
    _ = _preload_model(model=model, content=test_string, device=device)
  File "/app/src/marqo/tensor_search/on_start_script.py", line 278, in _preload_model
    _ = vectorise(
  File "/app/src/marqo/s2_inference/s2_inference.py", line 72, in vectorise
    return _vectorise_without_cache(model_cache_key, content, normalize_embeddings, modality, media_download_headers,
  File "/app/src/marqo/s2_inference/s2_inference.py", line 135, in _vectorise_without_cache
    return _encode_without_cache(model_cache_key, content, normalize_embeddings, modality, media_download_headers, **kwargs)
  File "/app/src/marqo/s2_inference/s2_inference.py", line 146, in _encode_without_cache
    vectorised = model.encode(
  File "/app/src/marqo/s2_inference/multimodal_model_load.py", line 116, in encode
    print(**kwargs)
TypeError: 'normalize' is an invalid keyword argument for print()
```

* **What is the new behavior (if this is a feature change)?**
we fix the bug

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)

no
* **Related Python client changes** (link commit/PR here)
no

* **Related documentation changes** (link commit/PR here)
no

* **Other information**:
no

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

