### PR TITLE
Add privileged to cuda tests

### DIFF
--- a/tests/api_tests/v1/scripts/start_cuda_docker_marqo.sh
+++ b/tests/api_tests/v1/scripts/start_cuda_docker_marqo.sh
@@ -13,7 +13,7 @@ docker rm -f marqo 2>/dev/null || true
 # -d detaches docker from process (so subprocess does not wait for it)
 # ${@:+"$@"} adds ALL args (past $1) if any exist.
 set -x
-docker run -d --name marqo --gpus all -p 8882:8882 \
+docker run -d --privileged --name marqo --gpus all -p 8882:8882 \
   -e MARQO_ENABLE_BATCH_APIS=TRUE \
   -e MARQO_MAX_CUDA_MODEL_MEMORY=15 \
   -e MARQO_MAX_CPU_MODEL_MEMORY=15 \


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
The Marqo container in the API tests can't find the GPU. However, when I try to SSH into the instance and spin up a Marqo container, the new container can find the GPU.  We are not sure about the root cause yet. Adding `--privileged` is just a work around.

* **What is the new behavior (if this is a feature change)?**
Adding `--privileged` to CUDA API tests.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Have unit tests been run against this PR?** (Has there also been any additional testing?)


* **Related Python client changes** (link commit/PR here)


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

