### PR TITLE
[Releases 2.13] Add support for legacy OpenAI CLIP model

### DIFF
--- a/src/marqo/core/inference/embedding_models/open_clip_model.py
+++ b/src/marqo/core/inference/embedding_models/open_clip_model.py
@@ -210,7 +210,8 @@ class OPEN_CLIP(AbstractCLIPModel):
 
     def _load_tokenizer_from_checkpoint(self) -> Callable:
         if not self.model_properties.tokenizer:
-            return open_clip.get_tokenizer(self.model_properties.name)
+            # Replace '/'with '-' to support old clip model name style
+            return open_clip.get_tokenizer(self.model_properties.name.replace("/", "-"))
         else:
             logger.info(f"Custom HFTokenizer is provided. Loading...")
             return HFTokenizer(self.model_properties.tokenizer)

--- a/tests/core/inference/test_open_clip_model_load.py
+++ b/tests/core/inference/test_open_clip_model_load.py
@@ -277,3 +277,15 @@ class TestOpenCLIPModelLoad(TestCase):
                 repo_location=ModelLocation(**model_properties["model_location"]),
                 auth=model_auth,
             )
+
+    def test_load_legacy_openai_clip_model(self):
+        """A test to ensure old OpenAI CLIP models (e.g., ViT-B/32) are loaded correctly."""
+        model_properties = {
+            "name": "ViT-B/32", # Legacy model name
+            "type": "open_clip",
+            "url": "https://openaipublic.azureedge.net/clip/models/40d365715913c9d"
+                   "a98579312b702a82c18be219cc2a73407c4526f58eba950af/ViT-B-32.pt",
+            "dimensions": 512
+        }
+        model = OPEN_CLIP(model_properties=model_properties, device="cpu")
+        model.load()

--- a/tests/core/inference/test_open_clip_model_load.py
+++ b/tests/core/inference/test_open_clip_model_load.py
@@ -281,7 +281,7 @@ class TestOpenCLIPModelLoad(TestCase):
     def test_load_legacy_openai_clip_model(self):
         """A test to ensure old OpenAI CLIP models (e.g., ViT-B/32) are loaded correctly."""
         model_properties = {
-            "name": "ViT-B/32", # Legacy model name
+            "name": "ViT-B/32", # Old OpenAI CLIP model name
             "type": "open_clip",
             "url": "https://github.com/mlfoundations/open_clip/releases/download/v0.2-weights/vit_b_32-quickgelu-laion400m_e32-46683a32.pt",
             "dimensions": 512

--- a/tests/core/inference/test_open_clip_model_load.py
+++ b/tests/core/inference/test_open_clip_model_load.py
@@ -283,8 +283,7 @@ class TestOpenCLIPModelLoad(TestCase):
         model_properties = {
             "name": "ViT-B/32", # Legacy model name
             "type": "open_clip",
-            "url": "https://openaipublic.azureedge.net/clip/models/40d365715913c9d"
-                   "a98579312b702a82c18be219cc2a73407c4526f58eba950af/ViT-B-32.pt",
+            "url": "https://github.com/mlfoundations/open_clip/releases/download/v0.2-weights/vit_b_32-quickgelu-laion400m_e32-46683a32.pt",
             "dimensions": 512
         }
         model = OPEN_CLIP(model_properties=model_properties, device="cpu")


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
In release 2.12, we introduced a regression that the old OpenAI CLIP model (e.g., ViT-B/32) can't be loaded properly. The tokenizer loading will error out.

* **What is the new behavior (if this is a feature change)?**
We fix this bug. The model can be loaded properly.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
yes

* **Related Python client changes** (link commit/PR here)
no

* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

