### PR TITLE
Make compatibility tests run on releases branch and make them run on all previous patch versions

### DIFF
--- a/.github/workflows/backwards_compatibility_marqo_orchestrator.yml
+++ b/.github/workflows/backwards_compatibility_marqo_orchestrator.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - mainline
+      - releases/*
     paths-ignore:
       - '**.md'
   workflow_dispatch:


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
* Feature


* **What is the current behavior?** (You can also link to an open issue here)
* Currently compatibility tests (i.e backwards compatibility and rollback tests both) run on the previous patch version along with up to n-1 previous minor versions. 


* **What is the new behavior (if this is a feature change)?**
* With this change the compatibility tests will run on all the previous patch versions of a minor version along with up to n previous minor versions 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
* No


* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
* Manual testing has been done


* **Related Python client changes** (link commit/PR here)
* NA


* **Related documentation changes** (link commit/PR here)
* NA


* **Other information**:
* NA


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

