### PR TITLE
Change back to use pull_requst trigger

### DIFF
--- a/.github/workflows/cpu_local_marqo.yml
+++ b/.github/workflows/cpu_local_marqo.yml
@@ -33,7 +33,7 @@ on:
       - releases/*
     paths-ignore:
       - '**.md'
-  pull_request_target:
+  pull_request:
     branches:
       - mainline
       - releases/*
@@ -44,7 +44,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: cpu-local-api-tests-${{ github.head_ref || github.ref }}
+  group: cpu-local-api-tests-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -94,9 +94,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          # if triggered by a pull_request_target event, we should use the merge ref of the PR
-          # if triggered by a push event, github.ref points to the head of the source branch
-          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v3

--- a/.github/workflows/largemodel_unit_test_CI.yml
+++ b/.github/workflows/largemodel_unit_test_CI.yml
@@ -10,7 +10,7 @@ on:
       - releases/*
     paths-ignore:
       - '**.md'
-  pull_request_target:
+  pull_request:
     branches:
       - mainline
       - releases/*
@@ -18,7 +18,7 @@ on:
       - '**.md'
 
 concurrency:
-  group: large-model-unit-tests-${{ github.head_ref || github.ref }}
+  group: large-model-unit-tests-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -69,9 +69,6 @@ jobs:
         with:
           fetch-depth: 0
           path: marqo
-          # if triggered by a pull_request_target event, we should use the merge ref of the PR
-          # if triggered by a push event, github.ref points to the head of the source branch
-          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v3

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -8,13 +8,13 @@ on:
     branches:
       - mainline
       - releases/*
-  pull_request_target:
+  pull_request:
     branches:
       - mainline
       - releases/*
 
 concurrency:
-  group: unit-tests-${{ github.head_ref || github.ref }}
+  group: unit-tests-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -65,9 +65,6 @@ jobs:
         with:
           fetch-depth: 0
           path: marqo
-          # if triggered by a pull_request_target event, we should use the merge ref of the PR
-          # if triggered by a push event, github.ref points to the head of the source branch
-          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v3


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Process fix

* **What is the current behavior?** (You can also link to an open issue here)
- we use pull_request_target trigger so that the forked PR can trigger the build run with Action secrets. However, this caused inconvenece to PRs making change to the GH actions. They cannot be tested properly in PR builds (GH always triggers the build with workflow yaml on the base branch)

* **What is the new behavior (if this is a feature change)?**
- we change back to use pull_request trigger so GH action on the PR branch is used in PR builds. Please note this means community forked PR won't be able to trigger build correctly again. We will find another solution to this issue


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
No

* **Related Python client changes** (link commit/PR here)
No

* **Related documentation changes** (link commit/PR here)
NO

* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

