### PR TITLE
Improve PreprocessingConfig class hierarchy to support Json or Msgpack encoding

### DIFF
--- a/src/marqo/core/inference/api/inference.py
+++ b/src/marqo/core/inference/api/inference.py
@@ -3,10 +3,10 @@ from typing import Optional, Dict, Any, List, Tuple, Union
 
 import pydantic
 from numpy import ndarray
-from pydantic import StrictStr, root_validator, ValidationError
+from pydantic import StrictStr, root_validator
 
 from marqo.base_model import ImmutableBaseModel
-from marqo.core.inference.api import PreprocessingConfig, InferenceError, Modality
+from marqo.core.inference.api import InferenceError, Modality, PreprocessingConfigType
 # TODO Ideally this should be in a shared module
 from marqo.tensor_search.models.private_models import ModelAuth
 
@@ -23,17 +23,16 @@ class InferenceRequest(ImmutableBaseModel):
     contents: List[str] = pydantic.Field(min_items=1)
     device: Optional[str] = pydantic.Field(default=None)
     model_config: ModelConfig = pydantic.Field(alias='modelConfig')
-    preprocessing_config: PreprocessingConfig = pydantic.Field(alias='preprocessingConfig')
+    preprocessing_config: PreprocessingConfigType = pydantic.Field(alias='preprocessingConfig')
     use_inference_cache: bool = pydantic.Field(default=False, alias='useInferenceCache')
 
     @root_validator(pre=False)
     def check_preprocessing_config_matches_modality(cls, values):
         modality: Modality = values.get('modality')
-        preprocessing_config: PreprocessingConfig = values.get('preprocessing_config')
-        supported_modalities = preprocessing_config.supported_modalities
+        preprocessing_config: PreprocessingConfigType = values.get('preprocessing_config')
 
-        if modality not in supported_modalities:
-            raise ValueError(f"{type(preprocessing_config)} only supports modality: {supported_modalities}, "
+        if not modality or modality.value != preprocessing_config.modality:
+            raise ValueError(f"{type(preprocessing_config)} only supports modality: {preprocessing_config.modality}, "
                              f"but modality: {modality} is specified in the request")
 
         return values

--- a/src/marqo/core/inference/api/preprocessing_config.py
+++ b/src/marqo/core/inference/api/preprocessing_config.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional, Dict, Literal, List, Set
+from typing import Optional, Dict, Literal, List, Set, Union
 
 import pydantic
 from pydantic import root_validator
@@ -10,12 +10,8 @@ from marqo.core.inference.api.modality import Modality
 
 class PreprocessingConfig(ImmutableBaseModel, ABC):
     """Parent class of preprocessing config for all modality types"""
+    modality: str
     should_chunk: bool = pydantic.Field(default=False, alias='shouldChunk')
-
-    @property
-    @abstractmethod
-    def supported_modalities(self) -> Set[Modality]:
-        pass
 
 
 class ChunkConfig(ImmutableBaseModel):
@@ -29,6 +25,7 @@ class TextChunkConfig(ChunkConfig):
 
 class TextPreprocessingConfig(PreprocessingConfig):
     """Preprocessing config for text modality"""
+    modality: Literal[Modality.TEXT] = Modality.TEXT
     text_prefix: Optional[str] = pydantic.Field(default=None, alias='textPrefix')
     chunk_config: Optional[TextChunkConfig] = pydantic.Field(default=None, alias='chunkConfig')
 
@@ -42,13 +39,10 @@ class TextPreprocessingConfig(PreprocessingConfig):
             raise ValueError("`chunk_config` must not be provided when `should_chunk` is False.")
         return values
 
-    @property
-    def supported_modalities(self) -> Set[Modality]:
-        return {Modality.TEXT}
-
 
 class ImagePreprocessingConfig(PreprocessingConfig):
     """Preprocessing config for image modality"""
+    modality: Literal[Modality.IMAGE] = Modality.IMAGE
     download_timeout_ms: Optional[int] = pydantic.Field(default=None, alias='downloadTimeoutMs')
     download_thread_count: Optional[int] = pydantic.Field(default=None, alias='downloadThreadCount')
     download_header: Optional[Dict[str, str]] = pydantic.Field(default=None, alias='downloadHeader')
@@ -72,13 +66,10 @@ class ImagePreprocessingConfig(PreprocessingConfig):
             raise ValueError("`patch_method` must not be provided when `should_chunk` is False.")
         return values
 
-    @property
-    def supported_modalities(self) -> Set[Modality]:
-        return {Modality.IMAGE}
 
-
-class AudioVideoPreprocessingConfig(PreprocessingConfig):
-    """Preprocessing config for audio and video modality"""
+class AudioPreprocessingConfig(PreprocessingConfig):
+    """Preprocessing config for audio modality"""
+    modality: Literal[Modality.AUDIO] = Modality.AUDIO
     download_thread_count: Optional[int] = pydantic.Field(default=None, alias='downloadThreadCount')
     download_header: Optional[Dict[str, str]] = pydantic.Field(default=None, alias='downloadHeader')
     chunk_config: Optional[ChunkConfig] = pydantic.Field(default=None, alias='chunkConfig')
@@ -93,7 +84,25 @@ class AudioVideoPreprocessingConfig(PreprocessingConfig):
             raise ValueError("`chunk_config` must not be provided when `should_chunk` is False.")
         return values
 
-    @property
-    def supported_modalities(self) -> Set[Modality]:
-        return {Modality.AUDIO, Modality.VIDEO}
 
+class VideoPreprocessingConfig(PreprocessingConfig):
+    """Preprocessing config for video modality"""
+    modality: Literal[Modality.VIDEO] = Modality.VIDEO
+    download_thread_count: Optional[int] = pydantic.Field(default=None, alias='downloadThreadCount')
+    download_header: Optional[Dict[str, str]] = pydantic.Field(default=None, alias='downloadHeader')
+    chunk_config: Optional[ChunkConfig] = pydantic.Field(default=None, alias='chunkConfig')
+
+    @root_validator
+    def validate_chunk_config(cls, values):
+        should_chunk = values.get('should_chunk')
+        chunk_config = values.get('chunk_config')
+        if should_chunk and chunk_config is None:
+            raise ValueError("`chunk_config` must be provided when `should_chunk` is True.")
+        if not should_chunk and chunk_config is not None:
+            raise ValueError("`chunk_config` must not be provided when `should_chunk` is False.")
+        return values
+
+
+PreprocessingConfigType = Union[
+    TextPreprocessingConfig, ImagePreprocessingConfig, AudioPreprocessingConfig, VideoPreprocessingConfig
+]

--- a/tests/unit_tests/marqo/core/inference/api/test_inference_model_classes.py
+++ b/tests/unit_tests/marqo/core/inference/api/test_inference_model_classes.py
@@ -4,7 +4,7 @@ import numpy as np
 from pydantic import ValidationError
 
 from marqo.core.inference.api import ModelConfig, InferenceRequest, Modality, TextPreprocessingConfig, \
-    AudioVideoPreprocessingConfig, ImagePreprocessingConfig, InferenceError, InferenceResult
+    AudioPreprocessingConfig, VideoPreprocessingConfig, ImagePreprocessingConfig, InferenceError, InferenceResult
 from marqo.tensor_search.models.external_apis.hf import HfAuth
 from marqo.tensor_search.models.private_models import ModelAuth
 
@@ -132,8 +132,8 @@ class TestInferenceRequest(unittest.TestCase):
         """Test creating a valid InferenceRequest with all required fields."""
         for modality, preprocessing_config in [
             (Modality.TEXT, TextPreprocessingConfig()),
-            (Modality.AUDIO, AudioVideoPreprocessingConfig()),
-            (Modality.VIDEO, AudioVideoPreprocessingConfig()),
+            (Modality.AUDIO, AudioPreprocessingConfig()),
+            (Modality.VIDEO, VideoPreprocessingConfig()),
             (Modality.IMAGE, ImagePreprocessingConfig()),
         ]:
             with self.subTest(modality=modality, preprocessing_config=preprocessing_config):
@@ -149,13 +149,20 @@ class TestInferenceRequest(unittest.TestCase):
     def test_invalid_inference_request_for_non_matching_modality(self):
         for modality, preprocessing_config in [
             (Modality.TEXT, ImagePreprocessingConfig()),
-            (Modality.TEXT, AudioVideoPreprocessingConfig()),
+            (Modality.TEXT, AudioPreprocessingConfig()),
+            (Modality.TEXT, VideoPreprocessingConfig()),
+
             (Modality.IMAGE, TextPreprocessingConfig()),
-            (Modality.IMAGE, AudioVideoPreprocessingConfig()),
+            (Modality.IMAGE, AudioPreprocessingConfig()),
+            (Modality.IMAGE, VideoPreprocessingConfig()),
+
             (Modality.AUDIO, TextPreprocessingConfig()),
             (Modality.AUDIO, ImagePreprocessingConfig()),
+            (Modality.AUDIO, VideoPreprocessingConfig()),
+
             (Modality.VIDEO, TextPreprocessingConfig()),
             (Modality.VIDEO, ImagePreprocessingConfig()),
+            (Modality.VIDEO, AudioPreprocessingConfig()),
         ]:
 
             with self.subTest(modality=modality, preprocessing_config=preprocessing_config):
@@ -187,7 +194,7 @@ class TestInferenceRequest(unittest.TestCase):
             device="cuda",
             use_inference_cache=True,
             model_config=self.model_config,
-            preprocessing_config=AudioVideoPreprocessingConfig()
+            preprocessing_config=AudioPreprocessingConfig()
         )
         self.assertEqual(request.device, "cuda")
         self.assertTrue(request.use_inference_cache)

--- a/tests/unit_tests/marqo/core/inference/api/test_preprocessing_config.py
+++ b/tests/unit_tests/marqo/core/inference/api/test_preprocessing_config.py
@@ -3,7 +3,7 @@ import unittest
 from pydantic import ValidationError
 
 from marqo.core.inference.api import ChunkConfig, TextChunkConfig, TextPreprocessingConfig, ImagePreprocessingConfig, \
-    AudioVideoPreprocessingConfig, Modality
+    AudioPreprocessingConfig, VideoPreprocessingConfig
 
 
 class TestChunkConfig(unittest.TestCase):
@@ -185,9 +185,6 @@ class TestTextPreprocessingConfig(unittest.TestCase):
         self.assertIn('"TextPreprocessingConfig" is immutable and does not support item assignment',
                       str(context.exception))
 
-    def test_supported_modalities(self):
-        self.assertSetEqual(TextPreprocessingConfig().supported_modalities, {Modality.TEXT})
-
 
 class TestImagePreprocessingConfig(unittest.TestCase):
     def test_default_values(self):
@@ -271,20 +268,17 @@ class TestImagePreprocessingConfig(unittest.TestCase):
             config.should_chunk = True
         self.assertIn('"ImagePreprocessingConfig" is immutable and does not support item assignment', str(context.exception))
 
-    def test_supported_modalities(self):
-        self.assertSetEqual(ImagePreprocessingConfig().supported_modalities, {Modality.IMAGE})
 
-
-class TestAudioVideoPreprocessingConfig(unittest.TestCase):
+class TestAudioPreprocessingConfig(unittest.TestCase):
     def test_default_values(self):
-        config = AudioVideoPreprocessingConfig()
+        config = AudioPreprocessingConfig()
         self.assertFalse(config.should_chunk)
         self.assertIsNone(config.chunk_config)
         self.assertIsNone(config.download_header)
         self.assertIsNone(config.download_thread_count)
 
     def test_valid_configuration_without_chunking(self):
-        config = AudioVideoPreprocessingConfig(
+        config = AudioPreprocessingConfig(
             should_chunk=False,
             download_header={"Authorization": "Bearer token"},
             download_thread_count=4,
@@ -296,7 +290,7 @@ class TestAudioVideoPreprocessingConfig(unittest.TestCase):
         self.assertEqual(config.download_thread_count, 4)
 
     def test_valid_configuration_with_chunking(self):
-        config = AudioVideoPreprocessingConfig(
+        config = AudioPreprocessingConfig(
             should_chunk=True,
             download_header={"Authorization": "Bearer token"},
             download_thread_count=4,
@@ -316,7 +310,7 @@ class TestAudioVideoPreprocessingConfig(unittest.TestCase):
         Test that a ValidationError is raised when should_chunk is False but chunk_config is provided.
         """
         with self.assertRaises(ValidationError) as context:
-            AudioVideoPreprocessingConfig(
+            AudioPreprocessingConfig(
                 should_chunk=False,
                 chunk_config=ChunkConfig(split_length=10, split_overlap=2),
             )
@@ -327,14 +321,14 @@ class TestAudioVideoPreprocessingConfig(unittest.TestCase):
         Test that a ValidationError is raised when should_chunk is False but chunk_config is provided.
         """
         with self.assertRaises(ValidationError) as context:
-            AudioVideoPreprocessingConfig(
+            AudioPreprocessingConfig(
                 should_chunk=True
             )
         self.assertIn("`chunk_config` must be provided when `should_chunk` is True.", str(context.exception))
 
     def test_aliases_are_handled_correctly(self):
         """Test that aliases are correctly parsed."""
-        config = AudioVideoPreprocessingConfig(
+        config = AudioPreprocessingConfig(
             shouldChunk=True,
             downloadThreadCount=2,
             downloadHeader={"Content-Type": "application/json"},
@@ -346,10 +340,84 @@ class TestAudioVideoPreprocessingConfig(unittest.TestCase):
         self.assertEqual(config.chunk_config, ChunkConfig(splitLength=10, splitOverlap=2))
 
     def test_immutability(self):
-        config = AudioVideoPreprocessingConfig()
+        config = AudioPreprocessingConfig()
         with self.assertRaises(TypeError) as context:
             config.should_chunk = True
-        self.assertIn('"AudioVideoPreprocessingConfig" is immutable and does not support item assignment', str(context.exception))
+        self.assertIn('"AudioPreprocessingConfig" is immutable and does not support item assignment', str(context.exception))
 
-    def test_supported_modalities(self):
-        self.assertSetEqual(AudioVideoPreprocessingConfig().supported_modalities, {Modality.AUDIO, Modality.VIDEO})
+
+class TestVideoPreprocessingConfig(unittest.TestCase):
+    def test_default_values(self):
+        config = VideoPreprocessingConfig()
+        self.assertFalse(config.should_chunk)
+        self.assertIsNone(config.chunk_config)
+        self.assertIsNone(config.download_header)
+        self.assertIsNone(config.download_thread_count)
+
+    def test_valid_configuration_without_chunking(self):
+        config = VideoPreprocessingConfig(
+            should_chunk=False,
+            download_header={"Authorization": "Bearer token"},
+            download_thread_count=4,
+        )
+
+        self.assertFalse(config.should_chunk)
+        self.assertIsNone(config.chunk_config)
+        self.assertEqual(config.download_header, {"Authorization": "Bearer token"})
+        self.assertEqual(config.download_thread_count, 4)
+
+    def test_valid_configuration_with_chunking(self):
+        config = VideoPreprocessingConfig(
+            should_chunk=True,
+            download_header={"Authorization": "Bearer token"},
+            download_thread_count=4,
+            chunk_config=ChunkConfig(
+                split_length=10,
+                split_overlap=2
+            )
+        )
+
+        self.assertTrue(config.should_chunk)
+        self.assertEqual(config.download_header, {"Authorization": "Bearer token"})
+        self.assertEqual(config.download_thread_count, 4)
+        self.assertEqual(config.chunk_config, ChunkConfig(split_length=10, split_overlap=2))
+
+    def test_should_not_chunk_with_chunk_config(self):
+        """
+        Test that a ValidationError is raised when should_chunk is False but chunk_config is provided.
+        """
+        with self.assertRaises(ValidationError) as context:
+            VideoPreprocessingConfig(
+                should_chunk=False,
+                chunk_config=ChunkConfig(split_length=10, split_overlap=2),
+            )
+        self.assertIn("`chunk_config` must not be provided when `should_chunk` is False.", str(context.exception))
+
+    def test_should_chunk_without_chunk_config(self):
+        """
+        Test that a ValidationError is raised when should_chunk is False but chunk_config is provided.
+        """
+        with self.assertRaises(ValidationError) as context:
+            VideoPreprocessingConfig(
+                should_chunk=True
+            )
+        self.assertIn("`chunk_config` must be provided when `should_chunk` is True.", str(context.exception))
+
+    def test_aliases_are_handled_correctly(self):
+        """Test that aliases are correctly parsed."""
+        config = VideoPreprocessingConfig(
+            shouldChunk=True,
+            downloadThreadCount=2,
+            downloadHeader={"Content-Type": "application/json"},
+            chunkConfig=ChunkConfig(splitLength=10, splitOverlap=2),
+        )
+        self.assertTrue(config.should_chunk)
+        self.assertEqual(config.download_thread_count, 2)
+        self.assertEqual(config.download_header, {"Content-Type": "application/json"})
+        self.assertEqual(config.chunk_config, ChunkConfig(splitLength=10, splitOverlap=2))
+
+    def test_immutability(self):
+        config = VideoPreprocessingConfig()
+        with self.assertRaises(TypeError) as context:
+            config.should_chunk = True
+        self.assertIn('"VideoPreprocessingConfig" is immutable and does not support item assignment', str(context.exception))


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Refactoring

* **What is the current behavior?** (You can also link to an open issue here)
The PreprocessingConfig class hierarchy does not have a discriminator field so it cannot be automatically deserialised by pydantic

* **What is the new behavior (if this is a feature change)?**
Add a modality field as a discriminator field, which replaces the supported modality property as well.
Split AudioVideoPreprocessingConfig to AudioPreprocessingConfig and VideoPreprocessingConfig
Define a new Union type for all the preprocessing configs to be used in InferenceRequest

In this way these model classes can be auto converted to pydantic model objects during remote calls, no matter what encoding protocol is used.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No. The interface is internal, and haven't been used in any code yet.

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
Yes

* **Related Python client changes** (link commit/PR here)
No

* **Related documentation changes** (link commit/PR here)
No

* **Other information**:


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

