### PR TITLE
Fix the validation regressions for unstructured indexes

### DIFF
--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_document.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_document.py
@@ -46,7 +46,7 @@ class SemiStructuredVespaDocument(MarqoBaseModel):
     @classmethod
     def from_vespa_document(cls, document: Dict, marqo_index: SemiStructuredMarqoIndex) -> "SemiStructuredVespaDocument":
         """
-        Instantiate an UnstructuredVespaDocument from a Vespa document.
+        Instantiate an SemiStructuredVespaDocument from a Vespa document.
         Used in get_document_by_id or get_documents_by_ids
         """
         fields = document.get(cls._VESPA_DOC_FIELDS, {})
@@ -76,10 +76,11 @@ class SemiStructuredVespaDocument(MarqoBaseModel):
 
     @classmethod
     def from_marqo_document(cls, document: Dict, marqo_index: SemiStructuredMarqoIndex) -> "SemiStructuredVespaDocument":
-        """Instantiate an UnstructuredVespaDocument from a valid Marqo document for feeding to Vespa"""
+        """Instantiate an SemiStructuredVespaDocument from a valid Marqo document for feeding to Vespa"""
 
         if index_constants.MARQO_DOC_ID not in document:
-            raise VespaDocumentParsingError(
+            # Please note we still use unstructured in the error message since it will be exposed to user
+            raise MarqoDocumentParsingError(
                 f"Unstructured Marqo document does not have a {index_constants.MARQO_DOC_ID} field. "
                 f"This should be assigned for a valid document")
 
@@ -116,7 +117,7 @@ class SemiStructuredVespaDocument(MarqoBaseModel):
                         instance.fixed_fields.float_fields[f"{field_name}.{k}"] = float(v)
                         instance.fixed_fields.score_modifiers_fields[f"{field_name}.{k}"] = v
             else:
-                raise VespaDocumentParsingError(
+                raise MarqoDocumentParsingError(
                     f"In document {doc_id}, field {field_name} has an "
                     f"unsupported type {type(field_content)} which has not been validated in advance.")
 

--- a/src/marqo/core/unstructured_vespa_index/unstructured_document.py
+++ b/src/marqo/core/unstructured_vespa_index/unstructured_document.py
@@ -1,13 +1,11 @@
 import json
-from copy import deepcopy
 from typing import List, Dict, Any
-import semver
 
-from pydantic import Field, BaseModel
+from pydantic import Field
+
 from marqo.base_model import MarqoBaseModel
-
 from marqo.core import constants as index_constants
-from marqo.core.exceptions import VespaDocumentParsingError
+from marqo.core.exceptions import VespaDocumentParsingError, MarqoDocumentParsingError
 from marqo.core.unstructured_vespa_index import common as unstructured_common
 
 
@@ -89,7 +87,7 @@ class UnstructuredVespaDocument(MarqoBaseModel):
         add_documents"""
 
         if index_constants.MARQO_DOC_ID not in document:
-            raise VespaDocumentParsingError(f"Unstructured Marqo document does not have a {index_constants.MARQO_DOC_ID} field. "
+            raise MarqoDocumentParsingError(f"Unstructured Marqo document does not have a {index_constants.MARQO_DOC_ID} field. "
                              f"This should be assigned for a valid document")
 
         doc_id = document[index_constants.MARQO_DOC_ID]
@@ -124,7 +122,7 @@ class UnstructuredVespaDocument(MarqoBaseModel):
                         instance.fields.float_fields[f"{key}.{k}"] = float(v)
                         instance.fields.score_modifiers_fields[f"{key}.{k}"] = v
             else:
-                raise VespaDocumentParsingError(f"In document {doc_id}, field {key} has an "
+                raise MarqoDocumentParsingError(f"In document {doc_id}, field {key} has an "
                                  f"unsupported type {type(value)} which has not been validated in advance.")
 
         instance.fields.vespa_multimodal_params = document.get(unstructured_common.MARQO_DOC_MULTIMODAL_PARAMS, {})

--- a/src/marqo/core/vespa_index/add_documents_handler.py
+++ b/src/marqo/core/vespa_index/add_documents_handler.py
@@ -10,7 +10,7 @@ from marqo.core.models.add_docs_params import AddDocsParams, BatchVectorisationM
 from marqo.core.inference.tensor_fields_container import Chunker, TensorFieldsContainer, TensorFieldContent, \
     TextChunker, ImageChunker, AudioVideoChunker, ModelConfig, Vectoriser, ContentChunkType
 from marqo.core.exceptions import AddDocumentsError, DuplicateDocumentError, MarqoDocumentParsingError, InternalError, \
-    UnsupportedFeatureError
+    UnsupportedFeatureError, VespaDocumentParsingError
 from marqo.core.models import MarqoIndex
 from marqo.core.models.marqo_add_documents_response import MarqoAddDocumentsItem, MarqoAddDocumentsResponse
 from marqo.core.models.marqo_index import FieldType

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.13.1"
+__version__ = "2.13.2"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/tests/tensor_search/integ_tests/test_add_documents_semi_structured.py
+++ b/tests/tensor_search/integ_tests/test_add_documents_semi_structured.py
@@ -322,7 +322,10 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
         self.tags_ = [
             [{"_id": "to_fail_123", "tags": ["wow", "this", False]}],
             [{"_id": "to_fail_124", "tags": [1, None, 3]}],
-            [{"_id": "to_fail_125", "tags": [{}]}]
+            [{"_id": "to_fail_125", "tags": [{}]}],
+            [{"_id": "to_fail_126", "tags": [1, 2, 3]}],
+            [{"_id": "to_fail_127", "tags": [1.0, 2.0, 3.0]}],
+            [{"_id": "to_fail_128", "tags": [1, 2.0, 3]}],
         ]
         bad_doc_args = self.tags_
         for bad_doc_arg in bad_doc_args:
@@ -336,7 +339,9 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
                     )
                 ).dict(exclude_none=True, by_alias=True)
                 assert add_res['errors'] is True
-                assert all(['error' in item for item in add_res['items'] if item['_id'].startswith('to_fail')])
+                assert all(['error' in item for item in add_res['items']])
+                assert all(['Unstructured Marqo index only supports string lists.' in item['message']
+                            for item in add_res['items']])
 
     def test_add_documents_set_device(self):
         """

--- a/tests/tensor_search/integ_tests/test_add_documents_structured.py
+++ b/tests/tensor_search/integ_tests/test_add_documents_structured.py
@@ -500,7 +500,9 @@ class TestAddDocumentsStructured(MarqoTestCase):
                     )
                 ).dict(exclude_none=True, by_alias=True)
                 assert add_res['errors'] is True
-                assert all(['error' in item for item in add_res['items'] if item['_id'].startswith('to_fail')])
+                assert all(['error' in item for item in add_res['items']])
+                assert all(['All list elements must be of the same type and that type must be int, float or string'
+                            in item['message'] for item in add_res['items']])
 
     def test_add_documents_set_device(self):
         """

--- a/tests/tensor_search/integ_tests/test_add_documents_unstructured.py
+++ b/tests/tensor_search/integ_tests/test_add_documents_unstructured.py
@@ -333,7 +333,10 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
         self.tags_ = [
             [{"_id": "to_fail_123", "tags": ["wow", "this", False]}],
             [{"_id": "to_fail_124", "tags": [1, None, 3]}],
-            [{"_id": "to_fail_125", "tags": [{}]}]
+            [{"_id": "to_fail_125", "tags": [{}]}],
+            [{"_id": "to_fail_126", "tags": [1, 2, 3]}],
+            [{"_id": "to_fail_127", "tags": [1.0, 2.0, 3.0]}],
+            [{"_id": "to_fail_128", "tags": [1, 2.0, 3]}],
         ]
         bad_doc_args = self.tags_
         for bad_doc_arg in bad_doc_args:
@@ -347,7 +350,9 @@ class TestAddDocumentsUnstructured(MarqoTestCase):
                     )
                 ).dict(exclude_none=True, by_alias=True)
                 assert add_res['errors'] is True
-                assert all(['error' in item for item in add_res['items'] if item['_id'].startswith('to_fail')])
+                assert all(['error' in item for item in add_res['items']])
+                assert all(['Unstructured Marqo index only supports string lists.' in item['message']
+                            for item in add_res['items']])
 
     def test_add_documents_set_device(self):
         """


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
- List type of unstructured index is not validated correctly. numeric list is not captured in the validation and a generic error is raised when converting it to Vespa array type, causing the whole batch to fail
- Custom vector field not included in tensor fields will be silently ignored

* **What is the new behavior (if this is a feature change)?**
- Numeric list type is captured earlier in the validation phase, which only cause the individual doc to fail, with a proper error message in the response
- Custom vector field not included in tensor fields will cause the whole batch to fail. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
Yes

* **Related Python client changes** (link commit/PR here)
No

* **Related documentation changes** (link commit/PR here)
No

* **Other information**:


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

