### PR TITLE
Add hf_transfer to dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY vespa .
 RUN mvn clean package
 
 # Stage 2: Base image for Python setup
-FROM marqoai/marqo-base:46 as base_image
+FROM marqoai/marqo-base:47 as base_image
 
 # Allow mounting volume containing data and configs for vespa
 VOLUME /opt/vespa/var


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

* **What is the current behavior?** (You can also link to an open issue here)
we use python based packages to download models from huggingface. The speed is slow for large models.

* **What is the new behavior (if this is a feature change)?**
We add hf_transfer to the dependencies. Users can set `HF_HUB_ENABLE_HF_TRANSFER=1` as an environment variable to enable a faster downloading speed.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)


* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

