### PR TITLE
Fix a bug that the EC2 instance is not terminated if unit tests failed

### DIFF
--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -280,10 +280,12 @@ jobs:
   Stop-Runner:
     name: Stop self-hosted EC2 runner
     needs:
+      - Check-Changes # required to start the main job when the runner is ready
       - Start-Runner # required to get output from the start-runner job
       - Test-Marqo # required to wait when the main job is done
     runs-on: ubuntu-latest
-    if: ${{ needs.Start-Runner.outputs.label != null }}
+    if: |
+      always() && nees.Start-Runner.result == 'success'
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -135,7 +135,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          exit 1
           pip install -r marqo-base/requirements/amd64-gpu-requirements.txt
           # override base requirements with marqo requirements, if needed:
           pip install -r marqo/requirements.dev.txt

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -135,6 +135,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          exit 1
           pip install -r marqo-base/requirements/amd64-gpu-requirements.txt
           # override base requirements with marqo requirements, if needed:
           pip install -r marqo/requirements.dev.txt

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -62,7 +62,7 @@ jobs:
           echo "Head commit: $HEAD_COMMIT"
 
           # Perform the diff to check for non-documentation changes
-          if git diff --name-only $BASE_COMMIT $HEAD_COMMIT -- | grep -vE '\.(md|yml)$'; then
+          if git diff --name-only $BASE_COMMIT $HEAD_COMMIT -- | grep -vE '\.(md)$'; then
             echo "doc_only=false" >> $GITHUB_ENV
             echo "doc_only=false" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -283,7 +283,7 @@ jobs:
       - Start-Runner # required to get output from the start-runner job
       - Test-Marqo # required to wait when the main job is done
     runs-on: ubuntu-latest
-    if: ${{ always() }}
+    if: ${{ needs.Start-Runner.outputs.label != null }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -285,7 +285,7 @@ jobs:
       - Test-Marqo # required to wait when the main job is done
     runs-on: ubuntu-latest
     if: |
-      always() && nees.Start-Runner.result == 'success'
+      always() && needs.Start-Runner.result == 'success'
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -281,7 +281,6 @@ jobs:
     name: Stop self-hosted EC2 runner
     needs:
       - Start-Runner # required to get output from the start-runner job
-      - Test-Marqo # required to wait when the main job is done
     runs-on: ubuntu-latest
     if: ${{ needs.Start-Runner.outputs.label != null }}
     steps:

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -62,7 +62,7 @@ jobs:
           echo "Head commit: $HEAD_COMMIT"
 
           # Perform the diff to check for non-documentation changes
-          if git diff --name-only $BASE_COMMIT $HEAD_COMMIT -- | grep -vE '\.(md)$'; then
+          if git diff --name-only $BASE_COMMIT $HEAD_COMMIT -- | grep -vE '\.(md|yml)$'; then
             echo "doc_only=false" >> $GITHUB_ENV
             echo "doc_only=false" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -281,6 +281,7 @@ jobs:
     name: Stop self-hosted EC2 runner
     needs:
       - Start-Runner # required to get output from the start-runner job
+      - Test-Marqo # required to wait when the main job is done
     runs-on: ubuntu-latest
     if: ${{ needs.Start-Runner.outputs.label != null }}
     steps:

--- a/.github/workflows/unit_test_200gb_CI.yml
+++ b/.github/workflows/unit_test_200gb_CI.yml
@@ -282,9 +282,8 @@ jobs:
     needs:
       - Start-Runner # required to get output from the start-runner job
       - Test-Marqo # required to wait when the main job is done
-      - Check-Changes
     runs-on: ubuntu-latest
-    if: ${{ needs.start-runner.outputs.label }} # Only stop the runner if it was started
+    if: ${{ always() }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
The EC2 instance is not terminated if unit tests failed

* **What is the new behavior (if this is a feature change)?**
I have verified that:
1. If a unit tests run is needed and it failed, the ec2 instance will be terminated;
2. If a unit tests run is not needed, no ec2 instance will be started and the termination job won't run.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Have unit tests been run against this PR?** (Has there also been any additional testing?)


* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

