### PR TITLE
Fix a bug that custom languagebind models do not accept `supportedModalities` in model properties

### DIFF
--- a/src/marqo/tensor_search/add_docs.py
+++ b/src/marqo/tensor_search/add_docs.py
@@ -84,6 +84,15 @@ def threaded_download_and_preprocess_content(allocated_docs: List[dict],
         metric_obj = RequestMetricsStore.for_request()
         RequestMetricsStore.set_in_request(metrics=metric_obj)
 
+    # For backward compatibility, we should accept both supportedModalities and supported_modalities
+    if marqo_index_model.properties.get("supported_modalities") and marqo_index_model.properties.get("supportedModalities"):
+        raise InvalidModelPropertiesError(
+            "Model properties must have either 'supported_modalities' or 'supportedModalities', not both"
+        )
+    else:
+        supported_modalities = marqo_index_model.properties.get('supported_modalities') or \
+                                marqo_index_model.properties.get('supportedModalities')
+
     with metric_obj.time(f"{_id}.thread_time"):
         for doc in allocated_docs:
             for field in list(doc):
@@ -104,8 +113,8 @@ def threaded_download_and_preprocess_content(allocated_docs: List[dict],
                         is_structured_index and media_field_types_mapping[field] == FieldType.ImagePointer): # Don't use infer modality in structured image pointers
 
                         if marqo_index_model.properties.get('type') in [ModelType.LanguageBind] \
-                            and marqo_index_model.properties.get('supported_modalities') is not None \
-                            and Modality.IMAGE not in marqo_index_model.properties.get('supported_modalities'):
+                            and supported_modalities is not None \
+                            and Modality.IMAGE not in supported_modalities:
 
                             media_repo[doc[field]] = UnsupportedModalityError(
                                 f"Model {marqo_index_model.name} does not support {inferred_modality}")
@@ -150,7 +159,7 @@ def threaded_download_and_preprocess_content(allocated_docs: List[dict],
                                 f"Model {marqo_index_model.name} does not support {inferred_modality}")
                             continue
                         
-                        if inferred_modality not in marqo_index_model.properties.get('supported_modalities'):
+                        if inferred_modality not in supported_modalities:
                             media_repo[doc[field]] = UnsupportedModalityError(
                                 f"Model {marqo_index_model.name} does not support {inferred_modality}")
                             continue

--- a/src/marqo/tensor_search/add_docs.py
+++ b/src/marqo/tensor_search/add_docs.py
@@ -91,7 +91,7 @@ def threaded_download_and_preprocess_content(allocated_docs: List[dict],
         )
     else:
         supported_modalities = marqo_index_model.properties.get('supported_modalities') or \
-                                marqo_index_model.properties.get('supportedModalities')
+                                marqo_index_model.properties.get('supportedModalities') or []
 
     with metric_obj.time(f"{_id}.thread_time"):
         for doc in allocated_docs:

--- a/src/marqo/tensor_search/on_start_script.py
+++ b/src/marqo/tensor_search/on_start_script.py
@@ -284,9 +284,12 @@ class SetEnableVideoGPUAcceleration:
                 self.logger.debug(f"Failed to use GPU acceleration for video processing. We will disable it. "
                                   f"Original error message: {e}")
                 os.environ[EnvVars.MARQO_ENABLE_VIDEO_GPU_ACCELERATION] = "FALSE"
+                logger.info(f"Video processing with GPU acceleration is: disabled.")
         elif env_value == "TRUE":
             self._check_video_gpu_acceleration_availability()
+            logger.info(f"Video processing with GPU acceleration is: enabled.")
         elif env_value == "FALSE":
+            logger.info(f"Video processing with GPU acceleration is: disabled.")
             pass
         else:
             raise exceptions.EnvVarError(

--- a/src/marqo/tensor_search/on_start_script.py
+++ b/src/marqo/tensor_search/on_start_script.py
@@ -284,12 +284,12 @@ class SetEnableVideoGPUAcceleration:
                 self.logger.debug(f"Failed to use GPU acceleration for video processing. We will disable it. "
                                   f"Original error message: {e}")
                 os.environ[EnvVars.MARQO_ENABLE_VIDEO_GPU_ACCELERATION] = "FALSE"
-                logger.info(f"Video processing with GPU acceleration is: disabled.")
+                logger.info(f"Video processing with GPU acceleration is disabled")
         elif env_value == "TRUE":
             self._check_video_gpu_acceleration_availability()
-            logger.info(f"Video processing with GPU acceleration is: enabled.")
+            logger.info(f"Video processing with GPU acceleration is enabled")
         elif env_value == "FALSE":
-            logger.info(f"Video processing with GPU acceleration is: disabled.")
+            logger.info(f"Video processing with GPU acceleration is disabled")
             pass
         else:
             raise exceptions.EnvVarError(

--- a/tests/tensor_search/integ_tests/test_add_documents_combined.py
+++ b/tests/tensor_search/integ_tests/test_add_documents_combined.py
@@ -1144,27 +1144,29 @@ class TestLanguageBindModelAddDocumentCombined(MarqoTestCase):
             model=Model(
                 name="my-custom-language-bind-model",
                 properties={
-                "dimensions": 768,
-                "type": "languagebind",
-                "supportedModalities": ["text", "audio", "video", "image"],
-                "modelLocation": {
-                    "video": {
-                        "hf": {
-                            "repoId": "Marqo/LanguageBind_Video_V1.5_FT",
+                    "dimensions": 768,
+                    "type": "languagebind",
+                    "supportedModalities": ["text", "audio", "video", "image"],
+                    "modelLocation": {
+                        "video": {
+                            "hf": {
+                                "repoId": "Marqo/LanguageBind_Video_V1.5_FT",
+                            },
                         },
+                        "audio": {
+                            "hf": {
+                                "repoId": "Marqo/LanguageBind_Audio_FT",
+                            },
+                        },
+                        "image":{
+                            "hf": {
+                                "repoId": "Marqo/LanguageBind_Image",
+                            },
+                        }
                     },
-                    "audio": {
-                        "hf": {
-                            "repoId": "Marqo/LanguageBind_Audio_FT",
-                        },
-                    },
-                    "image":{
-                        "hf": {
-                            "repoId": "Marqo/LanguageBind_Image",
-                        },
-                    }
                 },
-            }),
+                custom=True
+            ),
             treat_urls_and_pointers_as_images = True,
             treat_urls_and_pointers_as_media = True
         )
@@ -1182,6 +1184,10 @@ class TestLanguageBindModelAddDocumentCombined(MarqoTestCase):
     def tearDownClass(cls) -> None:
         super().tearDownClass()
         s2_inference.clear_loaded_models()
+
+    def test_nothing(self):
+        print
+
 
     def test_language_bind_model_can_add_all_media_modalities(self):
         """Test to ensure that the LanguageBind model can add all media types to the index"""

--- a/tests/tensor_search/integ_tests/test_add_documents_combined.py
+++ b/tests/tensor_search/integ_tests/test_add_documents_combined.py
@@ -1185,10 +1185,6 @@ class TestLanguageBindModelAddDocumentCombined(MarqoTestCase):
         super().tearDownClass()
         s2_inference.clear_loaded_models()
 
-    def test_nothing(self):
-        print
-
-
     def test_language_bind_model_can_add_all_media_modalities(self):
         """Test to ensure that the LanguageBind model can add all media types to the index"""
         documents = [

--- a/tests/tensor_search/integ_tests/test_add_documents_combined.py
+++ b/tests/tensor_search/integ_tests/test_add_documents_combined.py
@@ -1139,10 +1139,42 @@ class TestLanguageBindModelAddDocumentCombined(MarqoTestCase):
             treat_urls_and_pointers_as_media=True
         )
 
-        cls.indexes = cls.create_indexes([structured_language_bind_index, unstructured_language_bind_index])
+        unstructured_custom_language_bind_index = cls.unstructured_marqo_index_request(
+            name="unstructured_image_index_custom" + str(uuid.uuid4()).replace('-', ''),
+            model=Model(
+                name="my-custom-language-bind-model",
+                properties={
+                "dimensions": 768,
+                "type": "languagebind",
+                "supportedModalities": ["text", "audio", "video", "image"],
+                "modelLocation": {
+                    "video": {
+                        "hf": {
+                            "repoId": "Marqo/LanguageBind_Video_V1.5_FT",
+                        },
+                    },
+                    "audio": {
+                        "hf": {
+                            "repoId": "Marqo/LanguageBind_Audio_FT",
+                        },
+                    },
+                    "image":{
+                        "hf": {
+                            "repoId": "Marqo/LanguageBind_Image",
+                        },
+                    }
+                },
+            }),
+            treat_urls_and_pointers_as_images = True,
+            treat_urls_and_pointers_as_media = True
+        )
+
+        cls.indexes = cls.create_indexes([structured_language_bind_index, unstructured_language_bind_index,
+                                          unstructured_custom_language_bind_index])
 
         cls.structured_language_bind_index_name = structured_language_bind_index.name
         cls.unstructured_language_bind_index_name = unstructured_language_bind_index.name
+        cls.unstructured_custom_language_bind_index_name= unstructured_custom_language_bind_index.name
 
         s2_inference.clear_loaded_models()
 
@@ -1347,3 +1379,51 @@ class TestLanguageBindModelAddDocumentCombined(MarqoTestCase):
                         text=test_case,
                         search_method = "TENSOR"
                     )
+
+    def test_custom_languagebind_model(self):
+        """Test the custom languagebind model in add_documents and search end-to-end."""
+        docs = [
+            {
+                "_id": "1",
+                "text_field_1": "This is a test text",
+                "image_field_1": TestImageUrls.IMAGE1.value,
+                "audio_field_1": TestAudioUrls.AUDIO1.value,
+                "video_field_1": TestVideoUrls.VIDEO1.value
+            }
+        ]
+        with self.subTest("custom-languagebind-model-add-documents"):
+            res = tensor_search.add_documents(
+                self.config,
+                add_docs_params=AddDocsParams(
+                    index_name=self.unstructured_custom_language_bind_index_name,
+                    docs=docs,
+                    tensor_fields=["text_field_1", "image_field_1", "audio_field_1", "video_field_1"]
+                )
+            )
+
+            self.assertEqual(False, res.errors)
+            self.assertEqual(
+                1,
+                self.monitoring.get_index_stats_by_name(
+                    index_name=self.unstructured_custom_language_bind_index_name).number_of_documents)
+            self.assertGreaterEqual(
+                4,
+                self.monitoring.get_index_stats_by_name(
+                    index_name=self.unstructured_custom_language_bind_index_name).number_of_vectors
+            )
+
+        search_test_cases = [
+            ("This is a test text", "text"),
+            (TestImageUrls.IMAGE1.value, "image"),
+            (TestAudioUrls.AUDIO1.value, "audio"),
+            (TestVideoUrls.VIDEO1.value, "video")
+        ]
+
+        for query, modality in search_test_cases:
+            with self.subTest(f"custom-languagebind-model-search-{modality}"):
+                _ = tensor_search.search(
+                    config=self.config,
+                    index_name=self.unstructured_custom_language_bind_index_name,
+                    text=query,
+                    search_method = "TENSOR"
+                )


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
We only accept `supported_modalities`. If user provided `supportedModalities`, a 500 error will be raised.

* **What is the new behavior (if this is a feature change)?**
We accept  both `supported_modalities` and `supportedModalitis`.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Have unit tests been run against this PR?** (Has there also been any additional testing?)


* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

