### PR TITLE
Fix a bug where attributes_to_retrieve does not work for non-string fields in unstructured indexes created with Marqo 2.13

### DIFF
--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_document.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_document.py
@@ -116,6 +116,10 @@ class SemiStructuredVespaDocument(MarqoBaseModel):
                     elif isinstance(v, float):
                         instance.fixed_fields.float_fields[f"{field_name}.{k}"] = float(v)
                         instance.fixed_fields.score_modifiers_fields[f"{field_name}.{k}"] = v
+                    else:
+                        raise MarqoDocumentParsingError(f"In document {doc_id}, field {field_name} has an "
+                                                        f"unsupported element type {type(v)} for key {k} "
+                                                        f"which has not been validated in advance.")
             else:
                 raise MarqoDocumentParsingError(
                     f"In document {doc_id}, field {field_name} has an "
@@ -168,9 +172,24 @@ class SemiStructuredVespaDocument(MarqoBaseModel):
                 marqo_document[key] = []
             marqo_document[key].append(value)
 
-        # marqo_document.update(self.fixed_fields.short_string_fields)
-        marqo_document.update(self.fixed_fields.int_fields)
-        marqo_document.update(self.fixed_fields.float_fields)
+        for key, value in self.fixed_fields.int_fields.items():
+            if '.' in key:
+                map_field, map_key = key.split('.', 1)
+                if map_field not in marqo_document:
+                    marqo_document[map_field] = {}
+                marqo_document[map_field][map_key] = int(value)
+            else:
+                marqo_document[key] = int(value)
+
+        for key, value in self.fixed_fields.float_fields.items():
+            if '.' in key:
+                map_field, map_key = key.split('.', 1)
+                if map_field not in marqo_document:
+                    marqo_document[map_field] = {}
+                marqo_document[map_field][map_key] = float(value)
+            else:
+                marqo_document[key] = float(value)
+
         marqo_document.update({k: bool(v) for k, v in self.fixed_fields.bool_fields.items()})
         marqo_document[index_constants.MARQO_DOC_ID] = self.fixed_fields.marqo__id
 

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_document.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_document.py
@@ -116,10 +116,6 @@ class SemiStructuredVespaDocument(MarqoBaseModel):
                     elif isinstance(v, float):
                         instance.fixed_fields.float_fields[f"{field_name}.{k}"] = float(v)
                         instance.fixed_fields.score_modifiers_fields[f"{field_name}.{k}"] = v
-                    else:
-                        raise MarqoDocumentParsingError(f"In document {doc_id}, field {field_name} has an "
-                                                        f"unsupported element type {type(v)} for key {k} "
-                                                        f"which has not been validated in advance.")
             else:
                 raise MarqoDocumentParsingError(
                     f"In document {doc_id}, field {field_name} has an "

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_document.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_document.py
@@ -168,23 +168,11 @@ class SemiStructuredVespaDocument(MarqoBaseModel):
                 marqo_document[key] = []
             marqo_document[key].append(value)
 
-        for key, value in self.fixed_fields.int_fields.items():
-            if '.' in key:
-                map_field, map_key = key.split('.', 1)
-                if map_field not in marqo_document:
-                    marqo_document[map_field] = {}
-                marqo_document[map_field][map_key] = int(value)
-            else:
-                marqo_document[key] = int(value)
-
-        for key, value in self.fixed_fields.float_fields.items():
-            if '.' in key:
-                map_field, map_key = key.split('.', 1)
-                if map_field not in marqo_document:
-                    marqo_document[map_field] = {}
-                marqo_document[map_field][map_key] = float(value)
-            else:
-                marqo_document[key] = float(value)
+        # Add int and float fields back
+        # Please note that int-map and float-map fields are flattened in the result. The correct behaviour is to convert
+        # them back to the format when they are indexed. We will keep the behaviour as is to avoid breaking changes.
+        marqo_document.update(self.fixed_fields.int_fields)
+        marqo_document.update(self.fixed_fields.float_fields)
 
         marqo_document.update({k: bool(v) for k, v in self.fixed_fields.bool_fields.items()})
         marqo_document[index_constants.MARQO_DOC_ID] = self.fixed_fields.marqo__id

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -44,14 +44,17 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
     def to_vespa_query(self, marqo_query: MarqoQuery) -> Dict[str, Any]:
         # Verify attributes to retrieve, if defined
         if marqo_query.attributes_to_retrieve is not None:
-            # Always retrieve static fields content to extract non-string values from combined fields
-            marqo_query.attributes_to_retrieve.extend([
-                common.VESPA_FIELD_ID,
-                common.STRING_ARRAY,
-                common.INT_FIELDS,
-                common.FLOAT_FIELDS,
-                common.BOOL_FIELDS,
-            ])
+            if len(marqo_query.attributes_to_retrieve) > 0:
+                # Retrieve static fields content to extract non-string values from combined fields
+                marqo_query.attributes_to_retrieve.extend([
+                    common.STRING_ARRAY,
+                    common.INT_FIELDS,
+                    common.FLOAT_FIELDS,
+                    common.BOOL_FIELDS,
+                ])
+
+            marqo_query.attributes_to_retrieve.append(common.VESPA_FIELD_ID)
+
             # add chunk field names for tensor fields
             marqo_query.attributes_to_retrieve.extend(
                 [self.get_marqo_index().tensor_field_map[att].chunk_field_name

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -44,14 +44,20 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
     def to_vespa_query(self, marqo_query: MarqoQuery) -> Dict[str, Any]:
         # Verify attributes to retrieve, if defined
         if marqo_query.attributes_to_retrieve is not None:
-            marqo_query.attributes_to_retrieve.append(common.VESPA_FIELD_ID)
+            # Always retrieve static fields content to extract non-string values from combined fields
+            marqo_query.attributes_to_retrieve.extend([
+                common.VESPA_FIELD_ID,
+                common.STRING_ARRAY,
+                common.INT_FIELDS,
+                common.FLOAT_FIELDS,
+                common.BOOL_FIELDS,
+            ])
             # add chunk field names for tensor fields
             marqo_query.attributes_to_retrieve.extend(
                 [self.get_marqo_index().tensor_field_map[att].chunk_field_name
                  for att in marqo_query.attributes_to_retrieve
                  if att in self.get_marqo_index().tensor_field_map]
             )
-
         # Hybrid must be checked first since it is a subclass of Tensor and Lexical
         if isinstance(marqo_query, MarqoHybridQuery):
             return StructuredVespaIndex._to_vespa_hybrid_query(self, marqo_query)

--- a/src/marqo/core/unstructured_vespa_index/unstructured_document.py
+++ b/src/marqo/core/unstructured_vespa_index/unstructured_document.py
@@ -122,10 +122,6 @@ class UnstructuredVespaDocument(MarqoBaseModel):
                     elif isinstance(v, float):
                         instance.fields.float_fields[f"{key}.{k}"] = float(v)
                         instance.fields.score_modifiers_fields[f"{key}.{k}"] = v
-                    else:
-                        raise MarqoDocumentParsingError(f"In document {doc_id}, field {key} has an "
-                                                        f"unsupported element type {type(v)} for key {k} "
-                                                        f"which has not been validated in advance.")
             else:
                 raise MarqoDocumentParsingError(f"In document {doc_id}, field {key} has an "
                                                 f"unsupported type {type(value)} which has not been "

--- a/src/marqo/core/unstructured_vespa_index/unstructured_document.py
+++ b/src/marqo/core/unstructured_vespa_index/unstructured_document.py
@@ -23,7 +23,7 @@ class UnstructuredVespaDocumentFields(MarqoBaseModel):
     score_modifiers_fields: Dict[str, Any] = Field(default_factory=dict, alias=unstructured_common.SCORE_MODIFIERS)
     vespa_chunks: List[str] = Field(default_factory=list, alias=unstructured_common.VESPA_DOC_CHUNKS)
     vespa_embeddings: Dict[str, Any] = Field(default_factory=dict, alias=unstructured_common.VESPA_DOC_EMBEDDINGS)
-    vespa_multimodal_params: Dict[str, str] = Field(default_factory=dict,
+    vespa_multimodal_params: Dict[str, str] = Field(default_factory=str,
                                                     alias=unstructured_common.VESPA_DOC_MULTIMODAL_PARAMS)
     vector_counts: int = Field(default=0, alias=unstructured_common.FIELD_VECTOR_COUNT)
 

--- a/src/marqo/core/unstructured_vespa_index/unstructured_document.py
+++ b/src/marqo/core/unstructured_vespa_index/unstructured_document.py
@@ -154,23 +154,10 @@ class UnstructuredVespaDocument(MarqoBaseModel):
             marqo_document[key].append(value)
 
         # Add int and float fields back
-        for key, value in self.fields.int_fields.items():
-            if '.' in key:
-                map_field, map_key = key.split('.', 1)
-                if map_field not in marqo_document:
-                    marqo_document[map_field] = {}
-                marqo_document[map_field][map_key] = int(value)
-            else:
-                marqo_document[key] = int(value)
-
-        for key, value in self.fields.float_fields.items():
-            if '.' in key:
-                map_field, map_key = key.split('.', 1)
-                if map_field not in marqo_document:
-                    marqo_document[map_field] = {}
-                marqo_document[map_field][map_key] = float(value)
-            else:
-                marqo_document[key] = float(value)
+        # Please note that int-map and float-map fields are flattened in the result. The correct behaviour is to convert
+        # them back to the format when they are indexed. We will keep the behaviour as is to avoid breaking changes.
+        marqo_document.update(self.fields.int_fields)
+        marqo_document.update(self.fields.float_fields)
 
         marqo_document.update({k: bool(v) for k, v in self.fields.bool_fields.items()})
         marqo_document[index_constants.MARQO_DOC_ID] = self.fields.marqo__id

--- a/src/marqo/core/unstructured_vespa_index/unstructured_document.py
+++ b/src/marqo/core/unstructured_vespa_index/unstructured_document.py
@@ -23,7 +23,7 @@ class UnstructuredVespaDocumentFields(MarqoBaseModel):
     score_modifiers_fields: Dict[str, Any] = Field(default_factory=dict, alias=unstructured_common.SCORE_MODIFIERS)
     vespa_chunks: List[str] = Field(default_factory=list, alias=unstructured_common.VESPA_DOC_CHUNKS)
     vespa_embeddings: Dict[str, Any] = Field(default_factory=dict, alias=unstructured_common.VESPA_DOC_EMBEDDINGS)
-    vespa_multimodal_params: Dict[str, str] = Field(default_factory=str,
+    vespa_multimodal_params: Dict[str, str] = Field(default_factory=dict,
                                                     alias=unstructured_common.VESPA_DOC_MULTIMODAL_PARAMS)
     vector_counts: int = Field(default=0, alias=unstructured_common.FIELD_VECTOR_COUNT)
 
@@ -77,9 +77,9 @@ class UnstructuredVespaDocument(MarqoBaseModel):
             if unstructured_common.VESPA_DOC_HYBRID_RAW_TENSOR_SCORE in fields else None
 
         return cls(id=document[cls._VESPA_DOC_ID],
-                    raw_tensor_score = raw_tensor_score,
-                    raw_lexical_score = raw_lexical_score,
-                    fields=UnstructuredVespaDocumentFields(**fields))
+                   raw_tensor_score=raw_tensor_score,
+                   raw_lexical_score=raw_lexical_score,
+                   fields=UnstructuredVespaDocumentFields(**fields))
 
     @classmethod
     def from_marqo_document(cls, document: Dict, filter_string_max_length: int) -> "UnstructuredVespaDocument":
@@ -87,8 +87,9 @@ class UnstructuredVespaDocument(MarqoBaseModel):
         add_documents"""
 
         if index_constants.MARQO_DOC_ID not in document:
-            raise MarqoDocumentParsingError(f"Unstructured Marqo document does not have a {index_constants.MARQO_DOC_ID} field. "
-                             f"This should be assigned for a valid document")
+            raise MarqoDocumentParsingError(f"Unstructured Marqo document does not have a "
+                                            f"{index_constants.MARQO_DOC_ID} field. "
+                                            f"This should be assigned for a valid document")
 
         doc_id = document[index_constants.MARQO_DOC_ID]
         instance = cls(id=doc_id, fields=UnstructuredVespaDocumentFields(marqo__id=doc_id))
@@ -121,9 +122,14 @@ class UnstructuredVespaDocument(MarqoBaseModel):
                     elif isinstance(v, float):
                         instance.fields.float_fields[f"{key}.{k}"] = float(v)
                         instance.fields.score_modifiers_fields[f"{key}.{k}"] = v
+                    else:
+                        raise MarqoDocumentParsingError(f"In document {doc_id}, field {key} has an "
+                                                        f"unsupported element type {type(v)} for key {k} "
+                                                        f"which has not been validated in advance.")
             else:
                 raise MarqoDocumentParsingError(f"In document {doc_id}, field {key} has an "
-                                 f"unsupported type {type(value)} which has not been validated in advance.")
+                                                f"unsupported type {type(value)} which has not been "
+                                                f"validated in advance.")
 
         instance.fields.vespa_multimodal_params = document.get(unstructured_common.MARQO_DOC_MULTIMODAL_PARAMS, {})
         instance.fields.vespa_embeddings = document.get(index_constants.MARQO_DOC_EMBEDDINGS, {})
@@ -152,8 +158,24 @@ class UnstructuredVespaDocument(MarqoBaseModel):
             marqo_document[key].append(value)
 
         # Add int and float fields back
-        marqo_document.update(self.fields.int_fields)
-        marqo_document.update(self.fields.float_fields)
+        for key, value in self.fields.int_fields.items():
+            if '.' in key:
+                map_field, map_key = key.split('.', 1)
+                if map_field not in marqo_document:
+                    marqo_document[map_field] = {}
+                marqo_document[map_field][map_key] = int(value)
+            else:
+                marqo_document[key] = int(value)
+
+        for key, value in self.fields.float_fields.items():
+            if '.' in key:
+                map_field, map_key = key.split('.', 1)
+                if map_field not in marqo_document:
+                    marqo_document[map_field] = {}
+                marqo_document[map_field][map_key] = float(value)
+            else:
+                marqo_document[key] = float(value)
+
         marqo_document.update({k: bool(v) for k, v in self.fields.bool_fields.items()})
         marqo_document[index_constants.MARQO_DOC_ID] = self.fields.marqo__id
 

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -1798,7 +1798,11 @@ def unstructured_index_attributes_to_retrieve(marqo_doc: Dict[str, Any], attribu
     str, Any]:
     # attributes_to_retrieve should already be validated at the start of search
     attributes_to_retrieve = list(set(attributes_to_retrieve).union({"_id", "_score", "_highlights"}))
-    return {k: v for k, v in marqo_doc.items() if k in attributes_to_retrieve}
+    return {k: v for k, v in marqo_doc.items() if k in attributes_to_retrieve or
+            # Please note that numeric map fields are flattened for unstructured or semi-structured indexes.
+            # Therefore, when filtering on attributes_to_retrieve, we need to also include flattened map fields
+            # with the specified attributes as prefixes. We keep this behaviour only for compatibility reasons.
+            any([k.startswith(attribute + ".") for attribute in attributes_to_retrieve])}
 
 
 def assign_query_to_vector_job(

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -1781,7 +1781,8 @@ def gather_documents_from_response(response: QueryResult, marqo_index: MarqoInde
         marqo_doc = vespa_index.to_marqo_document(doc.dict(), return_highlights=highlights)
         marqo_doc['_score'] = doc.relevance
 
-        if marqo_index.type == IndexType.Unstructured and attributes_to_retrieve is not None:
+        if (marqo_index.type in [IndexType.Unstructured, IndexType.SemiStructured] and
+                attributes_to_retrieve is not None):
             # For an unstructured index, we do the attributes_to_retrieve after search
             marqo_doc = unstructured_index_attributes_to_retrieve(marqo_doc, attributes_to_retrieve)
 

--- a/tests/core/semi_structured_vespa_index/test_semi_structured_vespa_index.py
+++ b/tests/core/semi_structured_vespa_index/test_semi_structured_vespa_index.py
@@ -1,0 +1,111 @@
+import re
+import time
+import unittest
+from typing import List, Set
+
+from marqo import version
+from marqo.core.models import MarqoTensorQuery, MarqoLexicalQuery
+from marqo.core.models.marqo_index import SemiStructuredMarqoIndex, Model, TextPreProcessing, TextSplitMethod, \
+    ImagePreProcessing, HnswConfig, VectorNumericType, DistanceMetric, Field, FieldType, FieldFeature, TensorField
+from marqo.core.semi_structured_vespa_index.common import STRING_ARRAY, BOOL_FIELDS, INT_FIELDS, FLOAT_FIELDS, \
+    VESPA_FIELD_ID
+from marqo.core.semi_structured_vespa_index.semi_structured_vespa_index import SemiStructuredVespaIndex
+from marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema import SemiStructuredVespaSchema
+
+
+class TestSemiStructuredVespaIndexToVespaQuery(unittest.TestCase):
+
+    def test_to_vespa_query_should_include_static_fields_when_attributes_to_retrieve_is_not_empty(self):
+        marqo_index = self._semi_structured_marqo_index(name='index1', lexical_field_names=['title'],
+                                                        tensor_field_names=['title'])
+        vespa_index = SemiStructuredVespaIndex(marqo_index)
+
+        for marqo_query in [
+            MarqoTensorQuery(index_name=marqo_index.name, limit=10, offset=0,
+                             attributes_to_retrieve=['title'], vector_query=[1.0] * 10),
+            MarqoLexicalQuery(index_name=marqo_index.name, limit=10, offset=0,
+                              attributes_to_retrieve=['title'], and_phrases=['hello'], or_phrases=['world']),
+            # MarqoHybridSearch yql is just a placeholder and is generated in customer search component.
+        ]:
+            with self.subTest(test_query=marqo_query):
+                query = vespa_index.to_vespa_query(marqo_query)
+                fields = self._extract_fields_from_yql(query['yql'])
+
+                self.assertSetEqual({VESPA_FIELD_ID, 'title', 'marqo__chunks_title', STRING_ARRAY,
+                                     BOOL_FIELDS, INT_FIELDS, FLOAT_FIELDS}, fields)
+
+    def test_to_vespa_query_should_not_include_static_fields_when_attributes_to_retrieve_is_empty(self):
+        marqo_index = self._semi_structured_marqo_index(name='index1', lexical_field_names=['title'],
+                                                        tensor_field_names=['title'])
+        vespa_index = SemiStructuredVespaIndex(marqo_index)
+
+        for marqo_query in [
+            MarqoTensorQuery(index_name=marqo_index.name, limit=10, offset=0,
+                             attributes_to_retrieve=[], vector_query=[1.0] * 10),
+            MarqoLexicalQuery(index_name=marqo_index.name, limit=10, offset=0,
+                              attributes_to_retrieve=[], and_phrases=['hello'], or_phrases=['world']),
+            # MarqoHybridSearch yql is just a placeholder and is generated in customer search component.
+        ]:
+            with self.subTest(test_query=marqo_query):
+                query = vespa_index.to_vespa_query(marqo_query)
+                fields = self._extract_fields_from_yql(query['yql'])
+
+                self.assertSetEqual({VESPA_FIELD_ID}, fields)
+
+    def _extract_fields_from_yql(self, yql: str) -> Set[str]:
+        # Define the regex pattern to extract fields from the SELECT clause
+        pattern = r"select\s+(.*?)\s+from"
+
+        # Search for the fields between SELECT and FROM
+        match = re.search(pattern, yql, re.IGNORECASE)
+
+        if match:
+            # Extract the fields and split them by commas, trimming any extra spaces
+            fields = match.group(1).split(',')
+            return set([field.strip() for field in fields])
+        else:
+            raise ValueError("No fields found in the query.")
+
+    def _semi_structured_marqo_index(self, name='index_name',
+                                     lexical_field_names: List[str] = [],
+                                     tensor_field_names: List[str] = []):
+        return SemiStructuredMarqoIndex(
+            name=name,
+            schema_name=name,
+            model=Model(name='hf/all_datasets_v4_MiniLM-L6'),
+            normalize_embeddings=True,
+            text_preprocessing=TextPreProcessing(
+                split_length=2,
+                split_overlap=0,
+                split_method=TextSplitMethod.Sentence
+            ),
+            image_preprocessing=ImagePreProcessing(
+                patch_method=None
+            ),
+            distance_metric=DistanceMetric.Angular,
+            vector_numeric_type=VectorNumericType.Float,
+            hnsw_config=HnswConfig(
+                ef_construction=128,
+                m=16
+            ),
+            marqo_version=version.get_version(),
+            created_at=time.time(),
+            updated_at=time.time(),
+            treat_urls_and_pointers_as_images=True,
+            treat_urls_and_pointers_as_media=True,
+            filter_string_max_length=100,
+            lexical_fields=[
+                Field(name=field_name, type=FieldType.Text,
+                      features=[FieldFeature.LexicalSearch],
+                      lexical_field_name=f'{SemiStructuredVespaSchema.FIELD_INDEX_PREFIX}{field_name}')
+                for field_name in lexical_field_names
+            ],
+            tensor_fields=[
+                TensorField(
+                    name=field_name,
+                    chunk_field_name=f'{SemiStructuredVespaSchema.FIELD_CHUNKS_PREFIX}{field_name}',
+                    embeddings_field_name=f'{SemiStructuredVespaSchema.FIELD_EMBEDDING_PREFIX}{field_name}',
+                )
+                for field_name in tensor_field_names
+            ]
+        )

--- a/tests/tensor_search/integ_tests/test_get_documents_by_ids.py
+++ b/tests/tensor_search/integ_tests/test_get_documents_by_ids.py
@@ -63,6 +63,15 @@ class TestGetDocuments(MarqoTestCase):
     def test_get_documents_by_ids(self):
         for index in self.indexes:
             with self.subTest(f"Index type: {index.type}. Index name: {index.name}"):
+                if index.type == IndexType.Structured:
+                    tensor_fields = None
+                    mappings = None
+                    flatten_map_fields = False
+                else:
+                    tensor_fields = ["title1", "desc2", "custom_vector_field"]
+                    mappings = {"custom_vector_field": {"type": "custom_vector"}}
+                    flatten_map_fields = True
+
                 docs = [
                     {"_id": "1", "title1": "content 1", "int_field": 1, "int_map_field": {"a": 1}, "float_field": 2.9,
                      "float_map_field": {"b": 2.9}, "bool_field": True, "string_array_field": ["a", "b", "c"]},
@@ -73,10 +82,8 @@ class TestGetDocuments(MarqoTestCase):
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name, docs=docs, device="cpu",
-                        tensor_fields=["title1", "desc2", "custom_vector_field"] if isinstance(index, UnstructuredMarqoIndex) else None,
-                        mappings={
-                            "custom_vector_field": {"type": "custom_vector"}
-                        } if isinstance(index, UnstructuredMarqoIndex) else None
+                        tensor_fields=tensor_fields,
+                        mappings=mappings
                     )
                 )
                 res = tensor_search.get_documents_by_ids(
@@ -87,9 +94,20 @@ class TestGetDocuments(MarqoTestCase):
                 for i in range(3):
                     self.assertEqual(res['results'][i]['_found'], True)
 
-                    for field, value in docs[i].items():
-                        expected_value = value["content"] if field == "custom_vector_field" else value
-                        self.assertEqual(expected_value, res['results'][i][field])
+                    for field_name, value in res['results'][i].items():
+                        if field_name in [enums.TensorField.tensor_facets, "_found"]:
+                            # ignore meta fields
+                            continue
+                        if field_name == "custom_vector_field":
+                            expected_value = docs[i]["custom_vector_field"]["content"]
+                        elif flatten_map_fields and '.' in field_name:
+                            # unstructured and semi-structured indexes have all map fields flattened
+                            map_field_name, key = field_name.split('.', 1)
+                            expected_value = docs[i][map_field_name][key]
+                        else:
+                            expected_value = docs[i][field_name]
+
+                        self.assertEqual(expected_value, value)
 
                     self.assertIn(enums.TensorField.tensor_facets, res['results'][i])
                     self.assertIn(enums.TensorField.embedding, res['results'][i][enums.TensorField.tensor_facets][0])

--- a/tests/tensor_search/integ_tests/test_get_documents_by_ids.py
+++ b/tests/tensor_search/integ_tests/test_get_documents_by_ids.py
@@ -1,24 +1,18 @@
 import functools
 import os
-import pprint
-import unittest
 import uuid
 from unittest import mock
+from unittest.mock import patch
 
-from marqo.api.exceptions import IndexNotFoundError
 from marqo.api.exceptions import (
-    InvalidDocumentIdError, InvalidArgError,
+    InvalidArgError,
     IllegalRequestedDocCount
 )
-from marqo.tensor_search import enums
-from marqo.tensor_search import tensor_search
-from marqo.core.models.add_docs_params import AddDocsParams
-from tests.marqo_test import MarqoTestCase
 from marqo.core.models.marqo_index import *
 from marqo.core.models.marqo_index_request import FieldRequest
-from unittest.mock import patch
-import os
-import pprint
+from marqo.tensor_search import enums
+from marqo.tensor_search import tensor_search
+from tests.marqo_test import MarqoTestCase
 from tests.utils.transition import *
 
 
@@ -33,15 +27,29 @@ class TestGetDocuments(MarqoTestCase):
             fields=[
                 FieldRequest(name='title1', type=FieldType.Text),
                 FieldRequest(name='desc2', type=FieldType.Text),
+                FieldRequest(name='int_field', type=FieldType.Int),
+                FieldRequest(name='int_map_field', type=FieldType.MapInt),
+                FieldRequest(name='float_field', type=FieldType.Float),
+                FieldRequest(name='float_map_field', type=FieldType.MapFloat),
+                FieldRequest(name='string_array_field', type=FieldType.ArrayText),
+                FieldRequest(name='bool_field', type=FieldType.Bool),
+                FieldRequest(name='custom_vector_field', type=FieldType.CustomVector),
             ],
-            tensor_fields=["title1", "desc2"]
+            tensor_fields=["title1", "desc2", "custom_vector_field"]
         )
-        unstructured_text_index_with_random_model_request = cls.unstructured_marqo_index_request(model=Model(name='random'))
+        unstructured_text_index_with_random_model_request = cls.unstructured_marqo_index_request(
+            model=Model(name='random'),
+            marqo_version='2.12.0'
+        )
+        semi_structured_text_index_with_random_model_request = cls.unstructured_marqo_index_request(
+            model=Model(name='random'),
+        )
 
         # List of indexes to loop through per test. Test itself should extract index name.
         cls.indexes = cls.create_indexes([
             structured_text_index_with_random_model_request,
-            unstructured_text_index_with_random_model_request
+            unstructured_text_index_with_random_model_request,
+            semi_structured_text_index_with_random_model_request
         ])
 
     def setUp(self) -> None:
@@ -56,13 +64,20 @@ class TestGetDocuments(MarqoTestCase):
         for index in self.indexes:
             with self.subTest(f"Index type: {index.type}. Index name: {index.name}"):
                 docs = [
-                    {"_id": "1", "title1": "content 1"}, {"_id": "2", "title1": "content 2"},
+                    {"_id": "1", "title1": "content 1", "int_field": 1, "int_map_field": {"a": 1}, "float_field": 2.9,
+                     "float_map_field": {"b": 2.9}, "bool_field": True, "string_array_field": ["a", "b", "c"]},
+                    {"_id": "2", "title1": "content 2", "custom_vector_field": {"content": "a", "vector": [1.0] * 384}},
                     {"_id": "3", "title1": "content 3"}
                 ]
                 self.add_documents(
                     config=self.config,
-                    add_docs_params=AddDocsParams(index_name=index.name, docs=docs, device="cpu",
-                    tensor_fields=["title1", "desc2"] if isinstance(index, UnstructuredMarqoIndex) else None)
+                    add_docs_params=AddDocsParams(
+                        index_name=index.name, docs=docs, device="cpu",
+                        tensor_fields=["title1", "desc2", "custom_vector_field"] if isinstance(index, UnstructuredMarqoIndex) else None,
+                        mappings={
+                            "custom_vector_field": {"type": "custom_vector"}
+                        } if isinstance(index, UnstructuredMarqoIndex) else None
+                    )
                 )
                 res = tensor_search.get_documents_by_ids(
                     config=self.config, index_name=index.name, document_ids=['1', '2', '3'],
@@ -71,8 +86,11 @@ class TestGetDocuments(MarqoTestCase):
                 # Check that the documents are found and have the correct content
                 for i in range(3):
                     self.assertEqual(res['results'][i]['_found'], True)
-                    self.assertEqual(res['results'][i]['_id'], docs[i]['_id'])
-                    self.assertEqual(res['results'][i]['title1'], docs[i]['title1'])
+
+                    for field, value in docs[i].items():
+                        expected_value = value["content"] if field == "custom_vector_field" else value
+                        self.assertEqual(expected_value, res['results'][i][field])
+
                     self.assertIn(enums.TensorField.tensor_facets, res['results'][i])
                     self.assertIn(enums.TensorField.embedding, res['results'][i][enums.TensorField.tensor_facets][0])
 

--- a/tests/tensor_search/integ_tests/test_get_documents_by_ids.py
+++ b/tests/tensor_search/integ_tests/test_get_documents_by_ids.py
@@ -28,9 +28,17 @@ class TestGetDocuments(MarqoTestCase):
                 FieldRequest(name='title1', type=FieldType.Text),
                 FieldRequest(name='desc2', type=FieldType.Text),
                 FieldRequest(name='int_field', type=FieldType.Int),
+                FieldRequest(name='int_array_field', type=FieldType.ArrayInt),
                 FieldRequest(name='int_map_field', type=FieldType.MapInt),
                 FieldRequest(name='float_field', type=FieldType.Float),
+                FieldRequest(name='float_array_field', type=FieldType.ArrayFloat),
                 FieldRequest(name='float_map_field', type=FieldType.MapFloat),
+                FieldRequest(name='long_field', type=FieldType.Long),
+                FieldRequest(name='long_array_field', type=FieldType.ArrayLong),
+                FieldRequest(name='long_map_field', type=FieldType.MapLong),
+                FieldRequest(name='double_field', type=FieldType.Double),
+                FieldRequest(name='double_array_field', type=FieldType.ArrayDouble),
+                FieldRequest(name='double_map_field', type=FieldType.MapDouble),
                 FieldRequest(name='string_array_field', type=FieldType.ArrayText),
                 FieldRequest(name='bool_field', type=FieldType.Bool),
                 FieldRequest(name='custom_vector_field', type=FieldType.CustomVector),
@@ -60,18 +68,54 @@ class TestGetDocuments(MarqoTestCase):
     def tearDown(self) -> None:
         self.device_patcher.stop()
 
-    def test_get_documents_by_ids(self):
-        for index in self.indexes:
-            with self.subTest(f"Index type: {index.type}. Index name: {index.name}"):
-                if index.type == IndexType.Structured:
-                    tensor_fields = None
-                    mappings = None
-                    flatten_map_fields = False
-                else:
-                    tensor_fields = ["title1", "desc2", "custom_vector_field"]
-                    mappings = {"custom_vector_field": {"type": "custom_vector"}}
-                    flatten_map_fields = True
+    def test_get_documents_by_ids_structured(self):
+        index = self.indexes[0]
 
+        docs = [
+            {"_id": "1", "title1": "content 1",
+             "int_field": 1, "int_array_field": [1, 2], "int_map_field": {"a": 1},
+             "float_field": 2.9, "float_array_field": [1.0, 2.0], "float_map_field": {"b": 2.9},
+             "long_field": 10, "long_array_field": [10, 20], "long_map_field": {"a": 10},
+             "double_field": 3.9, "double_array_field": [3.0, 5.0], "double_map_field": {"b": 5.9},
+             "bool_field": True, "string_array_field": ["a", "b", "c"]},
+            {"_id": "2", "title1": "content 2", "custom_vector_field": {"content": "a", "vector": [1.0] * 384}},
+            {"_id": "3", "title1": "content 3"}
+        ]
+
+        self.add_documents(
+            config=self.config,
+            add_docs_params=AddDocsParams(
+                index_name=index.name, docs=docs, device="cpu"
+            )
+        )
+        res = tensor_search.get_documents_by_ids(
+            config=self.config, index_name=index.name, document_ids=['1', '2', '3'],
+            show_vectors=True).dict(exclude_none=True, by_alias=True)
+
+        # Check that the documents are found and have the correct content
+        for i in range(3):
+            self.assertEqual(res['results'][i]['_found'], True)
+
+            for field_name, value in res['results'][i].items():
+                if field_name in [enums.TensorField.tensor_facets, "_found"]:
+                    # ignore meta fields
+                    continue
+                if field_name == "custom_vector_field":
+                    expected_value = docs[i]["custom_vector_field"]["content"]
+                else:
+                    expected_value = docs[i][field_name]
+
+                self.assertEqual(expected_value, value)
+
+            self.assertIn(enums.TensorField.tensor_facets, res['results'][i])
+            self.assertIn(enums.TensorField.embedding, res['results'][i][enums.TensorField.tensor_facets][0])
+
+    def test_get_documents_by_ids_unstructured(self):
+        for index in self.indexes:
+            if index.type == IndexType.Structured:
+                continue
+
+            with self.subTest(f"Index type: {index.type}. Index name: {index.name}"):
                 docs = [
                     {"_id": "1", "title1": "content 1", "int_field": 1, "int_map_field": {"a": 1}, "float_field": 2.9,
                      "float_map_field": {"b": 2.9}, "bool_field": True, "string_array_field": ["a", "b", "c"]},
@@ -82,8 +126,8 @@ class TestGetDocuments(MarqoTestCase):
                     config=self.config,
                     add_docs_params=AddDocsParams(
                         index_name=index.name, docs=docs, device="cpu",
-                        tensor_fields=tensor_fields,
-                        mappings=mappings
+                        tensor_fields=["title1", "desc2", "custom_vector_field"],
+                        mappings={"custom_vector_field": {"type": "custom_vector"}}
                     )
                 )
                 res = tensor_search.get_documents_by_ids(
@@ -100,7 +144,7 @@ class TestGetDocuments(MarqoTestCase):
                             continue
                         if field_name == "custom_vector_field":
                             expected_value = docs[i]["custom_vector_field"]["content"]
-                        elif flatten_map_fields and '.' in field_name:
+                        elif '.' in field_name:
                             # unstructured and semi-structured indexes have all map fields flattened
                             map_field_name, key = field_name.split('.', 1)
                             expected_value = docs[i][map_field_name][key]

--- a/tests/tensor_search/integ_tests/test_search_semi_structured.py
+++ b/tests/tensor_search/integ_tests/test_search_semi_structured.py
@@ -828,50 +828,86 @@ class TestSearchSemiStructured(MarqoTestCase):
                     self.assertEqual(set(expected_ids), set([hit["_id"] for hit in res["hits"]]))
 
     def test_attributes_to_retrieve(self):
-        docs = [
-            {
-                "field_1": "Exact match hehehe",
-                "field_2": "baaadd",
-                "random_field": "res res res",
-                "random_lala": "res res res haha",
-                "marqomarqo": "check check haha",
+        doc = {
+            "short_string_field": "Exact match hehehe",
+            "long_string_field": "This is a very long string." * 10,
+            "int_field": 123,
+            "float_field": 123.0,
+            "string_array": ["123", "123"],
+            "int_map": {"a": 1, "b": 2},
+            "float_map": {"c": 1.0, "d": 2.0},
+            "bool_field": True,
+            "bool_field2": False,
+            "custom_vector_field": {
+                "content": "abcd",
+                "vector": [1.0] * 384
             }
-        ]
-
-        test_inputs = (
-            (["void_field"], {"_id", "_score", "_highlights"}),
-            ([], {"_id", "_score", "_highlights"}),
-            (["field_1"], {"field_1", "_id", "_score", "_highlights"}),
-            (["field_1", "field_2"], {"field_1", "field_2", "_id", "_score", "_highlights"}),
-            (["field_1", "random_field"], {"field_1", "random_field", "_id", "_score", "_highlights"}),
-            (["field_1", "random_field", "random_lala"],
-             {"field_1", "random_field", "random_lala", "_id", "_score", "_highlights"}),
-            (["field_1", "random_field", "random_lala", "marqomarqo"],
-             {"field_1", "random_field", "random_lala", "marqomarqo", "_id", "_score", "_highlights"}),
-            (["field_1", "field_2", "random_field", "random_lala", "marqomarqo"],
-             {"field_1", "field_2", "random_field", "random_lala", "marqomarqo", "_id", "_score", "_highlights"}),
-            (None, {"field_1", "field_2", "random_field", "random_lala", "marqomarqo", "_id", "_score", "_highlights"}),
-        )
+        }
 
         self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
-                docs=docs,
-                tensor_fields=["field_1", "field_2"]
+                docs=[doc],
+                tensor_fields=["short_string_field" , "custom_vector_field", "multimodal_combo_field"],
+                mappings={
+                    "custom_vector_field": {"type": "custom_vector"},
+                    "multimodal_combo_field": {
+                        "type": "multimodal_combination",
+                        "weights": {"short_string_field": 1.0, "long_string_field": 2.0}
+                    }
+                }
             )
         )
 
+        # meta fields are always returned
+        meta_fields = {"_id", "_score", "_highlights"}
+
+        test_cases = (
+            (None, doc.keys()),  # not provided
+            ([], set()),  # no field is selected
+            (list(doc.keys()), doc.keys()),  # all fields are selected
+            (["non_existent_field"], set()),  # non_existent field is provided
+            (["multimodal_combo_field"], set()),  # multimodal_combination fields cannot be selected
+
+            # one field
+            (["short_string_field"],  {"short_string_field"}),
+            (["long_string_field"],  {"long_string_field"}),
+            (["int_field"],  {"int_field"}),
+            (["float_field"],  {"float_field"}),
+            (["string_array"],  {"string_array"}),
+            (["int_map"],  {"int_map"}),
+            (["float_map"],  {"float_map"}),
+            (["bool_field"],  {"bool_field"}),
+            (["custom_vector_field"],  {"custom_vector_field"}),
+            # combination of short and long string fields
+            (["short_string_field", "long_string_field"],  {"short_string_field", "long_string_field"}),
+            # combination of int and int map fields
+            (["int_field", "int_map"], {"int_field", "int_map"}),
+            # combination of fload and fload map fields
+            (["float_field", "float_map"], {"float_field", "float_map"}),
+            # multiple boolean fields
+            (["bool_field", "bool_field2"], {"bool_field", "bool_field2"}),
+            # combination of all types of fields include non-existent fields
+            (["short_string_field", "long_string_field", "int_map", "bool_field", "multimodal_combo_field", "string_array", "custom_vector_field"],
+             {"short_string_field", "long_string_field", "int_map", "bool_field", "string_array", "custom_vector_field"})
+        )
+
         for search_method in [SearchMethod.LEXICAL, SearchMethod.TENSOR]:
-            for searchable_attributes, expected_fields in test_inputs:
-                with self.subTest(
-                        f"search_method = {search_method}, searchable_attributes={searchable_attributes}, expected_fields = {expected_fields}"):
+            for attributes_to_retrieve, expected_fields in test_cases:
+                with self.subTest(f"search_method = {search_method}, attributes_to_retrieve={attributes_to_retrieve}, "
+                                  f"expected_fields = {expected_fields}"):
+
                     res = tensor_search.search(
                         config=self.config, index_name=self.default_text_index, text="Exact match hehehe",
-                        attributes_to_retrieve=searchable_attributes, search_method=search_method
+                        attributes_to_retrieve=attributes_to_retrieve, search_method=search_method
                     )
-
-                    self.assertEqual(expected_fields, set(res["hits"][0].keys()))
+                    self.assertSetEqual(expected_fields | meta_fields, set(res["hits"][0].keys()))
+                    for attribute in expected_fields:
+                        if attribute == "custom_vector_field":
+                            self.assertEqual(res["hits"][0][attribute], doc[attribute]["content"])
+                        else:
+                            self.assertEqual(res["hits"][0][attribute], doc[attribute])
 
     def test_limit_results(self):
         """"""

--- a/tests/tensor_search/integ_tests/test_search_semi_structured.py
+++ b/tests/tensor_search/integ_tests/test_search_semi_structured.py
@@ -862,35 +862,43 @@ class TestSearchSemiStructured(MarqoTestCase):
 
         # meta fields are always returned
         meta_fields = {"_id", "_score", "_highlights"}
+        non_map_fields = {"short_string_field", "long_string_field", "int_field", "float_field", "bool_field",
+                          "bool_field2", "string_array", "custom_vector_field"}
+        map_fields_flattened = {"int_map.a", "int_map.b", "float_map.c", "float_map.d"}
 
         test_cases = (
-            (None, doc.keys()),  # not provided
+            # attributes_to_retrieve, expectured result
             ([], set()),  # no field is selected
-            (list(doc.keys()), doc.keys()),  # all fields are selected
             (["non_existent_field"], set()),  # non_existent field is provided
             (["multimodal_combo_field"], set()),  # multimodal_combination fields cannot be selected
 
+            # None or all fields
+            (None, non_map_fields | map_fields_flattened),  # not provided
+            (list(doc.keys()), non_map_fields | map_fields_flattened),  # all fields are selected
+
             # one field
-            (["short_string_field"],  {"short_string_field"}),
-            (["long_string_field"],  {"long_string_field"}),
-            (["int_field"],  {"int_field"}),
-            (["float_field"],  {"float_field"}),
-            (["string_array"],  {"string_array"}),
-            (["int_map"],  {"int_map"}),
-            (["float_map"],  {"float_map"}),
-            (["bool_field"],  {"bool_field"}),
-            (["custom_vector_field"],  {"custom_vector_field"}),
+            (["short_string_field"], {"short_string_field"}),
+            (["long_string_field"], {"long_string_field"}),
+            (["int_field"], {"int_field"}),
+            (["float_field"], {"float_field"}),
+            (["string_array"], {"string_array"}),
+            (["int_map"], {"int_map.a", "int_map.b"}),
+            (["float_map"], {"float_map.c", "float_map.d"}),
+            (["bool_field"], {"bool_field"}),
+            (["custom_vector_field"], {"custom_vector_field"}),
             # combination of short and long string fields
-            (["short_string_field", "long_string_field"],  {"short_string_field", "long_string_field"}),
+            (["short_string_field", "long_string_field"], {"short_string_field", "long_string_field"}),
             # combination of int and int map fields
-            (["int_field", "int_map"], {"int_field", "int_map"}),
+            (["int_field", "int_map"], {"int_field", "int_map.a", "int_map.b"}),
             # combination of fload and fload map fields
-            (["float_field", "float_map"], {"float_field", "float_map"}),
+            (["float_field", "float_map"], {"float_field", "float_map.c", "float_map.d"}),
             # multiple boolean fields
             (["bool_field", "bool_field2"], {"bool_field", "bool_field2"}),
             # combination of all types of fields include non-existent fields
-            (["short_string_field", "long_string_field", "int_map", "bool_field", "multimodal_combo_field", "string_array", "custom_vector_field"],
-             {"short_string_field", "long_string_field", "int_map", "bool_field", "string_array", "custom_vector_field"})
+            (["short_string_field", "long_string_field", "int_map", "bool_field", "multimodal_combo_field",
+              "string_array", "custom_vector_field"],
+             {"short_string_field", "long_string_field", "int_map.a", "int_map.b", "bool_field", "string_array",
+              "custom_vector_field"})
         )
 
         for search_method in [SearchMethod.LEXICAL, SearchMethod.TENSOR]:
@@ -906,6 +914,9 @@ class TestSearchSemiStructured(MarqoTestCase):
                     for attribute in expected_fields:
                         if attribute == "custom_vector_field":
                             self.assertEqual(res["hits"][0][attribute], doc[attribute]["content"])
+                        elif '.' in attribute:
+                            map_field_name, key = attribute.split('.', maxsplit=1)
+                            self.assertEqual(res["hits"][0][attribute], doc[map_field_name][key])
                         else:
                             self.assertEqual(res["hits"][0][attribute], doc[attribute])
 

--- a/tests/tensor_search/integ_tests/test_search_semi_structured.py
+++ b/tests/tensor_search/integ_tests/test_search_semi_structured.py
@@ -867,7 +867,7 @@ class TestSearchSemiStructured(MarqoTestCase):
         map_fields_flattened = {"int_map.a", "int_map.b", "float_map.c", "float_map.d"}
 
         test_cases = (
-            # attributes_to_retrieve, expectured result
+            # attributes_to_retrieve, expected result excluding meta_fields
             ([], set()),  # no field is selected
             (["non_existent_field"], set()),  # non_existent field is provided
             (["multimodal_combo_field"], set()),  # multimodal_combination fields cannot be selected

--- a/tests/tensor_search/integ_tests/test_search_structured.py
+++ b/tests/tensor_search/integ_tests/test_search_structured.py
@@ -77,10 +77,19 @@ class TestSearchStructured(MarqoTestCase):
                              features=[FieldFeature.ScoreModifier]),
                 FieldRequest(name="score_mods_long", type=FieldType.Long,
                              features=[FieldFeature.ScoreModifier]),
+                FieldRequest(name="int_array", type=FieldType.ArrayInt),
+                FieldRequest(name="float_array", type=FieldType.ArrayFloat),
+                FieldRequest(name="long_array", type=FieldType.ArrayLong),
+                FieldRequest(name="double_array", type=FieldType.ArrayDouble),
+                FieldRequest(name="multimodal_combo_field", type=FieldType.MultimodalCombination, dependent_fields={
+                    "text_field_1": 1.0, "text_field_2": 2.0
+                }),
+                FieldRequest(name="custom_vector_field", type=FieldType.CustomVector)
             ],
 
             tensor_fields=["text_field_1", "text_field_2", "text_field_3",
-                           "text_field_4", "text_field_5", "text_field_6"]
+                           "text_field_4", "text_field_5", "text_field_6",
+                           "multimodal_combo_field", "custom_vector_field"]
         )
         default_text_index_encoded_name = cls.structured_marqo_index_request(
             name='a-b_' + str(uuid.uuid4()).replace('-', ''),
@@ -659,53 +668,76 @@ class TestSearchStructured(MarqoTestCase):
     #                 self.assertEqual(expected_ids, [hit["_id"] for hit in res["hits"]])
 
     def test_attributes_to_retrieve(self):
-        docs = [
-            {
-                "text_field_1": "Exact match hehehe",
-                "text_field_2": "baaadd",
-                "text_field_3": "res res res",
-                "text_field_4": "res res res haha",
-                "text_field_5": "check check haha",
-            }
-        ]
 
-        test_inputs = (
-            ([], {"_id", "_score", "_highlights"}),
-            (["text_field_1"], {"text_field_1", "_id", "_score", "_highlights"}),
-            (["text_field_1", "text_field_2"], {"text_field_1", "text_field_2", "_id", "_score", "_highlights"}),
-            (["text_field_1", "text_field_3"], {"text_field_1", "text_field_3", "_id", "_score", "_highlights"}),
-            (["text_field_1", "text_field_3", "text_field_4"],
-             {"text_field_1", "text_field_3", "text_field_4", "_id", "_score", "_highlights"}),
-            (["text_field_1", "text_field_3", "text_field_4", "text_field_5"],
-             {"text_field_1", "text_field_3", "text_field_4", "text_field_5", "_id", "_score", "_highlights"}),
-            (["text_field_1", "text_field_2", "text_field_3", "text_field_4", "text_field_5"],
-             {"text_field_1", "text_field_2", "text_field_3", "text_field_4", "text_field_5", "_id", "_score",
-              "_highlights"}),
-            # TODO Fix this subtest
-            # Not running this test case until we solve the bool issue
-            # (None, {"text_field_1", "text_field_2", "text_field_3", "text_field_4", "text_field_5", "_id", "_score",
-            #         "_highlights"}),
-        )
+        doc = {
+            "text_field_1": "Exact match hehehe",
+            "text_field_2": "This is a very long string." * 10,
+            "int_field_1": 123,
+            "float_field_1": 123.0,
+            "long_field_1": 1234,
+            "double_field_1": 1234.0,
+            "list_field_1": ["123", "123"],
+            "map_score_mods_int": {"a": 1, "b": 2},
+            "map_score_mods_float": {"c": 1.0, "d": 2.0},
+            "map_score_mods_long": {"a": 1, "b": 2},
+            "map_score_mods_double": {"c": 1.0, "d": 2.0},
+            "bool_field_1": True,
+            "bool_field_2": False,
+            "int_array": [1, 2, 3],
+            "long_array": [1, 2, 3, 4, 5],
+            "float_array": [1.0, 2.0, 3.0],
+            "double_array": [3.09, 2.09, 3.12],
+            "custom_vector_field": {
+                "content": "abcd",
+                "vector": [1.0] * 384
+            },
+        }
 
-        self.add_documents(
+        res = self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
-                docs=docs,
-            )
+                docs=[doc],
+                mappings={
+                    "multimodal_combo_field": {
+                        "type": "multimodal_combination",
+                        "weights": {"text_field_1": 2.0, "text_field_2": 3.0}
+                    }
+                }
+            ),
         )
 
+        print(res)
+
+        # meta fields are always returned
+        meta_fields = {"_id", "_score", "_highlights"}
+
+        test_cases = ((
+            # attributes_to_retrieve, expected result excluding meta_fields
+            ([], set()),  # no field is selected
+            (["multimodal_combo_field"], set()),  # multimodal_combination fields cannot be selected
+            (None, doc.keys()),  # not provided
+            (list(doc.keys()), doc.keys()),  # all fields are selected
+        )
+            + tuple([([field], {field}) for field in doc.keys()])  # one field
+            + tuple((random_fields, set(random_fields)) for random_fields in
+                    [random.sample(doc.keys(), random.randint(2, len(doc))) for _ in range(10)]))  # random n(>1) fields, 10 times
+
         for search_method in [SearchMethod.LEXICAL, SearchMethod.TENSOR]:
-            for attributes_to_retrieve, expected_fields in test_inputs:
-                with self.subTest(
-                        f"search_method = {search_method}, attributes_to_retrieve={attributes_to_retrieve},"
-                        f" expected_fields = {expected_fields}"):
+            for attributes_to_retrieve, expected_fields in test_cases:
+                with self.subTest(f"search_method = {search_method}, attributes_to_retrieve={attributes_to_retrieve}, "
+                                  f"expected_fields = {expected_fields}"):
+
                     res = tensor_search.search(
                         config=self.config, index_name=self.default_text_index, text="Exact match hehehe",
                         attributes_to_retrieve=attributes_to_retrieve, search_method=search_method
                     )
-
-                    self.assertEqual(expected_fields, set(res["hits"][0].keys()))
+                    self.assertSetEqual(expected_fields | meta_fields, set(res["hits"][0].keys()))
+                    for attribute in expected_fields:
+                        if attribute == "custom_vector_field":
+                            self.assertEqual(res["hits"][0][attribute], doc[attribute]["content"])
+                        else:
+                            self.assertEqual(res["hits"][0][attribute], doc[attribute])
 
     def test_limit_results(self):
         vocab_source = "https://www.mit.edu/~ecprice/wordlist.10000"

--- a/tests/tensor_search/integ_tests/test_search_unstructured.py
+++ b/tests/tensor_search/integ_tests/test_search_unstructured.py
@@ -882,7 +882,7 @@ class TestSearchUnstructured(MarqoTestCase):
         map_fields_flattened = {"int_map.a", "int_map.b", "float_map.c", "float_map.d"}
 
         test_cases = (
-            # attributes_to_retrieve, expectured result
+            # attributes_to_retrieve, expected result excluding meta_fields
             ([], set()),  # no field is selected
             (["non_existent_field"], set()),  # non_existent field is provided
             (["multimodal_combo_field"], set()),  # multimodal_combination fields cannot be selected

--- a/tests/tensor_search/integ_tests/test_search_unstructured.py
+++ b/tests/tensor_search/integ_tests/test_search_unstructured.py
@@ -843,50 +843,89 @@ class TestSearchUnstructured(MarqoTestCase):
                     self.assertEqual(set(expected_ids), set([hit["_id"] for hit in res["hits"]]))
 
     def test_attributes_to_retrieve(self):
-        docs = [
-            {
-                "field_1": "Exact match hehehe",
-                "field_2": "baaadd",
-                "random_field": "res res res",
-                "random_lala": "res res res haha",
-                "marqomarqo": "check check haha",
+        doc = {
+            "short_string_field": "Exact match hehehe",
+            "long_string_field": "This is a very long string." * 10,
+            "int_field": 123,
+            "float_field": 123.0,
+            "string_array": ["123", "123"],
+            "int_map": {"a": 1, "b": 2},
+            "float_map": {"c": 1.0, "d": 2.0},
+            "bool_field": True,
+            "bool_field2": False,
+            "custom_vector_field": {
+                "content": "abcd",
+                "vector": [1.0] * 384
             }
-        ]
-
-        test_inputs = (
-            (["void_field"], {"_id", "_score", "_highlights"}),
-            ([], {"_id", "_score", "_highlights"}),
-            (["field_1"], {"field_1", "_id", "_score", "_highlights"}),
-            (["field_1", "field_2"], {"field_1", "field_2", "_id", "_score", "_highlights"}),
-            (["field_1", "random_field"], {"field_1", "random_field", "_id", "_score", "_highlights"}),
-            (["field_1", "random_field", "random_lala"],
-             {"field_1", "random_field", "random_lala", "_id", "_score", "_highlights"}),
-            (["field_1", "random_field", "random_lala", "marqomarqo"],
-             {"field_1", "random_field", "random_lala", "marqomarqo", "_id", "_score", "_highlights"}),
-            (["field_1", "field_2", "random_field", "random_lala", "marqomarqo"],
-             {"field_1", "field_2", "random_field", "random_lala", "marqomarqo", "_id", "_score", "_highlights"}),
-            (None, {"field_1", "field_2", "random_field", "random_lala", "marqomarqo", "_id", "_score", "_highlights"}),
-        )
+        }
 
         self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(
                 index_name=self.default_text_index,
-                docs=docs,
-                tensor_fields=["field_1", "field_2"]
+                docs=[doc],
+                tensor_fields=["short_string_field", "custom_vector_field", "multimodal_combo_field"],
+                mappings={
+                    "custom_vector_field": {"type": "custom_vector"},
+                    "multimodal_combo_field": {
+                        "type": "multimodal_combination",
+                        "weights": {"short_string_field": 1.0, "long_string_field": 2.0}
+                    }
+                }
             )
         )
 
+        # meta fields are always returned
+        meta_fields = {"_id", "_score", "_highlights"}
+
+        test_cases = (
+            # attributes_to_retrieve, expectured result
+            (None, doc.keys()),  # not provided
+            ([], set()),  # no field is selected
+            (list(doc.keys()), doc.keys()),  # all fields are selected
+            (["non_existent_field"], set()),  # non_existent field is provided
+            (["multimodal_combo_field"], set()),  # multimodal_combination fields cannot be selected
+
+            # one field
+            (["short_string_field"], {"short_string_field"}),
+            (["long_string_field"], {"long_string_field"}),
+            (["int_field"], {"int_field"}),
+            (["float_field"], {"float_field"}),
+            (["string_array"], {"string_array"}),
+            (["int_map"], {"int_map"}),
+            (["float_map"], {"float_map"}),
+            (["bool_field"], {"bool_field"}),
+            (["custom_vector_field"], {"custom_vector_field"}),
+            # combination of short and long string fields
+            (["short_string_field", "long_string_field"], {"short_string_field", "long_string_field"}),
+            # combination of int and int map fields
+            (["int_field", "int_map"], {"int_field", "int_map"}),
+            # combination of fload and fload map fields
+            (["float_field", "float_map"], {"float_field", "float_map"}),
+            # multiple boolean fields
+            (["bool_field", "bool_field2"], {"bool_field", "bool_field2"}),
+            # combination of all types of fields include non-existent fields
+            (["short_string_field", "long_string_field", "int_map", "bool_field", "multimodal_combo_field",
+              "string_array", "custom_vector_field"],
+             {"short_string_field", "long_string_field", "int_map", "bool_field", "string_array",
+              "custom_vector_field"})
+        )
+
         for search_method in [SearchMethod.LEXICAL, SearchMethod.TENSOR]:
-            for searchable_attributes, expected_fields in test_inputs:
-                with self.subTest(
-                        f"search_method = {search_method}, searchable_attributes={searchable_attributes}, expected_fields = {expected_fields}"):
+            for attributes_to_retrieve, expected_fields in test_cases:
+                with self.subTest(f"search_method = {search_method}, attributes_to_retrieve={attributes_to_retrieve}, "
+                                  f"expected_fields = {expected_fields}"):
+
                     res = tensor_search.search(
                         config=self.config, index_name=self.default_text_index, text="Exact match hehehe",
-                        attributes_to_retrieve=searchable_attributes, search_method=search_method
+                        attributes_to_retrieve=attributes_to_retrieve, search_method=search_method
                     )
-
-                    self.assertEqual(expected_fields, set(res["hits"][0].keys()))
+                    self.assertSetEqual(expected_fields | meta_fields, set(res["hits"][0].keys()))
+                    for attribute in expected_fields:
+                        if attribute == "custom_vector_field":
+                            self.assertEqual(res["hits"][0][attribute], doc[attribute]["content"])
+                        else:
+                            self.assertEqual(res["hits"][0][attribute], doc[attribute])
 
     def test_limit_results(self):
         """"""

--- a/tests/tensor_search/integ_tests/test_search_unstructured.py
+++ b/tests/tensor_search/integ_tests/test_search_unstructured.py
@@ -877,14 +877,19 @@ class TestSearchUnstructured(MarqoTestCase):
 
         # meta fields are always returned
         meta_fields = {"_id", "_score", "_highlights"}
+        non_map_fields = {"short_string_field", "long_string_field", "int_field", "float_field", "bool_field",
+                          "bool_field2", "string_array", "custom_vector_field"}
+        map_fields_flattened = {"int_map.a", "int_map.b", "float_map.c", "float_map.d"}
 
         test_cases = (
             # attributes_to_retrieve, expectured result
-            (None, doc.keys()),  # not provided
             ([], set()),  # no field is selected
-            (list(doc.keys()), doc.keys()),  # all fields are selected
             (["non_existent_field"], set()),  # non_existent field is provided
             (["multimodal_combo_field"], set()),  # multimodal_combination fields cannot be selected
+
+            # None or all fields
+            (None, non_map_fields | map_fields_flattened),  # not provided
+            (list(doc.keys()), non_map_fields | map_fields_flattened),  # all fields are selected
 
             # one field
             (["short_string_field"], {"short_string_field"}),
@@ -892,22 +897,22 @@ class TestSearchUnstructured(MarqoTestCase):
             (["int_field"], {"int_field"}),
             (["float_field"], {"float_field"}),
             (["string_array"], {"string_array"}),
-            (["int_map"], {"int_map"}),
-            (["float_map"], {"float_map"}),
+            (["int_map"], {"int_map.a", "int_map.b"}),
+            (["float_map"], {"float_map.c", "float_map.d"}),
             (["bool_field"], {"bool_field"}),
             (["custom_vector_field"], {"custom_vector_field"}),
             # combination of short and long string fields
             (["short_string_field", "long_string_field"], {"short_string_field", "long_string_field"}),
             # combination of int and int map fields
-            (["int_field", "int_map"], {"int_field", "int_map"}),
+            (["int_field", "int_map"], {"int_field", "int_map.a", "int_map.b"}),
             # combination of fload and fload map fields
-            (["float_field", "float_map"], {"float_field", "float_map"}),
+            (["float_field", "float_map"], {"float_field", "float_map.c", "float_map.d"}),
             # multiple boolean fields
             (["bool_field", "bool_field2"], {"bool_field", "bool_field2"}),
             # combination of all types of fields include non-existent fields
             (["short_string_field", "long_string_field", "int_map", "bool_field", "multimodal_combo_field",
               "string_array", "custom_vector_field"],
-             {"short_string_field", "long_string_field", "int_map", "bool_field", "string_array",
+             {"short_string_field", "long_string_field", "int_map.a", "int_map.b", "bool_field", "string_array",
               "custom_vector_field"})
         )
 
@@ -924,6 +929,9 @@ class TestSearchUnstructured(MarqoTestCase):
                     for attribute in expected_fields:
                         if attribute == "custom_vector_field":
                             self.assertEqual(res["hits"][0][attribute], doc[attribute]["content"])
+                        elif '.' in attribute:
+                            map_field_name, key = attribute.split('.', maxsplit=1)
+                            self.assertEqual(res["hits"][0][attribute], doc[map_field_name][key])
                         else:
                             self.assertEqual(res["hits"][0][attribute], doc[attribute])
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
There are three issues for unstructured index
<img width="996" alt="image" src="https://github.com/user-attachments/assets/dacb8a0c-f35b-41d5-9ec6-7078d8f7979b">

* **What is the new behavior (if this is a feature change)?**
- See the second row and last colume, we'll fix the regression for 2.13 unstructured index, and fix the missing int/float map in legacy unstructured index, but keep the map fields flattened for compatibility reasons. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes, if the user's client code depends on the flattened map fields, they will need to change it since the new behaviour will return maps as is. 

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
Yes

* **Related Python client changes** (link commit/PR here)
No

* **Related documentation changes** (link commit/PR here)
No

* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

