### PR TITLE
[Releases/2.16] Fix map field's prefix not being set in marqo__field_types when partial updating + add api tests 

### DIFF
--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -437,12 +437,18 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
             field_type = vespa_field_types.get(field_name) # Get field type from the field passed in the request
 
             if not field_exists_in_original_doc or field_value_changed:
-                vespa_fields[vespa_field_name] = {"assign": field_value}
+                vespa_fields[vespa_field_name] = {"assign": field_value} # assign statement for adding / updating the field value in marqo__int_fields / marqo__float_fields
 
                 # Set field type metadata by creating an assign statement
-                vespa_fields[vespa_field_types_field_name] = {"assign": field_type}
+                vespa_fields[vespa_field_types_field_name] = {"assign": field_type} # assign statement for adding / updating the field type in marqo__field_types
+                
+                # Handle creating update statements for the map field name. 
+                if "." in field_name:
+                    # For fields like "map1.key1", extract the map name "map1"
+                    map_name = self._extract_map_name_from_field(field_name)
+                    # Create assign statement for adding / updating statement for the map field. This is done for the prefix in a flattened map field name.
+                    vespa_fields[f'{common.VESPA_DOC_FIELD_TYPES}{{{map_name}}}'] = {"assign": vespa_field_types.get(map_name)}
 
-                # Update field type metadata dictionary, so we can use it later when defining the update pre-condition to send to vespa
                 fields_changed = True
 
         # Remove fields no longer in map
@@ -453,16 +459,34 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
             if (original_field_name not in numeric_field_map and
                 original_doc.fixed_fields.field_types.get(original_field_name) in (MarqoFieldTypes.INT_MAP.value, MarqoFieldTypes.FLOAT_MAP.value)):
 
+                map_name = self._extract_map_name_from_field(original_field_name)
                 vespa_field_name = f'{field_prefix}{{{original_field_name}}}'
                 vespa_field_types_field_name = f'{common.VESPA_DOC_FIELD_TYPES}{{{original_field_name}}}'
 
-                vespa_fields[vespa_field_name] = {"remove": 0}
-                vespa_fields[vespa_field_types_field_name] = {"remove": 0}
+                vespa_fields[vespa_field_name] = {"remove": 0} # remove statement for removing the field from marqo__int_fields / marqo__float_fields
+                vespa_fields[vespa_field_types_field_name] = {"remove": 0} # remove statement for removing the field from marqo__field_types.
                 vespa_field_types.pop(original_field_name, None)
+
+                if vespa_field_types.get(map_name) is None: # Remove statement for removing the map field from marqo__field_types. This is prefix for a flattened map field.
+                    vespa_fields[f'{common.VESPA_DOC_FIELD_TYPES}{{{map_name}}}'] = {"remove": 0}
+                    
                 fields_changed = True
 
         return fields_changed
     
+    def _extract_map_name_from_field(self, field_name: str) -> str:
+        """Extract the map name from a flattened field name.
+        For fields like "map_name.key_name", this method extracts the map name portion.
+        
+        Args:
+            field_name: The flattened field name (e.g., "map1.key1")
+        Returns:
+            The map name portion of the field (e.g., "map1")
+        """
+        if "." in field_name:
+            return field_name.split(".", 1)[0]
+        return field_name
+
     def _handle_boolean_field(
         self,
         field_name: str,

--- a/tests/api_tests/v1/tests/api_tests/unstructured_index/test_update_documents_unstructured_index.py
+++ b/tests/api_tests/v1/tests/api_tests/unstructured_index/test_update_documents_unstructured_index.py
@@ -71,9 +71,7 @@ class TestUpdateDocumentsInUnstructuredIndex(MarqoTestCase):
         add_docs_response = self.client.index(self.text_index_name).add_documents(documents = text_docs, mappings = mappings, tensor_fields = tensor_fields)
 
         self.assertFalse(add_docs_response["errors"])
-
-        update_docs_response = self.client.index(self.text_index_name).update_documents(
-            [{
+        update_doc = {
                 '_id': '1',
                 'bool_field': False,
                 'update_field_that_doesnt_exist': 500,
@@ -86,24 +84,195 @@ class TestUpdateDocumentsInUnstructuredIndex(MarqoTestCase):
                     'c': 3.0,
                 },
                 'string_array': ["ccc"]
-            }]
-        )
+            }
+        
+        update_docs_response = self.client.index(self.text_index_name).update_documents([
+            update_doc])
 
         assert update_docs_response["errors"] == False
 
         get_docs_response = self.client.index(self.text_index_name).get_document(document_id = '1')
+        
+        # Use the helper method to verify all fields
+        self._verify_document_fields(get_docs_response, get_docs_response)
 
-        self.assertEqual(get_docs_response['bool_field'], False)
-        self.assertEqual(get_docs_response['int_field'], 1)
-        self.assertEqual(get_docs_response['float_field'], 500.0)
-        self.assertEqual(get_docs_response['int_map.a'], 2)
-        self.assertEqual(get_docs_response['float_map.c'], 3.0)
-        self.assertEqual(get_docs_response['string_array'], ["ccc"])
-        self.assertEqual(get_docs_response['update_field_that_doesnt_exist'], 500)
-        self.assertEqual(get_docs_response['string_array2'], ["123", "456"])
+    def test_add_new_fields_with_update_documents_api(self):
+        """Test that new fields can be added to a document using partial updates.
+        
+        This test verifies that a document can be initially created with minimal fields,
+        then updated to add new fields of various types, and that these fields are
+        correctly stored and retrievable.
 
-    def test_update_document_with_ids_change_field_type(self):
+        Note: this test only covers the fields that can be successfully added.
+        """
+        # First add a minimal document with just an ID
+        initial_doc = [{
+            '_id': 'minimal_doc',
+            'tensor_field': 'initial content'  # Need at least one field for indexing
+        }]
+        
+        # Add the minimal document
+        add_docs_response = self.client.index(self.text_index_name).add_documents(
+            documents=initial_doc,
+            tensor_fields=['tensor_field']
+        )
+        self.assertFalse(add_docs_response["errors"])
+        
+        # Now update the document with new fields of various types. 
+        # We won't be adding new lexical fields, as that is not supported. 
+        update_doc = {
+            '_id': 'minimal_doc',
+            'new_int_field': 42,
+            'new_float_field': 3.14159,
+            'new_bool_field': True,
+            'new_int_map': {
+                'key1': 100,
+                'key2': 200
+            },
+            'new_float_map': {
+                'pi': 3.14,
+                'e': 2.718
+            }
+        }
+        update_docs_response = self.client.index(self.text_index_name).update_documents([update_doc])
+        
+        self.assertFalse(update_docs_response["errors"])
+        
+        # Get the document back and verify all fields exist with correct values
+        get_docs_response = self.client.index(self.text_index_name).get_document(document_id='minimal_doc')
+        
+        # Verify original field
+        self.assertEqual(get_docs_response['tensor_field'], 'initial content')
+        
+        # Check all fields in the update document
+        self._verify_document_fields(update_doc, get_docs_response)
 
+    def test_add_new_tensor_field_with_update_documents_api(self):
+        """Test that adding new tensor fields via update_documents fails.
+        
+        This test verifies that attempting to add new tensor fields during an update operation
+        results in appropriate error responses, as these field types cannot be added after 
+        initial document creation.
+        """
+        # First add a minimal document with just an ID and a tensor field
+        initial_doc = [{
+            '_id': 'tensor_update_doc',
+            'tensor_field': 'initial content'  # Need at least one field for indexing
+        }]
+        
+        # Add the minimal document
+        add_docs_response = self.client.index(self.text_index_name).add_documents(
+            documents=initial_doc,
+            tensor_fields=['tensor_field']
+        )
+        self.assertFalse(add_docs_response["errors"])
+        
+        # Try to update with a new tensor field
+        update_docs_response = self.client.index(self.text_index_name).update_documents([{
+            '_id': 'tensor_update_doc',
+            'new_tensor_field': 'This should fail'
+        }])
+        
+        # Verify that errors were returned
+        self.assertTrue(update_docs_response["errors"], 
+                       "Expected error when adding new tensor field but got success")
+        
+        # Check the error details
+        error_details = update_docs_response["items"][0]
+        self.assertEqual(error_details["status"], 400, 
+                        "Expected status code 400 for tensor field but got {error_details['status']}")
+
+        # Assert the error message
+        self.assertIn("new_tensor_field of type str does not exist in the original document. "
+                      "Marqo does not support adding new lexical fields in partial updates"
+                      , error_details["error"])
+
+    def test_add_new_string_array_with_update_documents_api(self):
+        """Test that adding new string arrays via update_documents fails.
+        
+        This test verifies that attempting to add new string arrays during an update operation
+        results in appropriate error responses, as these field types cannot be added after 
+        initial document creation.
+        """
+        # First add a minimal document with just an ID and a tensor field
+        initial_doc = [{
+            '_id': 'string_array_update_doc',
+            'tensor_field': 'initial content'  # Need at least one field for indexing
+        }]
+        
+        # Add the minimal document
+        add_docs_response = self.client.index(self.text_index_name).add_documents(
+            documents=initial_doc,
+            tensor_fields=['tensor_field']
+        )
+        self.assertFalse(add_docs_response["errors"])
+        
+        # Try to update with a new string array
+        update_docs_response = self.client.index(self.text_index_name).update_documents([{
+            '_id': 'string_array_update_doc',
+            'new_string_array': ['item1', 'item2']
+        }])
+        
+        # Verify that errors were returned
+        self.assertTrue(update_docs_response["errors"], 
+                       "Expected error when adding new string array but got success")
+        
+        # Check the error details
+        error_details = update_docs_response["items"][0]
+        self.assertEqual(error_details["status"], 400, 
+                        "Expected status code 400 for string array but got {error_details['status']}")
+
+        # Assert the error message
+        self.assertIn("Unstructured index updates only support updating existing string array fields"
+                      , error_details["error"])
+
+    def test_add_new_string_field_with_update_documents_api(self):
+        """Test that adding new string fields via update_documents fails.
+        
+        This test verifies that attempting to add new string fields during an update operation
+        results in appropriate error responses, as these field types cannot be added after 
+        initial document creation.
+        """
+        # First add a minimal document with just an ID and a tensor field
+        initial_doc = [{
+            '_id': 'string_field_update_doc',
+            'tensor_field': 'initial content'  # Need at least one field for indexing
+        }]
+        
+        # Add the minimal document
+        add_docs_response = self.client.index(self.text_index_name).add_documents(
+            documents=initial_doc,
+            tensor_fields=['tensor_field']
+        )
+        self.assertFalse(add_docs_response["errors"])
+        
+        # Try to update with a new string field
+        update_docs_response = self.client.index(self.text_index_name).update_documents([{
+            '_id': 'string_field_update_doc',
+            'new_string_field': 'This should also fail'
+        }])
+        
+        # Verify that errors were returned
+        self.assertTrue(update_docs_response["errors"], 
+                       "Expected error when adding new string field but got success")
+        
+        # Check the error details
+        error_details = update_docs_response["items"][0]
+        self.assertEqual(error_details["status"], 400, 
+                        "Expected status code 400 for string field but got {error_details['status']}")
+
+        # Assert the error message
+        self.assertIn("new_string_field of type str does not exist in the original document. "
+                      "Marqo does not support adding new lexical fields in partial updates"
+                      , error_details["error"])
+
+    def test_update_document_and_change_field_type(self):
+        """Test that changing field types during document updates fails with appropriate errors.
+        
+        This test verifies that attempting to change a field's type (e.g., float to int, int to string)
+        during an update operation results in the expected error responses.
+        """
+        # First add a document with various field types
         text_docs = [{
             '_id': '1',
             'tensor_field': 'title',
@@ -134,39 +303,53 @@ class TestUpdateDocumentsInUnstructuredIndex(MarqoTestCase):
 
         tensor_fields = ['tensor_field', 'custom_vector_field', 'multimodal_combo_field']
 
-        add_docs_response = self.client.index(self.text_index_name).add_documents(documents = text_docs, mappings = mappings, tensor_fields = tensor_fields)
-
+        add_docs_response = self.client.index(self.text_index_name).add_documents(documents=text_docs, mappings=mappings, tensor_fields=tensor_fields)
         self.assertFalse(add_docs_response["errors"])
 
-        update_docs_response = self.client.index(self.text_index_name).update_documents(
-            [{
-                '_id': '1',
-                'bool_field': False,
-                'update_field_that_doesnt_exist': 500,
-                'int_field': 1,
-                'float_field': 500, # The request is same as the test case test_update_document_with_ids, except the float_field value is changed to int. This will result in a 412 condition check failed error.
-                'int_map': {
-                    'a': 2,
-                },
-                'float_map': {
-                    'c': 3.0,
-                },
-                'string_array': ["ccc"]
-            }]
-        )
+        # Define field type change scenarios to test
+        type_change_scenarios = [
+            {"field": "float_field", "new_value": 500, "original_type": "float", "new_type": "int"},
+            {"field": "int_field", "new_value": 123.5, "original_type": "int", "new_type": "float"},
+            {"field": "bool_field", "new_value": "true", "original_type": "bool", "new_type": "string"},
+            {"field": "short_string_field", "new_value": 42, "original_type": "string", "new_type": "int"},
+            {"field": "int_map", "new_value": {"a": 2.5}, "original_type": "int_map", "new_type": "float_map"},
+            {"field": "float_map", "new_value": {"c": 3}, "original_type": "float_map", "new_type": "int_map"},
+            {"field": "string_array", "new_value": 123, "original_type": "string_array", "new_type": "int"},
+            # Map to scalar type changes
+            {"field": "int_map", "new_value": 42, "original_type": "int_map", "new_type": "int"},
+            {"field": "int_map", "new_value": 42.5, "original_type": "int_map", "new_type": "float"},
+            {"field": "float_map", "new_value": 42, "original_type": "float_map", "new_type": "int"},
+            {"field": "float_map", "new_value": 42.5, "original_type": "float_map", "new_type": "float"}
+        ]
 
-        self.assertTrue(update_docs_response["errors"])
+        # Test each type change scenario in a subtest
+        for scenario in type_change_scenarios:
+            with self.subTest(f"Changing {scenario['field']} from {scenario['original_type']} to {scenario['new_type']}"):
+                update_payload = {
+                    '_id': '1',
+                    scenario['field']: scenario['new_value']
+                }
+                
+                update_docs_response = self.client.index(self.text_index_name).update_documents([update_payload])
 
-        self.assertEqual(update_docs_response['items'][0]['status'], 400)
-        self.assertIn("Marqo vector store couldn't update the document. Please see", update_docs_response['items'][0]['message'])
-        self.assertIn("reference/api/documents/update-documents/#response", update_docs_response['items'][0]['message'])
-
-    def test_concurrent_partial_update_requests(self):
+                # Verify the update failed with appropriate error
+                self.assertTrue(update_docs_response["errors"])
+                self.assertEqual(update_docs_response['items'][0]['status'], 400)
+                if scenario['original_type'] == "bool":
+                    self.assertIn("bool_field of type str does not exist in the original document. Marqo does not support adding new lexical fields in partial updates",
+                                  update_docs_response['items'][0]['error'])
+                else:
+                    self.assertIn("Marqo vector store couldn't update the document. Please see",
+                                  update_docs_response['items'][0]['message'])
+                    self.assertIn("reference/api/documents/update-documents/#response",
+                                  update_docs_response['items'][0]['message'])
+                
+    def test_concurrent_partial_update_requests_on_maps(self):
         """Test concurrent updates to different fields of the same document.
         
         This test verifies that:
         1. Multiple threads can update different fields of the same document concurrently
-        2. Updates are properly applied without conflicts
+        2. Updates are applied, some of which fail due to concurrent updates, but the final state is consistent
         3. The final document state reflects one of the updates correctly
         """
         # First add a document to update
@@ -187,6 +370,7 @@ class TestUpdateDocumentsInUnstructuredIndex(MarqoTestCase):
                 print(f"[{timestamp}] Rank update {i+1}/{len(rank_values)}: Setting rank to {new_rank}")
                 r = self.client.index(index_name).update_documents([{'_id': '3', 'score_map': {'rank': new_rank}}])
                 timestamp = datetime.now().strftime("%H:%M:%S.%f")[:-3]
+                # We can't be sure that the response will be error-free due to concurrent updates. So we will not check that here
                 print(f"[{timestamp}] Rank update {i+1} complete. Response: {r}")
                 time.sleep(0.5)  # Small delay between updates
 
@@ -196,6 +380,7 @@ class TestUpdateDocumentsInUnstructuredIndex(MarqoTestCase):
                 print(f"[{timestamp}] Popularity update {i+1}/{len(popularity_values)}: Setting popularity to {new_pop}")
                 r = self.client.index(index_name).update_documents([{'_id': '3', 'score_map': {'popularity': new_pop}}])
                 timestamp = datetime.now().strftime("%H:%M:%S.%f")[:-3]
+                # We can't be sure that the response will be error-free due to concurrent updates. So we will not check that here
                 print(f"[{timestamp}] Popularity update {i+1} complete. Response: {r}")
                 time.sleep(0.5)  # Same delay now for both threads
 
@@ -262,6 +447,107 @@ class TestUpdateDocumentsInUnstructuredIndex(MarqoTestCase):
             hit = search_result["hits"][0]
             self.assertAlmostEqual(hit["_score"], base_score + 1*updated_doc['score_map.popularity'], places = 5)
 
+    def test_concurrent_partial_update_requests_on_numeric_fields(self):
+        """Test concurrent updates to different fields of the same document.
+
+        This test verifies that:
+        1. Multiple threads can update different fields of the same document concurrently
+        2. Updates are properly applied without conflicts
+        3. The final document state reflects one of the updates correctly
+        """
+        # First add a document to update
+        text_docs = [{
+            '_id': '3',
+            'tensor_field': 'concurrent update test',
+            'description': 'This document will be updated by multiple threads',
+            'int_field': 100,
+            'float_field': 100.0,
+        }]
+
+        add_docs_response = self.client.index(self.text_index_name).add_documents(documents=text_docs, mappings={},
+                                                                                  tensor_fields=['tensor_field',
+                                                                                                 'description'])
+        self.assertFalse(add_docs_response["errors"])
+
+        def update_rank_thread(index_name, rank_values):
+            for i, new_rank in enumerate(rank_values):
+                timestamp = datetime.now().strftime("%H:%M:%S.%f")[:-3]
+                print(f"[{timestamp}] Rank update {i + 1}/{len(rank_values)}: Setting rank to {new_rank}")
+                r = self.client.index(index_name).update_documents([{'_id': '3', 'rank': new_rank}])
+                timestamp = datetime.now().strftime("%H:%M:%S.%f")[:-3]
+                print(f"[{timestamp}] Rank update {i + 1} complete. Response: {r}")
+                self.assertFalse(r["errors"]) # Assert that there are no errors in the response
+                time.sleep(0.5)  # Small delay between updates
+
+        def update_popularity_thread(index_name, popularity_values):
+            for i, new_pop in enumerate(popularity_values):
+                timestamp = datetime.now().strftime("%H:%M:%S.%f")[:-3]
+                print(
+                    f"[{timestamp}] Popularity update {i + 1}/{len(popularity_values)}: Setting popularity to {new_pop}")
+                r = self.client.index(index_name).update_documents([{'_id': '3', 'popularity': new_pop}])
+                timestamp = datetime.now().strftime("%H:%M:%S.%f")[:-3]
+                print(f"[{timestamp}] Popularity update {i + 1} complete. Response: {r}")
+                self.assertFalse(r["errors"]) # Assert that there are no errors in the response
+                time.sleep(0.5)  # Same delay now for both threads
+
+        rank_values = [0.85, 0.87, 0.90, 0.82, 0.88]
+        popularity_values = [0.72, 0.75, 0.79, 0.81, 0.78]
+
+        rank_thread = threading.Thread(target=update_rank_thread, args=(self.text_index_name, rank_values))
+        pop_thread = threading.Thread(target=update_popularity_thread, args=(self.text_index_name, popularity_values))
+
+        rank_thread.start()
+        pop_thread.start()
+
+        rank_thread.join()
+        pop_thread.join()
+
+        print(f"[{datetime.now().strftime('%H:%M:%S.%f')[:-3]}] Both updates completed")
+
+        # Get the document to verify updates
+        updated_doc = self.client.index(self.text_index_name).get_document(document_id='3')
+
+        # Check that only one of the fields is present (due to concurrent updates)
+        has_rank = 'rank' in updated_doc
+        has_popularity = 'popularity' in updated_doc
+
+        # Either rank or popularity should be present, but not both
+        self.assertTrue(has_rank and has_popularity, "Neither rank nor popularity field is present")
+
+        # If rank is present, verify it's one of the rank values
+        self.assertIn(updated_doc['rank'], rank_values,
+                      f"Rank value {updated_doc['rank']} is not in expected values {rank_values}")
+
+        # If popularity is present, verify it's one of the popularity values
+        self.assertIn(updated_doc['popularity'], popularity_values,
+                          f"Popularity value {updated_doc['popularity']} is not in expected values {popularity_values}")
+
+        # Verify original fields are still intact
+        self.assertEqual(updated_doc['tensor_field'], 'concurrent update test')
+        self.assertEqual(updated_doc['description'], 'This document will be updated by multiple threads')
+        self.assertEqual(updated_doc['int_field'], 100)
+        self.assertEqual(updated_doc['float_field'], 100.0)
+
+        # Test search with score modifiers using the updated field (whichever is present)
+        base_search_result = self.client.index(self.text_index_name).search("concurrent update")
+        base_score = base_search_result["hits"][0]["_score"]
+
+        search_result = self.client.index(self.text_index_name).search("concurrent update", score_modifiers={
+            "add_to_score": [{"field_name": "rank", "weight": 1}]
+        })
+
+        self.assertTrue(len(search_result["hits"]) > 0, "No search results found")
+        hit = search_result["hits"][0]
+        self.assertAlmostEqual(hit["_score"], base_score + 1 * updated_doc['rank'], places=5)
+
+        search_result = self.client.index(self.text_index_name).search("concurrent update", score_modifiers={
+            "add_to_score": [{"field_name": "popularity", "weight": 1}]
+        })
+
+        self.assertTrue(len(search_result["hits"]) > 0, "No search results found")
+        hit = search_result["hits"][0]
+        self.assertAlmostEqual(hit["_score"], base_score + 1 * updated_doc['popularity'], places=5)
+
     def test_update_document_with_changes_in_score_modifiers(self):
         """Test that score modifiers are correctly updated during partial document updates.
         
@@ -307,8 +593,7 @@ class TestUpdateDocumentsInUnstructuredIndex(MarqoTestCase):
 
         self.assertFalse(add_docs_response["errors"])
 
-        update_docs_response = self.client.index(self.text_index_name).update_documents(
-            [{
+        update_doc = {
                 '_id': '1',
                 'int_map': {
                     'a': 2,  # update int to int
@@ -320,20 +605,18 @@ class TestUpdateDocumentsInUnstructuredIndex(MarqoTestCase):
                 'new_int': 1,  # new int field
                 'new_float': 2.0,  # new float field
                 'new_map': {'a': 1, 'b': 2.0},  # new map field
-            }]
+        }
+
+        update_docs_response = self.client.index(self.text_index_name).update_documents(
+            [update_doc]
         )
 
         self.assertFalse(update_docs_response["errors"])
 
         # Get the document to verify updates
         updated_doc = self.client.index(self.text_index_name).get_document(document_id='1')
-        self.assertEqual(updated_doc['int_map.a'], 2)
-        self.assertEqual(updated_doc['int_map.d'], 5)
-        self.assertEqual(updated_doc['float_map.c'], 3.0)
-        self.assertEqual(updated_doc['new_int'], 1)
-        self.assertEqual(updated_doc['new_float'], 2.0)
-        self.assertEqual(updated_doc['new_map.a'], 1)
-        self.assertEqual(updated_doc['new_map.b'], 2.0)
+        
+        self._verify_document_fields(update_doc, updated_doc)
 
         # Test that score modifiers work correctly with the updated fields
         # First search without score modifier to get base score
@@ -388,3 +671,182 @@ class TestUpdateDocumentsInUnstructuredIndex(MarqoTestCase):
             places=5
         )
 
+    def test_concurrent_mixed_add_documents_and_update_documents_requests(self):
+        """Test concurrent updates using different API methods on the same document.
+
+        This test verifies that:
+        1. Multiple threads can update the same document using different API methods concurrently
+        2. One thread uses update_documents to modify specific fields
+        3. One thread uses add_documents to replace the entire document
+        4. The document remains in a consistent state after all operations
+        """
+        # First add a document to update
+        text_docs = [{
+            '_id': '4',
+            'tensor_field': 'mixed update test',
+            'description': 'This document will be updated by multiple threads using different methods',
+            'int_field': 100,
+            'float_field': 100.0,
+            'tags': ['initial', 'document'],
+        }]
+
+        add_docs_response = self.client.index(self.text_index_name).add_documents(
+            documents=text_docs,
+            mappings={},
+            tensor_fields=['tensor_field', 'description']
+        )
+        self.assertFalse(add_docs_response["errors"])
+
+        def update_documents_thread(index_name):
+            """Thread that updates specific fields using update_documents."""
+            for i in range(10):
+                timestamp = datetime.now().strftime("%H:%M:%S.%f")[:-3]
+                print(f"[{timestamp}] update_documents thread - iteration {i + 1}/10: Updating int_field and metadata")
+                r = self.client.index(index_name).update_documents([{
+                    '_id': '4',
+                    'int_field': 200 + i,
+                    'tensor_field': f'update_documents replaced content {i + 1}',
+                    'description': f'This document was updated in iteration {i + 1} inside an update_documents thread',
+                }])
+                self.assertTrue(r["errors"]) # We can be sure that the response will be error-free due to concurrent updates and the updates sent by the other add documents
+                # thread
+                timestamp = datetime.now().strftime("%H:%M:%S.%f")[:-3]
+                print(f"[{timestamp}] update_documents thread - iteration {i + 1} complete. Response: {r}")
+                time.sleep(0.5)  # Delay between updates
+
+        def add_documents_thread(index_name):
+            """Thread that replaces the entire document using add_documents."""
+            for i in range(10):
+                timestamp = datetime.now().strftime("%H:%M:%S.%f")[:-3]
+                print(f"[{timestamp}] add_documents thread - iteration {i + 1}/10: Replacing document")
+                r = self.client.index(index_name).add_documents(
+                    documents=[{
+                        '_id': '4',
+                        'tensor_field': f'add_documents replaced content {i + 1}',
+                        'description': f'This document was replaced in iteration {i + 1} inside an add_documents thread',
+                        'int_field': 300 + i,
+                        'float_field': 300.0 + i,
+                        'tags': ['replaced', f'iteration-{i + 1}'],
+                    }],
+                    tensor_fields=['tensor_field', 'description']
+                )
+                self.assertFalse(r["errors"]) # Assert that there are no errors in the response
+                timestamp = datetime.now().strftime("%H:%M:%S.%f")[:-3]
+                print(f"[{timestamp}] add_documents thread - iteration {i + 1} complete. Response: {r}")
+                time.sleep(0.5)  # Delay between updates
+
+        # Create and start threads
+        update_thread = threading.Thread(target=update_documents_thread, args=(self.text_index_name,))
+        add_thread = threading.Thread(target=add_documents_thread, args=(self.text_index_name,))
+
+        add_thread.start()
+        update_thread.start()
+
+        add_thread.join()
+        update_thread.join()
+
+        # Verify the final document state
+        final_doc = self.client.index(self.text_index_name).get_document(document_id='4')
+
+        # We can't predict exactly which thread's updates will be the final state
+        # but we can verify that the document exists and has expected structure
+        self.assertEqual(final_doc['_id'], '4')
+        self.assertIn('tensor_field', final_doc)
+        self.assertIn('description', final_doc)
+        self.assertIn('int_field', final_doc)
+        self.assertIn('float_field', final_doc)
+        self.assertIn('This document was replaced in iteration 10 inside an add_documents thread', final_doc['description'])
+        self.assertIn('add_documents replaced content 10', final_doc['tensor_field'])
+
+    def test_partial_update_new_map_field(self):
+        """
+        Test the following scenario:
+        1. Add a map with a partial update,
+        2. Update it with another partial update, remove the existing keys
+        3. Final state of the doc should only contain the Map sent in #2
+        """
+        text_docs = [
+            {
+                '_id': '4',
+                'text': 'This is a test document',
+                'rank': 100,
+            }
+        ]
+        add_docs_response = self.client.index(self.text_index_name).add_documents(
+            documents=text_docs,
+            mappings={},
+            tensor_fields=['text']
+        )
+
+        get_doc = self.client.index(self.text_index_name).get_document('4')
+        self.assertEqual(get_doc['rank'], text_docs[0]['rank'])
+
+        update_docs_response = self.client.index(self.text_index_name).update_documents(
+            [ {
+                '_id': '4',
+                'metadata': {'key1': 100.5}
+            }]
+        )
+        self.assertFalse(update_docs_response['errors'])
+
+        update_docs_response_2 = self.client.index(self.text_index_name).update_documents(
+            [{
+                '_id': '4',
+                'metadata': {'key2': 100.5},
+            }]
+        )
+
+        self.assertFalse(update_docs_response_2['errors'])
+
+        get_docs_result = self.client.index(index_name=self.text_index_name).get_document(document_id='4')
+        self.assertIsNone(get_docs_result.get('metadata.key1'))
+        self.assertEqual(get_docs_result['metadata.key2'], 100.5)
+
+        base_search_result = self.client.index(index_name=self.text_index_name).search("test document")
+        base_score = base_search_result["hits"][0]["_score"]
+
+        search_result_with_non_existent_score_modifier = self.client.index(index_name = self.text_index_name).search("test document", score_modifiers={
+            "add_to_score": [{"field_name": "metadata.key1", "weight": 1}]
+        })
+
+        score_with_non_existent_score_modifier = search_result_with_non_existent_score_modifier["hits"][0]["_score"]
+        # Since the score modifier should not exist after the map has been completely replaced, the scores should be the same
+        self.assertAlmostEqual(score_with_non_existent_score_modifier, base_score, 5)
+
+        search_with_existing_score_modifier = self.client.index(index_name = self.text_index_name).search("test document", score_modifiers={
+            "add_to_score": [{"field_name": "metadata.key2", "weight": 1}]
+        })
+
+        score_with_existing_score_modifier = search_with_existing_score_modifier["hits"][0]["_score"]
+        self.assertAlmostEqual(score_with_existing_score_modifier, base_score + 1*100.5, 5)
+
+
+    def _verify_document_fields(self, update_doc, get_docs_response):
+        """Verify that all fields in the update document are correctly stored in the retrieved document.
+        
+        This helper method checks each field in the update document against the retrieved document,
+        handling both simple fields and nested map fields appropriately.
+        
+        Args:
+            update_doc: The document used in the update operation
+            get_docs_response: The document retrieved from the index after update
+        """
+        for field, expected_value in update_doc.items():
+            if field == '_id':
+                continue
+            if isinstance(expected_value, dict):
+                # Handle map fields
+                for key, value in expected_value.items():
+                    flattened_field = f"{field}.{key}"
+                    self.assertEqual(
+                        get_docs_response[flattened_field], 
+                        value, 
+                        f"Field {flattened_field} value mismatch: expected {value}, got {get_docs_response[flattened_field]}"
+                    )
+            else:
+                # Handle simple fields
+                self.assertEqual(
+                    get_docs_response[field], 
+                    expected_value,
+                    f"Field {field} value mismatch: expected {expected_value}, got {get_docs_response[field]}"
+                )

--- a/tests/integ_tests/core/document/test_partial_update_semi_structured.py
+++ b/tests/integ_tests/core/document/test_partial_update_semi_structured.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Tuple
 
 import pytest
 
@@ -72,6 +72,55 @@ class TestPartialUpdate(MarqoTestCase):
             '2': self.doc2,
             '3': self.doc3
         }
+        self.field_to_field_type_doc1 = {
+            'string_array': MarqoFieldTypes.STRING_ARRAY.value,
+            'string_array2': MarqoFieldTypes.STRING_ARRAY.value,
+        }
+        self.field_to_field_type_doc2 = {
+            'string_array': MarqoFieldTypes.STRING_ARRAY.value,
+            'string_array2': MarqoFieldTypes.STRING_ARRAY.value,
+            'int_map': MarqoFieldTypes.INT_MAP.value,
+            'float_map': MarqoFieldTypes.FLOAT_MAP.value,
+            'bool_field': MarqoFieldTypes.BOOL.value,
+            'bool_field2': MarqoFieldTypes.BOOL.value,
+            'custom_vector_field': MarqoFieldTypes.TENSOR.value,
+            'multimodal_combo_field': MarqoFieldTypes.TENSOR.value, 
+            'tensor_field': MarqoFieldTypes.TENSOR.value,
+            'tensor_subfield': MarqoFieldTypes.TENSOR.value,
+            'short_string_field': MarqoFieldTypes.STRING.value,
+            'long_string_field': MarqoFieldTypes.STRING.value,
+            'lexical_field': MarqoFieldTypes.STRING.value,
+            'int_map.a': MarqoFieldTypes.INT_MAP.value, 
+            'int_map.b': MarqoFieldTypes.INT_MAP.value,
+            'float_map.c': MarqoFieldTypes.FLOAT_MAP.value,
+            'float_map.d': MarqoFieldTypes.FLOAT_MAP.value,
+            'float_field': MarqoFieldTypes.FLOAT.value,
+            'int_field': MarqoFieldTypes.INT.value,
+        }
+        self.field_to_field_type_doc3 = {
+            'bool_field': MarqoFieldTypes.BOOL.value,
+            'bool_field2': MarqoFieldTypes.BOOL.value,
+            'int_field': MarqoFieldTypes.INT.value,
+            'float_field': MarqoFieldTypes.FLOAT.value,
+            'int_map': MarqoFieldTypes.INT_MAP.value,
+            'float_map': MarqoFieldTypes.FLOAT_MAP.value,
+            'custom_vector_field': MarqoFieldTypes.TENSOR.value,
+            'multimodal_combo_field': MarqoFieldTypes.TENSOR.value,
+            'tensor_field': MarqoFieldTypes.TENSOR.value,
+            'tensor_subfield': MarqoFieldTypes.TENSOR.value,
+            'short_string_field': MarqoFieldTypes.STRING.value,
+            'long_string_field': MarqoFieldTypes.STRING.value,
+            'int_map.a': MarqoFieldTypes.INT_MAP.value,
+            'int_map.b': MarqoFieldTypes.INT_MAP.value,
+            'float_map.c': MarqoFieldTypes.FLOAT_MAP.value,
+            'float_map.d': MarqoFieldTypes.FLOAT_MAP.value,
+        }
+        self.doc_to_field_type_map = {
+            '1': self.field_to_field_type_doc1,
+            '2': self.field_to_field_type_doc2,
+            '3': self.field_to_field_type_doc3,
+        }
+
         self.add_documents(self.config, add_docs_params=AddDocsParams(
             index_name=self.index.name,
             docs=[self.doc, self.doc2, self.doc3],
@@ -112,7 +161,22 @@ class TestPartialUpdate(MarqoTestCase):
             else:
                 self.assertEqual(value, doc.get(field, None), f'{field} is changed.')
 
-    def _assert_field_types(self, id, field_type_pairs):
+    def _assert_field_types(self, id: str, field_type_pairs: List[Tuple[str, MarqoFieldTypes]]):
+        """
+        Verify that the field types of a document match the expected types.
+
+        This method retrieves the document from Vespa and checks that the field types
+        match the expected types provided in the `field_type_pairs` list.
+
+        Args:
+            id (str): The ID of the document to check.
+            field_type_pairs (List[Tuple[str, MarqoFieldTypes]]): A list of tuples where each tuple contains
+                a field name and its expected type.
+
+        Raises:
+            AssertionError: If any field type does not match the expected type.
+        """
+
         raw_vespa_doc = self.config.vespa_client.get_document(id, self.index.schema_name)
         vespa_fields = raw_vespa_doc.document.dict().get('fields')
 
@@ -120,6 +184,34 @@ class TestPartialUpdate(MarqoTestCase):
             expected_type = field_type.value if field_type is not None else None
             self.assertEqual(vespa_fields.get('marqo__field_types').get(field_name), expected_type,
                             f"Expected {field_name} to have type {expected_type} for document {id}")
+            
+        self._assert_field_types_not_changed(id, vespa_fields, [field_name for field_name, _ in field_type_pairs])
+            
+    def _assert_field_types_not_changed(self, id: str, vespa_fields: dict, excluded_fields: List[str]):
+        """Verify that field types remain unchanged except for the specified excluded fields.
+        
+        This helper method checks that all field types in the document match their expected values,
+        excluding the fields that were intentionally modified during the test.
+        
+        Args:
+            id: The document ID to check
+            excluded_fields: List of field names that were intentionally modified and should be excluded from verification
+        """
+        raw_vespa_doc = self.config.vespa_client.get_document(id, self.index.schema_name)
+        vespa_fields = raw_vespa_doc.document.dict().get('fields')
+        field_types = vespa_fields.get('marqo__field_types')
+        
+        for field, value in field_types.items(): 
+            if field in excluded_fields:
+                continue
+            
+            doc_to_field_type = self.doc_to_field_type_map[id]
+            # Verify field exists in either field_to_field_type or excluded_fields
+            if field not in doc_to_field_type and field not in excluded_fields:
+                self.fail(f"Field '{field}' found in field_types but doesn't exist in doc_to_field_type map or excluded_fields for document {id}. "
+                          f"This means it's an extra field that shouldn't be present in Marqo__field_types.")
+            
+            self.assertEqual(value, doc_to_field_type.get(field), f"Expected {field} to have type {value} for document {id}")
 
 
     # Test update single field
@@ -179,7 +271,6 @@ class TestPartialUpdate(MarqoTestCase):
                 self._assert_field_types(id, [
                     ('int_field', MarqoFieldTypes.INT)
                 ])
-
     def test_partial_update_to_non_existent_field(self):
         """Test that partial updates to non-existent fields are successful.
         
@@ -263,6 +354,7 @@ class TestPartialUpdate(MarqoTestCase):
 
                 # Verify field type
                 self._assert_field_types(id, [
+                    ('int_map', MarqoFieldTypes.INT_MAP),
                     ('int_map.c', MarqoFieldTypes.INT_MAP),
                     ('int_map.d', MarqoFieldTypes.INT_MAP),
                     ('int_map.a', None),
@@ -290,6 +382,7 @@ class TestPartialUpdate(MarqoTestCase):
 
                 # Verify field type
                 self._assert_field_types(id, [
+                    ('int_map', MarqoFieldTypes.INT_MAP),
                     ('int_map.f', MarqoFieldTypes.INT_MAP),
                     ('int_map.g', MarqoFieldTypes.INT_MAP),
                     ('int_map.a', None),
@@ -315,6 +408,7 @@ class TestPartialUpdate(MarqoTestCase):
 
                 # Verify field type
                 self._assert_field_types(id, [
+                    ('int_map', MarqoFieldTypes.INT_MAP),
                     ('int_map.d', MarqoFieldTypes.INT_MAP),
                     ('int_map.a', None),
                     ('int_map.b', None)
@@ -339,6 +433,7 @@ class TestPartialUpdate(MarqoTestCase):
 
                 # Verify field type
                 self._assert_field_types(id, [
+                    ('float_map', MarqoFieldTypes.FLOAT_MAP),
                     ('float_map.c', MarqoFieldTypes.FLOAT_MAP),
                     ('float_map.d', MarqoFieldTypes.FLOAT_MAP)
                 ])
@@ -372,8 +467,10 @@ class TestPartialUpdate(MarqoTestCase):
 
                 # Verify field types
                 self._assert_field_types(id, [
+                    ('int_map', MarqoFieldTypes.INT_MAP),
                     ('int_map.a', MarqoFieldTypes.INT_MAP),
                     ('int_map.b', None),
+                    ('float_map', MarqoFieldTypes.FLOAT_MAP),
                     ('float_map.c', MarqoFieldTypes.FLOAT_MAP),
                     ('float_map.d', None),
                     ('int_field', MarqoFieldTypes.INT),
@@ -554,13 +651,16 @@ class TestPartialUpdate(MarqoTestCase):
 
                 # Verify field types
                 field_type_pairs = [
+                    ('int_map', MarqoFieldTypes.INT_MAP),
                     ('int_map.a', MarqoFieldTypes.INT_MAP),
                     ('int_map.d', MarqoFieldTypes.INT_MAP),
+                    ('float_map', MarqoFieldTypes.FLOAT_MAP),
                     ('float_map.c', MarqoFieldTypes.FLOAT_MAP),
                     ('new_int', MarqoFieldTypes.INT),
                     ('new_float', MarqoFieldTypes.FLOAT),
                     ('new_map.a', MarqoFieldTypes.INT_MAP),
                     ('new_map.b', MarqoFieldTypes.FLOAT_MAP),
+                    ('new_map', MarqoFieldTypes.FLOAT_MAP),
                     ('int_map.b', None),
                     ('float_map.d', None)
                 ]
@@ -628,8 +728,10 @@ class TestPartialUpdate(MarqoTestCase):
                 # Verify field types using helper method
                 field_type_pairs = [
                     ('int_map_2.d', MarqoFieldTypes.INT_MAP),
+                    ('int_map_2', MarqoFieldTypes.INT_MAP),
                     ('int_map_2.e', MarqoFieldTypes.INT_MAP),
                     ('float_map_2.f', MarqoFieldTypes.FLOAT_MAP),
+                    ('float_map_2', MarqoFieldTypes.FLOAT_MAP),
                     ('new_int', MarqoFieldTypes.INT),
                     ('new_float', MarqoFieldTypes.FLOAT)
                 ]
@@ -740,6 +842,7 @@ class TestPartialUpdate(MarqoTestCase):
                     ('new_field', MarqoFieldTypes.INT),
                     ('new_float', MarqoFieldTypes.FLOAT),
                     ('new_int_map.a', MarqoFieldTypes.INT_MAP),
+                    ('new_int_map', MarqoFieldTypes.INT_MAP),
                     ('new_bool_field', MarqoFieldTypes.BOOL),
                     ('new_float_field', MarqoFieldTypes.FLOAT)
                 ]
@@ -899,10 +1002,12 @@ class TestPartialUpdate(MarqoTestCase):
                     id,
                     [
                         ('int_map.a', MarqoFieldTypes.INT_MAP),
+                        ('int_map', MarqoFieldTypes.INT_MAP),
                         ('int_map.b', MarqoFieldTypes.INT_MAP),
                         ('int_map.c', MarqoFieldTypes.INT_MAP),
                         ('float_map.c', MarqoFieldTypes.FLOAT_MAP),
-                        ('float_map.e', MarqoFieldTypes.FLOAT_MAP)
+                        ('float_map.e', MarqoFieldTypes.FLOAT_MAP),
+                        ('float_map', MarqoFieldTypes.FLOAT_MAP)
                     ]
                 )
 
@@ -1139,6 +1244,7 @@ class TestPartialUpdate(MarqoTestCase):
         updated_doc = tensor_search.get_document_by_id(self.config, self.index.name, '2')
         self.assertIsNone(updated_doc.get('float_map.c', None))
         self.assertIsNone(updated_doc.get('float_map.d', None))
+        self._assert_field_types('2', [('float_map', None), ('float_map.c', None), ('float_map.d', None)])
         self._assert_fields_unchanged(updated_doc, ['float_map.c', 'float_map.d'])
 
     def test_partial_update_should_reject_updating_dict_to_int_field(self):
@@ -1193,3 +1299,84 @@ class TestPartialUpdate(MarqoTestCase):
         self.assertEqual(400, res.items[0].status)
         self.assertIn("Marqo vector store couldn't update the document. Please see", res.items[0].error)
         self.assertIn('reference/api/documents/update-documents/#response', res.items[0].error)
+
+    def test_partial_update_adding_all_field_types_to_minimal_document(self):
+        """Test adding all possible field types to a minimal document via partial update.
+        
+        This test:
+        1. Creates a minimal document with just an ID
+        2. Performs a partial update to add all supported field types
+        3. Verifies that all field types are correctly set in the document
+        """
+        # Create a minimal document with just an ID
+        minimal_doc = {
+            "_id": "minimal_doc"
+        }
+        
+        # Add the minimal document to the index
+        self.add_documents(self.config, add_docs_params=AddDocsParams(
+            index_name=self.index.name,
+            docs=[minimal_doc],
+            tensor_fields=[]
+        ))
+        
+        # Verify the document exists
+        doc_before_update = tensor_search.get_document_by_id(self.config, self.index.name, "minimal_doc")
+        self.assertEqual("minimal_doc", doc_before_update["_id"])
+        
+        # Perform a partial update to add all supported field types
+        update_fields = {
+            "_id": "minimal_doc",
+            "short_string_field": "short string value",
+            "long_string_field": "This is a very long string value " * 10,
+            "int_field": 42,
+            "float_field": 3.14159,
+            "bool_field": True,
+            "bool_field2": False,
+            "int_map": {"key1": 1, "key2": 2, "key3": 3},
+            "float_map": {"key1": 1.1, "key2": 2.2, "key3": 3.3},
+            "string_array": ["value1", "value2", "value3"],
+            "lexical_field": "lexical field value"
+        }
+        
+        res = self.config.document.partial_update_documents([update_fields], self.index)
+        self.assertFalse(res.errors, f"Expected no errors when updating document, got: {res.items[0].error if res.errors else ''}")
+        
+        # Retrieve the updated document
+        updated_doc = tensor_search.get_document_by_id(self.config, self.index.name, "minimal_doc")
+        
+        # Verify all fields were added with correct values
+        self.assertEqual("short string value", updated_doc["short_string_field"])
+        self.assertEqual("This is a very long string value " * 10, updated_doc["long_string_field"])
+        self.assertEqual(42, updated_doc["int_field"])
+        self.assertEqual(3.14159, updated_doc["float_field"])
+        self.assertTrue(updated_doc["bool_field"])
+        self.assertFalse(updated_doc["bool_field2"])
+        self.assertEqual(1, updated_doc["int_map.key1"])
+        self.assertEqual(2, updated_doc["int_map.key2"])
+        self.assertEqual(3, updated_doc["int_map.key3"])
+        self.assertEqual(1.1, updated_doc["float_map.key1"])
+        self.assertEqual(2.2, updated_doc["float_map.key2"])
+        self.assertEqual(3.3, updated_doc["float_map.key3"])
+        self.assertEqual(["value1", "value2", "value3"], updated_doc["string_array"])
+        self.assertEqual("lexical field value", updated_doc["lexical_field"])
+        
+        # Verify field types
+        self._assert_field_types("minimal_doc", [
+            ("short_string_field", MarqoFieldTypes.STRING),
+            ("long_string_field", MarqoFieldTypes.STRING),
+            ("int_field", MarqoFieldTypes.INT),
+            ("float_field", MarqoFieldTypes.FLOAT),
+            ("bool_field", MarqoFieldTypes.BOOL),
+            ("bool_field2", MarqoFieldTypes.BOOL),
+            ("int_map", MarqoFieldTypes.INT_MAP),
+            ("int_map.key1", MarqoFieldTypes.INT_MAP),
+            ("int_map.key2", MarqoFieldTypes.INT_MAP),
+            ("int_map.key3", MarqoFieldTypes.INT_MAP),
+            ("float_map", MarqoFieldTypes.FLOAT_MAP),
+            ("float_map.key1", MarqoFieldTypes.FLOAT_MAP),
+            ("float_map.key2", MarqoFieldTypes.FLOAT_MAP),
+            ("float_map.key3", MarqoFieldTypes.FLOAT_MAP),
+            ("string_array", MarqoFieldTypes.STRING_ARRAY),
+            ("lexical_field", MarqoFieldTypes.STRING)
+        ])

--- a/tests/integ_tests/core/document/test_partial_update_semi_structured.py
+++ b/tests/integ_tests/core/document/test_partial_update_semi_structured.py
@@ -7,6 +7,8 @@ from marqo.core.models.add_docs_params import AddDocsParams
 from marqo.core.semi_structured_vespa_index.marqo_field_types import MarqoFieldTypes
 from marqo.tensor_search import tensor_search
 from integ_tests.marqo_test import MarqoTestCase
+import copy
+
 
 class TestPartialUpdate(MarqoTestCase):
     @classmethod
@@ -115,10 +117,29 @@ class TestPartialUpdate(MarqoTestCase):
             'float_map.c': MarqoFieldTypes.FLOAT_MAP.value,
             'float_map.d': MarqoFieldTypes.FLOAT_MAP.value,
         }
+        self.field_to_field_type_doc_minimal_doc = {
+            "short_string_field": MarqoFieldTypes.STRING.value,
+            "long_string_field": MarqoFieldTypes.STRING.value,
+            "int_field": MarqoFieldTypes.INT.value,
+            "float_field": MarqoFieldTypes.FLOAT.value,
+            "bool_field": MarqoFieldTypes.BOOL.value,
+            "bool_field2": MarqoFieldTypes.BOOL.value,
+            "int_map": MarqoFieldTypes.INT_MAP.value,
+            "float_map": MarqoFieldTypes.FLOAT_MAP.value,
+            "int_map.key1": MarqoFieldTypes.INT_MAP.value,
+            "int_map.key2": MarqoFieldTypes.INT_MAP.value,
+            "int_map.key3": MarqoFieldTypes.INT_MAP.value,
+            "float_map.key1": MarqoFieldTypes.FLOAT_MAP.value,
+            "float_map.key2": MarqoFieldTypes.FLOAT_MAP.value,
+            "float_map.key3": MarqoFieldTypes.FLOAT_MAP.value,
+            "string_array": MarqoFieldTypes.STRING_ARRAY.value,
+            "lexical_field": MarqoFieldTypes.STRING.value,
+        }
         self.doc_to_field_type_map = {
             '1': self.field_to_field_type_doc1,
             '2': self.field_to_field_type_doc2,
             '3': self.field_to_field_type_doc3,
+            'minimal_doc': self.field_to_field_type_doc_minimal_doc
         }
 
         self.add_documents(self.config, add_docs_params=AddDocsParams(
@@ -185,35 +206,57 @@ class TestPartialUpdate(MarqoTestCase):
             self.assertEqual(vespa_fields.get('marqo__field_types').get(field_name), expected_type,
                             f"Expected {field_name} to have type {expected_type} for document {id}")
             
-        self._assert_field_types_not_changed(id, vespa_fields, [field_name for field_name, _ in field_type_pairs])
+        self._assert_field_types_not_changed(id, vespa_fields, field_type_pairs)
             
-    def _assert_field_types_not_changed(self, id: str, vespa_fields: dict, excluded_fields: List[str]):
-        """Verify that field types remain unchanged except for the specified excluded fields.
-        
+    def _assert_field_types_not_changed(self, id: str, vespa_fields: dict, excluded_fields: List[Tuple[str, MarqoFieldTypes]]):
+        """
+        Verify that field types remain unchanged except for the specified excluded fields.
+
         This helper method checks that all field types in the document match their expected values,
         excluding the fields that were intentionally modified during the test.
-        
+
         Args:
-            id: The document ID to check
-            excluded_fields: List of field names that were intentionally modified and should be excluded from verification
+            id (str): The document ID to check.
+            vespa_fields (dict): The fields from the Vespa document.
+            excluded_fields (List[Tuple[str, MarqoFieldTypes]]): List of field names that were intentionally modified and should be excluded from verification.
         """
-        raw_vespa_doc = self.config.vespa_client.get_document(id, self.index.schema_name)
-        vespa_fields = raw_vespa_doc.document.dict().get('fields')
-        field_types = vespa_fields.get('marqo__field_types')
+        # Get the actual field types from the Vespa document
+        actual_field_types = vespa_fields.get('marqo__field_types')
+        # Get the expected field types from our mapping
+        doc_to_field_type = self.doc_to_field_type_map[id]
         
-        for field, value in field_types.items(): 
-            if field in excluded_fields:
-                continue
-            
-            doc_to_field_type = self.doc_to_field_type_map[id]
-            # Verify field exists in either field_to_field_type or excluded_fields
-            if field not in doc_to_field_type and field not in excluded_fields:
-                self.fail(f"Field '{field}' found in field_types but doesn't exist in doc_to_field_type map or excluded_fields for document {id}. "
-                          f"This means it's an extra field that shouldn't be present in Marqo__field_types.")
-            
-            self.assertEqual(value, doc_to_field_type.get(field), f"Expected {field} to have type {value} for document {id}")
+        # Create a copy of the expected field types and remove excluded fields
+        expected_field_types = copy.deepcopy(doc_to_field_type)
 
+        # Process each excluded field
+        for field_name, field_value in excluded_fields:
+            # If field value is None, remove the field from expected types if it exists. We do this because 
+            # fields of type None signify that the field was supposed to be removed from the document
+            if field_value is None:
+                if field_name in expected_field_types:
+                    del expected_field_types[field_name]
+            # Otherwise update the expected type with the new value. We do this because 
+            # this field signifies a new field that has been added to the document. 
+            else:
+                if field_name not in expected_field_types:
+                    expected_field_types[field_name] = field_value.value
 
+        # Compare actual and expected field types
+        is_expected_and_actual_equal = actual_field_types == expected_field_types
+        # If they don't match, find and report the differences
+        if not is_expected_and_actual_equal:
+            # Find common fields between actual and expected
+            intersection = set(actual_field_types.items()) & set(expected_field_types.items())
+            # Find fields that are in expected but not in actual
+            fields_present_in_expected_but_not_in_actual = set(expected_field_types.items()) - intersection
+            # Find fields that are in actual but not in expected  
+            fields_present_in_actual_but_not_in_expected = set(actual_field_types.items()) - intersection
+            # Report any missing fields that should be present
+            for field, _ in fields_present_in_expected_but_not_in_actual:
+                self.fail(f"Field {field} is present in expected field types but not in actual field types")
+            # Report any extra fields that shouldn't be present
+            for field, _ in fields_present_in_actual_but_not_in_expected:
+                self.fail(f"Field {field} is present in actual field types but not in expected field types")
     # Test update single field
     def test_partial_update_should_update_bool_field(self):
         """Test that boolean fields can be updated correctly via partial updates.
@@ -1007,6 +1050,7 @@ class TestPartialUpdate(MarqoTestCase):
                         ('int_map.c', MarqoFieldTypes.INT_MAP),
                         ('float_map.c', MarqoFieldTypes.FLOAT_MAP),
                         ('float_map.e', MarqoFieldTypes.FLOAT_MAP),
+                        ('float_map.d', None),
                         ('float_map', MarqoFieldTypes.FLOAT_MAP)
                     ]
                 )


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
1. Fixed a bug where when we insert a map using partial updates, the map prefix in a flattened map field name was not getting set in marqo__field_types
2. Adds some API tests in correspondence with the set of manual tests that we were running

* **What is the current behavior?** (You can also link to an open issue here)
* wrt the bug - currently if a map is inserted via a partial update (it must not exist from before), the marqo__field_types will consist of int_map.key1, int_map.key2 but no int_map. This doesn't happen when inserting maps via add_docs and is critical to prevent type conversions.

* **What is the new behavior (if this is a feature change)?**
* if a map is inserted via a partial update (it must not exist from before), the marqo__field_types will consist of int_map.key1: int_map_entry, int_map.key2: int_map_entry & int_map: int_map_entry. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
* No


* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
* Yes


* **Related Python client changes** (link commit/PR here)
* NA


* **Related documentation changes** (link commit/PR here)


* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

