### PR TITLE
Upgrade setup-python GH action to v5 to fix the python cache issue

### DIFF
--- a/.github/workflows/backwards_compatibility_marqo_execution.yml
+++ b/.github/workflows/backwards_compatibility_marqo_execution.yml
@@ -76,7 +76,7 @@ jobs:
 
       # Step to set up Python 3.9
       - name: Set up Python 3.9
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: "pip"

--- a/.github/workflows/backwards_compatibility_marqo_orchestrator.yml
+++ b/.github/workflows/backwards_compatibility_marqo_orchestrator.yml
@@ -99,7 +99,7 @@ jobs:
 
       # Step to set up Python 3.9
       - name: Set up Python 3.9
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
           cache: "pip"

--- a/.github/workflows/cpu_docker_marqo.yml
+++ b/.github/workflows/cpu_docker_marqo.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: "pip"

--- a/.github/workflows/cpu_local_marqo.yml
+++ b/.github/workflows/cpu_local_marqo.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: "pip"

--- a/.github/workflows/cuda_docker_marqo.yml
+++ b/.github/workflows/cuda_docker_marqo.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: "pip"

--- a/.github/workflows/cuda_docker_marqo_split.yml
+++ b/.github/workflows/cuda_docker_marqo_split.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: "pip"

--- a/.github/workflows/integration_tests_CI.yml
+++ b/.github/workflows/integration_tests_CI.yml
@@ -135,7 +135,7 @@ jobs:
           path: marqo
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: "pip"

--- a/.github/workflows/largemodel_integration_tests_CI.yml
+++ b/.github/workflows/largemodel_integration_tests_CI.yml
@@ -94,7 +94,7 @@ jobs:
           path: marqo
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: "pip"

--- a/.github/workflows/locust_perf_test.yml
+++ b/.github/workflows/locust_perf_test.yml
@@ -98,7 +98,7 @@ jobs:
           ref: ${{ github.event.inputs.marqo_ref }}
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
 

--- a/.github/workflows/test_documentation.yml
+++ b/.github/workflows/test_documentation.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: "pip"

--- a/.github/workflows/test_patches_merged.yml
+++ b/.github/workflows/test_patches_merged.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -32,7 +32,7 @@ jobs:
           path: marqo
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: "pip"


### PR DESCRIPTION
## Change Summary
* `actions/setup-python` v3 depends on `actions/cache` v2. 
* `actions/cache` v2 is deprecated post Feb 2025 due to the backend changes: details in this thread: https://github.com/actions/cache/discussions/1510
* This PR upgrades `setup-python` to the latest version so we don't run into the pip cache issue caused by the backend change.

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

