### PR TITLE
Fixing the score modifier not being updated bug. 

### DIFF
--- a/src/marqo/core/document/document.py
+++ b/src/marqo/core/document/document.py
@@ -20,6 +20,7 @@ from marqo.core.structured_vespa_index.structured_add_document_handler import St
 from marqo.core.unstructured_vespa_index.unstructured_add_document_handler import UnstructuredAddDocumentsHandler
 from marqo.core.vespa_index.vespa_index import for_marqo_index as vespa_index_factory
 from marqo.logging import get_logger
+from marqo.marqo_docs import update_documents_response
 from marqo.tensor_search.telemetry import RequestMetricsStore
 from marqo.vespa.models import UpdateDocumentsBatchResponse, VespaDocument
 from marqo.vespa.models.delete_document_response import DeleteAllDocumentsResponse
@@ -128,10 +129,14 @@ class Document:
         unsuccessful_docs: List[Tuple[int, MarqoUpdateDocumentsItem]] = []
 
         # Remove duplicated documents based on _id
-        partial_documents, doc_ids, documents_that_contain_maps = self.process_documents(partial_documents,
+        partial_documents, documents_that_contain_maps = self.process_documents(partial_documents,
                                                                                          unsuccessful_docs, is_index_semi_structured=marqo_index.type is IndexType.SemiStructured)
+        documents_that_contain_maps_but_dont_exist_in_vespa = set() # Set to keep track of documents that contain maps but don't exist in Vespa. This will remain unpopulated for structured indexes.
         existing_vespa_documents = {}
 
+        # This block will only execute for SemiStructured Indexes and in case the request has documents that contain maps.
+        # 1. Retrieve those documents, which contain maps in the update request, from Vespa.
+        # 2. If there's any documents that dont' exist in Vespa, we will append them to unsuccessful_docs
         if marqo_index.type is IndexType.SemiStructured and documents_that_contain_maps: # Only retrieve the document back if the partial update request contains maps and the index is semi-structured
             get_batch_response = self.vespa_client.get_batch(ids = list(documents_that_contain_maps), fields = [
                 VESPA_FIELD_ID, INT_FIELDS, FLOAT_FIELDS, VESPA_DOC_FIELD_TYPES, VESPA_DOC_CREATE_TIMESTAMP], schema = marqo_index.schema_name)
@@ -139,8 +144,18 @@ class Document:
             for resp in responses:
                 if resp.document:
                     existing_vespa_documents[resp.document.fields[VESPA_FIELD_ID]] = resp.document.dict()
+                else: 
+                    id = self.extract_document_id_from_vespa_id(resp) # Extract the document id from the Vespa response. Vespa response will contain the document id even though the document was not found.
+                    unsuccessful_docs.append((documents_that_contain_maps.get(id), MarqoAddDocumentsItem(id = id, 
+                                                                                                         status = int(api_exceptions.BadRequestError.status_code),
+                                                                                                         error = "Marqo vector store couldn't update the document. Please see: " + update_documents_response() + " for more details")))
+                    documents_that_contain_maps_but_dont_exist_in_vespa.add(id)
 
         for index, doc in enumerate(partial_documents):
+            if (marqo_index.type is IndexType.SemiStructured # Only have this check in place for SemiStructured indexes
+                    and documents_that_contain_maps_but_dont_exist_in_vespa
+                    and doc.get(MARQO_DOC_ID, '') in documents_that_contain_maps_but_dont_exist_in_vespa):
+                continue
             try:
                 vespa_document = VespaDocument(**vespa_index.to_vespa_partial_document(doc, existing_vespa_documents.get(doc.get(MARQO_DOC_ID, ''), None)))
                 vespa_documents.append(vespa_document)
@@ -182,7 +197,7 @@ class Document:
 
         if responses is not None:
             for resp in responses.responses:
-                doc_id = resp.id.split('::')[-1] if resp.id else None
+                doc_id = self.extract_document_id_from_vespa_id(resp)
                 status, message = self.vespa_client.translate_vespa_document_response(resp.status, None)
                 new_item = MarqoUpdateDocumentsItem(id=doc_id, status=status, message=message, error=message)
                 items.append(new_item)
@@ -195,7 +210,7 @@ class Document:
                                             processingTimeMs=(timer() - start_time) * 1000)
 
     def process_documents(self, documents: List[Dict], unsuccessful_docs: List[Tuple[int, MarqoUpdateDocumentsItem]],
-                          is_index_semi_structured = False) -> Tuple[List, set, set]:
+                          is_index_semi_structured = False) -> Tuple[List[Dict], Dict]:
         """Process documents to remove duplicates and identify documents containing maps.
         
         This method combines duplicate removal and map detection into a single pass through
@@ -210,11 +225,11 @@ class Document:
             Tuple containing:
             - List of deduplicated documents
             - Set of unique document IDs
-            - Set of document IDs that contain dictionary values
+            - Dictionary of document IDs that contain dictionary values and their index in the documents list
         """
         docs = []
         doc_ids = set()
-        documents_with_maps = set()
+        documents_with_maps = {}
         
         # Process documents in reverse to keep latest version of duplicates
         for i in range(len(documents) - 1, -1, -1):
@@ -238,11 +253,11 @@ class Document:
                     for field_name, field_value in doc.items():
                         if isinstance(field_value, dict):
                             if len(field_value) == 0: # If the dictionary is empty, get back the document so that we can update the doc with an empty dictionary (i.e remove the map from the doc).
-                                documents_with_maps.add(doc_id)
+                                documents_with_maps[doc_id] = i
                             else:
                                 for key, val in field_value.items():
                                     if isinstance(val, (int, float)):
-                                        documents_with_maps.add(doc_id)
+                                        documents_with_maps[doc_id] = i
                                         break
                                     else:
                                         raise MarqoDocumentParsingError(
@@ -263,7 +278,7 @@ class Document:
 
         # Reverse to preserve original order
         docs.reverse()
-        return docs, doc_ids, documents_with_maps
+        return docs, documents_with_maps
 
     def translate_add_documents_response(self, responses: Optional[FeedBatchResponse],
                                          index_name: str,
@@ -288,7 +303,7 @@ class Document:
 
         if responses is not None:
             for resp in responses.responses:
-                doc_id = resp.id.split('::')[-1] if resp.id else None
+                doc_id = self.extract_document_id_from_vespa_id(resp)
                 status, message = self.vespa_client.translate_vespa_document_response(resp.status, resp.message)
                 new_item = MarqoAddDocumentsItem(id=doc_id, status=status, message=message)
                 new_items.append(new_item)
@@ -299,3 +314,7 @@ class Document:
 
         return MarqoAddDocumentsResponse(errors=errors, index_name=index_name, items=new_items,
                                          processingTimeMs=add_docs_processing_time_ms)
+
+    def extract_document_id_from_vespa_id(self, resp):
+        doc_id = resp.id.split('::')[-1] if resp.id else None
+        return doc_id

--- a/src/marqo/core/document/document.py
+++ b/src/marqo/core/document/document.py
@@ -137,7 +137,8 @@ class Document:
                 VESPA_FIELD_ID, INT_FIELDS, FLOAT_FIELDS, VESPA_DOC_FIELD_TYPES, VESPA_DOC_CREATE_TIMESTAMP], schema = marqo_index.schema_name)
             responses = get_batch_response.responses
             for resp in responses:
-                existing_vespa_documents[resp.document.fields[VESPA_FIELD_ID]] = resp.document.dict()
+                if resp.document:
+                    existing_vespa_documents[resp.document.fields[VESPA_FIELD_ID]] = resp.document.dict()
 
         for index, doc in enumerate(partial_documents):
             try:

--- a/src/marqo/core/document/document.py
+++ b/src/marqo/core/document/document.py
@@ -138,7 +138,7 @@ class Document:
         # 1. Retrieve those documents, which contain maps in the update request, from Vespa.
         # 2. If there's any documents that dont' exist in Vespa, we will append them to unsuccessful_docs
         if marqo_index.type is IndexType.SemiStructured and documents_that_contain_maps: # Only retrieve the document back if the partial update request contains maps and the index is semi-structured
-            get_batch_response = self.vespa_client.get_batch(ids = list(documents_that_contain_maps), fields = [
+            get_batch_response = self.vespa_client.get_batch(ids = list(documents_that_contain_maps.keys()), fields = [
                 VESPA_FIELD_ID, INT_FIELDS, FLOAT_FIELDS, VESPA_DOC_FIELD_TYPES, VESPA_DOC_CREATE_TIMESTAMP], schema = marqo_index.schema_name)
             responses = get_batch_response.responses
             for resp in responses:
@@ -146,7 +146,7 @@ class Document:
                     existing_vespa_documents[resp.document.fields[VESPA_FIELD_ID]] = resp.document.dict()
                 else: 
                     id = self.extract_document_id_from_vespa_id(resp) # Extract the document id from the Vespa response. Vespa response will contain the document id even though the document was not found.
-                    unsuccessful_docs.append((documents_that_contain_maps.get(id), MarqoAddDocumentsItem(id = id, 
+                    unsuccessful_docs.append((documents_that_contain_maps.get(id), MarqoUpdateDocumentsItem(id = id,
                                                                                                          status = int(api_exceptions.BadRequestError.status_code),
                                                                                                          error = "Marqo vector store couldn't update the document. Please see: " + update_documents_response() + " for more details")))
                     documents_that_contain_maps_but_dont_exist_in_vespa.add(id)

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -326,17 +326,22 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
             ]
 
 
-        if len(score_modifier_to_be_removed) > 0 or len(score_modifier_to_be_removed) > 0:
-            vespa_fields[common.SCORE_MODIFIERS] = {
-                "modify": {
-                    "operation": "replace",
-                    "create": True,
-                    "cells": numeric_field_map
-                } if len(numeric_field_map) > 0 else None,
-                "remove": {
-                    "addresses": score_modifier_to_be_removed
-                } if len(score_modifier_to_be_removed) > 0 else None
+        score_modifiers = {}
+        
+        if len(numeric_field_map) > 0:
+            score_modifiers["modify"] = {
+                "operation": "replace",
+                "create": True,
+                "cells": numeric_field_map
             }
+            
+        if len(score_modifier_to_be_removed) > 0:
+            score_modifiers["remove"] = {
+                "addresses": score_modifier_to_be_removed
+            }
+            
+        if len(score_modifiers) > 0:
+            vespa_fields[common.SCORE_MODIFIERS] = score_modifiers
 
     def _process_field(
         self,
@@ -585,7 +590,7 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
         if lexical_field_name not in self.get_marqo_index().lexical_field_map:
             raise MarqoDocumentParsingError(
                 f'{field_name} of type str does not exist in the original document. '
-                'We do not support adding new lexical fields in partial updates'
+                'Marqo does not support adding new lexical fields in partial updates'
             )
 
         fields[lexical_field_name] = {"assign": value} # To create update statement for updating the lexical fields

--- a/tests/api_tests/v1/tests/api_tests/unstructured_index/test_update_documents_unstructured_index.py
+++ b/tests/api_tests/v1/tests/api_tests/unstructured_index/test_update_documents_unstructured_index.py
@@ -155,3 +155,77 @@ class TestUpdateDocumentsInUnstructuredIndex(MarqoTestCase):
         self.assertEqual(update_docs_response['items'][0]['status'], 400)
         self.assertIn("Marqo vector store couldn't update the document. Please see", update_docs_response['items'][0]['message'])
         self.assertIn("reference/api/documents/update-documents/#response", update_docs_response['items'][0]['message'])
+
+    def test_update_document_with_changes_in_score_modifiers(self):
+        # Test updating a document with new fields and updating existing fields
+        update_docs_response = self.client.index(self.text_index_name).update_documents(
+            [{
+                '_id': '1',
+                'int_map': {
+                    'a': 2,  # update int to int
+                    'd': 5,  # new entry in int map
+                },
+                'float_map': {
+                    'c': 3.0,  # update float to float
+                },
+                'new_int': 1,  # new int field
+                'new_float': 2.0,  # new float field
+                'new_map': {'a': 1, 'b': 2.0},  # new map field
+            }]
+        )
+
+        self.assertFalse(update_docs_response["errors"])
+
+        # Test that score modifiers work correctly with the updated fields
+        # First search without score modifier to get base score
+        base_search_result = self.client.index(self.text_index_name).search("title")
+        base_score = base_search_result["hits"][0]["_score"]
+        
+        # Search with score modifier weight=0 (should not change score)
+        search_result_weight_0 = self.client.index(self.text_index_name).search("title", score_modifiers={
+            "add_to_score": [{"field_name": "int_map.d", "weight": 0}]
+        })
+        self.assertAlmostEqual(search_result_weight_0["hits"][0]["_score"], base_score, places=5)
+        
+        # Search with score modifier weight=1 (should add int_map.d value to score)
+        search_result_weight_1 = self.client.index(self.text_index_name).search("title", score_modifiers={
+            "add_to_score": [{"field_name": "int_map.d", "weight": 1}]
+        })
+        # The score should be increased by weight * field_value = 1 * 5 = 5
+        self.assertAlmostEqual(
+            search_result_weight_1["hits"][0]["_score"], 
+            base_score + 5, 
+            places=5
+        )
+        
+        # Verify the field value is actually 5
+        self.assertEqual(search_result_weight_1["hits"][0]["int_map.d"], 5)
+        
+        # Now update the document again to change the score modifier field
+        update_docs_response_2 = self.client.index(self.text_index_name).update_documents(
+            [{
+                '_id': '1',
+                'int_map': {
+                    'd': 10,  # update the value from 5 to 10
+                }
+            }]
+        )
+        
+        self.assertFalse(update_docs_response_2["errors"])
+        
+        # Search again with score modifier weight=1 after update
+        search_result_after_update = self.client.index(self.text_index_name).search("title", score_modifiers={
+            "add_to_score": [{"field_name": "int_map.d", "weight": 1}]
+        })
+        
+        # Verify the field value is now 10
+        self.assertEqual(search_result_after_update["hits"][0]["int_map.d"], 10)
+        
+        # The score should now be increased by weight * new_field_value = 1 * 10 = 10
+        self.assertAlmostEqual(
+            search_result_after_update["hits"][0]["_score"], 
+            base_score + 10, 
+            places=5
+        )
+
+

--- a/tests/api_tests/v1/tests/api_tests/unstructured_index/test_update_documents_unstructured_index.py
+++ b/tests/api_tests/v1/tests/api_tests/unstructured_index/test_update_documents_unstructured_index.py
@@ -28,12 +28,6 @@ class TestUpdateDocumentsInUnstructuredIndex(MarqoTestCase):
         ])
 
         cls.indexes_to_delete = [cls.text_index_name]
-
-    def tearDown(self):
-        if self.indexes_to_delete:
-            self.clear_indexes(self.indexes_to_delete)
-
-    def test_update_document_with_ids(self):
         text_docs = [{
             '_id': '1',
             'tensor_field': 'title',
@@ -64,9 +58,15 @@ class TestUpdateDocumentsInUnstructuredIndex(MarqoTestCase):
 
         tensor_fields = ['tensor_field', 'custom_vector_field', 'multimodal_combo_field']
 
-        add_docs_response = self.client.index(self.text_index_name).add_documents(documents = text_docs, mappings = mappings, tensor_fields = tensor_fields)
+        add_docs_response = cls.client.index(cls.text_index_name).add_documents(documents = text_docs, mappings = mappings, tensor_fields = tensor_fields)
 
-        self.assertFalse(add_docs_response["errors"])
+        cls.assertFalse(add_docs_response["errors"])
+
+    def tearDown(self):
+        if self.indexes_to_delete:
+            self.clear_indexes(self.indexes_to_delete)
+
+    def test_update_document_with_ids(self):
 
         update_docs_response = self.client.index(self.text_index_name).update_documents(
             [{
@@ -99,39 +99,6 @@ class TestUpdateDocumentsInUnstructuredIndex(MarqoTestCase):
         self.assertEqual(get_docs_response['string_array2'], ["123", "456"])
 
     def test_update_document_with_ids_change_field_type(self):
-        text_docs = [{
-            '_id': '1',
-            'tensor_field': 'title',
-            'tensor_subfield': 'description',
-            "short_string_field": "shortstring",
-            "long_string_field": "Thisisaverylongstring" * 10,
-            "int_field": 123,
-            "float_field": 123.0,
-            "string_array": ["aaa", "bbb"],
-            "string_array2": ["123", "456"],
-            "int_map": {"a": 1, "b": 2},
-            "float_map": {"c": 1.0, "d": 2.0},
-            "bool_field": True,
-            "bool_field2": False,
-            "custom_vector_field": {
-                "content": "abcd",
-                "vector": [1.0] * 32
-            }
-        }]
-
-        mappings = {
-            "custom_vector_field": {"type": "custom_vector"},
-            "multimodal_combo_field": {
-                "type": "multimodal_combination",
-                "weights": {"tensor_field": 1.0, "tensor_subfield": 2.0}
-            }
-        }
-
-        tensor_fields = ['tensor_field', 'custom_vector_field', 'multimodal_combo_field']
-
-        add_docs_response = self.client.index(self.text_index_name).add_documents(documents = text_docs, mappings = mappings, tensor_fields = tensor_fields)
-
-        self.assertFalse(add_docs_response["errors"])
 
         update_docs_response = self.client.index(self.text_index_name).update_documents(
             [{
@@ -157,7 +124,15 @@ class TestUpdateDocumentsInUnstructuredIndex(MarqoTestCase):
         self.assertIn("reference/api/documents/update-documents/#response", update_docs_response['items'][0]['message'])
 
     def test_update_document_with_changes_in_score_modifiers(self):
-        # Test updating a document with new fields and updating existing fields
+        """Test that score modifiers are correctly updated during partial document updates.
+        
+        This test verifies that:
+        1. Score modifiers are properly updated when numeric fields are modified
+        2. New numeric fields are correctly added to score modifiers
+        3. The updated score modifiers affect search results as expected
+        """
+        # First add a document to update
+        """Test updating a document with new fields and updating existing fields."""
         update_docs_response = self.client.index(self.text_index_name).update_documents(
             [{
                 '_id': '1',
@@ -176,9 +151,20 @@ class TestUpdateDocumentsInUnstructuredIndex(MarqoTestCase):
 
         self.assertFalse(update_docs_response["errors"])
 
+        # Get the document to verify updates
+        updated_doc = self.client.index(self.text_index_name).get_document(document_id='1')
+        self.assertEqual(updated_doc['int_map.a'], 2)
+        self.assertEqual(updated_doc['int_map.d'], 5)
+        self.assertEqual(updated_doc['float_map.c'], 3.0)
+        self.assertEqual(updated_doc['new_int'], 1)
+        self.assertEqual(updated_doc['new_float'], 2.0)
+        self.assertEqual(updated_doc['new_map.a'], 1)
+        self.assertEqual(updated_doc['new_map.b'], 2.0)
+
         # Test that score modifiers work correctly with the updated fields
         # First search without score modifier to get base score
         base_search_result = self.client.index(self.text_index_name).search("title")
+        self.assertTrue(len(base_search_result["hits"]) > 0, "No search results found")
         base_score = base_search_result["hits"][0]["_score"]
         
         # Search with score modifier weight=0 (should not change score)

--- a/tests/api_tests/v1/tests/api_tests/unstructured_index/test_update_documents_unstructured_index.py
+++ b/tests/api_tests/v1/tests/api_tests/unstructured_index/test_update_documents_unstructured_index.py
@@ -28,6 +28,13 @@ class TestUpdateDocumentsInUnstructuredIndex(MarqoTestCase):
         ])
 
         cls.indexes_to_delete = [cls.text_index_name]
+
+    def tearDown(self):
+        if self.indexes_to_delete:
+            self.clear_indexes(self.indexes_to_delete)
+
+    def test_update_document_with_ids(self):
+
         text_docs = [{
             '_id': '1',
             'tensor_field': 'title',
@@ -58,15 +65,9 @@ class TestUpdateDocumentsInUnstructuredIndex(MarqoTestCase):
 
         tensor_fields = ['tensor_field', 'custom_vector_field', 'multimodal_combo_field']
 
-        add_docs_response = cls.client.index(cls.text_index_name).add_documents(documents = text_docs, mappings = mappings, tensor_fields = tensor_fields)
+        add_docs_response = self.client.index(self.text_index_name).add_documents(documents = text_docs, mappings = mappings, tensor_fields = tensor_fields)
 
-        cls.assertFalse(add_docs_response["errors"], "Error adding documents to index")
-
-    def tearDown(self):
-        if self.indexes_to_delete:
-            self.clear_indexes(self.indexes_to_delete)
-
-    def test_update_document_with_ids(self):
+        self.assertFalse(add_docs_response["errors"])
 
         update_docs_response = self.client.index(self.text_index_name).update_documents(
             [{
@@ -99,6 +100,40 @@ class TestUpdateDocumentsInUnstructuredIndex(MarqoTestCase):
         self.assertEqual(get_docs_response['string_array2'], ["123", "456"])
 
     def test_update_document_with_ids_change_field_type(self):
+
+        text_docs = [{
+            '_id': '1',
+            'tensor_field': 'title',
+            'tensor_subfield': 'description',
+            "short_string_field": "shortstring",
+            "long_string_field": "Thisisaverylongstring" * 10,
+            "int_field": 123,
+            "float_field": 123.0,
+            "string_array": ["aaa", "bbb"],
+            "string_array2": ["123", "456"],
+            "int_map": {"a": 1, "b": 2},
+            "float_map": {"c": 1.0, "d": 2.0},
+            "bool_field": True,
+            "bool_field2": False,
+            "custom_vector_field": {
+                "content": "abcd",
+                "vector": [1.0] * 32
+            }
+        }]
+
+        mappings = {
+            "custom_vector_field": {"type": "custom_vector"},
+            "multimodal_combo_field": {
+                "type": "multimodal_combination",
+                "weights": {"tensor_field": 1.0, "tensor_subfield": 2.0}
+            }
+        }
+
+        tensor_fields = ['tensor_field', 'custom_vector_field', 'multimodal_combo_field']
+
+        add_docs_response = self.client.index(self.text_index_name).add_documents(documents = text_docs, mappings = mappings, tensor_fields = tensor_fields)
+
+        self.assertFalse(add_docs_response["errors"])
 
         update_docs_response = self.client.index(self.text_index_name).update_documents(
             [{
@@ -133,6 +168,41 @@ class TestUpdateDocumentsInUnstructuredIndex(MarqoTestCase):
         """
         # First add a document to update
         """Test updating a document with new fields and updating existing fields."""
+
+        text_docs = [{
+            '_id': '1',
+            'tensor_field': 'title',
+            'tensor_subfield': 'description',
+            "short_string_field": "shortstring",
+            "long_string_field": "Thisisaverylongstring" * 10,
+            "int_field": 123,
+            "float_field": 123.0,
+            "string_array": ["aaa", "bbb"],
+            "string_array2": ["123", "456"],
+            "int_map": {"a": 1, "b": 2},
+            "float_map": {"c": 1.0, "d": 2.0},
+            "bool_field": True,
+            "bool_field2": False,
+            "custom_vector_field": {
+                "content": "abcd",
+                "vector": [1.0] * 32
+            }
+        }]
+
+        mappings = {
+            "custom_vector_field": {"type": "custom_vector"},
+            "multimodal_combo_field": {
+                "type": "multimodal_combination",
+                "weights": {"tensor_field": 1.0, "tensor_subfield": 2.0}
+            }
+        }
+
+        tensor_fields = ['tensor_field', 'custom_vector_field', 'multimodal_combo_field']
+
+        add_docs_response = self.client.index(self.text_index_name).add_documents(documents = text_docs, mappings = mappings, tensor_fields = tensor_fields)
+
+        self.assertFalse(add_docs_response["errors"])
+
         update_docs_response = self.client.index(self.text_index_name).update_documents(
             [{
                 '_id': '1',

--- a/tests/api_tests/v1/tests/api_tests/unstructured_index/test_update_documents_unstructured_index.py
+++ b/tests/api_tests/v1/tests/api_tests/unstructured_index/test_update_documents_unstructured_index.py
@@ -60,7 +60,7 @@ class TestUpdateDocumentsInUnstructuredIndex(MarqoTestCase):
 
         add_docs_response = cls.client.index(cls.text_index_name).add_documents(documents = text_docs, mappings = mappings, tensor_fields = tensor_fields)
 
-        cls.assertFalse(add_docs_response["errors"])
+        cls.assertFalse(add_docs_response["errors"], "Error adding documents to index")
 
     def tearDown(self):
         if self.indexes_to_delete:

--- a/tests/integ_tests/core/document/test_partial_update_semi_structured.py
+++ b/tests/integ_tests/core/document/test_partial_update_semi_structured.py
@@ -400,11 +400,11 @@ class TestPartialUpdate(MarqoTestCase):
         res = self.config.document.partial_update_documents([{
             '_id': '2',
             'int_map_2': {
-                'd': 5,  # new entry in int map
-                'e': 6,  # another new entry
+                'd': 5,  # adding entirely new map
+                'e': 6,
             },
             'float_map_2': {
-                'f': 4.0,  # new entry in float map
+                'f': 4.0,  # adding entirely new map
             },
             'new_int': 1,  # new int field
             'new_float': 2.0,  # new float field

--- a/tests/integ_tests/core/document/test_partial_update_semi_structured.py
+++ b/tests/integ_tests/core/document/test_partial_update_semi_structured.py
@@ -201,6 +201,20 @@ class TestPartialUpdate(MarqoTestCase):
         self.assertEqual(doc['int_map.b'], 3)
         self._assert_fields_unchanged(doc, ['int_map'])
 
+    def test_partial_update_should_replace_int_map(self):
+        """Test that partial updates to int maps are successful.
+
+        This test verifies that partial updates to int maps are successful.
+        """
+        res = self.config.document.partial_update_documents([{'_id': '2', 'int_map': {'f': 2, 'g': 3}}], self.index)
+        self.assertFalse(res.errors)
+        doc = tensor_search.get_document_by_id(self.config, self.index.name, '2')
+        self.assertEqual(doc['int_map.f'], 2)
+        self.assertEqual(doc['int_map.g'], 3)
+        self.assertEqual(doc.get('int_map.a'), None)
+        self.assertEqual(doc.get('int_map.b'), None)
+        self._assert_fields_unchanged(doc, ['int_map'])
+
     def test_partial_update_should_update_int_map_with_new_value(self):
         """Test that partial updates to int maps with new values are successful.
         

--- a/tests/integ_tests/core/document/test_partial_update_semi_structured.py
+++ b/tests/integ_tests/core/document/test_partial_update_semi_structured.py
@@ -202,9 +202,8 @@ class TestPartialUpdate(MarqoTestCase):
         self._assert_fields_unchanged(doc, ['int_map'])
 
     def test_partial_update_should_replace_int_map(self):
-        """Test that partial updates to int maps are successful.
-
-        This test verifies that partial updates to int maps are successful.
+        """Test that partial updates to int maps where we change the keys inside
+        a specific int map are successful
         """
         res = self.config.document.partial_update_documents([{'_id': '2', 'int_map': {'f': 2, 'g': 3}}], self.index)
         self.assertFalse(res.errors)
@@ -403,9 +402,7 @@ class TestPartialUpdate(MarqoTestCase):
         self.assertEqual(doc['marqo__score_modifiers']['cells']['int_map.d'], 5.0)
 
     def test_partial_update_should_add_score_modifiers(self):
-        """Test that partial updates to score modifiers are successful.
-
-        This test verifies that partial updates to score modifiers are successful.
+        """Test that partial updates which specifically add new fields reflect properly in score modifiers tensors.
         """
         # Create a document with existing fields first to verify we're only adding
         original_doc = tensor_search.get_document_by_id(self.config, self.index.name, '2')
@@ -439,6 +436,32 @@ class TestPartialUpdate(MarqoTestCase):
         self.assertEqual(doc['marqo__score_modifiers']['cells']['int_map_2.d'], 5.0)
         self.assertEqual(doc['marqo__score_modifiers']['cells']['int_map_2.e'], 6.0)
         self.assertEqual(doc['marqo__score_modifiers']['cells']['float_map_2.f'], 4.0)
+
+    def test_partial_update_only_update_existing_score_modifiers(self):
+        """
+        Test that partial updates which specifically change the existing keys inside existing maps
+         reflect properly in score modifiers tensors.
+        """
+        # Create a document with existing fields first to verify we're only adding
+        original_doc = tensor_search.get_document_by_id(self.config, self.index.name, '2')
+
+        # Perform update with only additions, not replacements
+        res = self.config.document.partial_update_documents([{
+            '_id': '2',
+            "int_map": {"a": 3, "b": 4},
+            "float_map": {"c": 3.0, "d": 4.0},
+        }], self.index)
+        self.assertFalse(res.errors)
+        res = self.config.vespa_client.get_document('2',
+                                                    self.config.index_management.get_index(self.index.name).schema_name)
+        doc = res.document.dict().get('fields')
+        # Verify original fields are preserved
+        self.assertEqual(doc['marqo__score_modifiers']['cells']['int_field'], 123.0)
+        self.assertEqual(doc['marqo__score_modifiers']['cells']['float_field'], 123.0)
+        self.assertEqual(doc['marqo__score_modifiers']['cells']['int_map.a'], 3.0)
+        self.assertEqual(doc['marqo__score_modifiers']['cells']['int_map.b'], 4.0)
+        self.assertEqual(doc['marqo__score_modifiers']['cells']['float_map.c'], 3.0)
+        self.assertEqual(doc['marqo__score_modifiers']['cells']['float_map.d'], 4.0)
 
     def test_partial_update_should_add_new_fields(self):
         """Test that partial updates to new fields are successful.

--- a/tests/integ_tests/core/document/test_partial_update_semi_structured.py
+++ b/tests/integ_tests/core/document/test_partial_update_semi_structured.py
@@ -474,7 +474,7 @@ class TestPartialUpdate(MarqoTestCase):
         """
         res = self.config.document.partial_update_documents([{'_id': '2', 'new_lexical_field': 'some string that signifies new lexical field'}], self.index)
         self.assertTrue(res.errors)
-        self.assertIn("new_lexical_field of type str does not exist in the original document. We do not support adding new lexical fields in partial updates", res.items[0].error)
+        self.assertIn("new_lexical_field of type str does not exist in the original document. Marqo does not support adding new lexical fields in partial updates", res.items[0].error)
         self.assertEqual(400, res.items[0].status)
 
     def test_partial_update_invalid_field_name(self):

--- a/tests/integ_tests/core/document/test_partial_update_semi_structured.py
+++ b/tests/integ_tests/core/document/test_partial_update_semi_structured.py
@@ -388,6 +388,43 @@ class TestPartialUpdate(MarqoTestCase):
         self.assertEqual(doc['marqo__score_modifiers']['cells']['new_map.b'], 2.0)
         self.assertEqual(doc['marqo__score_modifiers']['cells']['int_map.d'], 5.0)
 
+    def test_partial_update_should_add_score_modifiers(self):
+        """Test that partial updates to score modifiers are successful.
+
+        This test verifies that partial updates to score modifiers are successful.
+        """
+        # Create a document with existing fields first to verify we're only adding
+        original_doc = tensor_search.get_document_by_id(self.config, self.index.name, '2')
+        
+        # Perform update with only additions, not replacements
+        res = self.config.document.partial_update_documents([{
+            '_id': '2',
+            'int_map_2': {
+                'd': 5,  # new entry in int map
+                'e': 6,  # another new entry
+            },
+            'float_map_2': {
+                'f': 4.0,  # new entry in float map
+            },
+            'new_int': 1,  # new int field
+            'new_float': 2.0,  # new float field
+        }], self.index)
+        self.assertFalse(res.errors)
+        res = self.config.vespa_client.get_document('2',
+                                                    self.config.index_management.get_index(self.index.name).schema_name)
+        doc = res.document.dict().get('fields')
+        # Verify original fields are preserved
+        self.assertEqual(doc['marqo__score_modifiers']['cells']['int_field'], 123.0)
+        self.assertEqual(doc['marqo__score_modifiers']['cells']['float_field'], 123.0)
+        self.assertEqual(doc['marqo__score_modifiers']['cells']['int_map.a'], 1.0)
+        self.assertEqual(doc['marqo__score_modifiers']['cells']['float_map.c'], 1.0)
+                
+        # Verify new fields from the update call in this test 
+        self.assertEqual(doc['marqo__score_modifiers']['cells']['new_int'], 1.0)
+        self.assertEqual(doc['marqo__score_modifiers']['cells']['new_float'], 2.0)
+        self.assertEqual(doc['marqo__score_modifiers']['cells']['int_map_2.d'], 5.0)
+        self.assertEqual(doc['marqo__score_modifiers']['cells']['int_map_2.e'], 6.0)
+        self.assertEqual(doc['marqo__score_modifiers']['cells']['float_map_2.f'], 4.0)
 
     def test_partial_update_should_add_new_fields(self):
         """Test that partial updates to new fields are successful.

--- a/tests/integ_tests/core/document/test_partial_update_semi_structured.py
+++ b/tests/integ_tests/core/document/test_partial_update_semi_structured.py
@@ -856,3 +856,18 @@ class TestPartialUpdate(MarqoTestCase):
         self.assertIn("Marqo vector store couldn't update the document. Please see", res.items[0].error)
         self.assertTrue(res.errors)
         self.assertEqual(400, res.items[0].status)
+
+
+    def test_updating_non_existent_document_with_maps(self):
+        """
+        Test updating a non-existent document with maps.
+
+        This test verifies that attempting to update a non-existent document with a map field
+        results in an error response. It checks a special handling we have added for documents in update requests which contain maps fields.
+        These documents are not originally present in Vespa and Marqo must return appropriate response for them.
+        """
+        res =  self.config.document.partial_update_documents([{'_id': '4', 'metadata': {'key1': 2}}], self.index)
+        self.assertTrue(res.errors)
+        self.assertEqual(400, res.items[0].status)
+        self.assertIn("Marqo vector store couldn't update the document. Please see", res.items[0].error)
+        self.assertIn('reference/api/documents/update-documents/#response', res.items[0].error)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
* bug fix


* **What is the current behavior?** (You can also link to an open issue here)
* in cases where the partial update request is not changing the entire map, score modifiers were not getting updated. So for example 
* ```mq.index('my-index').add_documents(
    documents=[
        {
            '_id': '1',
            'text': 'This is a test document',
            'rank': 100,
            'metadata': {
                'key1': 1.5,
            }
        }
    ],
    tensor_fields=['text'],)

```mq.index('my-index').update_documents(
        [{'_id': '1', 'metadata': {'key1':300.2}}]
    )
```

Score modifiers were not getting updated for this scenario. 

* **What is the new behavior (if this is a feature change)?**
This is fixed now. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
* No


* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
* Manual testing has been done 


* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

