### PR TITLE
Add concurrency limit back for CPU local

### DIFF
--- a/.github/workflows/cpu_local_marqo.yml
+++ b/.github/workflows/cpu_local_marqo.yml
@@ -36,9 +36,9 @@ on:
 permissions:
   contents: read
 
-#concurrency:
-#  group: cpu-local-api-tests-${{ github.ref }}
-#  cancel-in-progress: true
+concurrency:
+ group: cpu-local-api-tests-${{ github.ref }}
+ cancel-in-progress: true
 
 jobs:
   Start-Runner:


### PR DESCRIPTION
This was removed in https://github.com/marqo-ai/marqo/pull/1047 mistakenly.