### PR TITLE
Fixed permission issue that's causing backwards compatibility test run to fail & made logic to run prepare mode tests more robust 

### DIFF
--- a/.github/workflows/backwards_compatibility_marqo_execution.yml
+++ b/.github/workflows/backwards_compatibility_marqo_execution.yml
@@ -45,7 +45,6 @@ jobs:
       contents: read
       actions: write
       id-token: write
-      ec2-actions: write
       checks: write
       deployments: write
       packages: write
@@ -138,7 +137,6 @@ jobs:
       contents: read
       actions: write
       id-token: write
-      ec2-actions: write
       checks: write
       deployments: write
       packages: write

--- a/.github/workflows/backwards_compatibility_marqo_execution.yml
+++ b/.github/workflows/backwards_compatibility_marqo_execution.yml
@@ -41,7 +41,15 @@ on:
 
 jobs:
   Start-Runner:
-    permissions: write-all
+    permissions:
+      contents: read
+      actions: write
+      id-token: write
+      ec2-actions: write
+      checks: write
+      deployments: write
+      packages: write
+      statuses: write
     name: Start self-hosted EC2 runner
     runs-on: ubuntu-latest
     outputs:
@@ -126,6 +134,15 @@ jobs:
 
   Stop-Runner:
     name: Stop self-hosted EC2 runner
+    permissions:
+      contents: read
+      actions: write
+      id-token: write
+      ec2-actions: write
+      checks: write
+      deployments: write
+      packages: write
+      statuses: write
     needs:
       - Start-Runner # required to get output from the start-runner job
       - backwards_compatibility # required to wait when the main job is done

--- a/.github/workflows/backwards_compatibility_marqo_execution.yml
+++ b/.github/workflows/backwards_compatibility_marqo_execution.yml
@@ -42,13 +42,11 @@ on:
 jobs:
   Start-Runner:
     permissions:
-      contents: read
-      actions: write
-      id-token: write
-      checks: write
-      deployments: write
-      packages: write
-      statuses: write
+      contents: read # This permission is necessary to read repository contents
+      actions: write # Used by machulav/ec2-github-runner@v2 for managing self-hosted runners. The workflow needs to create and manage GitHub Actions runners on EC2
+      id-token: write # Used by aws-actions/configure-aws-credentials@v4. Required for AWS authentication and OIDC token management
+      checks: write # Used implicitly by GitHub Actions to report job statuses and create check runs
+      statuses: write # Used implicitly by GitHub Actions to report job statuses and create check runs
     name: Start self-hosted EC2 runner
     runs-on: ubuntu-latest
     outputs:
@@ -134,13 +132,11 @@ jobs:
   Stop-Runner:
     name: Stop self-hosted EC2 runner
     permissions:
-      contents: read
-      actions: write
-      id-token: write
-      checks: write
-      deployments: write
-      packages: write
-      statuses: write
+      contents: read # This permission is necessary to read repository contents
+      actions: write # Used by machulav/ec2-github-runner@v2 for managing self-hosted runners. The workflow needs to create and manage GitHub Actions runners on EC2
+      id-token: write # Used by aws-actions/configure-aws-credentials@v4. Required for AWS authentication and OIDC token management
+      checks: write # Used implicitly by GitHub Actions to report job statuses and create check runs
+      statuses: write # Used implicitly by GitHub Actions to report job statuses and create check runs
     needs:
       - Start-Runner # required to get output from the start-runner job
       - backwards_compatibility # required to wait when the main job is done

--- a/.github/workflows/backwards_compatibility_marqo_orchestrator.yml
+++ b/.github/workflows/backwards_compatibility_marqo_orchestrator.yml
@@ -145,13 +145,11 @@ jobs:
     uses: ./.github/workflows/backwards_compatibility_marqo_execution.yml
     secrets: inherit
     permissions:
-      contents: read
-      actions: write
-      id-token: write
-      checks: write
-      deployments: write
-      packages: write
-      statuses: write
+      contents: read # This permission is necessary to read repository contents
+      actions: write # Used by machulav/ec2-github-runner@v2 for managing self-hosted runners. The workflow needs to create and manage GitHub Actions runners on EC2
+      id-token: write # Used by aws-actions/configure-aws-credentials@v4. Required for AWS authentication and OIDC token management
+      checks: write # Used implicitly by GitHub Actions to report job statuses and create check runs
+      statuses: write # Used implicitly by GitHub Actions to report job statuses and create check runs
     with:
       from_version: ${{ matrix.from_version }}
       to_version: ${{ needs.orchestrate.outputs.to_version }}

--- a/.github/workflows/backwards_compatibility_marqo_orchestrator.yml
+++ b/.github/workflows/backwards_compatibility_marqo_orchestrator.yml
@@ -144,6 +144,15 @@ jobs:
         from_version: ${{ fromJson(needs.orchestrate.outputs.list) }}
     uses: ./.github/workflows/backwards_compatibility_marqo_execution.yml
     secrets: inherit
+    permissions:
+      contents: read
+      actions: write
+      id-token: write
+      ec2-actions: write
+      checks: write
+      deployments: write
+      packages: write
+      statuses: write
     with:
       from_version: ${{ matrix.from_version }}
       to_version: ${{ needs.orchestrate.outputs.to_version }}

--- a/.github/workflows/backwards_compatibility_marqo_orchestrator.yml
+++ b/.github/workflows/backwards_compatibility_marqo_orchestrator.yml
@@ -54,7 +54,7 @@ jobs:
             echo "Image already exists in ECR, will not build and push again. Will be using the image digest from existing image"
             
             IMAGE_IDENTIFIER=$(echo "$IMAGE_DETAILS" | jq -r '.imageDetails[0].imageDigest')
-            REGISTRY_ID = "424082663841.dkr.ecr.us-east-1.amazonaws.com"
+            REGISTRY_ID="424082663841.dkr.ecr.us-east-1.amazonaws.com"
             FULL_IDENTIFIER="${REGISTRY_ID}/marqo-compatibility-tests@${IMAGE_IDENTIFIER}"
             echo "image_identifier=${FULL_IDENTIFIER}" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/backwards_compatibility_marqo_orchestrator.yml
+++ b/.github/workflows/backwards_compatibility_marqo_orchestrator.yml
@@ -148,7 +148,6 @@ jobs:
       contents: read
       actions: write
       id-token: write
-      ec2-actions: write
       checks: write
       deployments: write
       packages: write

--- a/.github/workflows/largemodel_unit_test_CI.yml
+++ b/.github/workflows/largemodel_unit_test_CI.yml
@@ -162,7 +162,7 @@ jobs:
           export PRIVATE_MODEL_TESTS_HF_TOKEN=${{ secrets.PRIVATE_MODEL_TESTS_HF_TOKEN }}
           
           export PYTHONPATH="./marqo/tests:./marqo/src:./marqo"
-          pytest marqo/tests --largemodel --ignore=marqo/tests/test_documentation.py --ignore=tests/backwards_compatibility_tests 
+          pytest marqo/tests --largemodel --ignore=marqo/tests/test_documentation.py --ignore=marqo/tests/backwards_compatibility_tests 
 
   Stop-Runner:
     name: Stop self-hosted EC2 runner

--- a/tests/backwards_compatibility_tests/conftest.py
+++ b/tests/backwards_compatibility_tests/conftest.py
@@ -28,5 +28,3 @@ def pytest_collection_modifyitems(config, items):
             test_case_version = semver.VersionInfo.parse(test_case_version)
             if test_case_version > version:
                 item.add_marker(pytest.mark.skip(reason=f"Test requires marqo_version {test_case_version} which is not greater than version supplied {version}. Skipping."))
-
-    logger.debug(f"Total collected tests: {len(items)}")


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix 


* **What is the current behavior?** (You can also link to an open issue here)
Compatibility tests are not running in marqo-ai/marqo repo due to providing overly permissive permission (i.e write-all) (https://github.com/marqo-ai/marqo/actions/runs/11951180519). These tests were earlier run on a forked repo and worked fine: (https://github.com/adityabharadwaj198/marqo/actions/runs/11927467398). While investigating the issue I found that some logic of how we run our prepare method could be improved, so I've fixed that as well. 

* **What is the new behavior (if this is a feature change)?**
Marqo compatibility tests will run in marqo-ai/marqo repo w/o failures 
1. (https://github.com/marqo-ai/marqo/actions/runs/11954641816/)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
* No


* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
* Added sample test run link: 
* 1. (https://github.com/marqo-ai/marqo/actions/runs/11954641816/)

* **Related Python client changes** (link commit/PR here)
* None

* **Related documentation changes** (link commit/PR here)
* None


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

