### PR TITLE
Move tensor_fields_container.py to vespa_index to get ready for the refactoring

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -49,6 +49,12 @@ jobs:
           # override base requirements with marqo requirements, if needed:
           pip install -r marqo/requirements.dev.txt
 
+      # Temporally add the nltk tokeniser to run tests of tensor_fields_container. Will remove once the chunking logic
+      # is removed from it in the next PR
+      - name: Download nltk data
+        run: |
+            python -m nltk.downloader punkt_tab
+
       - name: Run Unit Tests
         run: |
           cd marqo

--- a/src/marqo/core/structured_vespa_index/structured_add_document_handler.py
+++ b/src/marqo/core/structured_vespa_index/structured_add_document_handler.py
@@ -5,7 +5,7 @@ from marqo.core import constants
 from marqo.core.constants import MARQO_DOC_ID
 from marqo.core.vespa_index.add_documents_handler import AddDocumentsHandler, AddDocumentsError
 from marqo.core.models.add_docs_params import AddDocsParams
-from marqo.core.inference.tensor_fields_container import TensorFieldsContainer
+from marqo.core.vespa_index.tensor_fields_container import TensorFieldsContainer
 from marqo.core.models.marqo_index import FieldType, StructuredMarqoIndex
 from marqo.core.structured_vespa_index.structured_vespa_index import StructuredVespaIndex
 from marqo.exceptions import InvalidArgumentError

--- a/src/marqo/core/unstructured_vespa_index/unstructured_add_document_handler.py
+++ b/src/marqo/core/unstructured_vespa_index/unstructured_add_document_handler.py
@@ -7,7 +7,7 @@ from marqo import marqo_docs
 from marqo.api import exceptions as api_errors
 from marqo.core import constants
 from marqo.core.constants import MARQO_DOC_ID
-from marqo.core.inference.tensor_fields_container import TensorFieldsContainer, MODALITY_FIELD_TYPE_MAP
+from marqo.core.vespa_index.tensor_fields_container import TensorFieldsContainer, MODALITY_FIELD_TYPE_MAP
 from marqo.core.models import UnstructuredMarqoIndex
 from marqo.core.models.add_docs_params import AddDocsParams
 from marqo.core.models.marqo_index import FieldType

--- a/src/marqo/core/vespa_index/add_documents_handler.py
+++ b/src/marqo/core/vespa_index/add_documents_handler.py
@@ -6,14 +6,14 @@ from typing import List, Dict, Optional, Any, Tuple, Set
 
 from marqo.api import exceptions as api_errors
 from marqo.core.constants import MARQO_DOC_ID, MARQO_CUSTOM_VECTOR_NORMALIZATION_MINIMUM_VERSION
-from marqo.core.models.add_docs_params import AddDocsParams, BatchVectorisationMode
-from marqo.core.inference.tensor_fields_container import Chunker, TensorFieldsContainer, TensorFieldContent, \
-    TextChunker, ImageChunker, AudioVideoChunker, ModelConfig, Vectoriser, ContentChunkType
 from marqo.core.exceptions import AddDocumentsError, DuplicateDocumentError, MarqoDocumentParsingError, InternalError, \
-    UnsupportedFeatureError, VespaDocumentParsingError
+    UnsupportedFeatureError
 from marqo.core.models import MarqoIndex
+from marqo.core.models.add_docs_params import AddDocsParams, BatchVectorisationMode
 from marqo.core.models.marqo_add_documents_response import MarqoAddDocumentsItem, MarqoAddDocumentsResponse
 from marqo.core.models.marqo_index import FieldType
+from marqo.core.vespa_index.tensor_fields_container import Chunker, TensorFieldsContainer, TensorFieldContent, \
+    TextChunker, ImageChunker, AudioVideoChunker, ModelConfig, Vectoriser, ContentChunkType
 from marqo.logging import get_logger
 from marqo.tensor_search import validation, add_docs
 from marqo.tensor_search.telemetry import RequestMetricsStore

--- a/src/marqo/core/vespa_index/tensor_fields_container.py
+++ b/src/marqo/core/vespa_index/tensor_fields_container.py
@@ -1,7 +1,6 @@
-import hashlib
 import json
 from abc import ABC, abstractmethod
-from typing import List, Dict, Set, Optional, Any, Generator, Tuple, cast, TypeVar, Callable, Union
+from typing import List, Dict, Set, Optional, Any, Generator, Tuple, cast, TypeVar, Callable
 
 import numpy as np
 from PIL.Image import Image
@@ -10,17 +9,16 @@ from torch import Tensor
 
 from marqo.core import constants
 from marqo.core.constants import MARQO_DOC_ID
-from marqo.core.exceptions import AddDocumentsError, ModelError, InternalError
+from marqo.core.exceptions import AddDocumentsError, ModelError
 from marqo.core.models.marqo_index import FieldType, TextPreProcessing, ImagePreProcessing
 from marqo.s2_inference import errors as s2_inference_errors
 from marqo.s2_inference import s2_inference
 from marqo.s2_inference.multimodal_model_load import Modality
 from marqo.s2_inference.processing import image as image_processor
 from marqo.s2_inference.processing import text as text_processor
-
+from marqo.tensor_search.models.private_models import ModelAuth
 # TODO remove these deps
 from marqo.tensor_search.telemetry import RequestMetricsStore
-from marqo.tensor_search.models.private_models import ModelAuth
 
 # Content chunk of different modality can have different types
 # - Text: str

--- a/tests/unit_tests/marqo/core/vespa_index/test_add_documents_handler.py
+++ b/tests/unit_tests/marqo/core/vespa_index/test_add_documents_handler.py
@@ -4,26 +4,22 @@ from unittest.mock import patch
 
 import pytest
 
+from integ_tests.marqo_test import MarqoTestCase
+from integ_tests.marqo_test import TestAudioUrls, TestVideoUrls, TestImageUrls
 from marqo.core.constants import MARQO_DOC_ID
-from marqo.core.exceptions import DuplicateDocumentError, AddDocumentsError, MarqoDocumentParsingError, \
-    InternalError
-from marqo.core.inference.tensor_fields_container import TensorFieldsContainer
-from marqo.core.models.add_docs_params import AddDocsParams, BatchVectorisationMode
-from marqo.core.inference.tensor_fields_container import TensorFieldsContainer
 from marqo.core.exceptions import DuplicateDocumentError, AddDocumentsError, MarqoDocumentParsingError, InternalError
+from marqo.core.models.add_docs_params import AddDocsParams, BatchVectorisationMode
 from marqo.core.models.marqo_add_documents_response import MarqoAddDocumentsItem
 from marqo.core.models.marqo_index import FieldType
 from marqo.core.unstructured_vespa_index.unstructured_add_document_handler import \
     UnstructuredAddDocumentsHandler
 from marqo.core.vespa_index.add_documents_handler import AddDocumentsResponseCollector, AddDocumentsHandler
+from marqo.core.vespa_index.tensor_fields_container import TensorFieldsContainer
 from marqo.s2_inference import s2_inference
 from marqo.s2_inference.errors import S2InferenceError
-from marqo.s2_inference.types import Modality
 from marqo.s2_inference.multimodal_model_load import Modality
 from marqo.vespa.models import VespaDocument, FeedBatchResponse, FeedBatchDocumentResponse
 from marqo.vespa.models.get_document_response import Document, GetBatchResponse, GetBatchDocumentResponse
-from integ_tests.marqo_test import MarqoTestCase
-from integ_tests.marqo_test import TestAudioUrls, TestVideoUrls, TestImageUrls
 
 
 @pytest.mark.unittest

--- a/tests/unit_tests/marqo/core/vespa_index/test_tensor_field_chunkers.py
+++ b/tests/unit_tests/marqo/core/vespa_index/test_tensor_field_chunkers.py
@@ -6,7 +6,7 @@ import torch
 from PIL.Image import Image
 from torch import tensor
 
-from marqo.core.inference.tensor_fields_container import TextChunker, ImageChunker, AudioVideoChunker
+from marqo.core.vespa_index.tensor_fields_container import TextChunker, ImageChunker, AudioVideoChunker
 from marqo.core.exceptions import AddDocumentsError
 from marqo.core.models.marqo_index import TextPreProcessing, TextSplitMethod, ImagePreProcessing, PatchMethod
 from marqo.s2_inference.clip_utils import load_image_from_path
@@ -66,7 +66,7 @@ class TestTensorFieldChunkers(unittest.TestCase):
         self.assertEqual(1, len(content_chunks))
         self.assertIsInstance(content_chunks[0], Image)
 
-    @patch('marqo.core.inference.tensor_fields_container.image_processor.chunk_image')
+    @patch('marqo.core.vespa_index.tensor_fields_container.image_processor.chunk_image')
     def test_image_chunker_should_raise_error_when_chunking_fails(self, mock_chunk_image):
         image_url = TestImageUrls.HIPPO_REALISTIC.value
         media_repo = {image_url: load_image_from_path(image_url, {})}

--- a/tests/unit_tests/marqo/core/vespa_index/test_tensor_field_content.py
+++ b/tests/unit_tests/marqo/core/vespa_index/test_tensor_field_content.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 from PIL.Image import Image
 
-from marqo.core.inference.tensor_fields_container import TensorFieldContent, Chunker, MultiModalTensorFieldContent, \
+from marqo.core.vespa_index.tensor_fields_container import TensorFieldContent, Chunker, MultiModalTensorFieldContent, \
     Vectoriser
 from marqo.core.exceptions import AddDocumentsError
 from marqo.core.models.marqo_index import FieldType

--- a/tests/unit_tests/marqo/core/vespa_index/test_tensor_field_vectorisers.py
+++ b/tests/unit_tests/marqo/core/vespa_index/test_tensor_field_vectorisers.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 from PIL.Image import Image
 
-from marqo.core.inference.tensor_fields_container import SingleVectoriser, ModelConfig, BatchCachingVectoriser
+from marqo.core.vespa_index.tensor_fields_container import SingleVectoriser, ModelConfig, BatchCachingVectoriser
 from marqo.core.exceptions import AddDocumentsError, ModelError
 from marqo.s2_inference.clip_utils import load_image_from_path
 from marqo.s2_inference.errors import ModelDownloadError

--- a/tests/unit_tests/marqo/core/vespa_index/test_tensor_fields_container.py
+++ b/tests/unit_tests/marqo/core/vespa_index/test_tensor_fields_container.py
@@ -4,9 +4,9 @@ from typing import cast
 import pytest
 
 from marqo.core.constants import MARQO_DOC_ID, MARQO_DOC_TENSORS, MARQO_DOC_CHUNKS, MARQO_DOC_EMBEDDINGS
-from marqo.core.inference.tensor_fields_container import TensorFieldsContainer, MultiModalTensorFieldContent
 from marqo.core.exceptions import AddDocumentsError
-from marqo.core.models.marqo_index import FieldType, Field
+from marqo.core.models.marqo_index import FieldType
+from marqo.core.vespa_index.tensor_fields_container import TensorFieldsContainer, MultiModalTensorFieldContent
 
 
 @pytest.mark.unittest


### PR DESCRIPTION
The chunking and vectorisation logic will be removed from tensor_fields_container, so it makes sense to move it to vespa_index since it's only used by add_documents_handler.py

Also moved all the unit tests for these two files to unit_tests folder.

Note: This PR is the first one of tensor_fields_container refactoring PRs. It moves the code and tests to the target directory so following PRs can show the code change of these files correctly. 

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Refactoring

* **What is the current behavior?** (You can also link to an open issue here)
tensor_fields_container is in core.inference module

* **What is the new behavior (if this is a feature change)?**
tensor_fields_container is moved bo core.vespa_index module

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
Yes

* **Related Python client changes** (link commit/PR here)
No

* **Related documentation changes** (link commit/PR here)
No

* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

