### PR TITLE
Fix github action getting throttled by AWS

### DIFF
--- a/.github/workflows/backwards_compatibility_marqo_orchestrator.yml
+++ b/.github/workflows/backwards_compatibility_marqo_orchestrator.yml
@@ -143,6 +143,8 @@ jobs:
     strategy:
       matrix:
         from_version: ${{ fromJson(needs.orchestrate.outputs.list) }}
+      max-parallel: 5
+      fail-fast: false
     uses: ./.github/workflows/backwards_compatibility_marqo_execution.yml
     secrets: inherit
     permissions:
@@ -170,6 +172,8 @@ jobs:
     strategy:
       matrix:
         from_version: ${{ fromJson(needs.orchestrate.outputs.list) }}
+      max-parallel: 5
+      fail-fast: false
     uses: ./.github/workflows/backwards_compatibility_marqo_execution.yml
     secrets: inherit
     permissions:


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
* When parallel runs are running, backwards compatibility tests fail because of RequestLimitExceeded error. This change fixes that. 
* Also fail-fast is now set to false, so if one run fails others will not fail. 


* **What is the current behavior?** (You can also link to an open issue here)
* Currently, specific for releases with large number of test runs (like 2.13.6 which triggers 11 runs) RequestLimitExceeded error occurs. This is because it triggers 22 total runs. Fixed this by making 5 parallel runs at a time. 


* **What is the new behavior (if this is a feature change)?**
* Set max-parallel to 5 and fail-fast to false to avoid issues like the above. 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
* No


* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
* Yes: https://github.com/marqo-ai/marqo/actions/runs/13148448445/job/36691787133. The failure is a genuine failure, due to search result's score not matching, which will need to be checked further. 


* **Related Python client changes** (link commit/PR here)
* NA


* **Related documentation changes** (link commit/PR here)
* NA


* **Other information**:
* NA


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

