### PR TITLE
Skip unit tests when only making documentation changes

### DIFF
--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -46,7 +46,7 @@ jobs:
           echo "Head commit: $HEAD_COMMIT"
 
           # Perform the diff to check for non-documentation changes
-          if git diff --name-only $BASE_COMMIT $HEAD_COMMIT -- | grep -vE '\.(md|yml)$'; then
+          if git diff --name-only $BASE_COMMIT $HEAD_COMMIT -- | grep -vE '\.(md)$'; then
             echo "doc_only=false" >> $GITHUB_ENV
             echo "doc_only=false" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -71,8 +71,16 @@ jobs:
         run: |
           cd marqo
           set -x
-          git branch -a
-          if git diff --name-only origin/${{ github.base_ref }} origin/${{ github.head_ref }} -- | grep -vE '\.(md)$'; then
+          # Get the base and head commits from the GitHub event
+          BASE_COMMIT=${{ github.event.pull_request.base.sha }}
+          HEAD_COMMIT=${{ github.event.pull_request.head.sha }}
+  
+          # Debug: Print base and head commits
+          echo "Base commit: $BASE_COMMIT"
+          echo "Head commit: $HEAD_COMMIT"
+  
+          # Perform the diff to check for non-documentation changes
+          if git diff --name-only $BASE_COMMIT $HEAD_COMMIT -- | grep -vE '\.(md)$'; then
             echo "DOC_ONLY=false"
             echo "doc_only=false" >> $GITHUB_ENV
             echo "::set-output name=doc_only::false"
@@ -84,7 +92,9 @@ jobs:
 
   Test-Marqo:
     name: Run Unit Tests
-    needs: Check-Changes # required to start the main job when the runner is ready
+    needs:
+      - Check-Changes # required to start the main job when the runner is ready
+      - Start-Runner # required to get output from the start-runner job
     if: ${{ needs.Check-Changes.outputs.doc_only == 'false' }} # Run only if there are non-documentation changes
     runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
     environment: marqo-test-suite

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -70,6 +70,7 @@ jobs:
         id: set-output
         run: |
           cd marqo
+          set -x
           git fetch --depth=1 origin ${{ github.base_ref }}
           if git diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} | grep -vE '\.(md)$'; then
             echo "DOC_ONLY=false"

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -23,7 +23,6 @@ permissions:
 jobs:
   Check-Changes:
     runs-on: ubuntu-latest
-    needs: Start-Runner
     outputs:
       doc_only: ${{ steps.set-output.outputs.doc_only }}
     steps:
@@ -58,6 +57,8 @@ jobs:
   Start-Runner:
     name: Start self-hosted EC2 runner
     runs-on: ubuntu-latest
+    needs:
+      - Check-Changes
     if: ${{ needs.Check-Changes.outputs.doc_only == 'false' }} # Run only if there are non-documentation changes
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -76,7 +76,7 @@ jobs:
 
   Test-Marqo:
     name: Run Unit Tests
-    needs: Start-Runner # required to start the main job when the runner is ready
+    needs: Check-Changes # required to start the main job when the runner is ready
     if: ${{ needs.Check-Changes.outputs.doc_only == 'false' }} # Run only if there are non-documentation changes
     runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
     environment: marqo-test-suite

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -81,13 +81,11 @@ jobs:
   
           # Perform the diff to check for non-documentation changes
           if git diff --name-only $BASE_COMMIT $HEAD_COMMIT -- | grep -vE '\.(md)$'; then
-            echo "DOC_ONLY=false"
             echo "doc_only=false" >> $GITHUB_ENV
-            echo "::set-output name=doc_only::false"
+            echo "doc_only=false" >> $GITHUB_OUTPUT
           else
-            echo "DOC_ONLY=true"
             echo "doc_only=true" >> $GITHUB_ENV
-            echo "::set-output name=doc_only::true"
+            echo "doc_only=true" >> $GITHUB_OUTPUT
           fi
 
   Test-Marqo:

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - mainline
       - releases/*
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches:
       - mainline

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -70,6 +70,7 @@ jobs:
         id: set-output
         run: |
           cd marqo
+          git fetch --depth=1 origin ${{ github.base_ref }}
           if git diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} | grep -vE '\.(md)$'; then
             echo "DOC_ONLY=false"
             echo "doc_only=false" >> $GITHUB_ENV

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -71,7 +71,8 @@ jobs:
         run: |
           cd marqo
           set -x
-          if git diff --name-only origin/${{ github.base_ref }} ${{ github.head_ref }} -- | grep -vE '\.(md)$'; then
+          git branch -a
+          if git diff --name-only origin/${{ github.base_ref }} origin/${{ github.head_ref }} -- | grep -vE '\.(md)$'; then
             echo "DOC_ONLY=false"
             echo "doc_only=false" >> $GITHUB_ENV
             echo "::set-output name=doc_only::false"

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -21,9 +21,44 @@ permissions:
   contents: read
 
 jobs:
+  Check-Changes:
+    runs-on: ubuntu-latest
+    needs: Start-Runner
+    outputs:
+      doc_only: ${{ steps.set-output.outputs.doc_only }}
+    steps:
+      - name: Checkout marqo repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          path: marqo
+
+      - name: Check for Documentation-Only Changes
+        id: set-output
+        run: |
+          cd marqo
+          set -x
+          # Get the base and head commits from the GitHub event
+          BASE_COMMIT=${{ github.event.pull_request.base.sha }}
+          HEAD_COMMIT=${{ github.event.pull_request.head.sha }}
+
+          # Debug: Print base and head commits
+          echo "Base commit: $BASE_COMMIT"
+          echo "Head commit: $HEAD_COMMIT"
+
+          # Perform the diff to check for non-documentation changes
+          if git diff --name-only $BASE_COMMIT $HEAD_COMMIT -- | grep -vE '\.(md|yml)$'; then
+            echo "doc_only=false" >> $GITHUB_ENV
+            echo "doc_only=false" >> $GITHUB_OUTPUT
+          else
+            echo "doc_only=true" >> $GITHUB_ENV
+            echo "doc_only=true" >> $GITHUB_OUTPUT
+          fi
+
   Start-Runner:
     name: Start self-hosted EC2 runner
     runs-on: ubuntu-latest
+    if: ${{ needs.Check-Changes.outputs.doc_only == 'false' }} # Run only if there are non-documentation changes
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -53,40 +88,6 @@ jobs:
               {"Key": "WorlflowURL", "Value": "${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}"},
               {"Key": "PoloRole", "Value": "testing"}
             ]
-
-  Check-Changes:
-    runs-on: ubuntu-latest
-    needs: Start-Runner
-    outputs:
-      doc_only: ${{ steps.set-output.outputs.doc_only }}
-    steps:
-      - name: Checkout marqo repo
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          path: marqo
-
-      - name: Check for Documentation-Only Changes
-        id: set-output
-        run: |
-          cd marqo
-          set -x
-          # Get the base and head commits from the GitHub event
-          BASE_COMMIT=${{ github.event.pull_request.base.sha }}
-          HEAD_COMMIT=${{ github.event.pull_request.head.sha }}
-  
-          # Debug: Print base and head commits
-          echo "Base commit: $BASE_COMMIT"
-          echo "Head commit: $HEAD_COMMIT"
-  
-          # Perform the diff to check for non-documentation changes
-          if git diff --name-only $BASE_COMMIT $HEAD_COMMIT -- | grep -vE '\.(md)$'; then
-            echo "doc_only=false" >> $GITHUB_ENV
-            echo "doc_only=false" >> $GITHUB_OUTPUT
-          else
-            echo "doc_only=true" >> $GITHUB_ENV
-            echo "doc_only=true" >> $GITHUB_OUTPUT
-          fi
 
   Test-Marqo:
     name: Run Unit Tests
@@ -265,7 +266,7 @@ jobs:
       - Test-Marqo # required to wait when the main job is done
       - Check-Changes
     runs-on: ubuntu-latest
-    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
+    if: ${{ steps.start-ec2-runner.outputs.label }} # Only stop the runner if it was started
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -80,7 +80,7 @@ jobs:
           echo "Head commit: $HEAD_COMMIT"
   
           # Perform the diff to check for non-documentation changes
-          if git diff --name-only $BASE_COMMIT $HEAD_COMMIT -- | grep -vE '\.(md|yml)$'; then
+          if git diff --name-only $BASE_COMMIT $HEAD_COMMIT -- | grep -vE '\.(md)$'; then
             echo "doc_only=false" >> $GITHUB_ENV
             echo "doc_only=false" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -266,7 +266,7 @@ jobs:
       - Test-Marqo # required to wait when the main job is done
       - Check-Changes
     runs-on: ubuntu-latest
-    if: ${{ steps.start-ec2-runner.outputs.label }} # Only stop the runner if it was started
+    if: ${{ needs.start-runner.outputs.label }} # Only stop the runner if it was started
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -60,12 +60,16 @@ jobs:
     outputs:
       doc_only: ${{ steps.set-output.outputs.doc_only }}
     steps:
-      - name: Checkout code
+      - name: Checkout marqo repo
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          path: marqo
 
       - name: Check for Documentation-Only Changes
         id: set-output
         run: |
+          cd marqo
           if git diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} | grep -vE '\.(md)$'; then
             echo "DOC_ONLY=false"
             echo "doc_only=false" >> $GITHUB_ENV
@@ -83,12 +87,6 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
     environment: marqo-test-suite
     steps:
-      - name: Checkout marqo repo
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          path: marqo
-
       - name: Set up Python 3.9
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -8,14 +8,10 @@ on:
     branches:
       - mainline
       - releases/*
-    paths-ignore:
-      - '**/*.md'
   pull_request:
     branches:
       - mainline
       - releases/*
-    paths-ignore:
-      - '**/*.md'
 
 concurrency:
   group: unit-tests-${{ github.ref }}
@@ -58,9 +54,30 @@ jobs:
               {"Key": "PoloRole", "Value": "testing"}
             ]
 
+  Check-Changes:
+    runs-on: ubuntu-latest
+    outputs:
+      doc_only: ${{ steps.set-output.outputs.doc_only }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Check for Documentation-Only Changes
+        id: set-output
+        run: |
+          if git diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} | grep -vE '\.(md|txt|yml)$'; then
+            echo "DOC_ONLY=false"
+            echo "doc_only=false" >> $GITHUB_ENV
+            echo "::set-output name=doc_only::false"
+          else
+            echo "DOC_ONLY=true"
+            echo "doc_only=true" >> $GITHUB_ENV
+            echo "::set-output name=doc_only::true"
+
   Test-Marqo:
     name: Run Unit Tests
     needs: Start-Runner # required to start the main job when the runner is ready
+    if: ${{ needs.Check-Changes.outputs.doc_only == 'false' }} # Run only if there are non-documentation changes
     runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
     environment: marqo-test-suite
     steps:

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Check for Documentation-Only Changes
         id: set-output
         run: |
-          if git diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} | grep -vE '\.(md|txt|yml)$'; then
+          if git diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} | grep -vE '\.(md)$'; then
             echo "DOC_ONLY=false"
             echo "doc_only=false" >> $GITHUB_ENV
             echo "::set-output name=doc_only::false"

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           cd marqo
           set -x
-          if git diff --name-only origin/${{ github.base_ref }} ${{ github.head_ref }} | grep -vE '\.(md)$'; then
+          if git diff --name-only origin/${{ github.base_ref }} ${{ github.head_ref }} -- | grep -vE '\.(md)$'; then
             echo "DOC_ONLY=false"
             echo "doc_only=false" >> $GITHUB_ENV
             echo "::set-output name=doc_only::false"

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -99,6 +99,12 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
     environment: marqo-test-suite
     steps:
+      - name: Checkout marqo repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          path: marqo
+
       - name: Set up Python 3.9
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -71,8 +71,7 @@ jobs:
         run: |
           cd marqo
           set -x
-          git fetch --depth=1 origin ${{ github.base_ref }}
-          if git diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} | grep -vE '\.(md)$'; then
+          if git diff --name-only origin/${{ github.base_ref }} ${{ github.head_ref }} | grep -vE '\.(md)$'; then
             echo "DOC_ONLY=false"
             echo "doc_only=false" >> $GITHUB_ENV
             echo "::set-output name=doc_only::false"

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -8,10 +8,14 @@ on:
     branches:
       - mainline
       - releases/*
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     branches:
       - mainline
       - releases/*
+    paths-ignore:
+      - '**/*.md'
 
 concurrency:
   group: unit-tests-${{ github.ref }}

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -56,6 +56,7 @@ jobs:
 
   Check-Changes:
     runs-on: ubuntu-latest
+    needs: Start-Runner
     outputs:
       doc_only: ${{ steps.set-output.outputs.doc_only }}
     steps:
@@ -248,6 +249,7 @@ jobs:
     needs:
       - Start-Runner # required to get output from the start-runner job
       - Test-Marqo # required to wait when the main job is done
+      - Check-Changes
     runs-on: ubuntu-latest
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -80,7 +80,7 @@ jobs:
           echo "Head commit: $HEAD_COMMIT"
   
           # Perform the diff to check for non-documentation changes
-          if git diff --name-only $BASE_COMMIT $HEAD_COMMIT -- | grep -vE '\.(md)$'; then
+          if git diff --name-only $BASE_COMMIT $HEAD_COMMIT -- | grep -vE '\.(md|yml)$'; then
             echo "doc_only=false" >> $GITHUB_ENV
             echo "doc_only=false" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -73,6 +73,7 @@ jobs:
             echo "DOC_ONLY=true"
             echo "doc_only=true" >> $GITHUB_ENV
             echo "::set-output name=doc_only::true"
+          fi
 
   Test-Marqo:
     name: Run Unit Tests

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,7 @@
 # Release 2.15.0
 
+## test
+
 ## New Features
 - Global Score Modifiers for Hybrid Search ([#1082](https://github.com/marqo-ai/marqo/pull/1082)). Introduce global score modifiers for hybrid search, allowing fine-tuned adjustments to RRF scores in combined result lists. This enhancement provides better control over returned results in hybrid search scenarios. Use the `rerankDepth` parameter to control the number of hits to rerank. For detailed usage, check [here](https://docs.marqo.ai/latest/reference/api/search/search/#rerank-depth).
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,5 @@
 # Release 2.15.0
 
-## test
-
 ## New Features
 - Global Score Modifiers for Hybrid Search ([#1082](https://github.com/marqo-ai/marqo/pull/1082)). Introduce global score modifiers for hybrid search, allowing fine-tuned adjustments to RRF scores in combined result lists. This enhancement provides better control over returned results in hybrid search scenarios. Use the `rerankDepth` parameter to control the number of hits to rerank. For detailed usage, check [here](https://docs.marqo.ai/latest/reference/api/search/search/#rerank-depth).
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
workflow optimize

* **What is the current behavior?** (You can also link to an open issue here)
we need to run the unit tests even if it is just a documentation (`.md`) file change.

* **What is the new behavior (if this is a feature change)?**
We still need to run the unit tests workflow as there is a check.
However, we skip the real run and return pass directly.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Have unit tests been run against this PR?** (Has there also been any additional testing?)


* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

