### PR TITLE
Fixing the bug where map was not getting updated if the map wasn't present when the document was added using the add_documents call. 

### DIFF
--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -216,8 +216,10 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
         Returns:
             Dict containing the Vespa partial document format with:
             - 'id': Document ID
-            - 'field_types': Field name to type mapping
-            - 'fields': Field values
+            - 'field_types': Field name to type mapping. Later used to create pre-conditions
+            - 'fields': Field values. Each field is represented as an update statement, for the actual field, the field type metadata, and the score modifiers if applicable. Example:
+                - 'marqo__bool_fields{active}': {"assign": 1}
+                - 'marqo__field_type{active}': {"assign": "bool"}
             - 'create_timestamp': Original document timestamp if it exists
 
         Raises:
@@ -238,8 +240,6 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
         vespa_fields = {}
         vespa_field_types = {}
 
-        # Initialize dictionary to be later used for updating score modifiers. 
-        numeric_fields = {}
 
         numeric_field_map: Dict[str, Any] = dict() # This map is used to store the numeric fields in the document. It is used to update the numeric fields & score modifiers later
         if original_doc:
@@ -254,17 +254,10 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
             validate_field_name(field_name)
 
             # This method broadly processes the field based on its type and updates the vespa_fields,
-            # vespa_field_types, numeric_fields, numeric_field_map dictionaries. Numeric fields and numeric field maps
+            # vespa_field_types, numeric_field_map dictionaries. Numeric fields and numeric field maps
             # are special cases and are processed later.
-            self._process_field(
-                field_name=field_name,
-                value=value,
-                fields=vespa_fields,
-                field_types=vespa_field_types,
-                numeric_fields=numeric_fields,
-                numeric_field_map=numeric_field_map,
-                doc_id=doc_id
-            )
+            self._process_field(field_name=field_name, value=value, fields=vespa_fields, field_types=vespa_field_types,
+                                numeric_field_map=numeric_field_map, doc_id=doc_id)
 
         # This method creates the update statement for updating int fields / int map fields.
         int_fields_changed = self._create_update_statement_for_updating_numeric_and_numeric_map_field(
@@ -342,16 +335,8 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
         if len(score_modifiers) > 0:
             vespa_fields[common.SCORE_MODIFIERS] = score_modifiers
 
-    def _process_field(
-        self,
-        field_name: str,
-        value: Any,
-        fields: Dict[str, Any],
-        field_types: Dict[str, Any],
-        numeric_fields: Dict[str, Any],
-        numeric_field_map: Dict[str, Any],
-        doc_id: str
-    ) -> None:
+    def _process_field(self, field_name: str, value: Any, fields: Dict[str, Any], field_types: Dict[str, Any],
+                       numeric_field_map: Dict[str, Any], doc_id: str) -> None:
         """Process a single field from a document based on its type.
 
         This method determines the type of the field value and delegates processing to the appropriate handler method.
@@ -361,8 +346,7 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
             field_name: The name of the field being processed
             value: The value of the field, can be of the type bool, dict, int, float, list, or str
             fields: Dictionary to store the update statements corresponding to the processed fields 
-            field_types: Dictionary mapping field names to their Marqo field types
-            numeric_fields: Dictionary storing numeric field values for being later used to update score modifier 
+            field_types: Dictionary mapping field names to their Marqo field types. Later used to create pre-conditions.
             doc_id: The ID of the document containing this field
 
         Raises:
@@ -538,8 +522,10 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
             # Set the appropriate field type based on the value type
             if isinstance(v, int):
                 field_types[f'{field_name}.{k}'] = MarqoFieldTypes.INT_MAP.value
+                field_types[f'{field_name}'] = MarqoFieldTypes.INT_MAP.value
             else:  # Must be float based on the earlier check
                 field_types[f'{field_name}.{k}'] = MarqoFieldTypes.FLOAT_MAP.value
+                field_types[f'{field_name}'] = MarqoFieldTypes.FLOAT_MAP.value
 
     def _handle_string_array_field(
         self,

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -1,4 +1,3 @@
-import json
 from typing import Dict, Any, List, Optional, Type, Union, cast
 
 from marqo.core.constants import MARQO_DOC_HIGHLIGHTS, MARQO_DOC_ID
@@ -268,11 +267,11 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
             )
 
         # This method creates the update statement for updating int fields / int map fields.
-        int_fields_changed = self._update_numeric_field(
+        int_fields_changed = self._create_update_statement_for_updating_numeric_and_numeric_map_field(
             int, numeric_field_map, original_doc, vespa_fields, vespa_field_types
         )
         # This method creates the update statement for float numeric fields / float map fields.
-        float_fields_changed = self._update_numeric_field(
+        float_fields_changed = self._create_update_statement_for_updating_numeric_and_numeric_map_field(
             float, numeric_field_map, original_doc, vespa_fields, vespa_field_types
         )
 
@@ -372,9 +371,9 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
         if isinstance(value, bool):
             self._handle_boolean_field(field_name, value, fields, field_types)
         elif isinstance(value, dict):
-            self._handle_dict_field(field_name, value, doc_id, numeric_field_map)
+            self._handle_dict_field(field_name, value, doc_id, field_types, numeric_field_map)
         elif isinstance(value, (int, float)):
-            numeric_field_map[field_name] = value # sets information about numeric fields in a map so it the numeric field + score modifiers can be updated later
+            self._handle_numeric_field(field_name, value, field_types, numeric_field_map)
         elif isinstance(value, list):
             self._handle_string_array_field(field_name, value, fields, field_types)
         elif isinstance(value, str):
@@ -384,7 +383,15 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
                 f'Unsupported field type {type(value)} for field {field_name} in doc {doc_id}'
             )
 
-    def _update_numeric_field(
+    def _handle_numeric_field(self, field_name, value, field_types, numeric_field_map):
+        numeric_field_map[field_name] = value
+        if isinstance(value, int):
+            field_types[field_name] = MarqoFieldTypes.INT.value
+        elif isinstance(value, float):
+            field_types[field_name] = MarqoFieldTypes.FLOAT.value
+
+
+    def _create_update_statement_for_updating_numeric_and_numeric_map_field(
         self,
         numeric_type: Type[Union[int, float]],
         numeric_field_map: Dict[str, Union[int, float]],
@@ -392,27 +399,29 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
         vespa_fields: Dict[str, Any],
         vespa_field_types: Dict[str, Any]
     ) -> bool:
-        """Updates numeric fields (int/float) in Vespa documents.
+        """Creates update statements for numeric fields and their type metadata in Vespa documents.
         
-        This method processes numeric fields (integers or floats) for partial document updates.
-        It compares the new values with the original document (if it exists) and only updates
-        fields that have changed or are new. It also handles the field type metadata appropriately,
-        distinguishing between regular numeric fields and map types.
+        Processes numeric fields (integers, floats, int maps or float maps) for partial document updates in a semi-structured
+        Vespa index. The method handles both regular numeric fields and map-type fields,
+        comparing new values with the original document to minimize unnecessary updates.
         
         Args:
-            numeric_type: The type of numeric field (int or float) to process
-            numeric_field_map: Dictionary mapping field names to their numeric values
-            original_doc: The original Vespa document if it exists, used for comparison
-            vespa_fields: Dictionary to store the update statements for Vespa fields
-            vespa_field_types: Dictionary to store the field type metadata updates
+            numeric_type: The numeric type to process (int or float)
+            numeric_field_map: Dictionary of field names to their numeric values for updating
+            original_doc: The original Vespa document if it exists (for comparison)
+            vespa_fields: Dictionary to store the generated Vespa update statements
+            vespa_field_types: Dictionary to store field type metadata, later used to create pre-conditions
             
         Returns:
             bool: True if any fields were changed, False otherwise
             
-        Note:
-            - Fields that exist in the original document but not in the update request are preserved
-            - Map type fields that are no longer present will be removed
-            - Field type metadata is updated to maintain consistency with the field values
+        Behavior:
+        1. Iterate over the numeric_field_map and create update statements for the fields
+        that are present in the update request. This is only done if the field doesn't exist in the original document or if the field value has changed.
+        2. Also create update (i.e "assign") statements for the field type metadata, which are useful in the case of a new field being added.
+        3. Then iterate over the original fields which is a dictionary of all the fields inside marqo__int_fields / marqo__float_fields
+        4. During this iteration, create "remove" statements for the fields that are not in numeric_field_map and are of type int_map / float_map. This is done solely
+        for map fields to support complete map replacement (i.e replace an existing map with a new map of the same name but entirely different keys & values)
         """
         fields_changed = False
         field_prefix = common.INT_FIELDS if numeric_type is int else common.FLOAT_FIELDS
@@ -424,37 +433,31 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
                              else original_doc.fixed_fields.float_fields)
 
         # Process fields in update request
-        for field_name, value in numeric_field_map.items():
-            if not isinstance(value, numeric_type):
+        for field_name, field_value in numeric_field_map.items():
+            if not isinstance(field_value, numeric_type):
                 continue
                 
             vespa_field_name = f'{field_prefix}{{{field_name}}}'
             vespa_field_types_field_name = f'{common.VESPA_DOC_FIELD_TYPES}{{{field_name}}}'
 
             # Only set field value if it doesn't exist in the original set of fields or has changed
-            field_exists = original_doc is not None and field_name in original_fields
-            field_value_changed = field_exists and original_fields[field_name] != value
-            
-            if not field_exists or field_value_changed:
-                vespa_fields[vespa_field_name] = {"assign": value}
+            field_exists_in_original_doc = original_doc is not None and field_name in original_fields
+            field_value_changed = field_exists_in_original_doc and original_fields[field_name] != field_value
+            field_type = vespa_field_types.get(field_name) # Get field type from the field passed in the request
 
-                # Determine if field is a map type based on original document
-                is_map_type = (original_doc is not None and 
-                              original_doc.fixed_fields.field_types.get(field_name) in 
-                              (MarqoFieldTypes.INT_MAP.value, MarqoFieldTypes.FLOAT_MAP.value))
-                
-                # Set appropriate field type based on numeric_type and whether it's a map
-                field_type = (MarqoFieldTypes.INT_MAP if numeric_type is int else MarqoFieldTypes.FLOAT_MAP) if is_map_type else (MarqoFieldTypes.INT if numeric_type is int else MarqoFieldTypes.FLOAT)
+            if not field_exists_in_original_doc or field_value_changed:
+                vespa_fields[vespa_field_name] = {"assign": field_value}
 
-                # Set field type metadata by creating a assigned statement
-                vespa_fields[vespa_field_types_field_name] = {"assign": field_type.value}
+                # Set field type metadata by creating an assign statement
+                vespa_fields[vespa_field_types_field_name] = {"assign": field_type}
 
                 # Update field type metadata dictionary, so we can use it later when defining the update pre-condition to send to vespa
-                vespa_field_types[field_name] = field_type.value
                 fields_changed = True
 
         # Remove fields no longer in map
 
+        # This block of code only executes for map fields. This is because to replace an entire map, we need to remove the flattened keys that
+        # from marqo__int_fields / marqo__float_fields in case those fields are not present in the update request.
         for original_field_name in original_fields:
             if (original_field_name not in numeric_field_map and
                 original_doc.fixed_fields.field_types.get(original_field_name) in (MarqoFieldTypes.INT_MAP.value, MarqoFieldTypes.FLOAT_MAP.value)):
@@ -498,6 +501,7 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
         field_name: str,
         value: Dict[str, Any],
         doc_id: str,
+        field_types: Dict[str, str],
         numeric_field_map: Dict[str, Any]
     ) -> None:
         """Handle dictionary field processing for document updates.
@@ -525,10 +529,17 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
             
         # Add new entries
         for k, v in value.items():
-            if isinstance(v, (int, float)):
-                numeric_field_map[f'{field_name}.{k}'] = v
-            else:
-                raise MarqoDocumentParsingError(f'Unsupported field type {type(v)} for field {field_name} in doc {doc_id}')
+            if not isinstance(v, (int, float)):
+                raise MarqoDocumentParsingError(f'Unsupported field type {type(v)} for field {field_name} in doc {doc_id}. '
+                                               'We only support int and float types for map values when updating a document')
+                
+            numeric_field_map[f'{field_name}.{k}'] = v
+            
+            # Set the appropriate field type based on the value type
+            if isinstance(v, int):
+                field_types[f'{field_name}.{k}'] = MarqoFieldTypes.INT_MAP.value
+            else:  # Must be float based on the earlier check
+                field_types[f'{field_name}.{k}'] = MarqoFieldTypes.FLOAT_MAP.value
 
     def _handle_string_array_field(
         self,

--- a/tests/integ_tests/core/document/test_partial_update_semi_structured.py
+++ b/tests/integ_tests/core/document/test_partial_update_semi_structured.py
@@ -112,13 +112,14 @@ class TestPartialUpdate(MarqoTestCase):
             else:
                 self.assertEqual(value, doc.get(field, None), f'{field} is changed.')
 
-    def _assert_field_types(self, field_names, field_types, id):
+    def _assert_field_types(self, id, field_type_pairs):
         raw_vespa_doc = self.config.vespa_client.get_document(id, self.index.schema_name)
         vespa_fields = raw_vespa_doc.document.dict().get('fields')
 
-        for field_name, field_type in zip(field_names, field_types):
-            self.assertEqual(vespa_fields.get('marqo__field_types').get(field_name), field_type, 
-                            f"Expected {field_name} to have type {field_type} for document {id}")
+        for field_name, field_type in field_type_pairs:
+            expected_type = field_type.value if field_type is not None else None
+            self.assertEqual(vespa_fields.get('marqo__field_types').get(field_name), expected_type, 
+                            f"Expected {field_name} to have type {expected_type} for document {id}")
 
 
     # Test update single field
@@ -146,7 +147,9 @@ class TestPartialUpdate(MarqoTestCase):
                 self._assert_fields_unchanged(updated_doc, ['bool_field'])
 
                 # Verify field type
-                self._assert_field_types(['bool_field'], [MarqoFieldTypes.BOOL.value], id)
+                self._assert_field_types(id, [
+                    ('bool_field', MarqoFieldTypes.BOOL)
+                ])
 
     def test_partial_update_should_update_int_field_to_int(self):
         """Test that integer fields can be updated correctly via partial updates.
@@ -173,7 +176,9 @@ class TestPartialUpdate(MarqoTestCase):
 
                 
                 # Verify field type
-                self._assert_field_types(['int_field'], [MarqoFieldTypes.INT.value], id)
+                self._assert_field_types(id, [
+                    ('int_field', MarqoFieldTypes.INT)
+                ])
 
     def test_partial_update_to_non_existent_field(self): 
         """Test that partial updates to non-existent fields are successful.
@@ -193,7 +198,9 @@ class TestPartialUpdate(MarqoTestCase):
                 self._assert_fields_unchanged(doc, ['update_field_that_doesnt_exist'])
                 
                 # Verify field type
-                self._assert_field_types(['update_field_that_doesnt_exist'], [MarqoFieldTypes.INT.value], id)
+                self._assert_field_types(id, [
+                    ('update_field_that_doesnt_exist', MarqoFieldTypes.INT)
+                ])
 
 
     def test_partial_update_should_not_update_int_field_to_float(self):
@@ -230,7 +237,9 @@ class TestPartialUpdate(MarqoTestCase):
                 self._assert_fields_unchanged(doc, ['float_field'])
                 
                 # Verify field type
-                self._assert_field_types(['float_field'], [MarqoFieldTypes.FLOAT.value], id)
+                self._assert_field_types(id, [
+                    ('float_field', MarqoFieldTypes.FLOAT)
+                ])
 
     def test_partial_update_should_update_int_map(self):
         """Test that partial updates to int maps are successful.
@@ -253,7 +262,12 @@ class TestPartialUpdate(MarqoTestCase):
                 self._assert_fields_unchanged(doc, ['int_map'])
                 
                 # Verify field type
-                self._assert_field_types(['int_map.c', 'int_map.d', 'int_map.a', 'int_map.b'], [MarqoFieldTypes.INT_MAP.value, MarqoFieldTypes.INT_MAP.value, None, None], id)
+                self._assert_field_types(id, [
+                    ('int_map.c', MarqoFieldTypes.INT_MAP),
+                    ('int_map.d', MarqoFieldTypes.INT_MAP),
+                    ('int_map.a', None),
+                    ('int_map.b', None)
+                ])
     
     def test_partial_update_should_replace_int_map(self):
         """Test that partial updates to int maps where we change the keys inside
@@ -275,7 +289,12 @@ class TestPartialUpdate(MarqoTestCase):
                 self._assert_fields_unchanged(doc, ['int_map'])
                 
                 # Verify field type
-                self._assert_field_types(['int_map.f', 'int_map.g', 'int_map.a', 'int_map.b'], [MarqoFieldTypes.INT_MAP.value, MarqoFieldTypes.INT_MAP.value, None, None], id)
+                self._assert_field_types(id, [
+                    ('int_map.f', MarqoFieldTypes.INT_MAP),
+                    ('int_map.g', MarqoFieldTypes.INT_MAP),
+                    ('int_map.a', None),
+                    ('int_map.b', None)
+                ])
     
     def test_partial_update_should_update_int_map_with_new_value(self):
         """Test that partial updates to int maps with new values are successful."""
@@ -295,7 +314,11 @@ class TestPartialUpdate(MarqoTestCase):
                 self.assertEqual(doc['int_map.d'], 2, f"Expected int_map.d to be 2 for document {id}")
                 
                 # Verify field type
-                self._assert_field_types(['int_map.d', 'int_map.a', 'int_map.b'], [MarqoFieldTypes.INT_MAP.value, None, None], id)
+                self._assert_field_types(id, [
+                    ('int_map.d', MarqoFieldTypes.INT_MAP),
+                    ('int_map.a', None),
+                    ('int_map.b', None)
+                ])
     def test_partial_update_should_update_float_map(self):
         """Test that partial updates to float maps are successful.
         
@@ -315,7 +338,10 @@ class TestPartialUpdate(MarqoTestCase):
                 self._assert_fields_unchanged(doc, ['float_map'])
                 
                 # Verify field type
-                self._assert_field_types(['float_map.c', 'float_map.d'], [MarqoFieldTypes.FLOAT_MAP.value, MarqoFieldTypes.FLOAT_MAP.value], id)
+                self._assert_field_types(id, [
+                    ('float_map.c', MarqoFieldTypes.FLOAT_MAP),
+                    ('float_map.d', MarqoFieldTypes.FLOAT_MAP)
+                ])
 
     def test_partial_update_should_allow_changing_multiple_maps_in_same_request(self):
         """Test that partial updates to multiple maps in the same request are successful.
@@ -345,7 +371,15 @@ class TestPartialUpdate(MarqoTestCase):
                 self._assert_fields_unchanged(doc, ['int_map.a', 'int_map.b', 'float_map.d', 'float_map.c', 'int_field', 'bool_field', 'float_field'])
 
                 # Verify field types
-                self._assert_field_types(['int_map.a', 'int_map.b', 'float_map.c', 'float_map.d', 'int_field', 'bool_field', 'float_field'], [MarqoFieldTypes.INT_MAP.value, None, MarqoFieldTypes.FLOAT_MAP.value, None, MarqoFieldTypes.INT.value, MarqoFieldTypes.BOOL.value, MarqoFieldTypes.FLOAT.value], id)
+                self._assert_field_types(id, [
+                    ('int_map.a', MarqoFieldTypes.INT_MAP),
+                    ('int_map.b', None),
+                    ('float_map.c', MarqoFieldTypes.FLOAT_MAP),
+                    ('float_map.d', None),
+                    ('int_field', MarqoFieldTypes.INT),
+                    ('bool_field', MarqoFieldTypes.BOOL),
+                    ('float_field', MarqoFieldTypes.FLOAT)
+                ])
 
     def test_partial_update_should_update_string_array(self):
         """Test that partial updates to string arrays are successful.
@@ -365,7 +399,9 @@ class TestPartialUpdate(MarqoTestCase):
                 self._assert_fields_unchanged(doc, ['string_array'])
                 
                 # Verify field type
-                self._assert_field_types(['string_array'], [MarqoFieldTypes.STRING_ARRAY.value], id)
+                self._assert_field_types(id, [
+                    ('string_array', MarqoFieldTypes.STRING_ARRAY)
+                ])
     def test_partial_update_should_reject_new_string_array_field(self):
         """Test that partial updates to new string arrays are rejected."""
         test_docs = [self.doc, self.doc2, self.doc3]
@@ -398,7 +434,10 @@ class TestPartialUpdate(MarqoTestCase):
                 self._assert_fields_unchanged(doc, ['lexical_field', 'string_array'])
 
                 # Verify field types
-                self._assert_field_types(['lexical_field', 'string_array'], [MarqoFieldTypes.STRING.value, MarqoFieldTypes.STRING_ARRAY.value], id)
+                self._assert_field_types(id, [
+                    ('lexical_field', MarqoFieldTypes.STRING),
+                    ('string_array', MarqoFieldTypes.STRING_ARRAY)
+                ])
 
     def test_partial_update_should_update_short_string(self):
         """Test that partial updates to short strings are successful."""
@@ -417,7 +456,9 @@ class TestPartialUpdate(MarqoTestCase):
                 self._assert_fields_unchanged(doc, ['short_string_field'])
                 
                 # Verify field type
-                self._assert_field_types(['short_string_field'], [MarqoFieldTypes.STRING.value], id)
+                self._assert_field_types(id, [
+                    ('short_string_field', MarqoFieldTypes.STRING)
+                ])
 
     def test_partial_update_should_update_long_string(self):
         """Test that partial updates to long strings are successful."""
@@ -436,7 +477,9 @@ class TestPartialUpdate(MarqoTestCase):
                 self._assert_fields_unchanged(doc, ['long_string_field'])
                 
                 # Verify field type
-                self._assert_field_types(['long_string_field'], [MarqoFieldTypes.STRING.value], id)
+                self._assert_field_types(id, [
+                    ('long_string_field', MarqoFieldTypes.STRING)
+                ])
 
     def test_partial_update_should_update_long_string_to_short_string(self):
         """Test that partial updates to long strings to short strings are successful."""
@@ -455,7 +498,9 @@ class TestPartialUpdate(MarqoTestCase):
                 self._assert_fields_unchanged(doc, ['long_string_field'])
                 
                 # Verify field type
-                self._assert_field_types(['long_string_field'], [MarqoFieldTypes.STRING.value], id)
+                self._assert_field_types(id, [
+                    ('long_string_field', MarqoFieldTypes.STRING)
+                ])
 
     def test_partial_update_should_update_short_string_to_long_string(self):
         """Test that partial updates to short strings to long strings are successful."""
@@ -497,16 +542,19 @@ class TestPartialUpdate(MarqoTestCase):
                 self.assertFalse(res.errors, f"Expected no errors when updating document {id}")
                 
                 # Verify field types
-                # Verify field types
-                field_names = ['int_map.a', 'int_map.d', 'float_map.c', 'new_int', 'new_float', 
-                              'new_map.a', 'new_map.b', 'int_map.b', 'float_map.d']
-                field_types = [MarqoFieldTypes.INT_MAP.value, MarqoFieldTypes.INT_MAP.value, 
-                              MarqoFieldTypes.FLOAT_MAP.value, MarqoFieldTypes.INT.value, 
-                              MarqoFieldTypes.FLOAT.value, MarqoFieldTypes.INT_MAP.value, 
-                              MarqoFieldTypes.FLOAT_MAP.value, None, None]
+                field_type_pairs = [
+                    ('int_map.a', MarqoFieldTypes.INT_MAP),
+                    ('int_map.d', MarqoFieldTypes.INT_MAP),
+                    ('float_map.c', MarqoFieldTypes.FLOAT_MAP),
+                    ('new_int', MarqoFieldTypes.INT),
+                    ('new_float', MarqoFieldTypes.FLOAT),
+                    ('new_map.a', MarqoFieldTypes.INT_MAP),
+                    ('new_map.b', MarqoFieldTypes.FLOAT_MAP),
+                    ('int_map.b', None),
+                    ('float_map.d', None)
+                ]
                 
-                
-                self._assert_field_types(field_names, field_types, id)
+                self._assert_field_types(id, field_type_pairs)
                 
                 # Also check score modifiers values
                 raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
@@ -554,12 +602,14 @@ class TestPartialUpdate(MarqoTestCase):
                 
                 # Verify field types
                 # Verify field types using helper method
-                field_names = ['int_map_2.d', 'int_map_2.e', 'float_map_2.f', 'new_int', 'new_float']
-                field_types = [MarqoFieldTypes.INT_MAP.value, MarqoFieldTypes.INT_MAP.value, 
-                              MarqoFieldTypes.FLOAT_MAP.value, MarqoFieldTypes.INT.value, 
-                              MarqoFieldTypes.FLOAT.value]
-                
-                self._assert_field_types(field_names, field_types, id)
+                field_type_pairs = [
+                    ('int_map_2.d', MarqoFieldTypes.INT_MAP),
+                    ('int_map_2.e', MarqoFieldTypes.INT_MAP),
+                    ('float_map_2.f', MarqoFieldTypes.FLOAT_MAP),
+                    ('new_int', MarqoFieldTypes.INT),
+                    ('new_float', MarqoFieldTypes.FLOAT)
+                ]
+                self._assert_field_types(id, field_type_pairs)
                 
                 res = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
                 doc = res.document.dict().get('fields')
@@ -640,11 +690,14 @@ class TestPartialUpdate(MarqoTestCase):
                 self.assertEqual(10.0, doc['new_float_field'], f"Expected new_float_field to be 10.0 for document {id}")
                 
                 # Verify field types
-                field_names = ['new_field', 'new_float', 'new_int_map.a', 'new_bool_field', 'new_float_field']
-                field_types = [MarqoFieldTypes.INT.value, MarqoFieldTypes.FLOAT.value, MarqoFieldTypes.INT_MAP.value, 
-                               MarqoFieldTypes.BOOL.value, MarqoFieldTypes.FLOAT.value]
-                
-                self._assert_field_types(field_names, field_types, id)
+                field_type_pairs = [
+                    ('new_field', MarqoFieldTypes.INT),
+                    ('new_float', MarqoFieldTypes.FLOAT),
+                    ('new_int_map.a', MarqoFieldTypes.INT_MAP),
+                    ('new_bool_field', MarqoFieldTypes.BOOL),
+                    ('new_float_field', MarqoFieldTypes.FLOAT)
+                ]
+                self._assert_field_types(id, field_type_pairs)
 
     # Reject any tensor field change
     def test_partial_update_should_reject_tensor_field(self):
@@ -796,17 +849,15 @@ class TestPartialUpdate(MarqoTestCase):
                 self._assert_fields_unchanged(doc, ['int_map.a', 'int_map.b', 'int_map.c', 'float_map.c', 'float_map.e', 'float_map.d'])
                 
                 # Verify field types
-                # Verify field types
                 self._assert_field_types(
-                    ['int_map.a', 'int_map.b', 'int_map.c', 'float_map.c', 'float_map.e'],
+                    id,
                     [
-                        MarqoFieldTypes.INT_MAP.value,
-                        MarqoFieldTypes.INT_MAP.value,
-                        MarqoFieldTypes.INT_MAP.value,
-                        MarqoFieldTypes.FLOAT_MAP.value,
-                        MarqoFieldTypes.FLOAT_MAP.value
-                    ],
-                    id
+                        ('int_map.a', MarqoFieldTypes.INT_MAP),
+                        ('int_map.b', MarqoFieldTypes.INT_MAP),
+                        ('int_map.c', MarqoFieldTypes.INT_MAP),
+                        ('float_map.c', MarqoFieldTypes.FLOAT_MAP),
+                        ('float_map.e', MarqoFieldTypes.FLOAT_MAP)
+                    ]
                 )
 
     def test_partial_update_should_reject_invalid_map_values(self):

--- a/tests/integ_tests/core/document/test_partial_update_semi_structured.py
+++ b/tests/integ_tests/core/document/test_partial_update_semi_structured.py
@@ -4,6 +4,7 @@ import pytest
 
 from marqo.api.exceptions import InvalidFieldNameError
 from marqo.core.models.add_docs_params import AddDocsParams
+from marqo.core.semi_structured_vespa_index.marqo_field_types import MarqoFieldTypes
 from marqo.tensor_search import tensor_search
 from integ_tests.marqo_test import MarqoTestCase
 
@@ -22,12 +23,14 @@ class TestPartialUpdate(MarqoTestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.doc = {
+        self.doc = { # This document helps us understand / test behavior of partial updating fields when
+            # Those fields don't exist in the original document
             '_id': '1',
             "string_array": ["aaa", "bbb"],
             "string_array2": ["123", "456"],
         }
-        self.doc2 = {
+        self.doc2 = { # This document helps us test behavior of partial updating fields when
+            # Those fields already exist in the original document
             '_id': '2',
             'tensor_field': 'title',
             'tensor_subfield': 'description',
@@ -47,7 +50,7 @@ class TestPartialUpdate(MarqoTestCase):
             },
             "lexical_field": "some string that signifies lexical field"
         }
-        self.doc3 = {
+        self.doc3 = { # This document doesn't contain any string arrays, it's used to test adding new string arrays
             '_id': '3',
             'tensor_field': 'title',
             'tensor_subfield': 'description',
@@ -116,7 +119,7 @@ class TestPartialUpdate(MarqoTestCase):
         This test verifies that boolean fields can be updated for multiple documents
         while ensuring other fields remain unchanged.
         """
-        test_docs = [self.doc, self.doc2]
+        test_docs = [self.doc, self.doc2, self.doc3]
         
         # First update the documents
         for doc in test_docs:
@@ -132,6 +135,11 @@ class TestPartialUpdate(MarqoTestCase):
                 updated_doc = tensor_search.get_document_by_id(self.config, self.index.name, id)
                 self.assertFalse(updated_doc['bool_field'], f"Expected bool_field to be False for document {id}")
                 self._assert_fields_unchanged(updated_doc, ['bool_field'])
+
+                # Verify field type
+                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
+                vespa_fields = raw_vespa_doc.document.dict().get('fields')
+                self.assertEqual(vespa_fields['marqo__field_types']['bool_field'], 'bool', f"Expected bool_field to have type 'bool' for document {id}")
 
     def test_partial_update_should_update_int_field_to_int(self):
         """Test that integer fields can be updated correctly via partial updates.
@@ -156,330 +164,540 @@ class TestPartialUpdate(MarqoTestCase):
                 self.assertEqual(500, updated_doc['int_field'], f"Expected int_field to be 500 for document {id}")
                 self._assert_fields_unchanged(updated_doc, ['int_field'])
 
+                
+                # Verify field type
+                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
+                vespa_fields = raw_vespa_doc.document.dict().get('fields')
+                self.assertEqual(vespa_fields['marqo__field_types']['int_field'], MarqoFieldTypes.INT.value, f"Expected int_field to have type {MarqoFieldTypes.INT.value} for document {id}")
+
     def test_partial_update_to_non_existent_field(self): 
         """Test that partial updates to non-existent fields are successful.
         
         This test case basically verifies that we can add new fields via partial updates
         """
-        res = self.config.document.partial_update_documents([{'_id': '2', 'update_field_that_doesnt_exist': 500}], self.index)
-        self.assertFalse(res.errors)
-        doc = tensor_search.get_document_by_id(self.config, self.index.name, '2')
-        self.assertEqual(500, doc['update_field_that_doesnt_exist'])
-        self._assert_fields_unchanged(doc, ['update_field_that_doesnt_exist'])
+        test_docs = [self.doc, self.doc2, self.doc3]
+        
+        for doc in test_docs:
+            with self.subTest(f"Adding new field to document with ID {doc['_id']}"):
+                id = doc['_id']
+                res = self.config.document.partial_update_documents([{'_id': id, 'update_field_that_doesnt_exist': 500}], self.index)
+                self.assertFalse(res.errors, f"Expected no errors when updating document {id}")
+                
+                doc = tensor_search.get_document_by_id(self.config, self.index.name, id)
+                self.assertEqual(500, doc['update_field_that_doesnt_exist'], f"Expected new field value to be 500 for document {id}")
+                self._assert_fields_unchanged(doc, ['update_field_that_doesnt_exist'])
+                
+                # Verify field type
+                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
+                vespa_fields = raw_vespa_doc.document.dict().get('fields')
+                self.assertEqual(vespa_fields['marqo__field_types']['update_field_that_doesnt_exist'], MarqoFieldTypes.INT.value,
+                              f"Expected update_field_that_doesnt_exist to have type {MarqoFieldTypes.INT.value} for document {id}")
 
     def test_partial_update_should_not_update_int_field_to_float(self):
         """Test that partial updates to int fields are rejected when the value is a float.
         
         This test verifies that partial updates to int fields are rejected when the value is a float.
         """
-        res = self.config.document.partial_update_documents([{'_id': '2', 'int_field': 1.0}], self.index)
-        self.assertTrue(res.errors)
-        self.assertIn('reference/api/documents/update-documents/#response', res.items[0].error)
-        self.assertIn("Marqo vector store couldn't update the document. Please see", res.items[0].error)
-        self.assertEqual(400, res.items[0].status)
+        test_docs = [self.doc2, self.doc3]
+        
+        for doc in test_docs:
+            with self.subTest(f"Attempting to update int field to float for document with ID {doc['_id']}"):
+                id = doc['_id']
+                res = self.config.document.partial_update_documents([{'_id': id, 'int_field': 1.0}], self.index)
+                self.assertTrue(res.errors)
+                self.assertIn('reference/api/documents/update-documents/#response', res.items[0].error)
+                self.assertIn("Marqo vector store couldn't update the document. Please see", res.items[0].error)
+                self.assertEqual(400, res.items[0].status)
 
     def test_partial_update_should_update_float_field_to_float(self):
         """Test that partial updates to float fields are successful.
         
         This test verifies that partial updates to float fields are successful.
         """
-        res = self.config.document.partial_update_documents([{'_id': '2', 'float_field': 500.0}], self.index)
-        self.assertFalse(res.errors)
-        doc = tensor_search.get_document_by_id(self.config, self.index.name, '2')
-        self.assertEqual(500.0, doc['float_field'])
-        self._assert_fields_unchanged(doc, ['float_field'])
+        test_docs = [self.doc, self.doc2, self.doc3]
+        
+        for doc in test_docs:
+            with self.subTest(f"Updating float field for document with ID {doc['_id']}"):
+                id = doc['_id']
+                res = self.config.document.partial_update_documents([{'_id': id, 'float_field': 500.0}], self.index)
+                self.assertFalse(res.errors, f"Expected no errors when updating document {id}")
+                
+                doc = tensor_search.get_document_by_id(self.config, self.index.name, id)
+                self.assertEqual(500.0, doc['float_field'], f"Expected float_field to be 500.0 for document {id}")
+                self._assert_fields_unchanged(doc, ['float_field'])
+                
+                # Verify field type
+                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
+                vespa_fields = raw_vespa_doc.document.dict().get('fields')
+                self.assertEqual(vespa_fields['marqo__field_types']['float_field'], 'float', 
+                              f"Expected float_field to have type 'float' for document {id}")
 
     def test_partial_update_should_update_int_map(self):
         """Test that partial updates to int maps are successful.
         
         This test verifies that partial updates to int maps are successful.
         """
-        res = self.config.document.partial_update_documents([{'_id': '2', 'int_map': {'a': 2, 'b': 3}}], self.index)
-        self.assertFalse(res.errors)
-        doc = tensor_search.get_document_by_id(self.config, self.index.name, '2')
-        self.assertEqual(doc['int_map.a'], 2)
-        self.assertEqual(doc['int_map.b'], 3)
-        self._assert_fields_unchanged(doc, ['int_map'])
+        test_docs = [self.doc, self.doc2, self.doc3]
+        
+        for doc in test_docs:
+            with self.subTest(f"Updating int map for document with ID {doc['_id']}"):
+                id = doc['_id']
+                res = self.config.document.partial_update_documents([{'_id': id, 'int_map': {'c': 2, 'd': 3}}], self.index)
+                self.assertFalse(res.errors, f"Expected no errors when updating document {id}")
+                
+                doc = tensor_search.get_document_by_id(self.config, self.index.name, id)
+                self.assertEqual(doc['int_map.c'], 2, f"Expected int_map.c to be 2 for document {id}")
+                self.assertEqual(doc['int_map.d'], 3, f"Expected int_map.d to be 3 for document {id}")
+                self._assert_fields_unchanged(doc, ['int_map'])
+                
+                # Verify field type
+                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
+                vespa_fields = raw_vespa_doc.document.dict().get('fields')
+                self.assertEqual(vespa_fields['marqo__field_types']['int_map.c'], MarqoFieldTypes.INT_MAP.value, 
+                                  f"Expected int_map.c to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['int_map.d'], MarqoFieldTypes.INT_MAP.value, 
+                                  f"Expected int_map.d to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
 
     def test_partial_update_should_replace_int_map(self):
         """Test that partial updates to int maps where we change the keys inside
         a specific int map are successful
         """
-        res = self.config.document.partial_update_documents([{'_id': '2', 'int_map': {'f': 2, 'g': 3}}], self.index)
-        self.assertFalse(res.errors)
-        doc = tensor_search.get_document_by_id(self.config, self.index.name, '2')
-        self.assertEqual(doc['int_map.f'], 2)
-        self.assertEqual(doc['int_map.g'], 3)
-        self.assertEqual(doc.get('int_map.a'), None)
-        self.assertEqual(doc.get('int_map.b'), None)
-        self._assert_fields_unchanged(doc, ['int_map'])
+        test_docs = [self.doc,self.doc2, self.doc3]
+        
+        for doc in test_docs:
+            with self.subTest(f"Replacing int map keys for document with ID {doc['_id']}"):
+                id = doc['_id']
+                res = self.config.document.partial_update_documents([{'_id': id, 'int_map': {'f': 2, 'g': 3}}], self.index)
+                self.assertFalse(res.errors, f"Expected no errors when updating document {id}")
+                
+                doc = tensor_search.get_document_by_id(self.config, self.index.name, id)
+                self.assertEqual(doc['int_map.f'], 2, f"Expected int_map.f to be 2 for document {id}")
+                self.assertEqual(doc['int_map.g'], 3, f"Expected int_map.g to be 3 for document {id}")
+                self.assertEqual(doc.get('int_map.a'), None, f"Expected int_map.a to be None for document {id}")
+                self.assertEqual(doc.get('int_map.b'), None, f"Expected int_map.b to be None for document {id}")
+                self._assert_fields_unchanged(doc, ['int_map'])
+                
+                # Verify field type
+                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
+                vespa_fields = raw_vespa_doc.document.dict().get('fields')
+                self.assertEqual(vespa_fields['marqo__field_types']['int_map.f'], MarqoFieldTypes.INT_MAP.value, 
+                              f"Expected int_map.f to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['int_map.g'], MarqoFieldTypes.INT_MAP.value, 
+                              f"Expected int_map.g to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
 
     def test_partial_update_should_update_int_map_with_new_value(self):
-        """Test that partial updates to int maps with new values are successful.
+        """Test that partial updates to int maps with new values are successful."""
+        test_docs = [self.doc2, self.doc3]
         
-        This test verifies that partial updates to int maps with new values are successful.
-        """
-        res = self.config.document.partial_update_documents([{'_id': '2', 'int_map': {
-            'd': 2
-          }
-        }], self.index)
-        doc = tensor_search.get_document_by_id(self.config, self.index.name, '2')
-        self.assertIsNone(doc.get('int_map.a'))
-        self.assertIsNone(doc.get('int_map.b'))
-        self.assertEqual(doc['int_map.d'], 2)
+        for doc in test_docs:
+            with self.subTest(f"Adding new key to int map for document with ID {doc['_id']}"):
+                id = doc['_id']
+                res = self.config.document.partial_update_documents([{'_id': id, 'int_map': {
+                    'd': 2
+                }}], self.index)
+                self.assertFalse(res.errors, f"Expected no errors when updating document {id}")
+                
+                doc = tensor_search.get_document_by_id(self.config, self.index.name, id)
+                self.assertIsNone(doc.get('int_map.a'), f"Expected int_map.a to be None for document {id}")
+                self.assertIsNone(doc.get('int_map.b'), f"Expected int_map.b to be None for document {id}")
+                self.assertEqual(doc['int_map.d'], 2, f"Expected int_map.d to be 2 for document {id}")
+                
+                # Verify field type
+                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
+                vespa_fields = raw_vespa_doc.document.dict().get('fields')
+                self.assertEqual(vespa_fields['marqo__field_types']['int_map.d'], MarqoFieldTypes.INT_MAP.value, 
+                              f"Expected int_map.d to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
 
+                #Verify that the int_map.a and int_map.b is removed from the field types
+                self.assertEqual(vespa_fields['marqo__field_types'].get('int_map.a', None), None)
+                self.assertEqual(vespa_fields['marqo__field_types'].get('int_map.b', None), None)
 
     def test_partial_update_should_update_float_map(self):
         """Test that partial updates to float maps are successful.
         
         This test verifies that partial updates to float maps are successful.
         """
-        res = self.config.document.partial_update_documents([{'_id': '2', 'float_map': {'c': 2.0, 'd': 3.0}}],
-                                                            self.index)
-        self.assertFalse(res.errors)
-        doc = tensor_search.get_document_by_id(self.config, self.index.name, '2')
-        self.assertEqual(doc['float_map.c'], 2.0)
-        self.assertEqual(doc['float_map.d'], 3.0)
-        self._assert_fields_unchanged(doc, ['float_map'])
-
+        test_docs = [self.doc2, self.doc3]
+        
+        for doc in test_docs:
+            with self.subTest(f"Updating float map for document with ID {doc['_id']}"):
+                id = doc['_id']
+                res = self.config.document.partial_update_documents([{'_id': id, 'float_map': {'c': 2.0, 'd': 3.0}}], self.index)
+                self.assertFalse(res.errors, f"Expected no errors when updating document {id}")
+                
+                doc = tensor_search.get_document_by_id(self.config, self.index.name, id)
+                self.assertEqual(doc['float_map.c'], 2.0, f"Expected float_map.c to be 2.0 for document {id}")
+                self.assertEqual(doc['float_map.d'], 3.0, f"Expected float_map.d to be 3.0 for document {id}")
+                self._assert_fields_unchanged(doc, ['float_map'])
+                
+                # Verify field type
+                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
+                vespa_fields = raw_vespa_doc.document.dict().get('fields')
+                self.assertEqual(vespa_fields['marqo__field_types']['float_map.c'], MarqoFieldTypes.FLOAT_MAP.value, 
+                              f"Expected float_map.c to have type {MarqoFieldTypes.FLOAT_MAP.value} for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['float_map.d'], MarqoFieldTypes.FLOAT_MAP.value, 
+                              f"Expected float_map.d to have type {MarqoFieldTypes.FLOAT_MAP.value} for document {id}")
 
     def test_partial_update_should_allow_changing_multiple_maps_in_same_request(self):
         """Test that partial updates to multiple maps in the same request are successful.
         
         This test verifies that partial updates to multiple maps in the same request are successful.
         """
-
-
-        res = self.config.document.partial_update_documents([{'_id': '2', 'int_field': 2, 'int_map': {
-            'a': 2,  # update int to int
-        }, 'float_map': {
-            'c': 3.0,  # update float to float
-        }, 'bool_field': False, 'float_field': 500.0}], self.index)
-        self.assertFalse(res.errors)
-
-        doc = tensor_search.get_document_by_id(self.config, self.index.name, '2')
-        self.assertEqual(2, doc['int_field'])
-        self.assertFalse(doc['bool_field'])
-        self.assertEqual(500.0, doc['float_field'])
-        self.assertEqual(doc['int_map.a'], 2)
-        self.assertIsNone(doc.get('int_map.b'))
-        self.assertEqual(doc['float_map.c'], 3.0)
-        self.assertIsNone(doc.get('float_map.d'))
-        self._assert_fields_unchanged(doc, ['int_map.a', 'int_map.b', 'float_map.d', 'float_map.c', 'int_field', 'bool_field', 'float_field'])
+        test_docs = [self.doc2, self.doc3]
+        
+        for doc in test_docs:
+            with self.subTest(f"Updating multiple fields for document with ID {doc['_id']}"):
+                id = doc['_id']
+                res = self.config.document.partial_update_documents([{'_id': id, 'int_field': 2, 'int_map': {
+                    'a': 2,  # update int to int
+                }, 'float_map': {
+                    'c': 3.0,  # update float to float
+                }, 'bool_field': False, 'float_field': 500.0}], self.index)
+                self.assertFalse(res.errors, f"Expected no errors when updating document {id}")
+                
+                doc = tensor_search.get_document_by_id(self.config, self.index.name, id)
+                self.assertEqual(2, doc['int_field'], f"Expected int_field to be 2 for document {id}")
+                self.assertFalse(doc['bool_field'], f"Expected bool_field to be False for document {id}")
+                self.assertEqual(500.0, doc['float_field'], f"Expected float_field to be 500.0 for document {id}")
+                self.assertEqual(doc['int_map.a'], 2, f"Expected int_map.a to be 2 for document {id}")
+                self.assertIsNone(doc.get('int_map.b'), f"Expected int_map.b to be None for document {id}")
+                self.assertEqual(doc['float_map.c'], 3.0, f"Expected float_map.c to be 3.0 for document {id}")
+                self.assertIsNone(doc.get('float_map.d'), f"Expected float_map.d to be None for document {id}")
+                self._assert_fields_unchanged(doc, ['int_map.a', 'int_map.b', 'float_map.d', 'float_map.c', 'int_field', 'bool_field', 'float_field'])
 
     def test_partial_update_should_update_string_array(self):
         """Test that partial updates to string arrays are successful.
         
         This test verifies that partial updates to string arrays are successful.
         """
-        res = self.config.document.partial_update_documents([{'_id': '2', 'string_array': ["ccc"]}], self.index)
-        self.assertFalse(res.errors)
-
-        doc = tensor_search.get_document_by_id(self.config, self.index.name, '2')
-        self.assertEqual(["ccc"], doc['string_array'])
-        self._assert_fields_unchanged(doc, ['string_array'])
+        test_docs = [self.doc, self.doc2, self.doc3]
+        
+        for doc in test_docs:
+            with self.subTest(f"Updating string array for document with ID {doc['_id']}"):
+                id = doc['_id']
+                res = self.config.document.partial_update_documents([{'_id': id, 'string_array': ["ccc"]}], self.index)
+                self.assertFalse(res.errors, f"Expected no errors when updating document {id}")
+                
+                doc = tensor_search.get_document_by_id(self.config, self.index.name, id)
+                self.assertEqual(["ccc"], doc['string_array'], f"Expected string_array to be ['ccc'] for document {id}")
+                self._assert_fields_unchanged(doc, ['string_array'])
+                
+                # Verify field type
+                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
+                vespa_fields = raw_vespa_doc.document.dict().get('fields')
+                self.assertEqual(vespa_fields['marqo__field_types']['string_array'], 'string_array', 
+                              f"Expected string_array to have type 'string_array' for document {id}")
 
     def test_partial_update_should_reject_new_string_array_field(self):
-        """Test that partial updates to string arrays are successful.
-
-        This test verifies that partial updates to string arrays are successful.
-        """
-        res = self.config.document.partial_update_documents([{'_id': '2', 'string_array3': ["ccc"]}],
-                                                            self.index)
-        self.assertTrue(res.errors)
-        self.assertEqual(400, res.items[0].status)
-        self.assertIn('Unstructured index updates only support updating existing string array fields', res.items[0].error)
+        """Test that partial updates to new string arrays are rejected."""
+        test_docs = [self.doc, self.doc2, self.doc3]
+        
+        for doc in test_docs:
+            with self.subTest(f"Adding new string array for document with ID {doc['_id']}"):
+                id = doc['_id']
+                res = self.config.document.partial_update_documents([{'_id': id, 'string_array3': ["ccc"]}], self.index)
+                self.assertTrue(res.errors, f"Expected errors when adding new string array to document {id}")
+                self.assertEqual(400, res.items[0].status)
+                self.assertIn('Unstructured index updates only support updating existing string array fields', res.items[0].error)
 
     def test_partial_update_should_allow_adding_new_string_string_array_field_if_present_in_other_docs_in_same_index(self):
         """Tests that partial updates allow adding new string / string array fields if they are present in some other document in the same index.
 
         For example, doc2 contains lexical_field and string_array. Hence when we try to add lexical_field and string_array to doc1, it should be allowed.
         """
-        res = self.config.document.partial_update_documents([{'_id': '1', "lexical_field": "some value 2", 'string_array': ["ccc"]}],
-                                                            self.config.index_management.get_index(self.index.name))
-        self.assertFalse(res.errors)
-        doc = tensor_search.get_document_by_id(self.config, self.index.name, '1')
-        self.assertEqual("some value 2", doc['lexical_field'])
-        self.assertEqual(["ccc"], doc['string_array'])
+        test_docs = [self.doc, self.doc3]
+        
+        for doc in test_docs:
+            with self.subTest(f"Adding field from another document to document with ID {doc['_id']}"):
+                id = doc['_id']
+                res = self.config.document.partial_update_documents([{'_id': id, "lexical_field": "some value 2", 'string_array': ["ccc"]}],
+                                                                self.config.index_management.get_index(self.index.name))
+                self.assertFalse(res.errors, f"Expected no errors when updating document {id}")
+                
+                doc = tensor_search.get_document_by_id(self.config, self.index.name, id)
+                self.assertEqual("some value 2", doc['lexical_field'], f"Expected lexical_field to be 'some value 2' for document {id}")
+                self.assertEqual(["ccc"], doc['string_array'], f"Expected string_array to be ['ccc'] for document {id}")
 
     def test_partial_update_should_update_short_string(self):
-        """Test that partial updates to short strings are successful.
+        """Test that partial updates to short strings are successful."""
+        test_docs = [self.doc2, self.doc3]
         
-        This test verifies that partial updates to short strings are successful.
-        """
-        index = self.config.index_management.get_index(self.index.name)
-        res = self.config.document.partial_update_documents(
-            [{'_id': '2', 'short_string_field': 'updated_short_string'}], index)
-        self.assertFalse(res.errors)
-
-        doc = tensor_search.get_document_by_id(self.config, self.index.name, '2')
-        self.assertEqual('updated_short_string', doc['short_string_field'])
-        self._assert_fields_unchanged(doc, ['short_string_field'])
+        for doc in test_docs:
+            with self.subTest(f"Updating short string for document with ID {doc['_id']}"):
+                id = doc['_id']
+                index = self.config.index_management.get_index(self.index.name)
+                res = self.config.document.partial_update_documents(
+                    [{'_id': id, 'short_string_field': 'updated_short_string'}], index)
+                self.assertFalse(res.errors, f"Expected no errors when updating document {id}")
+                
+                doc = tensor_search.get_document_by_id(self.config, self.index.name, id)
+                self.assertEqual('updated_short_string', doc['short_string_field'], f"Expected short_string_field to be 'updated_short_string' for document {id}")
+                self._assert_fields_unchanged(doc, ['short_string_field'])
+                
+                # Verify field type
+                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
+                vespa_fields = raw_vespa_doc.document.dict().get('fields')
+                self.assertEqual(vespa_fields['marqo__field_types']['short_string_field'], 'string', 
+                              f"Expected short_string_field to have type 'string' for document {id}")
 
     def test_partial_update_should_update_long_string(self):
-        """Test that partial updates to long strings are successful.
+        """Test that partial updates to long strings are successful."""
+        test_docs = [self.doc2, self.doc3]
         
-        This test verifies that partial updates to long strings are successful.
-        """
-        index = self.config.index_management.get_index(self.index.name)
-        res = self.config.document.partial_update_documents(
-            [{'_id': '2', 'long_string_field': 'updated_long_string' * 10}], index)
-        self.assertFalse(res.errors)
-
-        doc = tensor_search.get_document_by_id(self.config, self.index.name, '2')
-        self.assertEqual('updated_long_string' * 10, doc['long_string_field'])
-        self._assert_fields_unchanged(doc, ['long_string_field'])
+        for doc in test_docs:
+            with self.subTest(f"Updating long string for document with ID {doc['_id']}"):
+                id = doc['_id']
+                index = self.config.index_management.get_index(self.index.name)
+                res = self.config.document.partial_update_documents(
+                    [{'_id': id, 'long_string_field': 'updated_long_string' * 10}], index)
+                self.assertFalse(res.errors, f"Expected no errors when updating document {id}")
+                
+                doc = tensor_search.get_document_by_id(self.config, self.index.name, id)
+                self.assertEqual('updated_long_string' * 10, doc['long_string_field'], f"Expected long_string_field to be updated for document {id}")
+                self._assert_fields_unchanged(doc, ['long_string_field'])
+                
+                # Verify field type
+                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
+                vespa_fields = raw_vespa_doc.document.dict().get('fields')
+                self.assertEqual(vespa_fields['marqo__field_types']['long_string_field'], 'string', 
+                              f"Expected long_string_field to have type 'string' for document {id}")
 
     def test_partial_update_should_update_long_string_to_short_string(self):
-        """Test that partial updates to long strings are successful.
+        """Test that partial updates to long strings to short strings are successful."""
+        test_docs = [self.doc2, self.doc3]
         
-        This test verifies that partial updates to long strings are successful.
-        """
-        res = tensor_search.search(self.config, self.index.name, text='*',
-                                   filter=f'long_string_field:{self.doc2["long_string_field"]}')
-        self.assertEqual(0, len(res['hits']))
-        index = self.config.index_management.get_index(self.index.name)
-
-        res = self.config.document.partial_update_documents([{'_id': '2', 'long_string_field': 'short'}], index)
-        self.assertFalse(res.errors)
-
-        doc = tensor_search.get_document_by_id(self.config, self.index.name, '2')
-        self.assertEqual('short', doc['long_string_field'])
-        self._assert_fields_unchanged(doc, ['long_string_field'])
-
-        res = tensor_search.search(self.config, self.index.name, text='*', filter=f'long_string_field:short')
-        self.assertEqual(1, len(res['hits']))
+        for doc in test_docs:
+            with self.subTest(f"Updating long string to short string for document with ID {doc['_id']}"):
+                id = doc['_id']
+                index = self.config.index_management.get_index(self.index.name)
+                res = self.config.document.partial_update_documents(
+                    [{'_id': id, 'long_string_field': 'short'}], index)
+                self.assertFalse(res.errors, f"Expected no errors when updating document {id}")
+                
+                doc = tensor_search.get_document_by_id(self.config, self.index.name, id)
+                self.assertEqual('short', doc['long_string_field'], f"Expected long_string_field to be 'short' for document {id}")
+                self._assert_fields_unchanged(doc, ['long_string_field'])
+                
+                # Verify field type
+                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
+                vespa_fields = raw_vespa_doc.document.dict().get('fields')
+                self.assertEqual(vespa_fields['marqo__field_types']['long_string_field'], MarqoFieldTypes.STRING.value, 
+                              f"Expected long_string_field to have type {MarqoFieldTypes.STRING.value} for document {id}")
 
     def test_partial_update_should_update_short_string_to_long_string(self):
-        """Test that partial updates to short strings are successful.
-        
-        This test verifies that partial updates to short strings are successful.
-        """
+        """Test that partial updates to short strings to long strings are successful."""
+
+        id = self.doc2['_id']
+        original_value = self.doc2["short_string_field"]
         res = tensor_search.search(self.config, self.index.name, text='*',
-                                   filter=f'short_string_field:{self.doc2["short_string_field"]}')
+                                filter=f'short_string_field:{original_value}')
         self.assertEqual(2, len(res['hits']))
 
         index = self.config.index_management.get_index(self.index.name)
+        res = self.config.document.partial_update_documents([{'_id': id, 'short_string_field': 'verylongstring'*10}], index)
+        self.assertFalse(res.errors, f"Expected no errors when updating document {id}")
 
-        res = self.config.document.partial_update_documents([{'_id': '2', 'short_string_field': 'verylongstring'*10}], index)
-        self.assertFalse(res.errors)
-
-        doc = tensor_search.get_document_by_id(self.config, self.index.name, '2')
-        self.assertEqual('verylongstring'*10, doc['short_string_field'])
+        doc = tensor_search.get_document_by_id(self.config, self.index.name, id)
+        self.assertEqual('verylongstring'*10, doc['short_string_field'], f"Expected short_string_field to be updated for document {id}")
         self._assert_fields_unchanged(doc, ['short_string_field'])
 
         res = tensor_search.search(self.config, self.index.name, text='*',
-                                   filter=f'short_string_field:{self.doc3["short_string_field"]}')
+                                filter=f'short_string_field:{original_value}')
         self.assertEqual(1, len(res['hits']))
 
     def test_partial_update_should_update_score_modifiers(self):
-        """Test that partial updates to score modifiers are successful.
+        """Test that partial updates to score modifiers are successful."""
+        test_docs = [self.doc2, self.doc3]
         
-        This test verifies that partial updates to score modifiers are successful.
-        """
-        res = self.config.document.partial_update_documents([{'_id': '2', 'int_map': {
-            'a': 2,  # update int to int
-            'd': 5,  # new entry in int map
-        }, 'float_map': {
-            'c': 3.0,  # update float to float
-        }, 'new_int' : 1,  # new int field
-            'new_float': 2.0,  # new float field
-            'new_map': {'a': 1, 'b': 2.0},  # new map field
-          }], self.index)
-        self.assertFalse(res.errors)
-        res = self.config.vespa_client.get_document('2', self.config.index_management.get_index(self.index.name).schema_name)
-        doc = res.document.dict().get('fields')
-        self.assertEqual(doc['marqo__score_modifiers']['cells']['int_field'], 123.0)
-        self.assertEqual(doc['marqo__score_modifiers']['cells']['float_field'], 123.0)
-        self.assertEqual(doc['marqo__score_modifiers']['cells']['int_map.a'], 2.0)
-        self.assertEqual(doc['marqo__score_modifiers']['cells']['float_map.c'], 3.0)
-        self.assertEqual(doc['marqo__score_modifiers']['cells'].get('int_map.b', None), None)
-        self.assertEqual(doc['marqo__score_modifiers']['cells'].get('float_map.d', None), None)
-        self.assertEqual(doc['marqo__score_modifiers']['cells']['new_int'], 1.0)
-        self.assertEqual(doc['marqo__score_modifiers']['cells']['new_float'], 2.0)
-        self.assertEqual(doc['marqo__score_modifiers']['cells']['new_map.a'], 1.0)
-        self.assertEqual(doc['marqo__score_modifiers']['cells']['new_map.b'], 2.0)
-        self.assertEqual(doc['marqo__score_modifiers']['cells']['int_map.d'], 5.0)
+        for doc in test_docs:
+            with self.subTest(f"Updating score modifiers for document with ID {doc['_id']}"):
+                id = doc['_id']
+                res = self.config.document.partial_update_documents([{'_id': id, 'int_map': {
+                    'a': 2,  # update int to int
+                    'd': 5,  # new entry in int map
+                }, 'float_map': {
+                    'c': 3.0,  # update float to float
+                }, 'new_int' : 1,  # new int field
+                    'new_float': 2.0,  # new float field
+                    'new_map': {'a': 1, 'b': 2.0},  # new map field
+                }], self.index)
+                self.assertFalse(res.errors, f"Expected no errors when updating document {id}")
+                
+                # Verify field types
+                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
+                vespa_fields = raw_vespa_doc.document.dict().get('fields')
+                
+                self.assertEqual(vespa_fields['marqo__field_types']['int_map.a'], MarqoFieldTypes.INT_MAP.value, 
+                              f"Expected int_map.a to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['int_map.d'], MarqoFieldTypes.INT_MAP.value, 
+                              f"Expected int_map.d to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['float_map.c'], MarqoFieldTypes.FLOAT_MAP.value, 
+                              f"Expected float_map.c to have type {MarqoFieldTypes.FLOAT_MAP.value} for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['new_int'], MarqoFieldTypes.INT.value, 
+                              f"Expected new_int to have type {MarqoFieldTypes.INT.value} for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['new_float'], MarqoFieldTypes.FLOAT.value, 
+                              f"Expected new_float to have type {MarqoFieldTypes.FLOAT.value} for document {id}")
+
+                # assert that the map keys that must've been removed don't exist in marqo__field_types
+                self.assertEqual(vespa_fields['marqo__field_types'].get('int_map.b', None), None)
+                self.assertEqual(vespa_fields['marqo__field_types'].get('float_map.d', None), None)
+
+                # Check the new map fields
+                self.assertEqual(vespa_fields['marqo__field_types']['new_map.a'], MarqoFieldTypes.INT_MAP.value, 
+                              f"Expected new_map.a to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['new_map.b'], MarqoFieldTypes.FLOAT_MAP.value, 
+                              f"Expected new_map.b to have type {MarqoFieldTypes.FLOAT_MAP.value} for document {id}")
+                
+                # Also check score modifiers values
+                doc = raw_vespa_doc.document.dict().get('fields')
+                int_field_val = self.id_to_doc[id].get('int_field', 0)
+                self.assertEqual(doc['marqo__score_modifiers']['cells']['int_field'], float(int_field_val))
+                float_field_val = self.id_to_doc[id].get('float_field', 0)
+                self.assertEqual(doc['marqo__score_modifiers']['cells']['float_field'], float(float_field_val))
+                self.assertEqual(doc['marqo__score_modifiers']['cells']['int_map.a'], 2.0)
+                self.assertEqual(doc['marqo__score_modifiers']['cells']['float_map.c'], 3.0)
+
+                # assert that the map keys that must've been removed don't exist in marqo__score_modifiers
+                self.assertEqual(doc['marqo__score_modifiers']['cells'].get('int_map.b', None), None)
+                self.assertEqual(doc['marqo__score_modifiers']['cells'].get('float_map.d', None), None)
+                self.assertEqual(doc['marqo__score_modifiers']['cells']['new_int'], 1.0)
+                self.assertEqual(doc['marqo__score_modifiers']['cells']['new_float'], 2.0)
+                self.assertEqual(doc['marqo__score_modifiers']['cells']['new_map.a'], 1.0)
+                self.assertEqual(doc['marqo__score_modifiers']['cells']['new_map.b'], 2.0)
+                self.assertEqual(doc['marqo__score_modifiers']['cells']['int_map.d'], 5.0)
 
     def test_partial_update_should_add_score_modifiers(self):
-        """Test that partial updates which specifically add new fields reflect properly in score modifiers tensors.
-        """
-        # Create a document with existing fields first to verify we're only adding
-        original_doc = tensor_search.get_document_by_id(self.config, self.index.name, '2')
+        """Test that partial updates which specifically add new fields reflect properly in score modifiers tensors."""
+        test_docs = [self.doc, self.doc2, self.doc3]
         
-        # Perform update with only additions, not replacements
-        res = self.config.document.partial_update_documents([{
-            '_id': '2',
-            'int_map_2': {
-                'd': 5,  # adding entirely new map
-                'e': 6,
-            },
-            'float_map_2': {
-                'f': 4.0,  # adding entirely new map
-            },
-            'new_int': 1,  # new int field
-            'new_float': 2.0,  # new float field
-        }], self.index)
-        self.assertFalse(res.errors)
-        res = self.config.vespa_client.get_document('2',
-                                                    self.config.index_management.get_index(self.index.name).schema_name)
-        doc = res.document.dict().get('fields')
-        # Verify original fields are preserved
-        self.assertEqual(doc['marqo__score_modifiers']['cells']['int_field'], 123.0)
-        self.assertEqual(doc['marqo__score_modifiers']['cells']['float_field'], 123.0)
-        self.assertEqual(doc['marqo__score_modifiers']['cells']['int_map.a'], 1.0)
-        self.assertEqual(doc['marqo__score_modifiers']['cells']['float_map.c'], 1.0)
+        for doc in test_docs:
+            with self.subTest(f"Adding score modifiers for document with ID {doc['_id']}"):
+                id = doc['_id']
+                # Create a document with existing fields first to verify we're only adding
+                original_doc = tensor_search.get_document_by_id(self.config, self.index.name, id)
                 
-        # Verify new fields from the update call in this test 
-        self.assertEqual(doc['marqo__score_modifiers']['cells']['new_int'], 1.0)
-        self.assertEqual(doc['marqo__score_modifiers']['cells']['new_float'], 2.0)
-        self.assertEqual(doc['marqo__score_modifiers']['cells']['int_map_2.d'], 5.0)
-        self.assertEqual(doc['marqo__score_modifiers']['cells']['int_map_2.e'], 6.0)
-        self.assertEqual(doc['marqo__score_modifiers']['cells']['float_map_2.f'], 4.0)
+                # Perform update with only additions, not replacements
+                res = self.config.document.partial_update_documents([{
+                    '_id': id,
+                    'int_map_2': {
+                        'd': 5,  # adding entirely new map
+                        'e': 6,
+                    },
+                    'float_map_2': {
+                        'f': 4.0,  # adding entirely new map
+                    },
+                    'new_int': 1,  # new int field
+                    'new_float': 2.0,  # new float field
+                }], self.index)
+                self.assertFalse(res.errors, f"Expected no errors when updating document {id}")
+                
+                # Verify field types
+                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
+                vespa_fields = raw_vespa_doc.document.dict().get('fields')
+                
+                self.assertEqual(vespa_fields['marqo__field_types']['int_map_2.d'], MarqoFieldTypes.INT_MAP.value, 
+                              f"Expected int_map_2.d to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['int_map_2.e'], MarqoFieldTypes.INT_MAP.value, 
+                              f"Expected int_map_2.e to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['float_map_2.f'], MarqoFieldTypes.FLOAT_MAP.value, 
+                              f"Expected float_map_2.f to have type {MarqoFieldTypes.FLOAT_MAP.value} for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['new_int'], MarqoFieldTypes.INT.value, 
+                              f"Expected new_int to have type {MarqoFieldTypes.INT.value} for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['new_float'], MarqoFieldTypes.FLOAT.value, 
+                              f"Expected new_float to have type {MarqoFieldTypes.FLOAT.value} for document {id}")
+                
+                res = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
+                doc = res.document.dict().get('fields')
+                
+                # Check score modifiers values for new fields
+                self.assertEqual(doc['marqo__score_modifiers']['cells']['int_map_2.d'], 5.0)
+                self.assertEqual(doc['marqo__score_modifiers']['cells']['int_map_2.e'], 6.0)
+                self.assertEqual(doc['marqo__score_modifiers']['cells']['float_map_2.f'], 4.0)
+                self.assertEqual(doc['marqo__score_modifiers']['cells']['new_int'], 1.0)
+                self.assertEqual(doc['marqo__score_modifiers']['cells']['new_float'], 2.0)
+                
+                # Verify original fields are preserved (with conditional checks)
+                int_field_val = self.id_to_doc[id].get('int_field')
+                if int_field_val:
+                    self.assertEqual(doc['marqo__score_modifiers']['cells']['int_field'], float(int_field_val))
+                float_field_val = self.id_to_doc[id].get('float_field', 0)
+                if float_field_val:
+                    self.assertEqual(doc['marqo__score_modifiers']['cells']['float_field'], float(float_field_val))
+                int_map_a_val = self.id_to_doc[id].get('int_map', {}).get('a', 0)
+                if int_map_a_val:
+                    self.assertEqual(doc['marqo__score_modifiers']['cells']['int_map.a'], float(int_map_a_val))
+                float_map_c_val = self.id_to_doc[id].get('float_map', {}).get('c', 0)
+                if float_map_c_val:
+                    self.assertEqual(doc['marqo__score_modifiers']['cells']['float_map.c'], float(float_map_c_val))
 
     def test_partial_update_only_update_existing_score_modifiers(self):
-        """
-        Test that partial updates which specifically change the existing keys inside existing maps
-         reflect properly in score modifiers tensors.
-        """
-        # Create a document with existing fields first to verify we're only adding
-        original_doc = tensor_search.get_document_by_id(self.config, self.index.name, '2')
+        """Test that partial updates which specifically change the existing keys inside existing maps
+         reflect properly in score modifiers tensors."""
+        test_docs = [self.doc2, self.doc3]
+        
+        for doc in test_docs:
+            with self.subTest(f"Updating existing score modifiers for document with ID {doc['_id']}"):
+                id = doc['_id']
+                # Create a document with existing fields first to verify we're only adding
+                original_doc = tensor_search.get_document_by_id(self.config, self.index.name, id)
 
-        # Perform update with only additions, not replacements
-        res = self.config.document.partial_update_documents([{
-            '_id': '2',
-            "int_map": {"a": 3, "b": 4},
-            "float_map": {"c": 3.0, "d": 4.0},
-        }], self.index)
-        self.assertFalse(res.errors)
-        res = self.config.vespa_client.get_document('2',
-                                                    self.config.index_management.get_index(self.index.name).schema_name)
-        doc = res.document.dict().get('fields')
-        # Verify original fields are preserved
-        self.assertEqual(doc['marqo__score_modifiers']['cells']['int_field'], 123.0)
-        self.assertEqual(doc['marqo__score_modifiers']['cells']['float_field'], 123.0)
-        self.assertEqual(doc['marqo__score_modifiers']['cells']['int_map.a'], 3.0)
-        self.assertEqual(doc['marqo__score_modifiers']['cells']['int_map.b'], 4.0)
-        self.assertEqual(doc['marqo__score_modifiers']['cells']['float_map.c'], 3.0)
-        self.assertEqual(doc['marqo__score_modifiers']['cells']['float_map.d'], 4.0)
+                # Perform update with only additions, not replacements
+                res = self.config.document.partial_update_documents([{
+                    '_id': id,
+                    "int_map": {"a": 3, "b": 4},
+                    "float_map": {"c": 3.0, "d": 4.0},
+                }], self.index)
+                self.assertFalse(res.errors, f"Expected no errors when updating document {id}")
+                
+                res = self.config.vespa_client.get_document(id,
+                                                        self.config.index_management.get_index(self.index.name).schema_name)
+                doc = res.document.dict().get('fields')
+                # Verify original fields are preserved
+                int_field_val = self.id_to_doc[id].get('int_field', 0)
+                self.assertEqual(doc['marqo__score_modifiers']['cells']['int_field'], float(int_field_val))
+                float_field_val = self.id_to_doc[id].get('float_field', 0)
+                self.assertEqual(doc['marqo__score_modifiers']['cells']['float_field'], float(float_field_val))
+                self.assertEqual(doc['marqo__score_modifiers']['cells']['int_map.a'], 3.0)
+                self.assertEqual(doc['marqo__score_modifiers']['cells']['int_map.b'], 4.0)
+                self.assertEqual(doc['marqo__score_modifiers']['cells']['float_map.c'], 3.0)
+                self.assertEqual(doc['marqo__score_modifiers']['cells']['float_map.d'], 4.0)
 
     def test_partial_update_should_add_new_fields(self):
-        """Test that partial updates to new fields are successful.
+        """Test that partial updates to new fields are successful."""
+        test_docs = [self.doc, self.doc2, self.doc3]
         
-        This test verifies that partial updates to new fields are successful.
-        """
-        res = self.config.document.partial_update_documents([{'_id': '2', 'new_field': 500, 'new_float': 500.0,
-                                                              'new_int_map':{'a':2},
-                                                              'new_bool_field': True,
-                                                              'new_float_field': 10.0
-                                                              }], self.config.index_management.get_index(self.index.name))
-        doc = tensor_search.get_document_by_id(self.config, self.index.name, '2')
-        self._assert_fields_unchanged(doc, [])
-        self.assertEqual(500.0, doc['new_float'])
-        self.assertEqual(2, doc['new_int_map.a'])
-        self.assertEqual(500, doc['new_field'])
-        self.assertEqual(True, doc['new_bool_field'])
-        self.assertEqual(10.0, doc['new_float_field'])
+        for doc in test_docs:
+            with self.subTest(f"Adding new fields to document with ID {doc['_id']}"):
+                id = doc['_id']
+                res = self.config.document.partial_update_documents([{'_id': id, 'new_field': 500, 'new_float': 500.0,
+                                                                'new_int_map':{'a':2},
+                                                                'new_bool_field': True,
+                                                                'new_float_field': 10.0
+                                                                }], self.config.index_management.get_index(self.index.name))
+                self.assertFalse(res.errors, f"Expected no errors when updating document {id}")
+                
+                doc = tensor_search.get_document_by_id(self.config, self.index.name, id)
+                self._assert_fields_unchanged(doc, [])
+                self.assertEqual(500.0, doc['new_float'], f"Expected new_float to be 500.0 for document {id}")
+                self.assertEqual(2, doc['new_int_map.a'], f"Expected new_int_map.a to be 2 for document {id}")
+                self.assertEqual(500, doc['new_field'], f"Expected new_field to be 500 for document {id}")
+                self.assertEqual(True, doc['new_bool_field'], f"Expected new_bool_field to be True for document {id}")
+                self.assertEqual(10.0, doc['new_float_field'], f"Expected new_float_field to be 10.0 for document {id}")
+                
+                # Verify field types
+                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
+                vespa_fields = raw_vespa_doc.document.dict().get('fields')
+                
+                self.assertEqual(vespa_fields['marqo__field_types']['new_field'], MarqoFieldTypes.INT.value,
+                              f"Expected new_field to have type {MarqoFieldTypes.INT.value} for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['new_float'], MarqoFieldTypes.FLOAT.value,
+                              f"Expected new_float to have type {MarqoFieldTypes.FLOAT.value} for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['new_int_map.a'], MarqoFieldTypes.INT_MAP.value,
+                              f"Expected new_int_map.a to have type {MarqoFieldTypes.INT.value} for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['new_bool_field'], MarqoFieldTypes.BOOL.value,
+                              f"Expected new_bool_field to have type {MarqoFieldTypes.BOOL.value} for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['new_float_field'], MarqoFieldTypes.FLOAT.value,
+                              f"Expected new_float_field to have type {MarqoFieldTypes.FLOAT.value} for document {id}")
 
     # Reject any tensor field change
     def test_partial_update_should_reject_tensor_field(self):
@@ -487,69 +705,99 @@ class TestPartialUpdate(MarqoTestCase):
         
         This test verifies that partial updates to tensor fields are rejected.
         """
-        res = self.config.document.partial_update_documents([{'_id': '2', 'tensor_field': 'new_title'}], self.index)
-        self.assertTrue(res.errors)
-        self.assertIn('reference/api/documents/update-documents/#response', res.items[0].error)
-        self.assertIn("Marqo vector store couldn't update the document. Please see", res.items[0].error)
-        self.assertEqual(400, res.items[0].status)
+        test_docs = [self.doc2, self.doc3]
+        
+        for doc in test_docs:
+            with self.subTest(f"Attempting to update tensor field for document with ID {doc['_id']}"):
+                id = doc['_id']
+                res = self.config.document.partial_update_documents([{'_id': id, 'tensor_field': 'new_title'}], self.index)
+                self.assertTrue(res.errors)
+                self.assertIn('reference/api/documents/update-documents/#response', res.items[0].error)
+                self.assertIn("Marqo vector store couldn't update the document. Please see", res.items[0].error)
+                self.assertEqual(400, res.items[0].status)
 
     def test_partial_update_should_reject_multi_modal_field_subfield(self):
         """Test that partial updates to tensor subfields are rejected.
         
         This test verifies that partial updates to tensor subfields are rejected.
         """
-        res = self.config.document.partial_update_documents([{'_id': '2', 'tensor_subfield': 'new_description'}], self.index)
-        self.assertTrue(res.errors)
-        self.assertIn('reference/api/documents/update-documents/#response', res.items[0].error)
-        self.assertIn("Marqo vector store couldn't update the document. Please see", res.items[0].error)
-        self.assertEqual(400, res.items[0].status)
+        test_docs = [self.doc2, self.doc3]
+        
+        for doc in test_docs:
+            with self.subTest(f"Attempting to update tensor subfield for document with ID {doc['_id']}"):
+                id = doc['_id']
+                res = self.config.document.partial_update_documents([{'_id': id, 'tensor_subfield': 'new_description'}], self.index)
+                self.assertTrue(res.errors)
+                self.assertIn('reference/api/documents/update-documents/#response', res.items[0].error)
+                self.assertIn("Marqo vector store couldn't update the document. Please see", res.items[0].error)
+                self.assertEqual(400, res.items[0].status)
 
     def test_partial_update_should_reject_custom_vector_field(self):
         """Test that partial updates to custom vector fields are rejected.
         
         This test verifies that partial updates to custom vector fields are rejected.
         """
-        res = self.config.document.partial_update_documents([{'_id': '2', 'custom_vector_field': {
-            "content": "efgh",
-            "vector": [1.0] * 32
-        }}], self.index)
-        self.assertTrue(res.errors)
-        self.assertEqual(400, res.items[0].status)
-        self.assertIn("Unsupported field type <class 'str'> for field custom_vector_field in doc 2. "
-                      "We only support int and float types for map values when updating a document", res.items[0].error)
+        test_docs = [self.doc , self.doc2, self.doc3]
+        
+        for doc in test_docs:
+            with self.subTest(f"Attempting to update custom vector field for document with ID {doc['_id']}"):
+                id = doc['_id']
+                res = self.config.document.partial_update_documents([{'_id': id, 'custom_vector_field': {
+                    "content": "efgh",
+                    "vector": [1.0] * 32
+                }}], self.index)
+                self.assertTrue(res.errors)
+                self.assertEqual(400, res.items[0].status)
+                self.assertIn(f"Unsupported field type <class 'str'> for field custom_vector_field in doc {id}. "
+                              "We only support int and float types for map values when updating a document", res.items[0].error)
 
     def test_partial_update_should_reject_multimodal_combo_field(self):
         """Test that partial updates to multimodal combo fields are rejected.
         
         This test verifies that partial updates to multimodal combo fields are rejected.
         """
-        res = self.config.document.partial_update_documents([{'_id': '2', 'multimodal_combo_field': {
-            "tensor_field": "new_title",
-            "tensor_subfield": "new_description"
-        }}], self.index)
-        self.assertTrue(res.errors)
-        self.assertIn("Unsupported field type <class 'str'> for field multimodal_combo_field in doc 2", res.items[0].error)
-        self.assertEqual(400, res.items[0].status)
+        test_docs = [self.doc2, self.doc3]
+        
+        for doc in test_docs:
+            with self.subTest(f"Attempting to update multimodal combo field for document with ID {doc['_id']}"):
+                id = doc['_id']
+                res = self.config.document.partial_update_documents([{'_id': id, 'multimodal_combo_field': {
+                    "tensor_field": "new_title",
+                    "tensor_subfield": "new_description"
+                }}], self.index)
+                self.assertTrue(res.errors)
+                self.assertIn(f"Unsupported field type <class 'str'> for field multimodal_combo_field in doc {id}", res.items[0].error)
+                self.assertEqual(400, res.items[0].status)
 
     def test_partial_update_should_reject_numeric_array_field_type(self):
         """Test that partial updates to numeric array fields are rejected.
         
         This test verifies that partial updates to numeric array fields are rejected.
         """
-        res = self.config.document.partial_update_documents([{'_id': '2', 'int_array': [1, 2, 3]}], self.index)
-        self.assertTrue(res.errors)
-        self.assertIn("Unstructured index updates only support updating existing string array fields", res.items[0].error)
-        self.assertEqual(400, res.items[0].status)
+        test_docs = [self.doc,self.doc2, self.doc3]
+        
+        for doc in test_docs:
+            with self.subTest(f"Attempting to update numeric array field for document with ID {doc['_id']}"):
+                id = doc['_id']
+                res = self.config.document.partial_update_documents([{'_id': id, 'int_array': [1, 2, 3]}], self.index)
+                self.assertTrue(res.errors)
+                self.assertIn("Unstructured index updates only support updating existing string array fields", res.items[0].error)
+                self.assertEqual(400, res.items[0].status)
 
     def test_partial_update_should_reject_new_lexical_field(self):
         """Test that partial updates to new lexical fields are rejected.
         
         This test verifies that partial updates to new lexical fields are rejected.
         """
-        res = self.config.document.partial_update_documents([{'_id': '2', 'new_lexical_field': 'some string that signifies new lexical field'}], self.index)
-        self.assertTrue(res.errors)
-        self.assertIn("new_lexical_field of type str does not exist in the original document. Marqo does not support adding new lexical fields in partial updates", res.items[0].error)
-        self.assertEqual(400, res.items[0].status)
+        test_docs = [self.doc, self.doc2, self.doc3]
+        
+        for doc in test_docs:
+            with self.subTest(f"Attempting to update new lexical field for document with ID {doc['_id']}"):
+                id = doc['_id']
+                res = self.config.document.partial_update_documents([{'_id': id, 'new_lexical_field': 'some string that signifies new lexical field'}], self.index)
+                self.assertTrue(res.errors)
+                self.assertIn("new_lexical_field of type str does not exist in the original document. Marqo does not support adding new lexical fields in partial updates", res.items[0].error)
+                self.assertEqual(400, res.items[0].status)
 
     def test_partial_update_invalid_field_name(self):
         """Test that partial updates to invalid field names are rejected.
@@ -572,58 +820,81 @@ class TestPartialUpdate(MarqoTestCase):
         verifies that all changes were applied correctly by retrieving the
         document and checking each individual key-value pair.
         """
-        res = self.config.document.partial_update_documents([{
-            '_id': '2',
-            'int_map': {
-                'a': 10,  # Update existing
-                'c': 3,   # Add new
-                'b': 20   # Update existing
-            },
-            'float_map': {
-                'c': 10.5,  # Update existing
-                'e': 5.5    # Add new
-            }
-        }], self.index)
-        self.assertFalse(res.errors)
+        test_docs = [self.doc,self.doc2, self.doc3]
         
-        doc = tensor_search.get_document_by_id(self.config, self.index.name, '2')
-        self.assertEqual(10, doc['int_map.a'])
-        self.assertEqual(20, doc['int_map.b'])
-        self.assertEqual(3, doc['int_map.c'])
-        self.assertEqual(10.5, doc['float_map.c'])
-        self.assertEqual(5.5, doc['float_map.e'])
-        self.assertEqual(None, doc.get('float_map.d', None))
-        self._assert_fields_unchanged(doc, ['int_map.a', 'int_map.b', 'int_map.c', 'float_map.c', 'float_map.e', 'float_map.d'])
+        for doc in test_docs:
+            with self.subTest(f"Updating mixed numeric maps for document with ID {doc['_id']}"):
+                id = doc['_id']
+                res = self.config.document.partial_update_documents([{
+                    '_id': id,
+                    'int_map': {
+                        'a': 10,  # Update existing
+                        'c': 3,   # Add new
+                        'b': 20   # Update existing
+                    },
+                    'float_map': {
+                        'c': 10.5,  # Update existing
+                        'e': 5.5    # Add new
+                    }
+                }], self.index)
+                self.assertFalse(res.errors, f"Expected no errors when updating document {id}")
+                
+                doc = tensor_search.get_document_by_id(self.config, self.index.name, id)
+                self.assertEqual(10, doc['int_map.a'])
+                self.assertEqual(20, doc['int_map.b'])
+                self.assertEqual(3, doc['int_map.c'])
+                self.assertEqual(10.5, doc['float_map.c'])
+                self.assertEqual(5.5, doc['float_map.e'])
+                self.assertEqual(None, doc.get('float_map.d', None))
+                self._assert_fields_unchanged(doc, ['int_map.a', 'int_map.b', 'int_map.c', 'float_map.c', 'float_map.e', 'float_map.d'])
+                
+                # Verify field types
+                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
+                vespa_fields = raw_vespa_doc.document.dict().get('fields')
+                
+                self.assertEqual(vespa_fields['marqo__field_types']['int_map.a'], MarqoFieldTypes.INT_MAP.value,
+                              f"Expected int_map.a to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['int_map.b'], MarqoFieldTypes.INT_MAP.value,
+                              f"Expected int_map.b to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['int_map.c'], MarqoFieldTypes.INT_MAP.value,
+                              f"Expected int_map.c to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['float_map.c'], MarqoFieldTypes.FLOAT_MAP.value,
+                              f"Expected float_map.c to have type {MarqoFieldTypes.FLOAT_MAP.value} for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['float_map.e'], MarqoFieldTypes.FLOAT_MAP.value,
+                              f"Expected float_map.e to have type {MarqoFieldTypes.FLOAT_MAP.value} for document {id}")
 
     def test_partial_update_should_reject_invalid_map_values(self):
         """Test rejection of invalid value types in numeric maps
         
         This test verifies that partial updates reject invalid value types in numeric maps.
         """
-        res = self.config.document.partial_update_documents([{
-            '_id': '2',
-            'int_map': {
-                'a': 'string',  # Invalid type
-                'b': 2.5,      # Invalid type
-                'c': True      # Invalid type
-            }
-        }], self.index)
-        self.assertTrue(res.errors)
-        self.assertIn("Unsupported field type <class 'str'> for field int_map in doc 2", res.items[0].error)
-        self.assertEqual(400, res.items[0].status)
+        test_docs = [self.doc,self.doc2, self.doc3]
+        
+        for doc in test_docs:
+            with self.subTest(f"Attempting to update invalid map values for document with ID {doc['_id']}"):
+                id = doc['_id']
+                res = self.config.document.partial_update_documents([{
+                    '_id': id,
+                    'int_map': {
+                        'a': 'string',  # Invalid type
+                        'b': 2.5,      # Invalid type
+                        'c': True      # Invalid type
+                    }
+                }], self.index)
+                self.assertTrue(res.errors)
+                self.assertIn(f"Unsupported field type <class 'str'> for field int_map in doc {id}", res.items[0].error)
+                self.assertEqual(400, res.items[0].status)
 
-        # Verify original values unchanged
-        doc = tensor_search.get_document_by_id(self.config, self.index.name, '2')
-        self.assertEqual(1, doc['int_map.a'])
-        self.assertEqual(2, doc['int_map.b'])
-        self._assert_fields_unchanged(doc, ['int_map.a', 'int_map.b'])
+                # Verify original values unchanged
+                get_docs = tensor_search.get_document_by_id(self.config, self.index.name, id)
+                if doc.get('int_map.a', None): # Only assert that the original values are unchanged if they exist in the original document
+                    self.assertEqual(1, get_docs['int_map.a'])
+                if get_docs.get('int_map.b', None): # Only assert that the original values are unchanged if they exist in the original document
+                    self.assertEqual(2, get_docs['int_map.b'])
+                self._assert_fields_unchanged(get_docs, ['int_map.a', 'int_map.b'])
 
     def test_partial_update_should_handle_multiple_docs(self):
-        """Test updating multiple documents in one request
-        
-        This test verifies that partial updates can correctly handle multiple documents
-        in a single request.
-        """
+        """Test updating multiple documents in one request"""
         updates = [
             {
                 '_id': '2',
@@ -651,11 +922,7 @@ class TestPartialUpdate(MarqoTestCase):
         self._assert_fields_unchanged(doc3, ['bool_field', 'int_map.a', 'int_map.b'])
 
     def test_partial_update_should_handle_duplicate_doc_ids(self):
-        """Test handling of duplicate document IDs in update request
-        
-        This test verifies that partial updates can correctly handle duplicate document IDs
-        in an update request.
-        """
+        """Test handling of duplicate document IDs in update request"""
         updates = [
             {
                 '_id': '2',

--- a/tests/integ_tests/core/document/test_partial_update_semi_structured.py
+++ b/tests/integ_tests/core/document/test_partial_update_semi_structured.py
@@ -112,6 +112,15 @@ class TestPartialUpdate(MarqoTestCase):
             else:
                 self.assertEqual(value, doc.get(field, None), f'{field} is changed.')
 
+    def _assert_field_types(self, field_names, field_types, id):
+        raw_vespa_doc = self.config.vespa_client.get_document(id, self.index.schema_name)
+        vespa_fields = raw_vespa_doc.document.dict().get('fields')
+
+        for field_name, field_type in zip(field_names, field_types):
+            self.assertEqual(vespa_fields.get('marqo__field_types').get(field_name), field_type, 
+                            f"Expected {field_name} to have type {field_type} for document {id}")
+
+
     # Test update single field
     def test_partial_update_should_update_bool_field(self):
         """Test that boolean fields can be updated correctly via partial updates.
@@ -137,9 +146,7 @@ class TestPartialUpdate(MarqoTestCase):
                 self._assert_fields_unchanged(updated_doc, ['bool_field'])
 
                 # Verify field type
-                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
-                vespa_fields = raw_vespa_doc.document.dict().get('fields')
-                self.assertEqual(vespa_fields['marqo__field_types']['bool_field'], 'bool', f"Expected bool_field to have type 'bool' for document {id}")
+                self._assert_field_types(['bool_field'], [MarqoFieldTypes.BOOL.value], id)
 
     def test_partial_update_should_update_int_field_to_int(self):
         """Test that integer fields can be updated correctly via partial updates.
@@ -166,9 +173,7 @@ class TestPartialUpdate(MarqoTestCase):
 
                 
                 # Verify field type
-                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
-                vespa_fields = raw_vespa_doc.document.dict().get('fields')
-                self.assertEqual(vespa_fields['marqo__field_types']['int_field'], MarqoFieldTypes.INT.value, f"Expected int_field to have type {MarqoFieldTypes.INT.value} for document {id}")
+                self._assert_field_types(['int_field'], [MarqoFieldTypes.INT.value], id)
 
     def test_partial_update_to_non_existent_field(self): 
         """Test that partial updates to non-existent fields are successful.
@@ -188,10 +193,8 @@ class TestPartialUpdate(MarqoTestCase):
                 self._assert_fields_unchanged(doc, ['update_field_that_doesnt_exist'])
                 
                 # Verify field type
-                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
-                vespa_fields = raw_vespa_doc.document.dict().get('fields')
-                self.assertEqual(vespa_fields['marqo__field_types']['update_field_that_doesnt_exist'], MarqoFieldTypes.INT.value,
-                              f"Expected update_field_that_doesnt_exist to have type {MarqoFieldTypes.INT.value} for document {id}")
+                self._assert_field_types(['update_field_that_doesnt_exist'], [MarqoFieldTypes.INT.value], id)
+
 
     def test_partial_update_should_not_update_int_field_to_float(self):
         """Test that partial updates to int fields are rejected when the value is a float.
@@ -227,10 +230,7 @@ class TestPartialUpdate(MarqoTestCase):
                 self._assert_fields_unchanged(doc, ['float_field'])
                 
                 # Verify field type
-                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
-                vespa_fields = raw_vespa_doc.document.dict().get('fields')
-                self.assertEqual(vespa_fields['marqo__field_types']['float_field'], 'float', 
-                              f"Expected float_field to have type 'float' for document {id}")
+                self._assert_field_types(['float_field'], [MarqoFieldTypes.FLOAT.value], id)
 
     def test_partial_update_should_update_int_map(self):
         """Test that partial updates to int maps are successful.
@@ -248,16 +248,13 @@ class TestPartialUpdate(MarqoTestCase):
                 doc = tensor_search.get_document_by_id(self.config, self.index.name, id)
                 self.assertEqual(doc['int_map.c'], 2, f"Expected int_map.c to be 2 for document {id}")
                 self.assertEqual(doc['int_map.d'], 3, f"Expected int_map.d to be 3 for document {id}")
+                self.assertEqual(doc.get('int_map.a'), None, f"Expected int_map.a to be None for document {id}")
+                self.assertEqual(doc.get('int_map.b'), None, f"Expected int_map.b to be None for document {id}")
                 self._assert_fields_unchanged(doc, ['int_map'])
                 
                 # Verify field type
-                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
-                vespa_fields = raw_vespa_doc.document.dict().get('fields')
-                self.assertEqual(vespa_fields['marqo__field_types']['int_map.c'], MarqoFieldTypes.INT_MAP.value, 
-                                  f"Expected int_map.c to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['int_map.d'], MarqoFieldTypes.INT_MAP.value, 
-                                  f"Expected int_map.d to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
-
+                self._assert_field_types(['int_map.c', 'int_map.d', 'int_map.a', 'int_map.b'], [MarqoFieldTypes.INT_MAP.value, MarqoFieldTypes.INT_MAP.value, None, None], id)
+    
     def test_partial_update_should_replace_int_map(self):
         """Test that partial updates to int maps where we change the keys inside
         a specific int map are successful
@@ -278,13 +275,8 @@ class TestPartialUpdate(MarqoTestCase):
                 self._assert_fields_unchanged(doc, ['int_map'])
                 
                 # Verify field type
-                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
-                vespa_fields = raw_vespa_doc.document.dict().get('fields')
-                self.assertEqual(vespa_fields['marqo__field_types']['int_map.f'], MarqoFieldTypes.INT_MAP.value, 
-                              f"Expected int_map.f to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['int_map.g'], MarqoFieldTypes.INT_MAP.value, 
-                              f"Expected int_map.g to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
-
+                self._assert_field_types(['int_map.f', 'int_map.g', 'int_map.a', 'int_map.b'], [MarqoFieldTypes.INT_MAP.value, MarqoFieldTypes.INT_MAP.value, None, None], id)
+    
     def test_partial_update_should_update_int_map_with_new_value(self):
         """Test that partial updates to int maps with new values are successful."""
         test_docs = [self.doc2, self.doc3]
@@ -303,15 +295,7 @@ class TestPartialUpdate(MarqoTestCase):
                 self.assertEqual(doc['int_map.d'], 2, f"Expected int_map.d to be 2 for document {id}")
                 
                 # Verify field type
-                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
-                vespa_fields = raw_vespa_doc.document.dict().get('fields')
-                self.assertEqual(vespa_fields['marqo__field_types']['int_map.d'], MarqoFieldTypes.INT_MAP.value, 
-                              f"Expected int_map.d to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
-
-                #Verify that the int_map.a and int_map.b is removed from the field types
-                self.assertEqual(vespa_fields['marqo__field_types'].get('int_map.a', None), None)
-                self.assertEqual(vespa_fields['marqo__field_types'].get('int_map.b', None), None)
-
+                self._assert_field_types(['int_map.d', 'int_map.a', 'int_map.b'], [MarqoFieldTypes.INT_MAP.value, None, None], id)
     def test_partial_update_should_update_float_map(self):
         """Test that partial updates to float maps are successful.
         
@@ -331,12 +315,7 @@ class TestPartialUpdate(MarqoTestCase):
                 self._assert_fields_unchanged(doc, ['float_map'])
                 
                 # Verify field type
-                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
-                vespa_fields = raw_vespa_doc.document.dict().get('fields')
-                self.assertEqual(vespa_fields['marqo__field_types']['float_map.c'], MarqoFieldTypes.FLOAT_MAP.value, 
-                              f"Expected float_map.c to have type {MarqoFieldTypes.FLOAT_MAP.value} for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['float_map.d'], MarqoFieldTypes.FLOAT_MAP.value, 
-                              f"Expected float_map.d to have type {MarqoFieldTypes.FLOAT_MAP.value} for document {id}")
+                self._assert_field_types(['float_map.c', 'float_map.d'], [MarqoFieldTypes.FLOAT_MAP.value, MarqoFieldTypes.FLOAT_MAP.value], id)
 
     def test_partial_update_should_allow_changing_multiple_maps_in_same_request(self):
         """Test that partial updates to multiple maps in the same request are successful.
@@ -365,6 +344,9 @@ class TestPartialUpdate(MarqoTestCase):
                 self.assertIsNone(doc.get('float_map.d'), f"Expected float_map.d to be None for document {id}")
                 self._assert_fields_unchanged(doc, ['int_map.a', 'int_map.b', 'float_map.d', 'float_map.c', 'int_field', 'bool_field', 'float_field'])
 
+                # Verify field types
+                self._assert_field_types(['int_map.a', 'int_map.b', 'float_map.c', 'float_map.d', 'int_field', 'bool_field', 'float_field'], [MarqoFieldTypes.INT_MAP.value, None, MarqoFieldTypes.FLOAT_MAP.value, None, MarqoFieldTypes.INT.value, MarqoFieldTypes.BOOL.value, MarqoFieldTypes.FLOAT.value], id)
+
     def test_partial_update_should_update_string_array(self):
         """Test that partial updates to string arrays are successful.
         
@@ -383,11 +365,7 @@ class TestPartialUpdate(MarqoTestCase):
                 self._assert_fields_unchanged(doc, ['string_array'])
                 
                 # Verify field type
-                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
-                vespa_fields = raw_vespa_doc.document.dict().get('fields')
-                self.assertEqual(vespa_fields['marqo__field_types']['string_array'], 'string_array', 
-                              f"Expected string_array to have type 'string_array' for document {id}")
-
+                self._assert_field_types(['string_array'], [MarqoFieldTypes.STRING_ARRAY.value], id)
     def test_partial_update_should_reject_new_string_array_field(self):
         """Test that partial updates to new string arrays are rejected."""
         test_docs = [self.doc, self.doc2, self.doc3]
@@ -417,6 +395,10 @@ class TestPartialUpdate(MarqoTestCase):
                 doc = tensor_search.get_document_by_id(self.config, self.index.name, id)
                 self.assertEqual("some value 2", doc['lexical_field'], f"Expected lexical_field to be 'some value 2' for document {id}")
                 self.assertEqual(["ccc"], doc['string_array'], f"Expected string_array to be ['ccc'] for document {id}")
+                self._assert_fields_unchanged(doc, ['lexical_field', 'string_array'])
+
+                # Verify field types
+                self._assert_field_types(['lexical_field', 'string_array'], [MarqoFieldTypes.STRING.value, MarqoFieldTypes.STRING_ARRAY.value], id)
 
     def test_partial_update_should_update_short_string(self):
         """Test that partial updates to short strings are successful."""
@@ -435,10 +417,7 @@ class TestPartialUpdate(MarqoTestCase):
                 self._assert_fields_unchanged(doc, ['short_string_field'])
                 
                 # Verify field type
-                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
-                vespa_fields = raw_vespa_doc.document.dict().get('fields')
-                self.assertEqual(vespa_fields['marqo__field_types']['short_string_field'], 'string', 
-                              f"Expected short_string_field to have type 'string' for document {id}")
+                self._assert_field_types(['short_string_field'], [MarqoFieldTypes.STRING.value], id)
 
     def test_partial_update_should_update_long_string(self):
         """Test that partial updates to long strings are successful."""
@@ -457,10 +436,7 @@ class TestPartialUpdate(MarqoTestCase):
                 self._assert_fields_unchanged(doc, ['long_string_field'])
                 
                 # Verify field type
-                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
-                vespa_fields = raw_vespa_doc.document.dict().get('fields')
-                self.assertEqual(vespa_fields['marqo__field_types']['long_string_field'], 'string', 
-                              f"Expected long_string_field to have type 'string' for document {id}")
+                self._assert_field_types(['long_string_field'], [MarqoFieldTypes.STRING.value], id)
 
     def test_partial_update_should_update_long_string_to_short_string(self):
         """Test that partial updates to long strings to short strings are successful."""
@@ -479,10 +455,7 @@ class TestPartialUpdate(MarqoTestCase):
                 self._assert_fields_unchanged(doc, ['long_string_field'])
                 
                 # Verify field type
-                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
-                vespa_fields = raw_vespa_doc.document.dict().get('fields')
-                self.assertEqual(vespa_fields['marqo__field_types']['long_string_field'], MarqoFieldTypes.STRING.value, 
-                              f"Expected long_string_field to have type {MarqoFieldTypes.STRING.value} for document {id}")
+                self._assert_field_types(['long_string_field'], [MarqoFieldTypes.STRING.value], id)
 
     def test_partial_update_should_update_short_string_to_long_string(self):
         """Test that partial updates to short strings to long strings are successful."""
@@ -524,31 +497,19 @@ class TestPartialUpdate(MarqoTestCase):
                 self.assertFalse(res.errors, f"Expected no errors when updating document {id}")
                 
                 # Verify field types
-                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
-                vespa_fields = raw_vespa_doc.document.dict().get('fields')
+                # Verify field types
+                field_names = ['int_map.a', 'int_map.d', 'float_map.c', 'new_int', 'new_float', 
+                              'new_map.a', 'new_map.b', 'int_map.b', 'float_map.d']
+                field_types = [MarqoFieldTypes.INT_MAP.value, MarqoFieldTypes.INT_MAP.value, 
+                              MarqoFieldTypes.FLOAT_MAP.value, MarqoFieldTypes.INT.value, 
+                              MarqoFieldTypes.FLOAT.value, MarqoFieldTypes.INT_MAP.value, 
+                              MarqoFieldTypes.FLOAT_MAP.value, None, None]
                 
-                self.assertEqual(vespa_fields['marqo__field_types']['int_map.a'], MarqoFieldTypes.INT_MAP.value, 
-                              f"Expected int_map.a to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['int_map.d'], MarqoFieldTypes.INT_MAP.value, 
-                              f"Expected int_map.d to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['float_map.c'], MarqoFieldTypes.FLOAT_MAP.value, 
-                              f"Expected float_map.c to have type {MarqoFieldTypes.FLOAT_MAP.value} for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['new_int'], MarqoFieldTypes.INT.value, 
-                              f"Expected new_int to have type {MarqoFieldTypes.INT.value} for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['new_float'], MarqoFieldTypes.FLOAT.value, 
-                              f"Expected new_float to have type {MarqoFieldTypes.FLOAT.value} for document {id}")
-
-                # assert that the map keys that must've been removed don't exist in marqo__field_types
-                self.assertEqual(vespa_fields['marqo__field_types'].get('int_map.b', None), None)
-                self.assertEqual(vespa_fields['marqo__field_types'].get('float_map.d', None), None)
-
-                # Check the new map fields
-                self.assertEqual(vespa_fields['marqo__field_types']['new_map.a'], MarqoFieldTypes.INT_MAP.value, 
-                              f"Expected new_map.a to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['new_map.b'], MarqoFieldTypes.FLOAT_MAP.value, 
-                              f"Expected new_map.b to have type {MarqoFieldTypes.FLOAT_MAP.value} for document {id}")
+                
+                self._assert_field_types(field_names, field_types, id)
                 
                 # Also check score modifiers values
+                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
                 doc = raw_vespa_doc.document.dict().get('fields')
                 int_field_val = self.id_to_doc[id].get('int_field', 0)
                 self.assertEqual(doc['marqo__score_modifiers']['cells']['int_field'], float(int_field_val))
@@ -592,19 +553,13 @@ class TestPartialUpdate(MarqoTestCase):
                 self.assertFalse(res.errors, f"Expected no errors when updating document {id}")
                 
                 # Verify field types
-                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
-                vespa_fields = raw_vespa_doc.document.dict().get('fields')
+                # Verify field types using helper method
+                field_names = ['int_map_2.d', 'int_map_2.e', 'float_map_2.f', 'new_int', 'new_float']
+                field_types = [MarqoFieldTypes.INT_MAP.value, MarqoFieldTypes.INT_MAP.value, 
+                              MarqoFieldTypes.FLOAT_MAP.value, MarqoFieldTypes.INT.value, 
+                              MarqoFieldTypes.FLOAT.value]
                 
-                self.assertEqual(vespa_fields['marqo__field_types']['int_map_2.d'], MarqoFieldTypes.INT_MAP.value, 
-                              f"Expected int_map_2.d to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['int_map_2.e'], MarqoFieldTypes.INT_MAP.value, 
-                              f"Expected int_map_2.e to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['float_map_2.f'], MarqoFieldTypes.FLOAT_MAP.value, 
-                              f"Expected float_map_2.f to have type {MarqoFieldTypes.FLOAT_MAP.value} for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['new_int'], MarqoFieldTypes.INT.value, 
-                              f"Expected new_int to have type {MarqoFieldTypes.INT.value} for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['new_float'], MarqoFieldTypes.FLOAT.value, 
-                              f"Expected new_float to have type {MarqoFieldTypes.FLOAT.value} for document {id}")
+                self._assert_field_types(field_names, field_types, id)
                 
                 res = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
                 doc = res.document.dict().get('fields')
@@ -685,19 +640,11 @@ class TestPartialUpdate(MarqoTestCase):
                 self.assertEqual(10.0, doc['new_float_field'], f"Expected new_float_field to be 10.0 for document {id}")
                 
                 # Verify field types
-                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
-                vespa_fields = raw_vespa_doc.document.dict().get('fields')
+                field_names = ['new_field', 'new_float', 'new_int_map.a', 'new_bool_field', 'new_float_field']
+                field_types = [MarqoFieldTypes.INT.value, MarqoFieldTypes.FLOAT.value, MarqoFieldTypes.INT_MAP.value, 
+                               MarqoFieldTypes.BOOL.value, MarqoFieldTypes.FLOAT.value]
                 
-                self.assertEqual(vespa_fields['marqo__field_types']['new_field'], MarqoFieldTypes.INT.value,
-                              f"Expected new_field to have type {MarqoFieldTypes.INT.value} for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['new_float'], MarqoFieldTypes.FLOAT.value,
-                              f"Expected new_float to have type {MarqoFieldTypes.FLOAT.value} for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['new_int_map.a'], MarqoFieldTypes.INT_MAP.value,
-                              f"Expected new_int_map.a to have type {MarqoFieldTypes.INT.value} for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['new_bool_field'], MarqoFieldTypes.BOOL.value,
-                              f"Expected new_bool_field to have type {MarqoFieldTypes.BOOL.value} for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['new_float_field'], MarqoFieldTypes.FLOAT.value,
-                              f"Expected new_float_field to have type {MarqoFieldTypes.FLOAT.value} for document {id}")
+                self._assert_field_types(field_names, field_types, id)
 
     # Reject any tensor field change
     def test_partial_update_should_reject_tensor_field(self):
@@ -849,19 +796,18 @@ class TestPartialUpdate(MarqoTestCase):
                 self._assert_fields_unchanged(doc, ['int_map.a', 'int_map.b', 'int_map.c', 'float_map.c', 'float_map.e', 'float_map.d'])
                 
                 # Verify field types
-                raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(self.index.name).schema_name)
-                vespa_fields = raw_vespa_doc.document.dict().get('fields')
-                
-                self.assertEqual(vespa_fields['marqo__field_types']['int_map.a'], MarqoFieldTypes.INT_MAP.value,
-                              f"Expected int_map.a to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['int_map.b'], MarqoFieldTypes.INT_MAP.value,
-                              f"Expected int_map.b to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['int_map.c'], MarqoFieldTypes.INT_MAP.value,
-                              f"Expected int_map.c to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['float_map.c'], MarqoFieldTypes.FLOAT_MAP.value,
-                              f"Expected float_map.c to have type {MarqoFieldTypes.FLOAT_MAP.value} for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['float_map.e'], MarqoFieldTypes.FLOAT_MAP.value,
-                              f"Expected float_map.e to have type {MarqoFieldTypes.FLOAT_MAP.value} for document {id}")
+                # Verify field types
+                self._assert_field_types(
+                    ['int_map.a', 'int_map.b', 'int_map.c', 'float_map.c', 'float_map.e'],
+                    [
+                        MarqoFieldTypes.INT_MAP.value,
+                        MarqoFieldTypes.INT_MAP.value,
+                        MarqoFieldTypes.INT_MAP.value,
+                        MarqoFieldTypes.FLOAT_MAP.value,
+                        MarqoFieldTypes.FLOAT_MAP.value
+                    ],
+                    id
+                )
 
     def test_partial_update_should_reject_invalid_map_values(self):
         """Test rejection of invalid value types in numeric maps
@@ -1124,6 +1070,18 @@ class TestPartialUpdate(MarqoTestCase):
         self.assertTrue(res.errors)
         self.assertEqual(400, res.items[0].status)
 
+    def test_updating_int_to_int_map(self):
+        """Test that partial updates changing int field to int maps are rejected.
+        """
+
+        res = self.config.document.partial_update_documents([{'_id': '2', 'int_field': {'a': 100}}], self.index)
+        print(res)
+        raw_vespa_doc = self.config.vespa_client.get_document('2', self.index.schema_name)
+        print(raw_vespa_doc)
+        self.assertTrue(res.errors)
+        self.assertIn('reference/api/documents/update-documents/#response', res.items[0].error)
+        self.assertIn("Marqo vector store couldn't update the document. Please see", res.items[0].error)
+        self.assertEqual(400, res.items[0].status)
 
     def test_updating_non_existent_document_with_maps(self):
         """

--- a/tests/integ_tests/tensor_search/integ_tests/test_add_documents_semi_structured.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_add_documents_semi_structured.py
@@ -9,6 +9,7 @@ import pytest
 from marqo.api.exceptions import BadRequestError
 from marqo.core.exceptions import IndexNotFoundError
 from marqo.core.models.marqo_index import *
+from marqo.core.semi_structured_vespa_index.marqo_field_types import MarqoFieldTypes
 from marqo.tensor_search import enums
 from marqo.tensor_search import tensor_search
 from marqo.core.models.add_docs_params import AddDocsParams
@@ -782,3 +783,101 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
         self.assertEqual(valid_url, doc["non_tensor_field"])
         self.assertEqual(1, len(doc[enums.TensorField.tensor_facets]))
         self.assertIn("title", doc[enums.TensorField.tensor_facets][0])
+
+
+    def test_original_document_has_correct_field_types(self):
+        """
+        This test is added in 2.16 release where we launched support for partial updates for unstructured indexes.
+        As part of this we introduced a new field in Vespa called marqo__field_types.
+        This field is used to store the field types of the fields that are added to the document.
+
+        Test that the original document has the correct field types for the fields that are added.
+        """
+        self.doc = { # This document helps us understand / test behavior of partial updating fields when
+            # Those fields don't exist in the original document
+            '_id': '1',
+            "string_array": ["aaa", "bbb"],
+            "string_array2": ["123", "456"],
+        }
+        self.doc2 = { # This document helps us test behavior of partial updating fields when
+            # Those fields already exist in the original document
+            '_id': '2',
+            'tensor_field': 'title',
+            'tensor_subfield': 'description',
+            "short_string_field": "shortstring",
+            "long_string_field": "Thisisaverylongstring" * 10,
+            "int_field": 123,
+            "float_field": 123.0,
+            "string_array": ["aaa", "bbb"],
+            "string_array2": ["123", "456"],
+            "int_map": {"a": 1, "b": 2},
+            "float_map": {"c": 1.0, "d": 2.0},
+            "bool_field": True,
+            "bool_field2": False,
+            "custom_vector_field": {
+                "content": "abcd",
+                "vector": [1.0] * 32
+            },
+            "lexical_field": "some string that signifies lexical field"
+        }
+        self.doc3 = { # This document doesn't contain any string arrays, it's used to test adding new string arrays
+            '_id': '3',
+            'tensor_field': 'title',
+            'tensor_subfield': 'description',
+            "short_string_field": "shortstring",
+            "long_string_field": "Thisisaverylongstring" * 10,
+            "int_field": 123,
+            "float_field": 123.0,
+            "int_map": {"a": 1, "b": 2},
+            "float_map": {"c": 1.0, "d": 2.0},
+            "bool_field": True,
+            "bool_field2": False,
+            "custom_vector_field": {
+                "content": "abcd",
+                "vector": [1.0] * 32
+            }
+        }
+        self.id_to_doc = {
+            '1': self.doc,
+            '2': self.doc2,
+            '3': self.doc3
+        }
+        self.add_documents(self.config, add_docs_params=AddDocsParams(
+            index_name=self.default_text_index,
+            docs=[self.doc, self.doc2, self.doc3],
+            tensor_fields=['tensor_field', 'custom_vector_field', 'multimodal_combo_field'],
+            mappings = {
+                "custom_vector_field": {"type": "custom_vector"},
+                "multimodal_combo_field": {
+                    "type": "multimodal_combination",
+                    "weights": {"tensor_field": 1.0, "tensor_subfield": 2.0}
+                }
+            }
+        ))
+        self.index = self.config.index_management.get_index(self.default_text_index)
+
+        for doc in [self.doc, self.doc2, self.doc3]:
+            id = doc['_id']
+            raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(
+                self.index.name).schema_name)
+            vespa_fields = raw_vespa_doc.document.dict().get('fields')
+            if id in ['1', '2']:
+                self.assertEqual(vespa_fields['marqo__field_types']['string_array'], MarqoFieldTypes.STRING_ARRAY.value, f"Expected string_array to have type 'string_array' for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['string_array2'], MarqoFieldTypes.STRING_ARRAY.value, f"Expected string_array2 to have type 'string_array' for document {id}")
+            if id in ['2', '3']:
+                self.assertEqual(vespa_fields['marqo__field_types']['int_map.a'], MarqoFieldTypes.INT_MAP.value, f"Expected int_map.a to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['int_map.b'], MarqoFieldTypes.INT_MAP.value, f"Expected int_map.b to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['float_map.c'], MarqoFieldTypes.FLOAT_MAP.value, f"Expected float_map.c to have type {MarqoFieldTypes.FLOAT_MAP.value} for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['float_map.d'], MarqoFieldTypes.FLOAT_MAP.value, f"Expected float_map.d to have type {MarqoFieldTypes.FLOAT_MAP.value} for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['bool_field'], MarqoFieldTypes.BOOL.value, f"Expected bool_field to have type 'bool' for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['short_string_field'], MarqoFieldTypes.STRING.value, f"Expected short_string_field to have type 'string' for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['long_string_field'], MarqoFieldTypes.STRING.value, f"Expected long_string_field to have type 'string' for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['int_field'], MarqoFieldTypes.INT.value, f"Expected int_field to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['float_field'], MarqoFieldTypes.FLOAT.value, f"Expected float_field to have type 'float' for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['bool_field2'], MarqoFieldTypes.BOOL.value, f"Expected bool_field2 to have type 'bool' for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['custom_vector_field'], MarqoFieldTypes.TENSOR.value, f"Expected custom_vector_field to have type 'custom_vector' for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['tensor_field'], MarqoFieldTypes.TENSOR.value, f"Expected tensor_field to have type 'tensor' for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['tensor_subfield'], MarqoFieldTypes.TENSOR.value, f"Expected tensor_subfield to have type 'tensor' for document {id}")
+                self.assertEqual(vespa_fields['marqo__field_types']['multimodal_combo_field'], MarqoFieldTypes.TENSOR.value, f"Expected multimodal_combo_field to have type 'tensor' for document {id}")
+            if id is '2':
+                self.assertEqual(vespa_fields['marqo__field_types']['lexical_field'], MarqoFieldTypes.STRING.value, f"Expected lexical_field to have type 'string' for document {id}")

--- a/tests/integ_tests/tensor_search/integ_tests/test_add_documents_semi_structured.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_add_documents_semi_structured.py
@@ -784,6 +784,10 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
         self.assertEqual(1, len(doc[enums.TensorField.tensor_facets]))
         self.assertIn("title", doc[enums.TensorField.tensor_facets][0])
 
+    def _assert_field_types(self, vespa_fields, field_names, field_types, id):
+        for field_name, field_type in zip(field_names, field_types):
+            self.assertEqual(vespa_fields['marqo__field_types'][field_name], field_type.value,
+                             f"Expected {field_name} to have type {field_type.value} for document {id}")
 
     def test_original_document_has_correct_field_types(self):
         """
@@ -793,14 +797,12 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
 
         Test that the original document has the correct field types for the fields that are added.
         """
-        self.doc = { # This document helps us understand / test behavior of partial updating fields when
-            # Those fields don't exist in the original document
+        self.doc = {
             '_id': '1',
             "string_array": ["aaa", "bbb"],
             "string_array2": ["123", "456"],
         }
-        self.doc2 = { # This document helps us test behavior of partial updating fields when
-            # Those fields already exist in the original document
+        self.doc2 = {
             '_id': '2',
             'tensor_field': 'title',
             'tensor_subfield': 'description',
@@ -820,7 +822,7 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
             },
             "lexical_field": "some string that signifies lexical field"
         }
-        self.doc3 = { # This document doesn't contain any string arrays, it's used to test adding new string arrays
+        self.doc3 = {
             '_id': '3',
             'tensor_field': 'title',
             'tensor_subfield': 'description',
@@ -836,11 +838,6 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
                 "content": "abcd",
                 "vector": [1.0] * 32
             }
-        }
-        self.id_to_doc = {
-            '1': self.doc,
-            '2': self.doc2,
-            '3': self.doc3
         }
         self.add_documents(self.config, add_docs_params=AddDocsParams(
             index_name=self.default_text_index,
@@ -861,23 +858,116 @@ class TestAddDocumentsSemiStructured(MarqoTestCase):
             raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(
                 self.index.name).schema_name)
             vespa_fields = raw_vespa_doc.document.dict().get('fields')
+
+            field_names = [
+                'int_map.a', 'int_map.b', 'float_map.c', 'float_map.d', 'bool_field',
+                'short_string_field', 'long_string_field', 'int_field', 'float_field',
+                'bool_field2', 'custom_vector_field', 'tensor_field', 'tensor_subfield',
+                'multimodal_combo_field'
+            ]
+            field_types = [
+                MarqoFieldTypes.INT_MAP, MarqoFieldTypes.INT_MAP, MarqoFieldTypes.FLOAT_MAP,
+                MarqoFieldTypes.FLOAT_MAP, MarqoFieldTypes.BOOL, MarqoFieldTypes.STRING,
+                MarqoFieldTypes.STRING, MarqoFieldTypes.INT, MarqoFieldTypes.FLOAT,
+                MarqoFieldTypes.BOOL, MarqoFieldTypes.TENSOR, MarqoFieldTypes.TENSOR,
+                MarqoFieldTypes.TENSOR, MarqoFieldTypes.TENSOR
+            ]
+
             if id in ['1', '2']:
-                self.assertEqual(vespa_fields['marqo__field_types']['string_array'], MarqoFieldTypes.STRING_ARRAY.value, f"Expected string_array to have type 'string_array' for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['string_array2'], MarqoFieldTypes.STRING_ARRAY.value, f"Expected string_array2 to have type 'string_array' for document {id}")
+                self._assert_field_types(vespa_fields, ['string_array', 'string_array2'], [MarqoFieldTypes.STRING_ARRAY, MarqoFieldTypes.STRING_ARRAY], id)
             if id in ['2', '3']:
-                self.assertEqual(vespa_fields['marqo__field_types']['int_map.a'], MarqoFieldTypes.INT_MAP.value, f"Expected int_map.a to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['int_map.b'], MarqoFieldTypes.INT_MAP.value, f"Expected int_map.b to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['float_map.c'], MarqoFieldTypes.FLOAT_MAP.value, f"Expected float_map.c to have type {MarqoFieldTypes.FLOAT_MAP.value} for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['float_map.d'], MarqoFieldTypes.FLOAT_MAP.value, f"Expected float_map.d to have type {MarqoFieldTypes.FLOAT_MAP.value} for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['bool_field'], MarqoFieldTypes.BOOL.value, f"Expected bool_field to have type 'bool' for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['short_string_field'], MarqoFieldTypes.STRING.value, f"Expected short_string_field to have type 'string' for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['long_string_field'], MarqoFieldTypes.STRING.value, f"Expected long_string_field to have type 'string' for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['int_field'], MarqoFieldTypes.INT.value, f"Expected int_field to have type {MarqoFieldTypes.INT_MAP.value} for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['float_field'], MarqoFieldTypes.FLOAT.value, f"Expected float_field to have type 'float' for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['bool_field2'], MarqoFieldTypes.BOOL.value, f"Expected bool_field2 to have type 'bool' for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['custom_vector_field'], MarqoFieldTypes.TENSOR.value, f"Expected custom_vector_field to have type 'custom_vector' for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['tensor_field'], MarqoFieldTypes.TENSOR.value, f"Expected tensor_field to have type 'tensor' for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['tensor_subfield'], MarqoFieldTypes.TENSOR.value, f"Expected tensor_subfield to have type 'tensor' for document {id}")
-                self.assertEqual(vespa_fields['marqo__field_types']['multimodal_combo_field'], MarqoFieldTypes.TENSOR.value, f"Expected multimodal_combo_field to have type 'tensor' for document {id}")
+                self._assert_field_types(vespa_fields, field_names, field_types, id)
             if id is '2':
-                self.assertEqual(vespa_fields['marqo__field_types']['lexical_field'], MarqoFieldTypes.STRING.value, f"Expected lexical_field to have type 'string' for document {id}")
+                self._assert_field_types(vespa_fields, ['lexical_field'], [MarqoFieldTypes.STRING], id)
+
+    def test_original_document_has_correct_field_types_tensor_field(self):
+        """
+        This test is added in 2.16 release where we launched support for partial updates for unstructured indexes.
+        As part of this we introduced a new field in Vespa called marqo__field_types.
+        This field is used to store the field types of the fields that are added to the document.
+
+        Test that the original document has the correct field types for the fields that are added.
+        """
+        self.doc = {
+            '_id': '1',
+            "string_array": ["aaa", "bbb"],
+            "string_array2": ["123", "456"],
+        }
+        self.doc2 = {
+            '_id': '2',
+            'tensor_field': 'title',
+            'tensor_subfield': 'description',
+            "short_string_field": "shortstring",
+            "long_string_field": "Thisisaverylongstring" * 10,
+            "int_field": 123,
+            "float_field": 123.0,
+            "string_array": ["aaa", "bbb"],
+            "string_array2": ["123", "456"],
+            "int_map": {"a": 1, "b": 2},
+            "float_map": {"c": 1.0, "d": 2.0},
+            "bool_field": True,
+            "bool_field2": False,
+            "custom_vector_field": {
+                "content": "abcd",
+                "vector": [1.0] * 32
+            },
+            "lexical_field": "some string that signifies lexical field"
+        }
+        self.doc3 = {
+            '_id': '3',
+            'tensor_field': 'title',
+            'tensor_subfield': 'description',
+            "short_string_field": "shortstring",
+            "long_string_field": "Thisisaverylongstring" * 10,
+            "int_field": 123,
+            "float_field": 123.0,
+            "int_map": {"a": 1, "b": 2},
+            "float_map": {"c": 1.0, "d": 2.0},
+            "bool_field": True,
+            "bool_field2": False,
+            "custom_vector_field": {
+                "content": "abcd",
+                "vector": [1.0] * 32
+            }
+        }
+        self.add_documents(self.config, add_docs_params=AddDocsParams(
+            index_name=self.default_text_index,
+            docs=[self.doc, self.doc2],
+            tensor_fields=['tensor_field', 'custom_vector_field', 'multimodal_combo_field'],
+            mappings = {
+                "custom_vector_field": {"type": "custom_vector"},
+                "multimodal_combo_field": {
+                    "type": "multimodal_combination",
+                    "weights": {"tensor_field": 1.0, "tensor_subfield": 2.0}
+                }
+            }
+        ))
+        resp = self.add_documents(self.config, add_docs_params=AddDocsParams(
+            index_name=self.default_text_index,
+            docs=[self.doc3],
+            tensor_fields=['custom_vector_field'],
+            mappings = {
+                "custom_vector_field": {"type": "custom_vector"},
+            }
+        ))
+
+        self.index = self.config.index_management.get_index(self.default_text_index)
+
+        for doc in [self.doc3]:
+            id = doc['_id']
+            raw_vespa_doc = self.config.vespa_client.get_document(id, self.config.index_management.get_index(
+                self.index.name).schema_name)
+            vespa_fields = raw_vespa_doc.document.dict().get('fields')
+            field_names = [
+                'int_map.a', 'int_map.b', 'float_map.c', 'float_map.d', 'bool_field',
+                'short_string_field', 'long_string_field', 'int_field', 'float_field',
+                'bool_field2', 'custom_vector_field', 'tensor_field', 'tensor_subfield'
+            ]
+            field_types = [
+                MarqoFieldTypes.INT_MAP, MarqoFieldTypes.INT_MAP, MarqoFieldTypes.FLOAT_MAP,
+                MarqoFieldTypes.FLOAT_MAP, MarqoFieldTypes.BOOL, MarqoFieldTypes.STRING,
+                MarqoFieldTypes.STRING, MarqoFieldTypes.INT, MarqoFieldTypes.FLOAT,
+                MarqoFieldTypes.BOOL, MarqoFieldTypes.TENSOR, MarqoFieldTypes.STRING,
+                MarqoFieldTypes.STRING
+            ]
+            self._assert_field_types(vespa_fields, field_names, field_types, id)


### PR DESCRIPTION
Fixing the bug where if the original document didn't contain any map fields, adding new maps with docs resulted in map type issues & later didn't allow us to properly update maps in subsequent  calls. 


Also added more robust testing where we are now testing the field_type metadata & running every test through 3 different docs

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
* Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
* In case a user didn't send in a map in an add_docs request, subsequent addition of a map field in an update docs request will lead to the map not getting replaced 




* **What is the new behavior (if this is a feature change)?**
* Even if a user's original documents didn't have a map to begin with, updates to maps will work as expected. 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
* Added more unit tests. Now every unit test checks if the marqo_field_types metadata field is having the correct value for a field. This is checked after both updation and addition of docs 
* Manually tested the test case for which this was failing:
* ![Screenshot 2025-03-06 at 4 43 02 PM](https://github.com/user-attachments/assets/3c6f8c4b-a140-4d9a-b59b-a187813910f3)



* **Related Python client changes** (link commit/PR here)
* NA

* **Related documentation changes** (link commit/PR here)
* NA


* **Other information**:
* NA


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

