### PR TITLE
Fix broken PR pipeline and run all tests on releases branches

### DIFF
--- a/.github/workflows/arm64_docker_marqo.yml
+++ b/.github/workflows/arm64_docker_marqo.yml
@@ -29,6 +29,7 @@ on:
   push:
     branches:
       - mainline
+      - releases/*
     paths-ignore:
       - '**.md'
 

--- a/.github/workflows/cpu_docker_marqo.yml
+++ b/.github/workflows/cpu_docker_marqo.yml
@@ -30,6 +30,7 @@ on:
   push:
     branches:
       - mainline
+      - releases/*
     paths-ignore:
       - '**.md'
 

--- a/.github/workflows/cpu_local_marqo.yml
+++ b/.github/workflows/cpu_local_marqo.yml
@@ -92,6 +92,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          # if triggered by a pull_request_target event, we should use the merge ref of the PR
+          # if triggered by a push event, github.ref points to the head of the source branch
+          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v3

--- a/.github/workflows/cpu_local_marqo.yml
+++ b/.github/workflows/cpu_local_marqo.yml
@@ -30,11 +30,13 @@ on:
   push:
     branches:
       - mainline
+      - releases/*
     paths-ignore:
       - '**.md'
   pull_request_target:
     branches:
       - mainline
+      - releases/*
     paths-ignore:
       - '**.md'
 

--- a/.github/workflows/cuda_docker_marqo.yml
+++ b/.github/workflows/cuda_docker_marqo.yml
@@ -30,6 +30,7 @@ on:
   push:
     branches:
       - mainline
+      - releases/*
     paths-ignore:
       - '**.md'
 

--- a/.github/workflows/largemodel_unit_test_CI.yml
+++ b/.github/workflows/largemodel_unit_test_CI.yml
@@ -67,6 +67,9 @@ jobs:
         with:
           fetch-depth: 0
           path: marqo
+          # if triggered by a pull_request_target event, we should use the merge ref of the PR
+          # if triggered by a push event, github.ref points to the head of the source branch
+          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v3

--- a/.github/workflows/largemodel_unit_test_CI.yml
+++ b/.github/workflows/largemodel_unit_test_CI.yml
@@ -7,11 +7,13 @@ on:
   push:
     branches:
       - mainline
+      - releases/*
     paths-ignore:
       - '**.md'
   pull_request_target:
     branches:
       - mainline
+      - releases/*
     paths-ignore:
       - '**.md'
 

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -65,6 +65,9 @@ jobs:
         with:
           fetch-depth: 0
           path: marqo
+          # if triggered by a pull_request_target event, we should use the merge ref of the PR
+          # if triggered by a push event, github.ref points to the head of the source branch
+          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v3


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix

* **What is the current behavior?** (You can also link to an open issue here)
- PR test pipelines gives false positive since they checkout the target branch of the PR
- only one unit test pipeline run on releases branch (for both push and pr event) 

* **What is the new behavior (if this is a feature change)?**
- PR test pipelines run on `refs/pull/<pr_number>/merge` which is a commit maintained by GH to merge changes on feature PR to mainline.
- all test pipelines will run on releases branches on push event. unit_test, largemodel_unit_test and api_test_marqo_local will run on pr event. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
No

* **Related Python client changes** (link commit/PR here)
No

* **Related documentation changes** (link commit/PR here)
No

* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

