### PR TITLE
Fixing compatibility tests folder name inside large model and unit test pytest runs

### DIFF
--- a/.github/workflows/largemodel_unit_test_CI.yml
+++ b/.github/workflows/largemodel_unit_test_CI.yml
@@ -167,7 +167,7 @@ jobs:
           cd marqo
           export PYTHONPATH="./tests:./src:."
           set -o pipefail
-          pytest --largemodel --ignore=tests/test_documentation.py --ignore=tests/backwards_compatibility_tests \
+          pytest --largemodel --ignore=tests/test_documentation.py --ignore=tests/compatibility_tests \
             --durations=100 --cov=src --cov-branch --cov-context=test \
             --cov-report=html:cov_html --cov-report=xml:cov.xml --cov-report term:skip-covered \
             --md-report --md-report-flavor gfm --md-report-output pytest_result_summary.md \

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -168,7 +168,7 @@ jobs:
           cd marqo
           export PYTHONPATH="./tests:./src:."
           set -o pipefail
-          pytest --ignore=tests/test_documentation.py --ignore=tests/backwards_compatibility_tests \
+          pytest --ignore=tests/test_documentation.py --ignore=tests/compatibility_tests \
             --durations=100 --cov=src --cov-branch --cov-context=test \
             --cov-report=html:cov_html --cov-report=xml:cov.xml --cov-report term:skip-covered \
             --md-report --md-report-flavor gfm --md-report-output pytest_result_summary.md \


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
* Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
* Pytest isn't ignoring backwards compatibility tests when running large model or unit tests. This is due to the fact that the compatibility tests directory's name was changed but it wasn't changed when passing --ignore argument to pytest.


* **What is the new behavior (if this is a feature change)?**
* Pytest will ignore compatibility tests when running large model or unit tests


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
* No


* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
* NA


* **Related Python client changes** (link commit/PR here)
* NA


* **Related documentation changes** (link commit/PR here)
* NA


* **Other information**:
* NA


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

