### PR TITLE
[Releases 2.13] Make custom vector query result JSON serializable

### DIFF
--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -1635,7 +1635,11 @@ def search(config: Config, index_name: str, text: Optional[Union[str, dict, Cust
         except Exception as e:
             raise api_exceptions.BadRequestError(f"reranking failure due to {str(e)}")
 
-    search_result["query"] = text
+    if isinstance(text, CustomVectorQuery):
+        search_result["query"] = text.dict()    # Make object JSON serializable
+    else:
+        search_result["query"] = text
+
     search_result["limit"] = result_count
     search_result["offset"] = offset
 

--- a/tests/tensor_search/integ_tests/test_hybrid_search.py
+++ b/tests/tensor_search/integ_tests/test_hybrid_search.py
@@ -14,6 +14,7 @@ from marqo.tensor_search.models.api_models import CustomVectorQuery
 from marqo.tensor_search.models.api_models import ScoreModifierLists
 from marqo.tensor_search.models.search import SearchContext
 from tests.marqo_test import MarqoTestCase, TestImageUrls
+from fastapi.responses import JSONResponse, ORJSONResponse
 
 
 class TestHybridSearch(MarqoTestCase):
@@ -361,6 +362,12 @@ class TestHybridSearch(MarqoTestCase):
                              sample_vector)
             self.assertIn("hits", res)
 
+            # Result should be JSON serializable
+            try:
+                ORJSONResponse(res)
+            except TypeError as e:
+                self.fail(f"Result is not JSON serializable: {e}")
+
         with self.subTest("Custom vector query, with context, with content"):
             @unittest.mock.patch("marqo.vespa.vespa_client.VespaClient.query", mock_vespa_client_query)
             def run():
@@ -398,6 +405,12 @@ class TestHybridSearch(MarqoTestCase):
                              [i*1.5 for i in sample_vector])    # Should average the query & context vectors
             self.assertIn("hits", res)
 
+            # Result should be JSON serializable
+            try:
+                ORJSONResponse(res)
+            except TypeError as e:
+                self.fail(f"Result is not JSON serializable: {e}")
+
         with self.subTest("Custom vector query, no content, no context, tensor/tensor"):
             @unittest.mock.patch("marqo.vespa.vespa_client.VespaClient.query", mock_vespa_client_query)
             def run():
@@ -431,6 +444,12 @@ class TestHybridSearch(MarqoTestCase):
             self.assertEqual(vespa_query_kwargs["query_features"]["marqo__query_embedding"],
                              sample_vector)
             self.assertIn("hits", res)
+
+            # Result should be JSON serializable
+            try:
+                ORJSONResponse(res)
+            except TypeError as e:
+                self.fail(f"Result is not JSON serializable: {e}")
 
     def test_hybrid_search_semi_structured_with_custom_vector_query(self):
         """
@@ -495,6 +514,12 @@ class TestHybridSearch(MarqoTestCase):
                              sample_vector)
             self.assertIn("hits", res)
 
+            # Result should be JSON serializable
+            try:
+                ORJSONResponse(res)
+            except TypeError as e:
+                self.fail(f"Result is not JSON serializable: {e}")
+
         with self.subTest("Custom vector query, with context, with content"):
             @unittest.mock.patch("marqo.vespa.vespa_client.VespaClient.query", mock_vespa_client_query)
             def run():
@@ -532,6 +557,12 @@ class TestHybridSearch(MarqoTestCase):
                              [i*1.5 for i in sample_vector])    # Should average the query & context vectors
             self.assertIn("hits", res)
 
+            # Result should be JSON serializable
+            try:
+                ORJSONResponse(res)
+            except TypeError as e:
+                self.fail(f"Result is not JSON serializable: {e}")
+
         with self.subTest("Custom vector query, no content, no context, tensor/tensor"):
             @unittest.mock.patch("marqo.vespa.vespa_client.VespaClient.query", mock_vespa_client_query)
             def run():
@@ -564,6 +595,12 @@ class TestHybridSearch(MarqoTestCase):
             self.assertEqual(vespa_query_kwargs["query_features"]["marqo__query_embedding"],
                              sample_vector)
             self.assertIn("hits", res)
+
+            # Result should be JSON serializable
+            try:
+                ORJSONResponse(res)
+            except TypeError as e:
+                self.fail(f"Result is not JSON serializable: {e}")
 
     def test_hybrid_search_disjunction_rrf_zero_alpha_same_as_lexical(self):
         """

--- a/tests/tensor_search/integ_tests/test_search_combined.py
+++ b/tests/tensor_search/integ_tests/test_search_combined.py
@@ -16,9 +16,10 @@ from marqo.core.models.marqo_query import MarqoLexicalQuery
 from marqo.core.models.score_modifier import ScoreModifierType, ScoreModifier
 from marqo.core.structured_vespa_index.structured_vespa_index import StructuredVespaIndex
 from marqo.core.unstructured_vespa_index.unstructured_vespa_index import UnstructuredVespaIndex
-from marqo.tensor_search.models.api_models import SearchQuery
+from marqo.tensor_search.models.api_models import SearchQuery, CustomVectorQuery
 from pydantic import ValidationError
 import marqo.api.exceptions as api_exceptions
+from fastapi.responses import JSONResponse, ORJSONResponse
 
 
 class TestSearch(MarqoTestCase):
@@ -1047,3 +1048,34 @@ class TestSearch(MarqoTestCase):
                             text=query, config=self.config, index_name=index_name.name,
                         )
                     self.assertIn("Error vectorising content", str(e.exception))
+
+    def test_search_results_always_json_serializable(self):
+        """
+        The search() text parameter can either be str, dict, or CustomVectorQuery.
+        All queries are returned in the result. Ensure all types of queries end up with JSON serializable results.
+        """
+
+        test_cases = [
+            "hello",
+            {"hello": 1, "another one": 2},
+            {"hello": 1.5, "another one": 2.34},
+            CustomVectorQuery(
+                customVector=CustomVectorQuery.CustomVector(
+                    content="hello",
+                    vector=[0 for _ in range(384)]
+                )
+            )
+        ]
+
+        for index in [self.structured_default_text_index, self.unstructured_default_text_index]:
+            for query in test_cases:
+                with self.subTest(index=index.type, query=query):
+                    res = tensor_search.search(
+                        text=query, config=self.config, index_name=index.name,
+                    )
+
+                    # Result should be JSON serializable
+                    try:
+                        ORJSONResponse(res)
+                    except TypeError as e:
+                        self.fail(f"Result is not JSON serializable: {e}")


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
custom vector queries do not work due to attempting to JSON serialize the result in the api layer with `ORJSONResponse`, but the result has a `CustomVectorQuery` object which is not serializable.

* **What is the new behavior (if this is a feature change)?**
Convert `CustomVectorQuery` object to dict in tensor search

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)


* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

