### PR TITLE
Generate coverage report for new code and show all reports in GH step summary

### DIFF
--- a/.github/workflows/largemodel_unit_test_CI.yml
+++ b/.github/workflows/largemodel_unit_test_CI.yml
@@ -163,7 +163,57 @@ jobs:
           export PRIVATE_MODEL_TESTS_HF_TOKEN=${{ secrets.PRIVATE_MODEL_TESTS_HF_TOKEN }}
           
           export PYTHONPATH="./marqo/tests:./marqo/src:./marqo"
-          pytest marqo/tests --largemodel --ignore=marqo/tests/test_documentation.py --ignore=marqo/tests/backwards_compatibility_tests 
+          set -o pipefail
+          pytest marqo/tests --largemodel --ignore=marqo/tests/test_documentation.py --ignore=marqo/tests/backwards_compatibility_tests \
+            --durations=100 --cov=src --cov-branch --cov-context=test \
+            --cov-report=html:cov_html --cov-report=xml:cov.xml --cov-report term:skip-covered \
+            --md-report --md-report-flavor gfm --md-report-output pytest_result_summary.md \
+            marqo/tests | tee pytest_output.txt
+
+      - name: Check Test Coverage of New Code
+        id: check_test_coverage
+        continue-on-error: true
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            export BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
+          else
+            export BASE_BRANCH=mainline
+          fi
+          
+          cd marqo
+          echo "Running diff-cover against branch $BASE_BRANCH"
+          git fetch origin $BASE_BRANCH:$BASE_BRANCH
+          diff-cover cov.xml --html-report diff_cov.html --markdown-report diff_cov.md \
+            --compare-branch $BASE_BRANCH
+
+      - name: Upload Test Report
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: marqo-test-report
+          path: |
+            marqo/cov_html/
+            marqo/diff_cov.html
+
+      - name: Test and coverage report summary
+        continue-on-error: true
+        run: |
+          echo "# Test Summary" >> $GITHUB_STEP_SUMMARY
+          cat marqo/pytest_result_summary.md >> $GITHUB_STEP_SUMMARY
+          
+          echo "# Coverage Summary, Slow Tests and Failed Tests" >> $GITHUB_STEP_SUMMARY
+          echo '```text' >> $GITHUB_STEP_SUMMARY
+          awk '/---------- coverage:/ {flag=1} flag' marqo/pytest_output.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          
+          cat marqo/diff_cov.md >> $GITHUB_STEP_SUMMARY
+
+      - name: Fail Job If Tests or Coverage Failed
+        if: ${{ steps.run_unit_tests.outcome == 'failure' || steps.check_test_coverage.outcome == 'failure' }}
+        run: |
+          echo "Tests or coverage checks failed. Marking job as failed."
+          exit 1
+        shell: bash
 
   Stop-Runner:
     name: Stop self-hosted EC2 runner

--- a/.github/workflows/largemodel_unit_test_CI.yml
+++ b/.github/workflows/largemodel_unit_test_CI.yml
@@ -150,6 +150,8 @@ jobs:
           echo "Deleted vespa_tester_app.zip"
 
       - name: Run Large Model Unit Tests
+        id: run_unit_tests
+        continue-on-error: true
         run: |
           # Define these for use by marqo
           export VESPA_CONFIG_URL=http://localhost:19071
@@ -165,7 +167,7 @@ jobs:
           cd marqo
           export PYTHONPATH="./tests:./src:."
           set -o pipefail
-          pytest --largemodel --ignore=marqo/tests/test_documentation.py --ignore=marqo/tests/backwards_compatibility_tests \
+          pytest --largemodel --ignore=tests/test_documentation.py --ignore=tests/backwards_compatibility_tests \
             --durations=100 --cov=src --cov-branch --cov-context=test \
             --cov-report=html:cov_html --cov-report=xml:cov.xml --cov-report term:skip-covered \
             --md-report --md-report-flavor gfm --md-report-output pytest_result_summary.md \

--- a/.github/workflows/largemodel_unit_test_CI.yml
+++ b/.github/workflows/largemodel_unit_test_CI.yml
@@ -162,13 +162,14 @@ jobs:
           export PRIVATE_MODEL_TESTS_AWS_SECRET_ACCESS_KEY=${{ secrets.PRIVATE_MODEL_TESTS_AWS_SECRET_ACCESS_KEY }}
           export PRIVATE_MODEL_TESTS_HF_TOKEN=${{ secrets.PRIVATE_MODEL_TESTS_HF_TOKEN }}
           
-          export PYTHONPATH="./marqo/tests:./marqo/src:./marqo"
+          cd marqo
+          export PYTHONPATH="./tests:./src:."
           set -o pipefail
-          pytest marqo/tests --largemodel --ignore=marqo/tests/test_documentation.py --ignore=marqo/tests/backwards_compatibility_tests \
+          pytest --largemodel --ignore=marqo/tests/test_documentation.py --ignore=marqo/tests/backwards_compatibility_tests \
             --durations=100 --cov=src --cov-branch --cov-context=test \
             --cov-report=html:cov_html --cov-report=xml:cov.xml --cov-report term:skip-covered \
             --md-report --md-report-flavor gfm --md-report-output pytest_result_summary.md \
-            marqo/tests | tee pytest_output.txt
+            tests | tee pytest_output.txt
 
       - name: Check Test Coverage of New Code
         id: check_test_coverage

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -89,6 +89,7 @@ jobs:
             python -m nltk.downloader punkt_tab
 
       - name: Build Vespa
+        if: false
         run: |
           systemctl stop unattended-upgrades
           apt-get remove -y unattended-upgrades
@@ -117,6 +118,7 @@ jobs:
           mvn clean package
 
       - name: Start Vespa
+        if: false
         run: |
           # Define these for checking if Vespa is ready
           export VESPA_CONFIG_URL=http://localhost:19071
@@ -153,6 +155,8 @@ jobs:
           echo "Deleted vespa_tester_app.zip"
 
       - name: Run Unit Tests
+        id: run_unit_tests
+        continue-on-error: true
         run: |
           # Define these for use by marqo
           export VESPA_CONFIG_URL=http://localhost:19071
@@ -165,13 +169,42 @@ jobs:
 
           cd marqo
           export PYTHONPATH="./tests:./src:."
-          pytest --ignore=tests/test_documentation.py --ignore=tests/backwards_compatibility_tests --durations=100 --cov=src --cov-branch --cov-context=test --cov-report=html:cov_html --cov-report=lcov:lcov.info tests
+          pytest --ignore=tests/test_documentation.py --ignore=tests/backwards_compatibility_tests --durations=100 --cov=src --cov-branch --cov-context=test \
+            --cov-report=html:cov_html --cov-report=xml:cov.xml --cov-report=lcov:lcov.info --cov-fail-under=25 \
+            tests/core/vespa_index/test_add_documents_handler.py
+
+      - name: Check Test Coverage of New Code
+        id: check_test_coverage
+        continue-on-error: true
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request_target" ]]; then
+            export BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
+          else
+            export BASE_BRANCH=mainline
+          fi
+          
+          cd marqo
+          echo "Running diff-cover against branch $BASE_BRANCH"
+          git fetch origin $BASE_BRANCH:$BASE_BRANCH
+          diff-cover cov.xml --html-report diff_cov.html --markdown-report diff_cov.md --fail-under=95 \
+            --compare-branch $BASE_BRANCH
 
       - name: Upload Test Report
         uses: actions/upload-artifact@v4
+        if: ${{ always() }}  # upload the coverage report even the previous step fails
+        continue-on-error: true
         with:
           name: marqo-test-report
-          path: marqo/cov_html/
+          path: |
+            marqo/cov_html/
+            diff_cov.html
+
+      - name: Fail Job If Tests or Coverage Failed
+        if: ${{ steps.run_unit_tests.outcome == 'failure' || steps.check_test_coverage.outcome == 'failure' }}
+        run: |
+          echo "Tests or coverage checks failed. Marking job as failed."
+          exit 1
+        shell: bash
 
   Stop-Runner:
     name: Stop self-hosted EC2 runner

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -209,6 +209,7 @@ jobs:
           
           echo "# Coverage Summary, Slow Tests and Failed Tests" >> $GITHUB_STEP_SUMMARY
           echo "```text" >> $GITHUB_STEP_SUMMARY
+          cat marqo/pytest_output.txt >> $GITHUB_STEP_SUMMARY
           awk '/---------- coverage:/ {flag=1} flag' marqo/pytest_output.txt >> $GITHUB_STEP_SUMMARY
           echo "```" >> $GITHUB_STEP_SUMMARY
           

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -186,7 +186,7 @@ jobs:
           cd marqo
           echo "Running diff-cover against branch $BASE_BRANCH"
           git fetch origin $BASE_BRANCH:$BASE_BRANCH
-          diff-cover cov.xml --html-report diff_cov.html --markdown-report diff_cov.md --fail-under=95 \
+          diff-cover cov.xml --html-report diff_cov.html --markdown-report diff_cov.md --fail-under=101 \
             --compare-branch $BASE_BRANCH
 
       - name: Upload Test Report
@@ -197,7 +197,7 @@ jobs:
           name: marqo-test-report
           path: |
             marqo/cov_html/
-            diff_cov.html
+            marqo/diff_cov.html
 
       - name: Fail Job If Tests or Coverage Failed
         if: ${{ steps.run_unit_tests.outcome == 'failure' || steps.check_test_coverage.outcome == 'failure' }}

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -210,7 +210,7 @@ jobs:
           
           echo "# Coverage Summary, Slow Tests and Failed Tests" >> $GITHUB_STEP_SUMMARY
           echo '```text' >> $GITHUB_STEP_SUMMARY
-          awk '/---------- coverage:/ {flag=1} flag' marqo/pytest_output.txt 
+          awk '/---------- coverage:/ {flag=1} flag' marqo/pytest_output.txt >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           
           cat marqo/diff_cov.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -170,10 +170,10 @@ jobs:
           cd marqo
           export PYTHONPATH="./tests:./src:."
           pytest --ignore=tests/test_documentation.py --ignore=tests/backwards_compatibility_tests --durations=100 --cov=src --cov-branch --cov-context=test \
-            --cov-report=html:cov_html --cov-report=xml:cov.xml --cov-report=lcov:lcov.info --cov-fail-under=35 \
-            --md-report --md-report-flavor gfm --md-report-exclude-outcomes passed skipped xpassed --md-report-verbose=1 \
-            --md-report-output pytest_result.md \
-            tests/core/vespa_index/test_add_documents_handler.py
+            --cov-report=html:cov_html --cov-report=xml:cov.xml --cov-report term:skip-covered --cov-fail-under=35 \
+            --md-report --md-report-flavor gfm --md-report-exclude-outcomes passed xpassed \
+            --md-report-output pytest_result_summary.md \
+            tests/core/vespa_index/test_add_documents_handler.py | tee pytest_output.txt
 
       - name: Check Test Coverage of New Code
         id: check_test_coverage
@@ -198,13 +198,12 @@ jobs:
           name: marqo-test-report
           path: |
             marqo/cov_html/
-            marqo/lcov.info
             marqo/diff_cov.html
 
       - name: Test and coverage report summary
         continue-on-error: true
         run: |
-          cat marqo/pytest_result.md >> $GITHUB_STEP_SUMMARY
+          cat marqo/pytest_result_summary.md >> $GITHUB_STEP_SUMMARY
           cat marqo/diff_cov.md >> $GITHUB_STEP_SUMMARY
 
       - name: Fail Job If Tests or Coverage Failed

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -169,7 +169,7 @@ jobs:
 
           cd marqo
           export PYTHONPATH="./tests:./src:."
-          set -e
+          set -euo pipefail
           pytest --ignore=tests/test_documentation.py --ignore=tests/backwards_compatibility_tests --durations=100 --cov=src --cov-branch --cov-context=test \
             --cov-report=html:cov_html --cov-report=xml:cov.xml --cov-report term:skip-covered --cov-fail-under=35 \
             --md-report --md-report-flavor gfm --md-report-exclude-outcomes passed xpassed \
@@ -208,7 +208,7 @@ jobs:
           cat marqo/pytest_result_summary.md >> $GITHUB_STEP_SUMMARY
           echo "# Coverage Summary, Slow Tests and Failed Tests" >> $GITHUB_STEP_SUMMARY
           echo "```text" >> $GITHUB_STEP_SUMMARY
-          awk '/---------- coverage:/ {flag=1} flag' pytest_output.txt >> $GITHUB_STEP_SUMMARY
+          awk '/---------- coverage:/ {flag=1} flag' marqo/pytest_output.txt >> $GITHUB_STEP_SUMMARY
           echo "```" >> $GITHUB_STEP_SUMMARY
           cat marqo/diff_cov.md >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -170,7 +170,7 @@ jobs:
           cd marqo
           export PYTHONPATH="./tests:./src:."
           pytest --ignore=tests/test_documentation.py --ignore=tests/backwards_compatibility_tests --durations=100 --cov=src --cov-branch --cov-context=test \
-            --cov-report=html:cov_html --cov-report=xml:cov.xml --cov-report=lcov:lcov.info --cov-fail-under=25 \
+            --cov-report=html:cov_html --cov-report=xml:cov.xml --cov-report=lcov:lcov.info --cov-fail-under=35 \
             tests/core/vespa_index/test_add_documents_handler.py
 
       - name: Check Test Coverage of New Code
@@ -186,7 +186,7 @@ jobs:
           cd marqo
           echo "Running diff-cover against branch $BASE_BRANCH"
           git fetch origin $BASE_BRANCH:$BASE_BRANCH
-          diff-cover cov.xml --html-report diff_cov.html --markdown-report diff_cov.md --fail-under=101 \
+          diff-cover cov.xml --html-report diff_cov.html --markdown-report diff_cov.md --fail-under=95 \
             --compare-branch $BASE_BRANCH
 
       - name: Upload Test Report
@@ -196,6 +196,7 @@ jobs:
           name: marqo-test-report
           path: |
             marqo/cov_html/
+            marqo/lcov.info
             marqo/diff_cov.html
 
       - name: Test and coverage report summary

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -171,7 +171,7 @@ jobs:
           export PYTHONPATH="./tests:./src:."
           set -o pipefail
           pytest --ignore=tests/test_documentation.py --durations=100 --cov=src --cov-branch --cov-context=test \
-            --cov-report=html:cov_html --cov-report=xml:cov.xml --cov-report term:skip-covered --cov-fail-under=35 \
+            --cov-report=html:cov_html --cov-report=xml:cov.xml --cov-report term:skip-covered --cov-fail-under=80 \
             --md-report --md-report-flavor gfm --md-report-output pytest_result_summary.md \
             tests/core/vespa_index/test_add_documents_handler.py | tee pytest_output.txt
 

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -171,6 +171,7 @@ jobs:
           export PYTHONPATH="./tests:./src:."
           pytest --ignore=tests/test_documentation.py --ignore=tests/backwards_compatibility_tests --durations=100 --cov=src --cov-branch --cov-context=test \
             --cov-report=html:cov_html --cov-report=xml:cov.xml --cov-report=lcov:lcov.info --cov-fail-under=35 \
+            --md-report --md-report-flavor gfm --md-report-exclude-outcomes passed skipped xpassed --md-report-output pytest_result.md \
             tests/core/vespa_index/test_add_documents_handler.py
 
       - name: Check Test Coverage of New Code
@@ -202,6 +203,7 @@ jobs:
       - name: Test and coverage report summary
         continue-on-error: true
         run: |
+          cat marqo/pytest_result.md >> $GITHUB_STEP_SUMMARY
           cat marqo/diff_cov.md >> $GITHUB_STEP_SUMMARY
 
       - name: Fail Job If Tests or Coverage Failed

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -191,13 +191,17 @@ jobs:
 
       - name: Upload Test Report
         uses: actions/upload-artifact@v4
-        if: ${{ always() }}  # upload the coverage report even the previous step fails
         continue-on-error: true
         with:
           name: marqo-test-report
           path: |
             marqo/cov_html/
             marqo/diff_cov.html
+
+      - name: Test and coverage report summary
+        continue-on-error: true
+        run: |
+          cat marqo/diff_cov.md >> $GITHUB_STEP_SUMMARY
 
       - name: Fail Job If Tests or Coverage Failed
         if: ${{ steps.run_unit_tests.outcome == 'failure' || steps.check_test_coverage.outcome == 'failure' }}

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -168,8 +168,9 @@ jobs:
           cd marqo
           export PYTHONPATH="./tests:./src:."
           set -o pipefail
-          pytest --ignore=tests/test_documentation.py --durations=100 --cov=src --cov-branch --cov-context=test \
-            --cov-report=html:cov_html --cov-report=xml:cov.xml --cov-report term:skip-covered --cov-fail-under=80 \
+          pytest --ignore=tests/test_documentation.py --ignore=tests/backwards_compatibility_tests \
+            --durations=100 --cov=src --cov-branch --cov-context=test \
+            --cov-report=html:cov_html --cov-report=xml:cov.xml --cov-report term:skip-covered \
             --md-report --md-report-flavor gfm --md-report-output pytest_result_summary.md \
             tests | tee pytest_output.txt
 
@@ -177,7 +178,7 @@ jobs:
         id: check_test_coverage
         continue-on-error: true
         run: |
-          if [[ "${GITHUB_EVENT_NAME}" == "pull_request_target" ]]; then
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
             export BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
           else
             export BASE_BRANCH=mainline
@@ -186,7 +187,7 @@ jobs:
           cd marqo
           echo "Running diff-cover against branch $BASE_BRANCH"
           git fetch origin $BASE_BRANCH:$BASE_BRANCH
-          diff-cover cov.xml --html-report diff_cov.html --markdown-report diff_cov.md --fail-under=90 \
+          diff-cover cov.xml --html-report diff_cov.html --markdown-report diff_cov.md \
             --compare-branch $BASE_BRANCH
 
       - name: Upload Test Report

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -174,7 +174,7 @@ jobs:
             --cov-report=html:cov_html --cov-report=xml:cov.xml --cov-report term:skip-covered --cov-fail-under=35 \
             --md-report --md-report-flavor gfm --md-report-exclude-outcomes passed xpassed \
             --md-report-output pytest_result_summary.md \
-            tests/core/vespa_index/test_add_documents_handler.py 2>&1 | tee pytest_output.txt
+            tests/core/vespa_index/test_add_documents_handler.py | tee pytest_output.txt
 
       - name: Check Test Coverage of New Code
         id: check_test_coverage
@@ -209,10 +209,9 @@ jobs:
           ls -al marqo/pytest_output.txt
           
           echo "# Coverage Summary, Slow Tests and Failed Tests" >> $GITHUB_STEP_SUMMARY
-          echo "```text" >> $GITHUB_STEP_SUMMARY
-          cat marqo/pytest_output.txt >> $GITHUB_STEP_SUMMARY
-          awk '/---------- coverage:/ {flag=1} flag' marqo/pytest_output.txt >> $GITHUB_STEP_SUMMARY
-          echo "```" >> $GITHUB_STEP_SUMMARY
+          echo '```text' >> $GITHUB_STEP_SUMMARY
+          awk '/---------- coverage:/ {flag=1} flag' marqo/pytest_output.txt 
+          echo '```' >> $GITHUB_STEP_SUMMARY
           
           cat marqo/diff_cov.md >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -206,10 +206,13 @@ jobs:
         run: |
           echo "# Test Summary" >> $GITHUB_STEP_SUMMARY
           cat marqo/pytest_result_summary.md >> $GITHUB_STEP_SUMMARY
+          
           echo "# Coverage Summary, Slow Tests and Failed Tests" >> $GITHUB_STEP_SUMMARY
           echo "```text" >> $GITHUB_STEP_SUMMARY
-          awk '/---------- coverage:/ {flag=1} flag' marqo/pytest_output.txt >> $GITHUB_STEP_SUMMARY
+          cat marqo/pytest_output.txt >> $GITHUB_STEP_SUMMARY
+#          awk '/---------- coverage:/ {flag=1} flag' marqo/pytest_output.txt >> $GITHUB_STEP_SUMMARY
           echo "```" >> $GITHUB_STEP_SUMMARY
+          
           cat marqo/diff_cov.md >> $GITHUB_STEP_SUMMARY
 
       - name: Fail Job If Tests or Coverage Failed

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -209,8 +209,7 @@ jobs:
           
           echo "# Coverage Summary, Slow Tests and Failed Tests" >> $GITHUB_STEP_SUMMARY
           echo "```text" >> $GITHUB_STEP_SUMMARY
-          cat marqo/pytest_output.txt >> $GITHUB_STEP_SUMMARY
-#          awk '/---------- coverage:/ {flag=1} flag' marqo/pytest_output.txt >> $GITHUB_STEP_SUMMARY
+          awk '/---------- coverage:/ {flag=1} flag' marqo/pytest_output.txt >> $GITHUB_STEP_SUMMARY
           echo "```" >> $GITHUB_STEP_SUMMARY
           
           cat marqo/diff_cov.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -171,7 +171,8 @@ jobs:
           export PYTHONPATH="./tests:./src:."
           pytest --ignore=tests/test_documentation.py --ignore=tests/backwards_compatibility_tests --durations=100 --cov=src --cov-branch --cov-context=test \
             --cov-report=html:cov_html --cov-report=xml:cov.xml --cov-report=lcov:lcov.info --cov-fail-under=35 \
-            --md-report --md-report-flavor gfm --md-report-exclude-outcomes passed skipped xpassed --md-report-output pytest_result.md \
+            --md-report --md-report-flavor gfm --md-report-exclude-outcomes passed skipped xpassed --md-report-verbose=1 \
+            --md-report-output pytest_result.md \
             tests/core/vespa_index/test_add_documents_handler.py
 
       - name: Check Test Coverage of New Code

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -169,8 +169,8 @@ jobs:
 
           cd marqo
           export PYTHONPATH="./tests:./src:."
-          set -euo pipefail
-          pytest --ignore=tests/test_documentation.py --ignore=tests/backwards_compatibility_tests --durations=100 --cov=src --cov-branch --cov-context=test \
+          set -o pipefail
+          pytest --ignore=tests/test_documentation.py --durations=100 --cov=src --cov-branch --cov-context=test \
             --cov-report=html:cov_html --cov-report=xml:cov.xml --cov-report term:skip-covered --cov-fail-under=35 \
             --md-report --md-report-flavor gfm --md-report-exclude-outcomes passed xpassed \
             --md-report-output pytest_result_summary.md \
@@ -206,9 +206,11 @@ jobs:
         run: |
           echo "# Test Summary" >> $GITHUB_STEP_SUMMARY
           cat marqo/pytest_result_summary.md >> $GITHUB_STEP_SUMMARY
+          ls -al marqo/pytest_output.txt
           
           echo "# Coverage Summary, Slow Tests and Failed Tests" >> $GITHUB_STEP_SUMMARY
           echo "```text" >> $GITHUB_STEP_SUMMARY
+          cat marqo/pytest_output.txt >> $GITHUB_STEP_SUMMARY
           awk '/---------- coverage:/ {flag=1} flag' marqo/pytest_output.txt >> $GITHUB_STEP_SUMMARY
           echo "```" >> $GITHUB_STEP_SUMMARY
           

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -174,7 +174,7 @@ jobs:
             --cov-report=html:cov_html --cov-report=xml:cov.xml --cov-report term:skip-covered --cov-fail-under=35 \
             --md-report --md-report-flavor gfm --md-report-exclude-outcomes passed xpassed \
             --md-report-output pytest_result_summary.md \
-            tests/core/vespa_index/test_add_documents_handler.py | tee pytest_output.txt
+            tests/core/vespa_index/test_add_documents_handler.py 2>&1 | tee pytest_output.txt
 
       - name: Check Test Coverage of New Code
         id: check_test_coverage
@@ -209,7 +209,6 @@ jobs:
           
           echo "# Coverage Summary, Slow Tests and Failed Tests" >> $GITHUB_STEP_SUMMARY
           echo "```text" >> $GITHUB_STEP_SUMMARY
-          cat marqo/pytest_output.txt >> $GITHUB_STEP_SUMMARY
           awk '/---------- coverage:/ {flag=1} flag' marqo/pytest_output.txt >> $GITHUB_STEP_SUMMARY
           echo "```" >> $GITHUB_STEP_SUMMARY
           

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -89,7 +89,6 @@ jobs:
             python -m nltk.downloader punkt_tab
 
       - name: Build Vespa
-        if: false
         run: |
           systemctl stop unattended-upgrades
           apt-get remove -y unattended-upgrades
@@ -118,7 +117,6 @@ jobs:
           mvn clean package
 
       - name: Start Vespa
-        if: false
         run: |
           # Define these for checking if Vespa is ready
           export VESPA_CONFIG_URL=http://localhost:19071
@@ -173,7 +171,7 @@ jobs:
           pytest --ignore=tests/test_documentation.py --durations=100 --cov=src --cov-branch --cov-context=test \
             --cov-report=html:cov_html --cov-report=xml:cov.xml --cov-report term:skip-covered --cov-fail-under=80 \
             --md-report --md-report-flavor gfm --md-report-output pytest_result_summary.md \
-            tests/core/vespa_index/test_add_documents_handler.py | tee pytest_output.txt
+            tests | tee pytest_output.txt
 
       - name: Check Test Coverage of New Code
         id: check_test_coverage

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -169,6 +169,7 @@ jobs:
 
           cd marqo
           export PYTHONPATH="./tests:./src:."
+          set -e
           pytest --ignore=tests/test_documentation.py --ignore=tests/backwards_compatibility_tests --durations=100 --cov=src --cov-branch --cov-context=test \
             --cov-report=html:cov_html --cov-report=xml:cov.xml --cov-report term:skip-covered --cov-fail-under=35 \
             --md-report --md-report-flavor gfm --md-report-exclude-outcomes passed xpassed \
@@ -203,7 +204,12 @@ jobs:
       - name: Test and coverage report summary
         continue-on-error: true
         run: |
+          echo "# Test Summary" >> $GITHUB_STEP_SUMMARY
           cat marqo/pytest_result_summary.md >> $GITHUB_STEP_SUMMARY
+          echo "# Coverage Summary, Slow Tests and Failed Tests" >> $GITHUB_STEP_SUMMARY
+          echo "```text" >> $GITHUB_STEP_SUMMARY
+          awk '/---------- coverage:/ {flag=1} flag' pytest_output.txt >> $GITHUB_STEP_SUMMARY
+          echo "```" >> $GITHUB_STEP_SUMMARY
           cat marqo/diff_cov.md >> $GITHUB_STEP_SUMMARY
 
       - name: Fail Job If Tests or Coverage Failed

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -172,8 +172,7 @@ jobs:
           set -o pipefail
           pytest --ignore=tests/test_documentation.py --durations=100 --cov=src --cov-branch --cov-context=test \
             --cov-report=html:cov_html --cov-report=xml:cov.xml --cov-report term:skip-covered --cov-fail-under=35 \
-            --md-report --md-report-flavor gfm --md-report-exclude-outcomes passed xpassed \
-            --md-report-output pytest_result_summary.md \
+            --md-report --md-report-flavor gfm --md-report-output pytest_result_summary.md \
             tests/core/vespa_index/test_add_documents_handler.py | tee pytest_output.txt
 
       - name: Check Test Coverage of New Code
@@ -189,7 +188,7 @@ jobs:
           cd marqo
           echo "Running diff-cover against branch $BASE_BRANCH"
           git fetch origin $BASE_BRANCH:$BASE_BRANCH
-          diff-cover cov.xml --html-report diff_cov.html --markdown-report diff_cov.md --fail-under=95 \
+          diff-cover cov.xml --html-report diff_cov.html --markdown-report diff_cov.md --fail-under=90 \
             --compare-branch $BASE_BRANCH
 
       - name: Upload Test Report
@@ -206,7 +205,6 @@ jobs:
         run: |
           echo "# Test Summary" >> $GITHUB_STEP_SUMMARY
           cat marqo/pytest_result_summary.md >> $GITHUB_STEP_SUMMARY
-          ls -al marqo/pytest_output.txt
           
           echo "# Coverage Summary, Slow Tests and Failed Tests" >> $GITHUB_STEP_SUMMARY
           echo '```text' >> $GITHUB_STEP_SUMMARY

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -2,3 +2,4 @@
 pyvespa==0.37.1
 pytest==7.4.3
 pytest-cov==5.0.0
+diff-cover==9.2.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,3 +3,4 @@ pyvespa==0.37.1
 pytest==7.4.3
 pytest-cov==5.0.0
 diff-cover==9.2.0
+pytest-md-report==0.6.2

--- a/src/marqo/core/vespa_index/add_documents_handler.py
+++ b/src/marqo/core/vespa_index/add_documents_handler.py
@@ -91,7 +91,7 @@ class AddDocumentsResponseCollector:
 
         self.responses.append((loc, MarqoAddDocumentsItem(
             id=doc_id if doc_id is not None else '',
-            status=200,
+            status=400,
         )))
 
         if loc is not None:

--- a/src/marqo/core/vespa_index/add_documents_handler.py
+++ b/src/marqo/core/vespa_index/add_documents_handler.py
@@ -94,6 +94,11 @@ class AddDocumentsResponseCollector:
             status=200,
         )))
 
+        if loc is not None:
+            "a"
+        else:
+            "b"
+
     def to_add_doc_responses(self, index_name: str) -> MarqoAddDocumentsResponse:
         processing_time = (timer() - self.start_time) * 1000
         # since we reversed the doc list to skip duplicate docs, we now need to reverse the response

--- a/src/marqo/core/vespa_index/add_documents_handler.py
+++ b/src/marqo/core/vespa_index/add_documents_handler.py
@@ -91,10 +91,10 @@ class AddDocumentsResponseCollector:
 
         self.responses.append((loc, MarqoAddDocumentsItem(
             id=doc_id if doc_id is not None else '',
-            status=400,
+            status=200,
         )))
 
-        if loc is not None:
+        if False:
             "a"
         else:
             "b"

--- a/src/marqo/core/vespa_index/add_documents_handler.py
+++ b/src/marqo/core/vespa_index/add_documents_handler.py
@@ -94,11 +94,6 @@ class AddDocumentsResponseCollector:
             status=200,
         )))
 
-        if False:
-            "a"
-        else:
-            "b"
-
     def to_add_doc_responses(self, index_name: str) -> MarqoAddDocumentsResponse:
         processing_time = (timer() - self.start_time) * 1000
         # since we reversed the doc list to skip duplicate docs, we now need to reverse the response


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Operational improvement

* **What is the current behavior?** (You can also link to an open issue here)
- we do not generate coverage report for new codes only
- we do not generate test report for largemodel unit test
- we do not display test and coverage summary in GH step summary

* **What is the new behavior (if this is a feature change)?**
- generate coverage report for new codes only ( we do not fail on the coverage threshold for now until we merge the coverage report of largemodel and unit tests)
- generate test report for largemodel unit test
- display test and coverage summary in GH step summary

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
No

* **Related Python client changes** (link commit/PR here)
No

* **Related documentation changes** (link commit/PR here)
No

* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

