### PR TITLE
(Release 2.14) Preserving document-process node in services.xml when bootstrapping Vespa app

### DIFF
--- a/src/marqo/core/index_management/vespa_application_package.py
+++ b/src/marqo/core/index_management/vespa_application_package.py
@@ -86,7 +86,7 @@ class ServicesXml:
         """
         container_element = self._ensure_only_one('container')
         for child in container_element.findall('*'):
-            if child.tag in ['document-api', 'search']:
+            if child.tag in ['document-api', 'document-processing', 'search']:
                 child.clear()
             elif child.tag != 'nodes':
                 container_element.remove(child)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
document-process node is removed from container section of services.xml when bootstrapping Vespa app using Marqo 2.13+. This caused some failures when upgrading some old Cloud indexes. Please see [this slack thread](https://marqo-ai.slack.com/archives/C03L2FWTGLE/p1734439370330959) for more details

* **What is the new behavior (if this is a feature change)?**
document-process node is preserved (but the attributes and child nodes will be cleared) in container section of services.xml. This is to make sure the bootstrap process is compatible with indexes created with IndexCreateWorkflowV2, which uses a services.xml template containing an empty document-processing node.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
Yes

* **Related Python client changes** (link commit/PR here)
No

* **Related documentation changes** (link commit/PR here)
No

* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

