### PR TITLE
Upgrade pydantic to v2 (PR1)

### DIFF
--- a/.github/workflows/run_required_checks.yml
+++ b/.github/workflows/run_required_checks.yml
@@ -24,10 +24,17 @@ jobs:
       - name: Check for Non-Markdown Changes
         id: check_changes
         run: |
-          if git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -vE '\.md$'; then
-            echo "non_documentation_changes_found=true" >> $GITHUB_OUTPUT
+          BEFORE="${{ github.event.before }}"
+          AFTER="${{ github.sha }}"
+          
+          if [ -z "$BEFORE" ] || \
+             git diff --name-only "$BEFORE" "$AFTER" | grep -qvE '\.md$'
+          then
+            # either BEFORE was empty, or we found at least one non‑.md change
+            echo "non_documentation_changes_found=true" >> "$GITHUB_OUTPUT"
           else
-            echo "non_documentation_changes_found=false" >> $GITHUB_OUTPUT
+            # BEFORE was set and all changed files end in .md
+            echo "non_documentation_changes_found=false" >> "$GITHUB_OUTPUT"
           fi
 
   Run-integration-tests:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,7 @@
 msgpack==1.1.0
 msgpack_numpy==0.4.8
 python-json-logger==3.3.0
+pydantic==2.11.1
+fastapi==0.115.12
+fastapi-utils==0.8.0
+uvicorn==0.34.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,10 @@
 # Marqo's requirements files are stored in marqo-base repo: https://github.com/marqo-ai/marqo-base/tree/main/requirements
+# Every time we upgrade dependencies, we need to build a new base image. This process often requires upgrading Vespa
+# as well (since Vespa regularly removes old version from their dns repo). In the long run, we'll merge marqo-base repo
+# back into marqo repo, and improve the image building process. In the short term, we will add new platform-agnostic
+# dependencies (or upgrades of these dependencies) in this file. Please not if the dependency is platform-relevant,
+# meaning you need to use one version for arm64 and another for amd64, you still need to follow the process in
+# marqo-base repo and build a new base image.
 
 msgpack==1.1.0
 msgpack_numpy==0.4.8

--- a/src/marqo/api/models/add_docs_objects.py
+++ b/src/marqo/api/models/add_docs_objects.py
@@ -1,8 +1,8 @@
 from typing import List, Dict
 from typing import Optional, Any, Sequence
 
-from pydantic import BaseModel, root_validator
-from pydantic import Field
+from pydantic.v1 import BaseModel, root_validator
+from pydantic.v1 import Field
 
 from marqo.tensor_search.enums import EnvVars
 from marqo.tensor_search.models.private_models import ModelAuth
@@ -25,7 +25,7 @@ class AddDocsBodyParams(BaseModel):
     mappings: Optional[dict] = None
     documents: Sequence[Dict[str, Any]]
     imageDownloadThreadCount: int = Field(default_factory=lambda: read_env_vars_and_defaults_ints(EnvVars.MARQO_IMAGE_DOWNLOAD_THREAD_COUNT_PER_REQUEST))
-    mediaDownloadThreadCount: Optional[int]
+    mediaDownloadThreadCount: Optional[int] = None
     textChunkPrefix: Optional[str] = None
 
     @root_validator

--- a/src/marqo/api/models/embed_request.py
+++ b/src/marqo/api/models/embed_request.py
@@ -5,8 +5,7 @@ https://pydantic-docs.helpmanual.io/usage/types/#enums-and-choices
 """
 from typing import Union, List, Dict, Optional
 
-import pydantic
-from pydantic.v1 import Field, root_validator
+from pydantic.v1 import Field, root_validator, validator
 
 from marqo.base_model import MarqoBaseModel
 from marqo.core.embed.embed import EmbedContentType
@@ -21,7 +20,7 @@ class EmbedRequest(MarqoBaseModel):
     modelAuth: Optional[ModelAuth] = None
     content_type: Optional[EmbedContentType] = Field(default=EmbedContentType.Query, alias="contentType")
 
-    @pydantic.v1.validator('content')
+    @validator('content')
     def validate_content(cls, value):
         # Iterate through content list items
         if (isinstance(value, list) or isinstance(value, dict)) and len(value) == 0:

--- a/src/marqo/api/models/embed_request.py
+++ b/src/marqo/api/models/embed_request.py
@@ -6,7 +6,7 @@ https://pydantic-docs.helpmanual.io/usage/types/#enums-and-choices
 from typing import Union, List, Dict, Optional
 
 import pydantic
-from pydantic import Field, root_validator
+from pydantic.v1 import Field, root_validator
 
 from marqo.base_model import MarqoBaseModel
 from marqo.core.embed.embed import EmbedContentType
@@ -21,7 +21,7 @@ class EmbedRequest(MarqoBaseModel):
     modelAuth: Optional[ModelAuth] = None
     content_type: Optional[EmbedContentType] = Field(default=EmbedContentType.Query, alias="contentType")
 
-    @pydantic.validator('content')
+    @pydantic.v1.validator('content')
     def validate_content(cls, value):
         # Iterate through content list items
         if (isinstance(value, list) or isinstance(value, dict)) and len(value) == 0:

--- a/src/marqo/api/models/get_batch_documents_request.py
+++ b/src/marqo/api/models/get_batch_documents_request.py
@@ -1,4 +1,4 @@
-from pydantic import Field, conlist
+from pydantic.v1 import Field, conlist
 
 from marqo.base_model import MarqoBaseModel
 

--- a/src/marqo/api/models/recommend_query.py
+++ b/src/marqo/api/models/recommend_query.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Union, Optional
 
 from marqo.core.models.interpolation_method import InterpolationMethod
 from marqo.tensor_search.models.api_models import BaseMarqoModel
-from pydantic import root_validator
+from pydantic.v1 import root_validator
 from marqo.tensor_search.models.score_modifiers_object import ScoreModifierLists
 
 

--- a/src/marqo/api/models/update_documents.py
+++ b/src/marqo/api/models/update_documents.py
@@ -1,6 +1,6 @@
 from typing import Dict, Any, List
 
-from pydantic import validator
+from pydantic.v1 import validator
 
 from marqo.base_model import ImmutableStrictBaseModel
 from marqo.api.exceptions import BadRequestError

--- a/src/marqo/base_model.py
+++ b/src/marqo/base_model.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class MarqoBaseModel(BaseModel):

--- a/src/marqo/core/embed/embed.py
+++ b/src/marqo/core/embed/embed.py
@@ -2,26 +2,23 @@ from enum import Enum
 from timeit import default_timer as timer
 from typing import List, Optional, Union, Dict
 
-import pydantic
-
-import marqo.api.exceptions as api_exceptions
-import marqo.s2_inference.errors as s2_inference_errors
 from marqo import exceptions as base_exceptions
 from marqo.core.index_management.index_management import IndexManagement
 from marqo.core.inference.api import Inference
-from marqo.tensor_search import utils
+from marqo.logging import get_logger
 from marqo.tensor_search.models.api_models import BulkSearchQueryEntity
 from marqo.tensor_search.models.private_models import ModelAuth
 from marqo.tensor_search.models.search import Qidx
 from marqo.tensor_search.telemetry import RequestMetricsStore
-from marqo.logging import get_logger
 from marqo.vespa.vespa_client import VespaClient
 
 logger = get_logger(__name__)
 
+
 class EmbedContentType(str, Enum):
     Query = "query"
     Document = "document"
+
 
 class Embed:
     def __init__(self, vespa_client: VespaClient, index_management: IndexManagement, inference: Inference):

--- a/src/marqo/core/inference/api/inference.py
+++ b/src/marqo/core/inference/api/inference.py
@@ -1,9 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import Optional, Dict, Any, List, Tuple, Union
 
-import pydantic
 from numpy import ndarray
-from pydantic.v1 import StrictStr, root_validator
+from pydantic.v1 import StrictStr, root_validator, Field
 
 from marqo.base_model import ImmutableBaseModel
 from marqo.core.inference.api import Modality, PreprocessingConfigType
@@ -12,21 +11,21 @@ from marqo.tensor_search.models.private_models import ModelAuth
 
 
 class ModelConfig(ImmutableBaseModel):
-    model_name: StrictStr = pydantic.v1.Field(alias='modelName')
-    model_properties: Optional[Dict[str, Any]] = pydantic.v1.Field(default=None, alias='modelProperties')
-    model_auth: Optional[ModelAuth] = pydantic.v1.Field(default=None, alias='modelAuth')
-    normalize_embeddings: bool = pydantic.v1.Field(default=True, alias='normalizeEmbeddings')
+    model_name: StrictStr = Field(alias='modelName')
+    model_properties: Optional[Dict[str, Any]] = Field(default=None, alias='modelProperties')
+    model_auth: Optional[ModelAuth] = Field(default=None, alias='modelAuth')
+    normalize_embeddings: bool = Field(default=True, alias='normalizeEmbeddings')
 
 
 class InferenceRequest(ImmutableBaseModel):
     modality: Modality
-    contents: List[str] = pydantic.v1.Field(min_items=1)
-    device: Optional[str] = pydantic.v1.Field(default=None)
-    model_config: ModelConfig = pydantic.v1.Field(alias='modelConfig')
-    preprocessing_config: PreprocessingConfigType = pydantic.v1.Field(alias='preprocessingConfig')
-    use_inference_cache: bool = pydantic.v1.Field(default=False, alias='useInferenceCache')
+    contents: List[str] = Field(min_items=1)
+    device: Optional[str] = Field(default=None)
+    model_config: ModelConfig = Field(alias='modelConfig')
+    preprocessing_config: PreprocessingConfigType = Field(alias='preprocessingConfig')
+    use_inference_cache: bool = Field(default=False, alias='useInferenceCache')
     # whether we should return error for individual content, when set to false, any error should fail the whole batch
-    return_individual_error: bool = pydantic.v1.Field(default=True, alias='returnIndividualError')
+    return_individual_error: bool = Field(default=True, alias='returnIndividualError')
 
     @root_validator(pre=False)
     def check_preprocessing_config_matches_modality(cls, values):
@@ -47,8 +46,8 @@ class InferenceErrorModel(ImmutableBaseModel):
     """
     A model class to store error information for each individual content
     """
-    status_code: int = pydantic.v1.Field(default=400)
-    error_code: str = pydantic.v1.Field(default='inference_error')
+    status_code: int = Field(default=400)
+    error_code: str = Field(default='inference_error')
     error_message: str
 
 

--- a/src/marqo/core/inference/api/inference.py
+++ b/src/marqo/core/inference/api/inference.py
@@ -3,7 +3,7 @@ from typing import Optional, Dict, Any, List, Tuple, Union
 
 import pydantic
 from numpy import ndarray
-from pydantic import StrictStr, root_validator
+from pydantic.v1 import StrictStr, root_validator
 
 from marqo.base_model import ImmutableBaseModel
 from marqo.core.inference.api import Modality, PreprocessingConfigType
@@ -12,21 +12,21 @@ from marqo.tensor_search.models.private_models import ModelAuth
 
 
 class ModelConfig(ImmutableBaseModel):
-    model_name: StrictStr = pydantic.Field(alias='modelName')
-    model_properties: Optional[Dict[str, Any]] = pydantic.Field(default=None, alias='modelProperties')
-    model_auth: Optional[ModelAuth] = pydantic.Field(default=None, alias='modelAuth')
-    normalize_embeddings: bool = pydantic.Field(default=True, alias='normalizeEmbeddings')
+    model_name: StrictStr = pydantic.v1.Field(alias='modelName')
+    model_properties: Optional[Dict[str, Any]] = pydantic.v1.Field(default=None, alias='modelProperties')
+    model_auth: Optional[ModelAuth] = pydantic.v1.Field(default=None, alias='modelAuth')
+    normalize_embeddings: bool = pydantic.v1.Field(default=True, alias='normalizeEmbeddings')
 
 
 class InferenceRequest(ImmutableBaseModel):
     modality: Modality
-    contents: List[str] = pydantic.Field(min_items=1)
-    device: Optional[str] = pydantic.Field(default=None)
-    model_config: ModelConfig = pydantic.Field(alias='modelConfig')
-    preprocessing_config: PreprocessingConfigType = pydantic.Field(alias='preprocessingConfig')
-    use_inference_cache: bool = pydantic.Field(default=False, alias='useInferenceCache')
+    contents: List[str] = pydantic.v1.Field(min_items=1)
+    device: Optional[str] = pydantic.v1.Field(default=None)
+    model_config: ModelConfig = pydantic.v1.Field(alias='modelConfig')
+    preprocessing_config: PreprocessingConfigType = pydantic.v1.Field(alias='preprocessingConfig')
+    use_inference_cache: bool = pydantic.v1.Field(default=False, alias='useInferenceCache')
     # whether we should return error for individual content, when set to false, any error should fail the whole batch
-    return_individual_error: bool = pydantic.Field(default=True, alias='returnIndividualError')
+    return_individual_error: bool = pydantic.v1.Field(default=True, alias='returnIndividualError')
 
     @root_validator(pre=False)
     def check_preprocessing_config_matches_modality(cls, values):
@@ -47,8 +47,8 @@ class InferenceErrorModel(ImmutableBaseModel):
     """
     A model class to store error information for each individual content
     """
-    status_code: int = pydantic.Field(default=400)
-    error_code: str = pydantic.Field(default='inference_error')
+    status_code: int = pydantic.v1.Field(default=400)
+    error_code: str = pydantic.v1.Field(default='inference_error')
     error_message: str
 
 

--- a/src/marqo/core/inference/api/preprocessing_config.py
+++ b/src/marqo/core/inference/api/preprocessing_config.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Optional, Dict, Literal, List, Set, Union
 
 import pydantic
-from pydantic import root_validator
+from pydantic.v1 import root_validator
 
 from marqo.base_model import ImmutableBaseModel
 from marqo.core.inference.api.modality import Modality
@@ -11,12 +11,12 @@ from marqo.core.inference.api.modality import Modality
 class PreprocessingConfig(ImmutableBaseModel, ABC):
     """Parent class of preprocessing config for all modality types"""
     modality: str
-    should_chunk: bool = pydantic.Field(default=False, alias='shouldChunk')
+    should_chunk: bool = pydantic.v1.Field(default=False, alias='shouldChunk')
 
 
 class ChunkConfig(ImmutableBaseModel):
-    split_length: int = pydantic.Field(gt=0, alias='splitLength')
-    split_overlap: int = pydantic.Field(ge=0, alias='splitOverlap')
+    split_length: int = pydantic.v1.Field(gt=0, alias='splitLength')
+    split_overlap: int = pydantic.v1.Field(ge=0, alias='splitOverlap')
 
     @root_validator
     def check_split_length_greater_than_overlap(cls, values):
@@ -29,14 +29,14 @@ class ChunkConfig(ImmutableBaseModel):
 
 
 class TextChunkConfig(ChunkConfig):
-    split_method: Literal['character', 'word', 'sentence', 'passage'] = pydantic.Field(alias='splitMethod')
+    split_method: Literal['character', 'word', 'sentence', 'passage'] = pydantic.v1.Field(alias='splitMethod')
 
 
 class TextPreprocessingConfig(PreprocessingConfig):
     """Preprocessing config for text modality"""
     modality: Literal[Modality.TEXT] = Modality.TEXT
-    text_prefix: Optional[str] = pydantic.Field(default=None, alias='textPrefix')
-    chunk_config: Optional[TextChunkConfig] = pydantic.Field(default=None, alias='chunkConfig')
+    text_prefix: Optional[str] = pydantic.v1.Field(default=None, alias='textPrefix')
+    chunk_config: Optional[TextChunkConfig] = pydantic.v1.Field(default=None, alias='chunkConfig')
 
     @root_validator
     def validate_chunk_config(cls, values):
@@ -52,15 +52,15 @@ class TextPreprocessingConfig(PreprocessingConfig):
 class ImagePreprocessingConfig(PreprocessingConfig):
     """Preprocessing config for image modality"""
     modality: Literal[Modality.IMAGE] = Modality.IMAGE
-    download_timeout_ms: int = pydantic.Field(default=3000, alias='downloadTimeoutMs')  # default to 3000ms
-    download_thread_count: Optional[int] = pydantic.Field(default=None, alias='downloadThreadCount')
-    download_header: Optional[Dict[str, str]] = pydantic.Field(default=None, alias='downloadHeader')
+    download_timeout_ms: int = pydantic.v1.Field(default=3000, alias='downloadTimeoutMs')  # default to 3000ms
+    download_thread_count: Optional[int] = pydantic.v1.Field(default=None, alias='downloadThreadCount')
+    download_header: Optional[Dict[str, str]] = pydantic.v1.Field(default=None, alias='downloadHeader')
 
     # image chunking TODO this is going away in future versions
     patch_method: Optional[
         # TODO check if we need to support all methods in image_processor.chunk_image method
         Literal['simple', 'frcnn', 'dino-v1', 'dino-v2', 'marqo-yolo']
-    ] = pydantic.Field(
+    ] = pydantic.v1.Field(
         default=None,
         alias='patchMethod'
     )
@@ -79,9 +79,9 @@ class ImagePreprocessingConfig(PreprocessingConfig):
 class AudioPreprocessingConfig(PreprocessingConfig):
     """Preprocessing config for audio modality"""
     modality: Literal[Modality.AUDIO] = Modality.AUDIO
-    download_thread_count: Optional[int] = pydantic.Field(default=None, alias='downloadThreadCount')
-    download_header: Optional[Dict[str, str]] = pydantic.Field(default=None, alias='downloadHeader')
-    chunk_config: Optional[ChunkConfig] = pydantic.Field(default=None, alias='chunkConfig')
+    download_thread_count: Optional[int] = pydantic.v1.Field(default=None, alias='downloadThreadCount')
+    download_header: Optional[Dict[str, str]] = pydantic.v1.Field(default=None, alias='downloadHeader')
+    chunk_config: Optional[ChunkConfig] = pydantic.v1.Field(default=None, alias='chunkConfig')
 
     @root_validator
     def validate_chunk_config(cls, values):
@@ -97,9 +97,9 @@ class AudioPreprocessingConfig(PreprocessingConfig):
 class VideoPreprocessingConfig(PreprocessingConfig):
     """Preprocessing config for video modality"""
     modality: Literal[Modality.VIDEO] = Modality.VIDEO
-    download_thread_count: Optional[int] = pydantic.Field(default=None, alias='downloadThreadCount')
-    download_header: Optional[Dict[str, str]] = pydantic.Field(default=None, alias='downloadHeader')
-    chunk_config: Optional[ChunkConfig] = pydantic.Field(default=None, alias='chunkConfig')
+    download_thread_count: Optional[int] = pydantic.v1.Field(default=None, alias='downloadThreadCount')
+    download_header: Optional[Dict[str, str]] = pydantic.v1.Field(default=None, alias='downloadHeader')
+    chunk_config: Optional[ChunkConfig] = pydantic.v1.Field(default=None, alias='chunkConfig')
 
     @root_validator
     def validate_chunk_config(cls, values):

--- a/src/marqo/core/inference/api/preprocessing_config.py
+++ b/src/marqo/core/inference/api/preprocessing_config.py
@@ -1,8 +1,7 @@
-from abc import ABC, abstractmethod
-from typing import Optional, Dict, Literal, List, Set, Union
+from abc import ABC
+from typing import Optional, Dict, Literal, Union
 
-import pydantic
-from pydantic.v1 import root_validator
+from pydantic.v1 import root_validator, Field
 
 from marqo.base_model import ImmutableBaseModel
 from marqo.core.inference.api.modality import Modality
@@ -11,12 +10,12 @@ from marqo.core.inference.api.modality import Modality
 class PreprocessingConfig(ImmutableBaseModel, ABC):
     """Parent class of preprocessing config for all modality types"""
     modality: str
-    should_chunk: bool = pydantic.v1.Field(default=False, alias='shouldChunk')
+    should_chunk: bool = Field(default=False, alias='shouldChunk')
 
 
 class ChunkConfig(ImmutableBaseModel):
-    split_length: int = pydantic.v1.Field(gt=0, alias='splitLength')
-    split_overlap: int = pydantic.v1.Field(ge=0, alias='splitOverlap')
+    split_length: int = Field(gt=0, alias='splitLength')
+    split_overlap: int = Field(ge=0, alias='splitOverlap')
 
     @root_validator
     def check_split_length_greater_than_overlap(cls, values):
@@ -29,14 +28,14 @@ class ChunkConfig(ImmutableBaseModel):
 
 
 class TextChunkConfig(ChunkConfig):
-    split_method: Literal['character', 'word', 'sentence', 'passage'] = pydantic.v1.Field(alias='splitMethod')
+    split_method: Literal['character', 'word', 'sentence', 'passage'] = Field(alias='splitMethod')
 
 
 class TextPreprocessingConfig(PreprocessingConfig):
     """Preprocessing config for text modality"""
     modality: Literal[Modality.TEXT] = Modality.TEXT
-    text_prefix: Optional[str] = pydantic.v1.Field(default=None, alias='textPrefix')
-    chunk_config: Optional[TextChunkConfig] = pydantic.v1.Field(default=None, alias='chunkConfig')
+    text_prefix: Optional[str] = Field(default=None, alias='textPrefix')
+    chunk_config: Optional[TextChunkConfig] = Field(default=None, alias='chunkConfig')
 
     @root_validator
     def validate_chunk_config(cls, values):
@@ -52,15 +51,15 @@ class TextPreprocessingConfig(PreprocessingConfig):
 class ImagePreprocessingConfig(PreprocessingConfig):
     """Preprocessing config for image modality"""
     modality: Literal[Modality.IMAGE] = Modality.IMAGE
-    download_timeout_ms: int = pydantic.v1.Field(default=3000, alias='downloadTimeoutMs')  # default to 3000ms
-    download_thread_count: Optional[int] = pydantic.v1.Field(default=None, alias='downloadThreadCount')
-    download_header: Optional[Dict[str, str]] = pydantic.v1.Field(default=None, alias='downloadHeader')
+    download_timeout_ms: int = Field(default=3000, alias='downloadTimeoutMs')  # default to 3000ms
+    download_thread_count: Optional[int] = Field(default=None, alias='downloadThreadCount')
+    download_header: Optional[Dict[str, str]] = Field(default=None, alias='downloadHeader')
 
     # image chunking TODO this is going away in future versions
     patch_method: Optional[
         # TODO check if we need to support all methods in image_processor.chunk_image method
         Literal['simple', 'frcnn', 'dino-v1', 'dino-v2', 'marqo-yolo']
-    ] = pydantic.v1.Field(
+    ] = Field(
         default=None,
         alias='patchMethod'
     )
@@ -79,9 +78,9 @@ class ImagePreprocessingConfig(PreprocessingConfig):
 class AudioPreprocessingConfig(PreprocessingConfig):
     """Preprocessing config for audio modality"""
     modality: Literal[Modality.AUDIO] = Modality.AUDIO
-    download_thread_count: Optional[int] = pydantic.v1.Field(default=None, alias='downloadThreadCount')
-    download_header: Optional[Dict[str, str]] = pydantic.v1.Field(default=None, alias='downloadHeader')
-    chunk_config: Optional[ChunkConfig] = pydantic.v1.Field(default=None, alias='chunkConfig')
+    download_thread_count: Optional[int] = Field(default=None, alias='downloadThreadCount')
+    download_header: Optional[Dict[str, str]] = Field(default=None, alias='downloadHeader')
+    chunk_config: Optional[ChunkConfig] = Field(default=None, alias='chunkConfig')
 
     @root_validator
     def validate_chunk_config(cls, values):
@@ -97,9 +96,9 @@ class AudioPreprocessingConfig(PreprocessingConfig):
 class VideoPreprocessingConfig(PreprocessingConfig):
     """Preprocessing config for video modality"""
     modality: Literal[Modality.VIDEO] = Modality.VIDEO
-    download_thread_count: Optional[int] = pydantic.v1.Field(default=None, alias='downloadThreadCount')
-    download_header: Optional[Dict[str, str]] = pydantic.v1.Field(default=None, alias='downloadHeader')
-    chunk_config: Optional[ChunkConfig] = pydantic.v1.Field(default=None, alias='chunkConfig')
+    download_thread_count: Optional[int] = Field(default=None, alias='downloadThreadCount')
+    download_header: Optional[Dict[str, str]] = Field(default=None, alias='downloadHeader')
+    chunk_config: Optional[ChunkConfig] = Field(default=None, alias='chunkConfig')
 
     @root_validator
     def validate_chunk_config(cls, values):

--- a/src/marqo/core/inference/tensor_fields_container.py
+++ b/src/marqo/core/inference/tensor_fields_container.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from typing import List, Dict, Set, Optional, Any, cast, Callable
 
 import numpy as np
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from marqo.core import constants
 from marqo.core.constants import MARQO_DOC_ID

--- a/src/marqo/core/models/add_docs_params.py
+++ b/src/marqo/core/models/add_docs_params.py
@@ -2,8 +2,8 @@ from typing import List
 from typing import Optional, Union, Any, Sequence
 
 import numpy as np
-from pydantic import BaseModel, validator, root_validator
-from pydantic import Field
+from pydantic.v1 import BaseModel, validator, root_validator
+from pydantic.v1 import Field
 
 from marqo import marqo_docs
 from marqo.api.exceptions import BadRequestError

--- a/src/marqo/core/models/facets_parameters.py
+++ b/src/marqo/core/models/facets_parameters.py
@@ -1,6 +1,7 @@
 from typing import List, Optional, Literal, Dict
 from marqo.base_model import StrictBaseModel
-from pydantic import Field, validator
+from pydantic.v1 import Field, validator
+
 
 class RangeConfiguration(StrictBaseModel):
     class Config:
@@ -16,6 +17,7 @@ class RangeConfiguration(StrictBaseModel):
             if to_value <= values['from_']:
                 raise ValueError("'to' value must be greater than 'from' value")
         return to_value
+
 
 class FieldFacetsConfiguration(StrictBaseModel):
     class Config:
@@ -62,6 +64,7 @@ class FieldFacetsConfiguration(StrictBaseModel):
         if ranges and values.get('type') != "number":
             raise ValueError("Ranges can only be used for 'number' facets")
         return ranges
+
 
 class FacetsParameters(StrictBaseModel):
     class Config:

--- a/src/marqo/core/models/hybrid_parameters.py
+++ b/src/marqo/core/models/hybrid_parameters.py
@@ -2,7 +2,7 @@ from enum import Enum
 from enum import Enum
 from typing import List, Optional, Union
 
-from pydantic import validator, root_validator
+from pydantic.v1 import validator, root_validator
 
 from marqo.base_model import StrictBaseModel
 from marqo.tensor_search.models.score_modifiers_object import ScoreModifierLists

--- a/src/marqo/core/models/marqo_add_documents_response.py
+++ b/src/marqo/core/models/marqo_add_documents_response.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Any, Dict, Set
 
-from pydantic import Field, root_validator
+from pydantic.v1 import Field, root_validator
 
 from marqo.base_model import MarqoBaseModel
 

--- a/src/marqo/core/models/marqo_get_documents_by_id_response.py
+++ b/src/marqo/core/models/marqo_get_documents_by_id_response.py
@@ -1,6 +1,6 @@
 from typing import Optional, Union, List, Dict, Any
 
-from pydantic import Field, root_validator
+from pydantic.v1 import Field, root_validator
 
 from marqo.base_model import MarqoBaseModel
 from marqo.core.models.marqo_add_documents_response import BatchResponseStats

--- a/src/marqo/core/models/marqo_index.py
+++ b/src/marqo/core/models/marqo_index.py
@@ -5,10 +5,10 @@ from typing import List, Optional, Dict, Any, Set, Union
 
 import pydantic
 import semver
-from pydantic import PrivateAttr, root_validator
-from pydantic import ValidationError, validator
-from pydantic.error_wrappers import ErrorWrapper
-from pydantic.utils import ROOT_KEY
+from pydantic.v1 import PrivateAttr, root_validator
+from pydantic.v1 import ValidationError, validator
+from pydantic.v1.error_wrappers import ErrorWrapper
+from pydantic.v1.utils import ROOT_KEY
 
 from marqo.base_model import ImmutableStrictBaseModel, ImmutableBaseModel, StrictBaseModel
 from marqo.core import constants
@@ -119,25 +119,25 @@ class TensorField(ImmutableStrictBaseModel):
 
 
 class HnswConfig(ImmutableStrictBaseModel):
-    ef_construction: int = pydantic.Field(gt=0, alias='efConstruction')
-    m: int = pydantic.Field(gt=0)
+    ef_construction: int = pydantic.v1.Field(gt=0, alias='efConstruction')
+    m: int = pydantic.v1.Field(gt=0)
 
 
 class TextPreProcessing(ImmutableStrictBaseModel):
-    split_length: int = pydantic.Field(gt=0, alias='splitLength')
-    split_overlap: int = pydantic.Field(ge=0, alias='splitOverlap')
-    split_method: TextSplitMethod = pydantic.Field(alias='splitMethod')
+    split_length: int = pydantic.v1.Field(gt=0, alias='splitLength')
+    split_overlap: int = pydantic.v1.Field(ge=0, alias='splitOverlap')
+    split_method: TextSplitMethod = pydantic.v1.Field(alias='splitMethod')
 
 class VideoPreProcessing(ImmutableStrictBaseModel):
-    split_length: int = pydantic.Field(gt=0, alias='splitLength')
-    split_overlap: int = pydantic.Field(ge=0, alias='splitOverlap')
+    split_length: int = pydantic.v1.Field(gt=0, alias='splitLength')
+    split_overlap: int = pydantic.v1.Field(ge=0, alias='splitOverlap')
 
 class AudioPreProcessing(ImmutableStrictBaseModel):
-    split_length: int = pydantic.Field(gt=0, alias='splitLength')
-    split_overlap: int = pydantic.Field(ge=0, alias='splitOverlap')
+    split_length: int = pydantic.v1.Field(gt=0, alias='splitLength')
+    split_overlap: int = pydantic.v1.Field(ge=0, alias='splitOverlap')
 
 class ImagePreProcessing(ImmutableStrictBaseModel):
-    patch_method: Optional[PatchMethod] = pydantic.Field(alias='patchMethod')
+    patch_method: Optional[PatchMethod] = pydantic.v1.Field(alias='patchMethod')
 
 
 class Model(StrictBaseModel):
@@ -274,10 +274,10 @@ class MarqoIndex(ImmutableBaseModel, ABC):
     vector_numeric_type: VectorNumericType
     hnsw_config: HnswConfig
     marqo_version: str
-    created_at: int = pydantic.Field(gt=0)
-    updated_at: int = pydantic.Field(gt=0)
+    created_at: int = pydantic.v1.Field(gt=0)
+    updated_at: int = pydantic.v1.Field(gt=0)
     _cache: Dict[str, Any] = PrivateAttr()
-    version: Optional[int] = pydantic.Field(default=None)
+    version: Optional[int] = pydantic.v1.Field(default=None)
 
     class Config(ImmutableBaseModel.Config):
         extra = "allow"

--- a/src/marqo/core/models/marqo_index.py
+++ b/src/marqo/core/models/marqo_index.py
@@ -2,9 +2,9 @@ import re
 from abc import ABC, abstractmethod
 from enum import Enum
 from typing import List, Optional, Dict, Any, Set, Union
-
-import pydantic
 import semver
+
+import pydantic.v1 as pydantic
 from pydantic.v1 import PrivateAttr, root_validator
 from pydantic.v1 import ValidationError, validator
 from pydantic.v1.error_wrappers import ErrorWrapper
@@ -119,25 +119,28 @@ class TensorField(ImmutableStrictBaseModel):
 
 
 class HnswConfig(ImmutableStrictBaseModel):
-    ef_construction: int = pydantic.v1.Field(gt=0, alias='efConstruction')
-    m: int = pydantic.v1.Field(gt=0)
+    ef_construction: int = pydantic.Field(gt=0, alias='efConstruction')
+    m: int = pydantic.Field(gt=0)
 
 
 class TextPreProcessing(ImmutableStrictBaseModel):
-    split_length: int = pydantic.v1.Field(gt=0, alias='splitLength')
-    split_overlap: int = pydantic.v1.Field(ge=0, alias='splitOverlap')
-    split_method: TextSplitMethod = pydantic.v1.Field(alias='splitMethod')
+    split_length: int = pydantic.Field(gt=0, alias='splitLength')
+    split_overlap: int = pydantic.Field(ge=0, alias='splitOverlap')
+    split_method: TextSplitMethod = pydantic.Field(alias='splitMethod')
+
 
 class VideoPreProcessing(ImmutableStrictBaseModel):
-    split_length: int = pydantic.v1.Field(gt=0, alias='splitLength')
-    split_overlap: int = pydantic.v1.Field(ge=0, alias='splitOverlap')
+    split_length: int = pydantic.Field(gt=0, alias='splitLength')
+    split_overlap: int = pydantic.Field(ge=0, alias='splitOverlap')
+
 
 class AudioPreProcessing(ImmutableStrictBaseModel):
-    split_length: int = pydantic.v1.Field(gt=0, alias='splitLength')
-    split_overlap: int = pydantic.v1.Field(ge=0, alias='splitOverlap')
+    split_length: int = pydantic.Field(gt=0, alias='splitLength')
+    split_overlap: int = pydantic.Field(ge=0, alias='splitOverlap')
+
 
 class ImagePreProcessing(ImmutableStrictBaseModel):
-    patch_method: Optional[PatchMethod] = pydantic.v1.Field(alias='patchMethod')
+    patch_method: Optional[PatchMethod] = pydantic.Field(alias='patchMethod')
 
 
 class Model(StrictBaseModel):
@@ -274,10 +277,10 @@ class MarqoIndex(ImmutableBaseModel, ABC):
     vector_numeric_type: VectorNumericType
     hnsw_config: HnswConfig
     marqo_version: str
-    created_at: int = pydantic.v1.Field(gt=0)
-    updated_at: int = pydantic.v1.Field(gt=0)
+    created_at: int = pydantic.Field(gt=0)
+    updated_at: int = pydantic.Field(gt=0)
     _cache: Dict[str, Any] = PrivateAttr()
-    version: Optional[int] = pydantic.v1.Field(default=None)
+    version: Optional[int] = pydantic.Field(default=None)
 
     class Config(ImmutableBaseModel.Config):
         extra = "allow"

--- a/src/marqo/core/models/marqo_index_request.py
+++ b/src/marqo/core/models/marqo_index_request.py
@@ -3,7 +3,7 @@ from typing import List, Dict, Optional
 import re
 
 import pydantic
-from pydantic import root_validator, validator
+from pydantic.v1 import root_validator, validator
 
 import marqo.core.models.marqo_index as marqo_index
 from marqo.base_model import StrictBaseModel, ImmutableStrictBaseModel
@@ -48,7 +48,7 @@ class FieldRequest(StrictBaseModel):
     name: str
     type: marqo_index.FieldType
     features: List[marqo_index.FieldFeature] = []
-    dependent_fields: Optional[Dict[str, float]] = pydantic.Field(alias='dependentFields')
+    dependent_fields: Optional[Dict[str, float]] = pydantic.v1.Field(alias='dependentFields')
     
     @validator('type', pre=True, always=True)
     def normalize_type(cls, v):

--- a/src/marqo/core/models/marqo_index_request.py
+++ b/src/marqo/core/models/marqo_index_request.py
@@ -1,13 +1,11 @@
+import re
 from abc import ABC
 from typing import List, Dict, Optional
-import re
 
-import pydantic
-from pydantic.v1 import root_validator, validator
+from pydantic.v1 import root_validator, validator, Field
 
 import marqo.core.models.marqo_index as marqo_index
 from marqo.base_model import StrictBaseModel, ImmutableStrictBaseModel
-from marqo import exceptions as base_exceptions
 
 
 class MarqoIndexRequest(ImmutableStrictBaseModel, ABC):
@@ -44,11 +42,12 @@ class UnstructuredMarqoIndexRequest(MarqoIndexRequest):
     treat_urls_and_pointers_as_media: bool
     filter_string_max_length: int
 
+
 class FieldRequest(StrictBaseModel):
     name: str
     type: marqo_index.FieldType
     features: List[marqo_index.FieldFeature] = []
-    dependent_fields: Optional[Dict[str, float]] = pydantic.v1.Field(alias='dependentFields')
+    dependent_fields: Optional[Dict[str, float]] = Field(alias='dependentFields')
     
     @validator('type', pre=True, always=True)
     def normalize_type(cls, v):

--- a/src/marqo/core/models/marqo_query.py
+++ b/src/marqo/core/models/marqo_query.py
@@ -2,7 +2,7 @@ from abc import ABC
 from enum import Enum
 from typing import List, Optional
 
-from pydantic import validator, root_validator
+from pydantic.v1 import validator, root_validator
 
 from marqo.base_model import StrictBaseModel
 from marqo.core.models.facets_parameters import FacetsParameters

--- a/src/marqo/core/models/marqo_update_documents_response.py
+++ b/src/marqo/core/models/marqo_update_documents_response.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from pydantic import Field, root_validator
+from pydantic.v1 import Field, root_validator
 
 from marqo.base_model import MarqoBaseModel
 from marqo.core.models.marqo_add_documents_response import BatchResponseStats

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_add_document_handler.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_add_document_handler.py
@@ -24,11 +24,11 @@ from marqo.vespa.vespa_client import VespaClient
 
 class SemiStructuredFieldCountConfig(ImmutableStrictBaseModel):
     # TODO find a way to decouple from env vars when retrieving configurations
-    max_lexical_field_count: int = pydantic.Field(default_factory=lambda: read_env_vars_and_defaults_ints(
+    max_lexical_field_count: int = pydantic.v1.Field(default_factory=lambda: read_env_vars_and_defaults_ints(
         EnvVars.MARQO_MAX_LEXICAL_FIELD_COUNT_UNSTRUCTURED))
-    max_tensor_field_count: int = pydantic.Field(default_factory=lambda: read_env_vars_and_defaults_ints(
+    max_tensor_field_count: int = pydantic.v1.Field(default_factory=lambda: read_env_vars_and_defaults_ints(
         EnvVars.MARQO_MAX_TENSOR_FIELD_COUNT_UNSTRUCTURED))
-    max_string_array_field_count: int = pydantic.Field(default_factory=lambda: read_env_vars_and_defaults_ints(
+    max_string_array_field_count: int = pydantic.v1.Field(default_factory=lambda: read_env_vars_and_defaults_ints(
         EnvVars.MARQO_MAX_STRING_ARRAY_FIELD_COUNT_UNSTRUCTURED))
 
 

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_add_document_handler.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_add_document_handler.py
@@ -1,6 +1,6 @@
 from typing import Dict, Any
 
-import pydantic
+import pydantic.v1 as pydantic
 
 from marqo.base_model import ImmutableStrictBaseModel
 from marqo.core import constants
@@ -24,11 +24,11 @@ from marqo.vespa.vespa_client import VespaClient
 
 class SemiStructuredFieldCountConfig(ImmutableStrictBaseModel):
     # TODO find a way to decouple from env vars when retrieving configurations
-    max_lexical_field_count: int = pydantic.v1.Field(default_factory=lambda: read_env_vars_and_defaults_ints(
+    max_lexical_field_count: int = pydantic.Field(default_factory=lambda: read_env_vars_and_defaults_ints(
         EnvVars.MARQO_MAX_LEXICAL_FIELD_COUNT_UNSTRUCTURED))
-    max_tensor_field_count: int = pydantic.v1.Field(default_factory=lambda: read_env_vars_and_defaults_ints(
+    max_tensor_field_count: int = pydantic.Field(default_factory=lambda: read_env_vars_and_defaults_ints(
         EnvVars.MARQO_MAX_TENSOR_FIELD_COUNT_UNSTRUCTURED))
-    max_string_array_field_count: int = pydantic.v1.Field(default_factory=lambda: read_env_vars_and_defaults_ints(
+    max_string_array_field_count: int = pydantic.Field(default_factory=lambda: read_env_vars_and_defaults_ints(
         EnvVars.MARQO_MAX_STRING_ARRAY_FIELD_COUNT_UNSTRUCTURED))
 
 

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_document.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_document.py
@@ -2,7 +2,7 @@ import json
 import uuid
 from typing import List, Dict, Any, Union, Optional
 
-from pydantic import Field
+from pydantic.v1 import Field
 
 from marqo.base_model import MarqoBaseModel
 from marqo.core import constants as index_constants, constants

--- a/src/marqo/core/unstructured_vespa_index/unstructured_add_document_handler.py
+++ b/src/marqo/core/unstructured_vespa_index/unstructured_add_document_handler.py
@@ -134,7 +134,7 @@ class UnstructuredAddDocumentsHandler(AddDocumentsHandler):
                 if self.tensor_fields_container.is_custom_tensor_field(field_name):
                     # TODO should is_non_tensor_field check be moved out to AddDocsParams validation?
                     # Please note that if one of the documents in the batch has a custom field which does not exist
-                    # in the tensor field, the whole batch will fail and user will get a 400 pydantic.ValidationError.
+                    # in the tensor field, the whole batch will fail and user will get a 400 pydantic.v1.ValidationError.
                     # We keep this behaviour unchanged to be compatible with the legacy unstructured index.
                     validate_custom_vector(field_content, not is_tensor_field, self.marqo_index.model.get_dimension())
                 elif self.marqo_index.parsed_marqo_version() < self._MINIMUM_MARQO_VERSION_SUPPORTS_MAP_NUMERIC_FIELDS:

--- a/src/marqo/core/unstructured_vespa_index/unstructured_document.py
+++ b/src/marqo/core/unstructured_vespa_index/unstructured_document.py
@@ -1,7 +1,7 @@
 import json
 from typing import List, Dict, Any
 
-from pydantic import Field
+from pydantic.v1 import Field
 
 from marqo.base_model import MarqoBaseModel
 from marqo.core import constants as index_constants

--- a/src/marqo/inference/native_inference/embedding_models/hugging_face_model.py
+++ b/src/marqo/inference/native_inference/embedding_models/hugging_face_model.py
@@ -6,7 +6,7 @@ from typing import Tuple, Callable, Optional
 import torch
 import torch.nn.functional as F
 from numpy import ndarray
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 from torch import Tensor
 from transformers import (AutoModel, AutoTokenizer)
 

--- a/src/marqo/inference/native_inference/embedding_models/hugging_face_model_properties.py
+++ b/src/marqo/inference/native_inference/embedding_models/hugging_face_model_properties.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from huggingface_hub import hf_hub_download
 from huggingface_hub.utils import HfHubHTTPError
-from pydantic import Field, validator, root_validator
+from pydantic.v1 import Field, validator, root_validator
 
 from marqo.base_model import ImmutableBaseModel
 from marqo.inference.native_inference.embedding_models.marqo_base_model_properties import MarqoBaseModelProperties

--- a/src/marqo/inference/native_inference/embedding_models/languagebind_model.py
+++ b/src/marqo/inference/native_inference/embedding_models/languagebind_model.py
@@ -3,7 +3,7 @@ import tempfile
 from contextlib import contextmanager
 
 import torch
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from marqo.base_model import MarqoBaseModel
 from marqo.core.exceptions import InternalError

--- a/src/marqo/inference/native_inference/embedding_models/languagebind_model_properties.py
+++ b/src/marqo/inference/native_inference/embedding_models/languagebind_model_properties.py
@@ -1,7 +1,7 @@
 from typing import Optional, List
 
-from pydantic import Field, root_validator
-from pydantic import validator
+from pydantic.v1 import Field, root_validator
+from pydantic.v1 import validator
 
 from marqo.base_model import MarqoBaseModel
 from marqo.inference.native_inference.embedding_models.marqo_base_model_properties import MarqoBaseModelProperties

--- a/src/marqo/inference/native_inference/embedding_models/marqo_base_model_properties.py
+++ b/src/marqo/inference/native_inference/embedding_models/marqo_base_model_properties.py
@@ -1,6 +1,6 @@
 from abc import ABC
 
-from pydantic import Field
+from pydantic.v1 import Field
 
 from marqo.base_model import ImmutableBaseModel
 

--- a/src/marqo/inference/native_inference/embedding_models/open_clip_model.py
+++ b/src/marqo/inference/native_inference/embedding_models/open_clip_model.py
@@ -6,7 +6,7 @@ import torch
 from PIL.Image import Image
 from open_clip.pretrained import _pcfg, _slpcfg, _apcfg
 from open_clip.transform import image_transform_v2, PreprocessCfg, merge_preprocess_dict
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 from torchvision.transforms import Compose
 
 from marqo import marqo_docs

--- a/src/marqo/inference/native_inference/embedding_models/open_clip_model_properties.py
+++ b/src/marqo/inference/native_inference/embedding_models/open_clip_model_properties.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Optional, List
 
-from pydantic import Field, root_validator
+from pydantic.v1 import Field, root_validator
 
 from marqo.inference.native_inference.embedding_models.marqo_base_model_properties import MarqoBaseModelProperties
 from marqo.tensor_search.models.private_models import ModelLocation

--- a/src/marqo/inference/native_inference/remote/client/inference_client.py
+++ b/src/marqo/inference/native_inference/remote/client/inference_client.py
@@ -60,5 +60,5 @@ class NativeInferenceClient(Inference):
         try:
             result_dict = msgpack.unpackb(response.content, raw=False)
             return InferenceResult.parse_obj(result_dict)
-        except (msgpack.ExtraData, msgpack.UnpackException, msgpack.UnpackValueError, pydantic.ValidationError) as e:
+        except (msgpack.ExtraData, msgpack.UnpackException, msgpack.UnpackValueError, pydantic.v1.ValidationError) as e:
             raise InferenceError(f"Error decoding MessagePack response: {str(e)}") from e

--- a/src/marqo/inference/native_inference/remote/client/inference_client.py
+++ b/src/marqo/inference/native_inference/remote/client/inference_client.py
@@ -1,6 +1,6 @@
 import httpx
-import pydantic
 from httpx import Timeout
+from pydantic.v1 import ValidationError
 
 from marqo import logging
 from marqo.core.inference.api import Inference, InferenceResult, InferenceRequest, InferenceError
@@ -60,5 +60,5 @@ class NativeInferenceClient(Inference):
         try:
             result_dict = msgpack.unpackb(response.content, raw=False)
             return InferenceResult.parse_obj(result_dict)
-        except (msgpack.ExtraData, msgpack.UnpackException, msgpack.UnpackValueError, pydantic.v1.ValidationError) as e:
+        except (msgpack.ExtraData, msgpack.UnpackException, msgpack.UnpackValueError, ValidationError) as e:
             raise InferenceError(f"Error decoding MessagePack response: {str(e)}") from e

--- a/src/marqo/inference/native_inference/remote/server/inference_api.py
+++ b/src/marqo/inference/native_inference/remote/server/inference_api.py
@@ -91,7 +91,7 @@ def vectorise(request: Request, raw_body: bytes = Body(...), config: Config = De
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Invalid MessagePack format: {str(e)}"
         ) from e
-    except pydantic.ValidationError as e:
+    except pydantic.v1.ValidationError as e:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=e.errors()

--- a/src/marqo/inference/native_inference/remote/server/inference_api.py
+++ b/src/marqo/inference/native_inference/remote/server/inference_api.py
@@ -1,5 +1,5 @@
-import pydantic
 from orjson import orjson
+from pydantic.v1 import ValidationError
 from starlette import status
 from starlette.responses import JSONResponse
 
@@ -91,7 +91,7 @@ def vectorise(request: Request, raw_body: bytes = Body(...), config: Config = De
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Invalid MessagePack format: {str(e)}"
         ) from e
-    except pydantic.v1.ValidationError as e:
+    except ValidationError as e:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=e.errors()

--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -1,6 +1,6 @@
 """The API entrypoint for Tensor Search"""
 import json
-from typing import List
+from typing import List, Type, Any, TypeVar
 
 import pydantic
 import uvicorn
@@ -8,6 +8,7 @@ from fastapi import Depends, FastAPI, Request
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, ORJSONResponse
+from pydantic.v1 import parse_obj_as
 from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY
 
 from marqo import config, marqo_docs
@@ -205,8 +206,8 @@ async def api_validation_exception_handler(request: Request, exc: RequestValidat
     )
 
 
-@app.exception_handler(pydantic.ValidationError)
-async def validation_exception_handler(request, exc: pydantic.ValidationError) -> JSONResponse:
+@app.exception_handler(pydantic.v1.ValidationError)
+async def validation_exception_handler(request, exc: pydantic.v1.ValidationError) -> JSONResponse:
     """Catch pydantic validation errors and rewrite as an InvalidArgError whilst keeping error messages from the ValidationError."""
     error_messages = [{
         'loc': error.get('loc', ''),
@@ -240,6 +241,19 @@ def marqo_internal_exception_handler(request, exc: api_exceptions.MarqoError):
         return JSONResponse(content=body, status_code=500)
 
 
+# TODO this a temporary fix due to the mixed use of pydantic v1 and v2.
+# The new FastAPI (using pydantic v2) auto converts the request body to a v2 model. It raises error when we
+# provide a v1 model type in the API method parameter. The workaround we use here take in the body as a dict and
+# manually converts it to an v1 model. It catches the v1.Validation error and converts it to FastAPI's
+# RequestValidationError to keep the behaviour consistent with the auto-injecting mechanism
+T = TypeVar('T')
+def parse_request_object(obj_type: Type[T], obj: Any) -> T:
+    try:
+        return parse_obj_as(obj_type, obj)
+    except pydantic.v1.ValidationError as e:
+        raise RequestValidationError(errors=e.errors()) from e
+
+
 @app.on_event("shutdown")
 def shutdown_event():
     """Close the Zookeeper client on shutdown."""
@@ -254,13 +268,16 @@ def root():
 
 
 @app.post("/indexes/{index_name}")
-def create_index(index_name: str, settings: IndexSettings, marqo_config: config.Config = Depends(get_config)):
+def create_index(index_name: str, settings_dict: dict, marqo_config: config.Config = Depends(get_config)):
     """
     Create index with settings. Please refer to the following documents for details about creating different types
     of index:
     - [Unstructured Index](https://docs.marqo.ai/latest/reference/api/indexes/create-index/)
     - [Structured Index](https://docs.marqo.ai/latest/reference/api/indexes/create-structured-index/)
     """
+    # TODO this a temporary fix due to the mixed use of pydantic v1 and v2.
+    #  IndexSettings can be injected after migrated to v2
+    settings = parse_request_object(IndexSettings, settings_dict)
     marqo_config.index_management.create_index(settings.to_marqo_index_request(index_name))
     return JSONResponse(
         content={
@@ -335,13 +352,17 @@ def get_index_stats(index_name: str, marqo_config: config.Config = Depends(get_c
 
 @app.post("/indexes/{index_name}/search")
 @throttle(RequestType.SEARCH)
-def search(search_query: SearchQuery, index_name: str, device: str = Depends(api_validation.validate_device),
+def search(index_name: str, search_query_dict: dict, device: str = Depends(api_validation.validate_device),
            marqo_config: config.Config = Depends(get_config)):
     """
     Search for documents matching a specific query in the given index. Please refer to
     [Search API document](https://docs.marqo.ai/latest/reference/api/search/search/) for details.
     """
     with RequestMetricsStore.for_request().time(f"POST /indexes/{index_name}/search"):
+        # TODO this a temporary fix due to the mixed use of pydantic v1 and v2.
+        #  SearchQuery can be injected after migrated to v2
+        search_query = parse_request_object(SearchQuery, search_query_dict)
+
         result = tensor_search.search(
             config=marqo_config, text=search_query.q,
             index_name=index_name, highlights=search_query.showHighlights,
@@ -367,7 +388,7 @@ def search(search_query: SearchQuery, index_name: str, device: str = Depends(api
 
 @app.post("/indexes/{index_name}/recommend")
 @throttle(RequestType.SEARCH)
-def recommend(query: RecommendQuery, index_name: str,
+def recommend(query_dict: dict, index_name: str,
               marqo_config: config.Config = Depends(get_config)):
     """
     Recommend similar documents. Input a list of existing document IDs or dict of IDs and weights, and the response
@@ -376,6 +397,10 @@ def recommend(query: RecommendQuery, index_name: str,
     Please refer to [Recommend API document](https://docs.marqo.ai/latest/reference/api/search/recommend/) for details.
     """
     with RequestMetricsStore.for_request().time(f"POST /indexes/{index_name}/search"):
+        # TODO this a temporary fix due to the mixed use of pydantic v1 and v2.
+        #  RecommendQuery can be injected after migrated to v2
+        query = parse_request_object(RecommendQuery, query_dict)
+
         return marqo_config.recommender.recommend(
             index_name=index_name,
             documents=query.documents,
@@ -398,7 +423,7 @@ def recommend(query: RecommendQuery, index_name: str,
 
 @app.post("/indexes/{index_name}/embed")
 @throttle(RequestType.SEARCH)
-def embed(embedding_request: EmbedRequest, index_name: str, device: str = Depends(api_validation.validate_device),
+def embed(embedding_request_dict: dict, index_name: str, device: str = Depends(api_validation.validate_device),
           marqo_config: config.Config = Depends(get_config)):
     """
     Vectorise a piece of content (string or weighted dictionary) or list of content and return the corresponding
@@ -406,6 +431,10 @@ def embed(embedding_request: EmbedRequest, index_name: str, device: str = Depend
     details.
     """
     with RequestMetricsStore.for_request().time(f"POST /indexes/{index_name}/embed"):
+        # TODO this a temporary fix due to the mixed use of pydantic v1 and v2.
+        #  EmbedRequest can be injected after migrated to v2
+        embedding_request = parse_request_object(EmbedRequest, embedding_request_dict)
+
         return marqo_config.embed.embed_content(
             content=embedding_request.content,
             index_name=index_name, device=device,
@@ -418,8 +447,8 @@ def embed(embedding_request: EmbedRequest, index_name: str, device: str = Depend
 @app.post("/indexes/{index_name}/documents")
 @throttle(RequestType.INDEX)
 def add_or_replace_documents(
-        body: AddDocsBodyParams,
         index_name: str,
+        body_dict: dict,
         marqo_config: config.Config = Depends(get_config),
         device: str = Depends(api_validation.validate_device)):
     """
@@ -427,6 +456,9 @@ def add_or_replace_documents(
     Please refer to [Add documents API](https://docs.marqo.ai/latest/reference/api/documents/add-or-replace-documents/)
     for details.
     """
+    # TODO this a temporary fix due to the mixed use of pydantic v1 and v2.
+    #  AddDocsBodyParams can be injected after migrated to v2
+    body = parse_request_object(AddDocsBodyParams, body_dict)
     add_docs_params = api_utils.add_docs_params_orchestrator(index_name=index_name, body=body,
                                                              device=device)
 
@@ -438,13 +470,17 @@ def add_or_replace_documents(
 @app.patch("/indexes/{index_name}/documents")
 @throttle(RequestType.PARTIAL_UPDATE)
 def update_documents(
-        body: UpdateDocumentsBodyParams,
         index_name: str,
+        body_dict: dict,
         marqo_config: config.Config = Depends(get_config)):
     """
     Update an array of documents in a given index. Please refer to
     [Update document API](https://docs.marqo.ai/latest/reference/api/documents/update-documents/) for details.
     """
+    # TODO this a temporary fix due to the mixed use of pydantic v1 and v2.
+    #  UpdateDocumentsBodyParams can be injected after migrated to v2
+    body = parse_request_object(UpdateDocumentsBodyParams, body_dict)
+
     res = marqo_config.document.partial_update_documents_by_index_name(
         index_name=index_name, partial_documents=body.documents)
 
@@ -541,19 +577,21 @@ def batch_delete_indexes(index_names: List[str], marqo_config: config.Config = D
 
 @app.post("/batch/indexes/create", include_in_schema=False)
 @utils.enable_batch_apis()
-def batch_create_indexes(index_settings_with_name_list: List[IndexSettingsWithName],
+def batch_create_indexes(index_settings_with_name_list: List[dict],
                          marqo_config: config.Config = Depends(get_config)):
     """An internal API used for testing processes. Not to be used by users."""
+    # TODO this a temporary fix due to the mixed use of pydantic v1 and v2.
+    #  IndexSettingsWithName can be injected after migrated to v2
+    index_settings = [parse_request_object(IndexSettingsWithName, settings) for settings in index_settings_with_name_list]
 
-    marqo_index_requests = [settings.to_marqo_index_request(settings.indexName) for
-                            settings in index_settings_with_name_list]
+    marqo_index_requests = [settings.to_marqo_index_request(settings.indexName) for settings in index_settings]
 
     marqo_config.index_management.batch_create_indexes(marqo_index_requests)
 
     return JSONResponse(
         content={
             "acknowledged": True,
-            "index_names": [settings.indexName for settings in index_settings_with_name_list]
+            "index_names": [settings.indexName for settings in index_settings]
         },
         status_code=200
     )
@@ -579,8 +617,13 @@ def upgrade_marqo(marqo_config: config.Config = Depends(get_config)):
 
 @app.post("/rollback", include_in_schema=False)
 @utils.enable_upgrade_api()
-def rollback_marqo(req: RollbackRequest, marqo_config: config.Config = Depends(get_config)):
+def rollback_marqo(req_dict: dict, marqo_config: config.Config = Depends(get_config)):
     """An internal API used for testing processes. Not to be used by users."""
+
+    # TODO this a temporary fix due to the mixed use of pydantic v1 and v2.
+    #  IndexSettingsWithName can be injected after migrated to v2
+    req = parse_request_object(RollbackRequest, req_dict)
+
     rollback_runner = RollbackRunner(marqo_config.vespa_client, marqo_config.index_management)
     rollback_runner.rollback(from_version=req.from_version, to_version=req.to_version)
 

--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -521,7 +521,7 @@ def get_documents_by_ids_via_get(
 @app.post("/indexes/{index_name}/documents/get-batch")
 def get_documents_by_ids_via_post(
         index_name: str,
-        get_batch_documents_request: GetBatchDocumentsRequest,
+        get_batch_documents_request_dict: dict,
         marqo_config: config.Config = Depends(get_config),
         expose_facets: bool = False
 ):
@@ -529,6 +529,10 @@ def get_documents_by_ids_via_post(
     Gets a selection of documents based on their IDs via a POST request. Please refer to
     [Get documents API](https://docs.marqo.ai/latest/reference/api/documents/get-multiple-documents/) for details.
     """
+    # TODO this a temporary fix due to the mixed use of pydantic v1 and v2.
+    #  GetBatchDocumentsRequest can be injected after migrated to v2
+    get_batch_documents_request = parse_request_object(GetBatchDocumentsRequest, get_batch_documents_request_dict)
+
     res = tensor_search.get_documents_by_ids(
         config=marqo_config, index_name=index_name, document_ids=get_batch_documents_request.document_ids,
         show_vectors=expose_facets

--- a/src/marqo/tensor_search/models/api_models.py
+++ b/src/marqo/tensor_search/models/api_models.py
@@ -4,21 +4,20 @@ Choices (enum-type structure) in fastAPI:
 https://pydantic-docs.helpmanual.io/usage/types/#enums-and-choices
 """
 
+import re
 from typing import Union, List, Dict, Optional
 
-import pydantic
 from pydantic.v1 import BaseModel, root_validator, validator, Field
 
 from marqo.base_model import ImmutableStrictBaseModel
 from marqo.core.models.facets_parameters import FacetsParameters
-from marqo.core.models.hybrid_parameters import HybridParameters, RetrievalMethod, RankingMethod
+from marqo.core.models.hybrid_parameters import HybridParameters, RankingMethod
 from marqo.core.models.marqo_index import MarqoIndex
 from marqo.tensor_search import validation
 from marqo.tensor_search.enums import SearchMethod
 from marqo.tensor_search.models.private_models import ModelAuth
 from marqo.tensor_search.models.score_modifiers_object import ScoreModifierLists
 from marqo.tensor_search.models.search import SearchContext, SearchContextTensor
-import re
 
 
 class BaseMarqoModel(BaseModel):
@@ -169,7 +168,7 @@ class SearchQuery(BaseMarqoModel):
 
         return values
 
-    @pydantic.v1.validator('searchMethod')
+    @validator('searchMethod')
     def validate_search_method(cls, value):
         return validation.validate_str_against_enum(
             value=value, enum_class=SearchMethod,

--- a/src/marqo/tensor_search/models/api_models.py
+++ b/src/marqo/tensor_search/models/api_models.py
@@ -7,7 +7,7 @@ https://pydantic-docs.helpmanual.io/usage/types/#enums-and-choices
 from typing import Union, List, Dict, Optional
 
 import pydantic
-from pydantic import BaseModel, root_validator, validator, Field
+from pydantic.v1 import BaseModel, root_validator, validator, Field
 
 from marqo.base_model import ImmutableStrictBaseModel
 from marqo.core.models.facets_parameters import FacetsParameters
@@ -169,7 +169,7 @@ class SearchQuery(BaseMarqoModel):
 
         return values
 
-    @pydantic.validator('searchMethod')
+    @pydantic.v1.validator('searchMethod')
     def validate_search_method(cls, value):
         return validation.validate_str_against_enum(
             value=value, enum_class=SearchMethod,

--- a/src/marqo/tensor_search/models/custom_vector_object.py
+++ b/src/marqo/tensor_search/models/custom_vector_object.py
@@ -2,7 +2,7 @@ from marqo.tensor_search.enums import MappingsObjectType
 from marqo.tensor_search.constants import ALLOWED_CUSTOM_VECTOR_CONTENT_TYPES
 from marqo.base_model import StrictBaseModel
 from typing import List, Union, Optional
-from pydantic import root_validator, validator
+from pydantic.v1 import root_validator, validator
 
 
 class CustomVector(StrictBaseModel):

--- a/src/marqo/tensor_search/models/external_apis/hf.py
+++ b/src/marqo/tensor_search/models/external_apis/hf.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import Field
+from pydantic.v1 import Field
 
 from marqo.tensor_search.models.external_apis.abstract_classes import (
     ObjectLocation, ExternalAuth

--- a/src/marqo/tensor_search/models/external_apis/s3.py
+++ b/src/marqo/tensor_search/models/external_apis/s3.py
@@ -1,4 +1,4 @@
-from pydantic.dataclasses import dataclass
+from pydantic.v1.dataclasses import dataclass
 from typing import Optional
 from marqo.tensor_search.models.external_apis.abstract_classes import (
     ObjectLocation, ExternalAuth

--- a/src/marqo/tensor_search/models/index_settings.py
+++ b/src/marqo/tensor_search/models/index_settings.py
@@ -1,7 +1,7 @@
 import time
 from typing import Dict, Any, Optional, List, Union
 
-from pydantic import root_validator
+from pydantic.v1 import root_validator
 
 import marqo.api.exceptions as api_exceptions
 import marqo.core.models.marqo_index as core

--- a/src/marqo/tensor_search/models/private_models.py
+++ b/src/marqo/tensor_search/models/private_models.py
@@ -4,10 +4,10 @@ For example models stored on custom Huggingface repos or on private s3 buckets
 """
 from marqo.tensor_search.models.external_apis.hf import HfAuth, HfModelLocation
 from marqo.tensor_search.models.external_apis.s3 import S3Auth, S3Location
-from pydantic import BaseModel, validator, root_validator
+from pydantic.v1 import BaseModel, validator, root_validator
 from marqo.api.exceptions import InvalidArgError
 from typing import Optional
-from pydantic import Field
+from pydantic.v1 import Field
 from marqo.base_model import ImmutableBaseModel, MarqoBaseModel
 
 class ModelAuth(ImmutableBaseModel):

--- a/src/marqo/tensor_search/models/score_modifiers_object.py
+++ b/src/marqo/tensor_search/models/score_modifiers_object.py
@@ -1,7 +1,7 @@
 import json
 from typing import List, Dict, Any, Optional
 
-from pydantic import BaseModel, validator, ValidationError
+from pydantic.v1 import BaseModel, validator, ValidationError
 
 from marqo.core.models.score_modifier import ScoreModifierType, ScoreModifier
 from marqo.api.exceptions import InvalidArgError

--- a/src/marqo/tensor_search/models/search.py
+++ b/src/marqo/tensor_search/models/search.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Union, List, Dict, Optional, NewType
 
-from pydantic import BaseModel, validator, ValidationError
+from pydantic.v1 import BaseModel, validator, ValidationError
 
 from marqo.api.exceptions import InvalidArgError
 from marqo.core.inference.api import Modality

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -628,7 +628,7 @@ def gather_documents_from_response(response: QueryResult, marqo_index: MarqoInde
     for doc in response.hits:
         if doc.id.startswith("group:facet:"): # Not an actual document id but group's id returned by vespa
             continue
-        marqo_doc = vespa_index.to_marqo_document(dict(doc), return_highlights=highlights)
+        marqo_doc = vespa_index.to_marqo_document(doc.dict(), return_highlights=highlights)
         marqo_doc['_score'] = doc.relevance
 
         if attributes_to_retrieve_set is not None:

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -626,9 +626,9 @@ def gather_documents_from_response(response: QueryResult, marqo_index: MarqoInde
     vespa_index = vespa_index_factory(marqo_index)
     hits = []
     for doc in response.hits:
-        if doc.id.startswith("group:facet:"): # Not an actual document id but group's id returned by vespa
+        if doc.id.startswith("group:facet:"):  # Not an actual document id but group's id returned by vespa
             continue
-        marqo_doc = vespa_index.to_marqo_document(doc.dict(), return_highlights=highlights)
+        marqo_doc = vespa_index.to_marqo_document(dict(doc), return_highlights=highlights)
         marqo_doc['_score'] = doc.relevance
 
         if attributes_to_retrieve_set is not None:

--- a/src/marqo/vespa/models/application_metrics.py
+++ b/src/marqo/vespa/models/application_metrics.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import List, Dict, Optional, Union, Any
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class Status(BaseModel):

--- a/src/marqo/vespa/models/delete_document_response.py
+++ b/src/marqo/vespa/models/delete_document_response.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 
 class DeleteDocumentResponse(BaseModel):

--- a/src/marqo/vespa/models/feed_response.py
+++ b/src/marqo/vespa/models/feed_response.py
@@ -1,6 +1,6 @@
 from typing import Optional, List
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 
 class FeedDocumentResponse(BaseModel):

--- a/src/marqo/vespa/models/get_document_response.py
+++ b/src/marqo/vespa/models/get_document_response.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, root_validator, Field
+from pydantic.v1 import BaseModel, root_validator, Field
 
 
 class Document(BaseModel):

--- a/src/marqo/vespa/models/query_result.py
+++ b/src/marqo/vespa/models/query_result.py
@@ -1,23 +1,23 @@
 from typing import List, Dict, Any, Optional
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 
 # See https://docs.vespa.ai/en/reference/default-result-format.html
 class RootFields(BaseModel):
-    total_count: Optional[int] = Field(alias='totalCount')
+    total_count: Optional[int] = Field(None, alias='totalCount')
 
 
 class Degraded(BaseModel):
-    adaptive_timeout: Optional[bool] = Field(alias='adaptive-timeout')
-    match_phase: Optional[bool] = Field(alias='match-phase')
-    non_ideal_state: Optional[bool] = Field(alias='non-ideal-state')
-    timeout: Optional[bool]
+    adaptive_timeout: Optional[bool] = Field(None, alias='adaptive-timeout')
+    match_phase: Optional[bool] = Field(None, alias='match-phase')
+    non_ideal_state: Optional[bool] = Field(None, alias='non-ideal-state')
+    timeout: Optional[bool] = None
 
 
 class Coverage(BaseModel):
     coverage: int
-    degraded: Optional[Degraded]
+    degraded: Optional[Degraded] = None
     documents: int
     full: bool
     nodes: int
@@ -27,37 +27,37 @@ class Coverage(BaseModel):
 
 class Error(BaseModel):
     code: int
-    summary: Optional[str]
-    source: Optional[str]
-    message: Optional[str]
-    stack_trace: Optional[str] = Field(alias='stackTrace')
-    transient: Optional[bool]
+    summary: Optional[str] = None
+    source: Optional[str] = None
+    message: Optional[str] = None
+    stack_trace: Optional[str] = Field(None, alias='stackTrace')
+    transient: Optional[bool] = None
 
 
 class AbstractChild(BaseModel):
     # label, value, and recursive children occur in aggregation results
-    id: Optional[str]
+    id: Optional[str] = None
     relevance: float
-    source: Optional[str]
-    label: Optional[str]
-    value: Optional[str]
-    coverage: Optional[Coverage]
-    errors: Optional[List[Error]]
-    children: Optional[List['Child']]
+    source: Optional[str] = None
+    label: Optional[str] = None
+    value: Optional[str] = None
+    coverage: Optional[Coverage] = None
+    errors: Optional[List[Error]] = None
+    children: Optional[List['Child']] = None
 
 
 class Child(AbstractChild):
-    fields: Optional[Dict[str, Any]]
+    fields: Optional[Dict[str, Any]] = None
 
 
 class Root(AbstractChild):
-    fields: Optional[RootFields]
+    fields: Optional[RootFields] = None
 
 
 class QueryResult(BaseModel):
     root: Root
-    timing: Optional[Dict[str, Any]]
-    trace: Optional[Dict[str, Any]]
+    timing: Optional[Dict[str, Any]] = None
+    trace: Optional[Dict[str, Any]] = None
 
     @property
     def hits(self) -> List[Child]:

--- a/src/marqo/vespa/models/update_response.py
+++ b/src/marqo/vespa/models/update_response.py
@@ -1,6 +1,6 @@
 from typing import Optional, List
 
-from pydantic import BaseModel, Field, root_validator
+from pydantic.v1 import BaseModel, Field, root_validator
 
 
 class UpdateDocumentResponse(BaseModel):

--- a/src/marqo/vespa/models/vespa_document.py
+++ b/src/marqo/vespa/models/vespa_document.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class VespaDocument(BaseModel):

--- a/tests/api_tests/v1/tests/api_tests/structured_index/test_partial_update_document.py
+++ b/tests/api_tests/v1/tests/api_tests/structured_index/test_partial_update_document.py
@@ -716,15 +716,17 @@ class TestStructuredUpdateDocuments(MarqoTestCase):
         update_doc_url = f"{base_url}/indexes/{self.update_doc_index_name}/documents"
 
         cases = [
-            ({"documents": {"_id": "1", "text_field": "updated text field"}}, "Documents is not a list"),
-            ([{"_id": "1", "text_field": "updated text field"}], "Body is missing the 'documents' key")
+            ({"documents": {"_id": "1", "text_field": "updated text field"}},
+             "value is not a valid list", "Documents is not a list"),
+            ([{"_id": "1", "text_field": "updated text field"}],
+             "Input should be a valid dictionary", "Body is missing the 'documents' key")
         ]
 
-        for bad_body, msg in cases:
+        for bad_body, expected_error, msg in cases:
             with self.subTest(f"{bad_body} - {msg}"):
                 r = requests.patch(update_doc_url, json=bad_body)
                 self.assertEqual(422, r.status_code)
-                self.assertIn("'body', 'documents'", str(r.json()))
+                self.assertIn(expected_error, str(r.json()))
 
     def test_too_many_documents_exceeds_max_batch_size(self):
         """Test that the update_documents method throws an error when the number of documents

--- a/tests/integ_tests/core/document/test_partial_document_update.py
+++ b/tests/integ_tests/core/document/test_partial_document_update.py
@@ -1,25 +1,21 @@
 import os
 import random
-import unittest
-import uuid
 import threading
+import uuid
 from unittest import mock
 
 import numpy as np
-import pytest
 
+from integ_tests.marqo_test import MarqoTestCase, TestImageUrls
 from marqo.api.exceptions import BadRequestError
 from marqo.api.models.update_documents import UpdateDocumentsBodyParams
-from marqo.core.exceptions import UnsupportedFeatureError
+from marqo.core.models.add_docs_params import AddDocsParams
 from marqo.core.models.marqo_index import *
 from marqo.core.models.marqo_index_request import FieldRequest
+from marqo.core.models.marqo_update_documents_response import MarqoUpdateDocumentsResponse, MarqoUpdateDocumentsItem
 from marqo.tensor_search import tensor_search
 from marqo.tensor_search.api import update_documents
-from marqo.core.models.add_docs_params import AddDocsParams
 from marqo.tensor_search.models.score_modifiers_object import ScoreModifierLists
-from integ_tests.marqo_test import MarqoTestCase, TestImageUrls
-from marqo.core.models.marqo_update_documents_response import MarqoUpdateDocumentsResponse, MarqoUpdateDocumentsItem
-
 
 
 class TestUpdate(MarqoTestCase):
@@ -181,7 +177,7 @@ class TestUpdate(MarqoTestCase):
             "text_field": "updated text field",
             "_id": "1"
         }
-        r = update_documents(body=UpdateDocumentsBodyParams(documents=[updated_doc]),
+        r = update_documents(body_dict={"documents": [updated_doc]},
                              index_name=self.structured_index_name, marqo_config=self.config)
         updated_doc = tensor_search.get_document_by_id(self.config, self.structured_index_name, updated_doc["_id"])
 
@@ -194,7 +190,7 @@ class TestUpdate(MarqoTestCase):
             "text_field_filter": "updated text field filter",
             "_id": "1"
         }
-        r = update_documents(body=UpdateDocumentsBodyParams(documents=[updated_doc]),
+        r = update_documents(body_dict={"documents": [updated_doc]},
                              index_name=self.structured_index_name, marqo_config=self.config)
         updated_doc = tensor_search.get_document_by_id(self.config, self.structured_index_name, updated_doc["_id"])
 
@@ -214,7 +210,7 @@ class TestUpdate(MarqoTestCase):
             "text_field_lexical": "search me please",
             "_id": "1"
         }
-        r = update_documents(body=UpdateDocumentsBodyParams(documents=[updated_doc]),
+        r = update_documents(body_dict={"documents": [updated_doc]},
                              index_name=self.structured_index_name, marqo_config=self.config)
         updated_doc = tensor_search.get_document_by_id(self.config, self.structured_index_name, updated_doc["_id"])
 
@@ -248,7 +244,7 @@ class TestUpdate(MarqoTestCase):
             "text_field_add": "I am a new field",
             "_id": "1"
         }
-        r = update_documents(body=UpdateDocumentsBodyParams(documents=[updated_doc]),
+        r = update_documents(body_dict={"documents": [updated_doc]},
                              index_name=self.structured_index_name, marqo_config=self.config)
         updated_doc = tensor_search.get_document_by_id(self.config, self.structured_index_name, updated_doc["_id"])
         self.assertEqual("I am a new field", updated_doc["text_field_add"])
@@ -269,7 +265,7 @@ class TestUpdate(MarqoTestCase):
             "_id": "1"
         }
 
-        r = update_documents(body=UpdateDocumentsBodyParams(documents=[updated_doc]),
+        r = update_documents(body_dict={"documents": [updated_doc]},
                              index_name=self.structured_index_name, marqo_config=self.config)
         updated_doc = tensor_search.get_document_by_id(self.config, self.structured_index_name, updated_doc["_id"])
         self.assertEqual(11, updated_doc["int_field"])
@@ -281,7 +277,7 @@ class TestUpdate(MarqoTestCase):
             "_id": "1"
         }
 
-        r = update_documents(body=UpdateDocumentsBodyParams(documents=[updated_doc]),
+        r = update_documents(body_dict={"documents": [updated_doc]},
                              index_name=self.structured_index_name, marqo_config=self.config)
         updated_doc = tensor_search.get_document_by_id(self.config, self.structured_index_name, updated_doc["_id"])
         self.assertEqual(22, updated_doc["int_field_filter"])
@@ -305,7 +301,7 @@ class TestUpdate(MarqoTestCase):
             "add_to_score": [{"field_name": "int_field_score_modifier", "weight": 1}]
         })
 
-        r = update_documents(body=UpdateDocumentsBodyParams(documents=[updated_doc]),
+        r = update_documents(body_dict={"documents": [updated_doc]},
                              index_name=self.structured_index_name, marqo_config=self.config)
         updated_doc = tensor_search.get_document_by_id(self.config, self.structured_index_name, updated_doc["_id"])
         self.assertEqual(33, updated_doc["int_field_score_modifier"])
@@ -321,7 +317,7 @@ class TestUpdate(MarqoTestCase):
             "_id": "1"
         }
 
-        r = update_documents(body=UpdateDocumentsBodyParams(documents=[updated_doc]),
+        r = update_documents(body_dict={"documents": [updated_doc]},
                              index_name=self.structured_index_name, marqo_config=self.config)
         updated_doc = tensor_search.get_document_by_id(self.config, self.structured_index_name, updated_doc["_id"])
         self.assertEqual(11.1, updated_doc["float_field"])
@@ -333,7 +329,7 @@ class TestUpdate(MarqoTestCase):
             "_id": "1"
         }
 
-        r = update_documents(body=UpdateDocumentsBodyParams(documents=[updated_doc]),
+        r = update_documents(body_dict={"documents": [updated_doc]},
                              index_name=self.structured_index_name, marqo_config=self.config)
         updated_doc = tensor_search.get_document_by_id(self.config, self.structured_index_name, updated_doc["_id"])
         self.assertEqual(22.2, updated_doc["float_field_filter"])
@@ -357,7 +353,7 @@ class TestUpdate(MarqoTestCase):
             "add_to_score": [{"field_name": "float_field_score_modifier", "weight": 1.0}]
         })
 
-        r = update_documents(body=UpdateDocumentsBodyParams(documents=[updated_doc]),
+        r = update_documents(body_dict={"documents": [updated_doc]},
                              index_name=self.structured_index_name, marqo_config=self.config)
         updated_doc = tensor_search.get_document_by_id(self.config, self.structured_index_name, updated_doc["_id"])
         self.assertEqual(33.3, updated_doc["float_field_score_modifier"])
@@ -382,7 +378,7 @@ class TestUpdate(MarqoTestCase):
             "bool_field_filter": False,
             "_id": "1"
         }
-        r = update_documents(body=UpdateDocumentsBodyParams(documents=[updated_doc]),
+        r = update_documents(body_dict={"documents": [updated_doc]},
                              index_name=self.structured_index_name, marqo_config=self.config)
         updated_doc = tensor_search.get_document_by_id(self.config, self.structured_index_name, updated_doc["_id"])
 
@@ -415,7 +411,7 @@ class TestUpdate(MarqoTestCase):
             "image_pointer_field": TestImageUrls.IMAGE2.value,
             "_id": "1"
         }
-        r = update_documents(body=UpdateDocumentsBodyParams(documents=[updated_doc]),
+        r = update_documents(body_dict={"documents": [updated_doc]},
                              index_name=self.structured_index_name, marqo_config=self.config)
         updated_doc = tensor_search.get_document_by_id(self.config, self.structured_index_name, updated_doc["_id"])
 
@@ -543,7 +539,7 @@ class TestUpdate(MarqoTestCase):
             "array_text_field": ["text3", "text4"],
             "_id": "1"
         }
-        r = update_documents(body=UpdateDocumentsBodyParams(documents=[updated_doc]),
+        r = update_documents(body_dict={"documents": [updated_doc]},
                              index_name=self.structured_index_name, marqo_config=self.config)
         updated_doc = tensor_search.get_document_by_id(self.config, self.structured_index_name, updated_doc["_id"])
 
@@ -592,7 +588,7 @@ class TestUpdate(MarqoTestCase):
             "float_field_score_modifier": 33.33,
             "bool_field_filter": True
         }
-        r = update_documents(body=UpdateDocumentsBodyParams(documents=[updated_doc]),
+        r = update_documents(body_dict={"documents": [updated_doc]},
                              index_name=self.structured_index_name, marqo_config=self.config)
         updated_doc = tensor_search.get_document_by_id(self.config, self.structured_index_name, updated_doc["_id"])
 
@@ -691,7 +687,7 @@ class TestUpdate(MarqoTestCase):
                     else:
                         raise ValueError(f"Invalid field name {picked_field}")
 
-                r = update_documents(body=UpdateDocumentsBodyParams(documents=[updated_doc]),
+                r = update_documents(body_dict={"documents": [updated_doc]},
                                      index_name=self.structured_index_name, marqo_config=self.config)
 
         number_of_threads = 10
@@ -756,7 +752,7 @@ class TestUpdate(MarqoTestCase):
                 for picked_field in picked_fields:
                     updated_doc[picked_field] = np.random.uniform(1, 100)
 
-                r = update_documents(body=UpdateDocumentsBodyParams(documents=[updated_doc]),
+                r = update_documents(body_dict={"documents": [updated_doc]},
                                      index_name=self.large_score_modifier_index_name, marqo_config=self.config)
 
         number_of_threads = 10
@@ -781,7 +777,7 @@ class TestUpdate(MarqoTestCase):
         # Let do a final update and do a score modifier search to ensure the document is not broken
         final_doc = {f"float_field_{i}": 1.0 for i in range(100)}
         final_doc["_id"] = "1"
-        r = update_documents(body=UpdateDocumentsBodyParams(documents=[final_doc]),
+        r = update_documents(body_dict={"documents": [final_doc]},
                              index_name=self.large_score_modifier_index_name,
                              marqo_config=self.config)
 
@@ -800,12 +796,12 @@ class TestUpdate(MarqoTestCase):
 
     def test_proper_error_raised_if_received_too_many_documents(self):
         with self.assertRaises(BadRequestError) as cm:
-            r = update_documents(body=UpdateDocumentsBodyParams(documents=[{"_id": "1"}] * 129),
+            r = update_documents(body_dict={"documents": [{"_id": "1"}] * 129},
                                  index_name=self.structured_index_name, marqo_config=self.config)
 
         # The same request (size) should work if the max batch size is increased
         with mock.patch.dict(os.environ, {"MARQO_MAX_DOCUMENTS_BATCH_SIZE": "129"}):
-            r = update_documents(body=UpdateDocumentsBodyParams(documents=[{"_id": "1"}] * 129),
+            r = update_documents(body_dict={"documents": [{"_id": "1"}] * 129},
                                  index_name=self.structured_index_name, marqo_config=self.config)
 
     def test_duplicate_ids_in_one_batch(self):

--- a/tests/integ_tests/core/index_management/test_index_validation.py
+++ b/tests/integ_tests/core/index_management/test_index_validation.py
@@ -1,7 +1,7 @@
 import unittest
 
 import pytest
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from marqo.core.index_management.index_management import IndexManagement
 

--- a/tests/integ_tests/core/inference/test_hugging_face_model_properties.py
+++ b/tests/integ_tests/core/inference/test_hugging_face_model_properties.py
@@ -2,7 +2,7 @@ import unittest
 from unittest import mock
 
 import pytest
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from marqo.inference.native_inference.embedding_models.hugging_face_model_properties import HuggingFaceModelProperties, \
     PoolingMethod

--- a/tests/integ_tests/core/inference/test_languagebind_model_properties.py
+++ b/tests/integ_tests/core/inference/test_languagebind_model_properties.py
@@ -1,7 +1,7 @@
 import unittest
 
 import pytest
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from marqo.core.inference.api.modality import Modality
 from marqo.inference.native_inference.embedding_models.languagebind_model_properties import *

--- a/tests/integ_tests/core/models/test_marqo_index.py
+++ b/tests/integ_tests/core/models/test_marqo_index.py
@@ -103,5 +103,5 @@ class TestStructuredMarqoIndex(MarqoTestCase):
                     self.assertEqual("value", parsed_index.random_field)
                     # assert that the extra field is kept after serialization
                     self.assertTrue("random_field" in parsed_index.json())
-                except pydantic.error_wrappers.ValidationError as e:
+                except pydantic.v1.error_wrappers.ValidationError as e:
                     self.fail(f"Pydantic validation failed: {e}")

--- a/tests/integ_tests/tensor_search/integ_tests/test_custom_vector_field.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_custom_vector_field.py
@@ -183,7 +183,7 @@ class TestCustomVectorField(MarqoTestCase):
         """
         Test the structured index cannot be created with a custom vector field not in tensor fields
         """
-        with self.assertRaises(pydantic.v1.error_wrappers.ValidationError) as err:
+        with self.assertRaises(pydantic.error_wrappers.ValidationError) as err:
             self.create_indexes([self.structured_marqo_index_request(
                 model=Model(name='open_clip/ViT-B-32/laion400m_e31'),
                 normalize_embeddings=False,
@@ -211,7 +211,7 @@ class TestCustomVectorField(MarqoTestCase):
         """
         for index in [self.unstructured_custom_index, self.semi_structured_custom_index]:
             with self.subTest(msg=f'{index.name}: {index.type}'):
-                with self.assertRaisesStrict(pydantic.v1.error_wrappers.ValidationError) as err:
+                with self.assertRaisesStrict(pydantic.error_wrappers.ValidationError) as err:
                     self.add_documents(
                         config=self.config, add_docs_params=AddDocsParams(
                             index_name=index.name,
@@ -586,7 +586,7 @@ class TestCustomVectorField(MarqoTestCase):
 
                 for case in test_cases:
                     with self.subTest(f"Case: {case}"):
-                        with self.assertRaises(pydantic.v1.ValidationError):
+                        with self.assertRaises(pydantic.ValidationError):
                             res = self.add_documents(
                                 config=self.config, add_docs_params=AddDocsParams(
                                     index_name=index.name,

--- a/tests/integ_tests/tensor_search/integ_tests/test_custom_vector_field.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_custom_vector_field.py
@@ -183,7 +183,7 @@ class TestCustomVectorField(MarqoTestCase):
         """
         Test the structured index cannot be created with a custom vector field not in tensor fields
         """
-        with self.assertRaises(pydantic.error_wrappers.ValidationError) as err:
+        with self.assertRaises(pydantic.v1.error_wrappers.ValidationError) as err:
             self.create_indexes([self.structured_marqo_index_request(
                 model=Model(name='open_clip/ViT-B-32/laion400m_e31'),
                 normalize_embeddings=False,
@@ -211,7 +211,7 @@ class TestCustomVectorField(MarqoTestCase):
         """
         for index in [self.unstructured_custom_index, self.semi_structured_custom_index]:
             with self.subTest(msg=f'{index.name}: {index.type}'):
-                with self.assertRaisesStrict(pydantic.error_wrappers.ValidationError) as err:
+                with self.assertRaisesStrict(pydantic.v1.error_wrappers.ValidationError) as err:
                     self.add_documents(
                         config=self.config, add_docs_params=AddDocsParams(
                             index_name=index.name,
@@ -586,7 +586,7 @@ class TestCustomVectorField(MarqoTestCase):
 
                 for case in test_cases:
                     with self.subTest(f"Case: {case}"):
-                        with self.assertRaises(pydantic.ValidationError):
+                        with self.assertRaises(pydantic.v1.ValidationError):
                             res = self.add_documents(
                                 config=self.config, add_docs_params=AddDocsParams(
                                     index_name=index.name,

--- a/tests/integ_tests/tensor_search/integ_tests/test_dict_score_modifiers.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_dict_score_modifiers.py
@@ -321,7 +321,7 @@ class TestDictScoreModifiers(MarqoTestCase):
                 r = update_documents(
                     marqo_config=self.config,
                     index_name=index.name,
-                    body=UpdateDocumentsBodyParams(documents=[updated_doc])
+                    body_dict={"documents": [updated_doc]}
                 )
 
                 # Get updated document and assert that the score modifier is 1.5

--- a/tests/integ_tests/tensor_search/integ_tests/test_no_model.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_no_model.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from marqo.api.exceptions import InvalidArgError
 from marqo.core.exceptions import IndexNotFoundError
-from pydantic.error_wrappers import ValidationError
+from pydantic.v1.error_wrappers import ValidationError
 from marqo.core.models.marqo_index import *
 from marqo.core.models.marqo_index_request import FieldRequest
 from marqo.tensor_search import tensor_search

--- a/tests/integ_tests/tensor_search/integ_tests/test_search_semi_structured.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_search_semi_structured.py
@@ -1,30 +1,28 @@
 import copy
-import math
 import os
 import random
 import unittest
 import uuid
 from unittest import mock
 
+import math
 import requests
-from pydantic import ValidationError
 
 import marqo.core.exceptions as core_exceptions
+from integ_tests.marqo_test import MarqoTestCase, TestImageUrls
+from integ_tests.tensor_search.integ_tests.common_test_constants import SPECIAL_CHARACTERS
 from marqo.api import exceptions as errors
 from marqo.api.exceptions import IndexNotFoundError
 from marqo.api.exceptions import InvalidArgError
-from marqo.vespa.exceptions import VespaStatusError
+from marqo.core.models.add_docs_params import AddDocsParams
 from marqo.core.models.marqo_index import *
 from marqo.s2_inference.s2_inference import get_model_properties_from_registry
 from marqo.tensor_search import tensor_search
 from marqo.tensor_search.enums import EnvVars
 from marqo.tensor_search.enums import SearchMethod
-from marqo.core.models.add_docs_params import AddDocsParams
-from marqo.tensor_search.models.search import SearchContext
-from integ_tests.marqo_test import MarqoTestCase, TestImageUrls
 from marqo.tensor_search.models.api_models import ScoreModifierLists
-from integ_tests.tensor_search.integ_tests.common_test_constants import SPECIAL_CHARACTERS
-
+from marqo.tensor_search.models.search import SearchContext
+from marqo.vespa.exceptions import VespaStatusError
 
 
 class TestSearchSemiStructured(MarqoTestCase):

--- a/tests/integ_tests/tensor_search/models/test_api_models.py
+++ b/tests/integ_tests/tensor_search/models/test_api_models.py
@@ -1,5 +1,5 @@
 from integ_tests.marqo_test import MarqoTestCase
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from marqo.core.models.hybrid_parameters import RankingMethod, RetrievalMethod, HybridParameters
 from marqo.tensor_search.enums import SearchMethod

--- a/tests/integ_tests/tensor_search/test_api.py
+++ b/tests/integ_tests/tensor_search/test_api.py
@@ -1,3 +1,7 @@
+import importlib
+import os
+import sys
+import unittest
 import uuid
 from unittest import mock
 from unittest.mock import patch
@@ -5,20 +9,14 @@ from unittest.mock import patch
 from fastapi.testclient import TestClient
 
 import marqo.tensor_search.api as api
+from integ_tests.marqo_test import MarqoTestCase
 from marqo import exceptions as base_exceptions
 from marqo.core import exceptions as core_exceptions
-from marqo.core.exceptions import CudaDeviceNotAvailableError, CudaOutOfMemoryError
+from marqo.core.models.marqo_add_documents_response import MarqoAddDocumentsResponse, MarqoAddDocumentsItem
 from marqo.core.models.marqo_index import FieldType
 from marqo.core.models.marqo_index_request import FieldRequest
 from marqo.tensor_search.enums import EnvVars
 from marqo.vespa import exceptions as vespa_exceptions
-from integ_tests.marqo_test import MarqoTestCase
-from marqo.core.models.marqo_add_documents_response import MarqoAddDocumentsResponse, MarqoAddDocumentsItem
-import importlib
-import sys
-import os
-
-import unittest
 
 
 class ApiTests(MarqoTestCase):

--- a/tests/integ_tests/tensor_search/test_api.py
+++ b/tests/integ_tests/tensor_search/test_api.py
@@ -6,6 +6,8 @@ import uuid
 from unittest import mock
 from unittest.mock import patch
 
+import pydantic
+from fastapi.exceptions import RequestValidationError
 from fastapi.testclient import TestClient
 
 import marqo.tensor_search.api as api
@@ -571,5 +573,40 @@ class TestApiErrors(MarqoTestCase):
                 response = self.client.get(f"/indexes/test_index/documents/1")
             mock_logger_error.assert_called_once()
             self.assertIn("internal_error_msg", str(mock_logger_error.call_args))
+
+    def test_parse_request_object_should_parse_pydantic_v1_model(self):
+        """Ensures parse_request_object parses pydantic v1 model"""
+        class PydanticV1Model(pydantic.v1.BaseModel):
+            field1: str
+
+        request_obj_dict = {"field1": "hello"}
+
+        model = api.parse_request_object(PydanticV1Model, request_obj_dict)
+
+        self.assertEqual(model.field1, "hello")
+
+    def test_parse_request_object_should_not_parse_pydantic_v2_model(self):
+        """Ensures parse_request_object does not parse pydantic v2 model"""
+        class PydanticV2Model(pydantic.BaseModel):
+            field1: str
+
+        request_obj_dict = {"field1": "hello"}
+
+        with self.assertRaises(RuntimeError) as context:
+            api.parse_request_object(PydanticV2Model, request_obj_dict)
+
+        self.assertIn('no validator found for', str(context.exception))
+
+    def test_parse_request_object_should_raise_request_validation_exception(self):
+        """Ensures parse_request_object raises RequestValidationError on pydantic v1 validation error"""
+        class PydanticV1Model(pydantic.v1.BaseModel):
+            field2: str
+
+        request_obj_dict = {"field1": "hello"}
+
+        with self.assertRaises(RequestValidationError) as context:
+            api.parse_request_object(PydanticV1Model, request_obj_dict)
+
+        self.assertIn('field required', str(context.exception.errors()))
 
     # TODO: Test how marqo handles generic exceptions, including Exception, RunTimeError, ValueError, etc.

--- a/tests/integ_tests/tensor_search/test_api_utils.py
+++ b/tests/integ_tests/tensor_search/test_api_utils.py
@@ -79,7 +79,7 @@ class TestDecodeQueryStringModelAuth(MarqoTestCase):
         self.assertEqual(result.hf, None)
 
     def test_decode_query_string_model_auth_invalid(self):
-        with self.assertRaises(pydantic.ValidationError):
+        with self.assertRaises(pydantic.v1.ValidationError):
             api_utils.decode_query_string_model_auth("invalid_url_encoded_string")
 
 @unittest.skip

--- a/tests/integ_tests/tensor_search/test_context_vectors_search.py
+++ b/tests/integ_tests/tensor_search/test_context_vectors_search.py
@@ -2,7 +2,7 @@ import os
 import unittest
 from unittest.mock import patch
 
-from pydantic.error_wrappers import ValidationError
+from pydantic.v1.error_wrappers import ValidationError
 
 from marqo.api.exceptions import InvalidArgError
 from marqo.core.models.marqo_index import *

--- a/tests/integ_tests/tensor_search/test_model_auth.py
+++ b/tests/integ_tests/tensor_search/test_model_auth.py
@@ -8,7 +8,7 @@ import unittest
 from unittest import mock
 from unittest import mock
 
-from pydantic.error_wrappers import ValidationError
+from pydantic.v1.error_wrappers import ValidationError
 from transformers import AutoModel, AutoTokenizer
 
 from marqo.api.exceptions import BadRequestError, ModelNotInCacheError

--- a/tests/integ_tests/tensor_search/test_prefix.py
+++ b/tests/integ_tests/tensor_search/test_prefix.py
@@ -154,10 +154,7 @@ class TestPrefix(MarqoTestCase):
 
                 embed_res = embed(
                     marqo_config=self.config, index_name=index.name,
-                    embedding_request=EmbedRequest(
-                        content=["hello"],
-                        content_type=None
-                    ),
+                    embedding_request_dict={"content": ["hello"]},
                     device="cpu"
                 )
 
@@ -213,19 +210,13 @@ class TestPrefix(MarqoTestCase):
 
                 embed_res_document_prefix = embed(
                     marqo_config=self.config, index_name=index.name,
-                    embedding_request=EmbedRequest(
-                        content=["hello"],
-                        content_type="document"
-                    ),
+                    embedding_request_dict={"content": ["hello"], "content_type": "document"},
                     device="cpu"
                 )
 
                 embed_res_no_prefix = embed(
                     marqo_config=self.config, index_name=index.name,
-                    embedding_request=EmbedRequest(
-                        content=["custom_prefix: hello"],
-                        content_type=None
-                    ),
+                    embedding_request_dict={"content": ["custom_prefix: hello"], "content_type": None},
                     device="cpu"
                 )
 
@@ -371,10 +362,7 @@ class TestPrefix(MarqoTestCase):
         # we hardcode the prefix into the text chunk and embed
         embed_res = embed(
             marqo_config=self.config, index_name=self.unstructured_index_with_override.name,
-            embedding_request=EmbedRequest(
-                content=["index-override: hello"],
-                content_type=None
-            ),
+            embedding_request_dict={"content": ["index-override: hello"]},
             device="cpu"
         )
 
@@ -414,10 +402,7 @@ class TestPrefix(MarqoTestCase):
                 # Embed request the same text
                 embed_res = embed(
                     marqo_config=self.config, index_name=index.name,
-                    embedding_request=EmbedRequest(
-                        content=["PREFIX: testing query"],
-                        content_type=None
-                    ),
+                    embedding_request_dict={"content": ["PREFIX: testing query"]},
                     device="cpu"
                 )
 

--- a/tests/integ_tests/tensor_search/test_score_modifiers_search.py
+++ b/tests/integ_tests/tensor_search/test_score_modifiers_search.py
@@ -11,7 +11,7 @@ from marqo.tensor_search.models.api_models import BulkSearchQuery, BulkSearchQue
 import pprint
 
 
-from pydantic.error_wrappers import ValidationError
+from pydantic.v1.error_wrappers import ValidationError
 import os
 
 @unittest.skip

--- a/tests/integ_tests/tensor_search/test_validation.py
+++ b/tests/integ_tests/tensor_search/test_validation.py
@@ -13,7 +13,7 @@ from marqo.tensor_search import validation
 from marqo.tensor_search.models.delete_docs_objects import MqDeleteDocsRequest
 from marqo.tensor_search.models.score_modifiers_object import ScoreModifierLists
 from marqo.tensor_search.models.search import SearchContext
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 
 class TestValidation(unittest.TestCase):

--- a/tests/unit_tests/marqo/api/models/test_get_batch_documents_request_model.py
+++ b/tests/unit_tests/marqo/api/models/test_get_batch_documents_request_model.py
@@ -1,6 +1,7 @@
 from marqo.api.models.get_batch_documents_request import GetBatchDocumentsRequest
 from unittest import TestCase
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
+
 
 class TestGetBatchDocumentsRequestModel(TestCase):
 

--- a/tests/unit_tests/marqo/core/inference/api/test_inference_model_classes.py
+++ b/tests/unit_tests/marqo/core/inference/api/test_inference_model_classes.py
@@ -1,7 +1,7 @@
 import unittest
 
 import numpy as np
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from marqo.core.inference.api import ModelConfig, InferenceRequest, Modality, TextPreprocessingConfig, \
     AudioPreprocessingConfig, VideoPreprocessingConfig, ImagePreprocessingConfig, InferenceResult, \

--- a/tests/unit_tests/marqo/core/inference/api/test_preprocessing_config.py
+++ b/tests/unit_tests/marqo/core/inference/api/test_preprocessing_config.py
@@ -1,6 +1,6 @@
 import unittest
 
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from marqo.core.inference.api import ChunkConfig, TextChunkConfig, TextPreprocessingConfig, ImagePreprocessingConfig, \
     AudioPreprocessingConfig, VideoPreprocessingConfig

--- a/tests/unit_tests/marqo/core/models/test_api_models.py
+++ b/tests/unit_tests/marqo/core/models/test_api_models.py
@@ -1,5 +1,5 @@
 import unittest
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from marqo.core.models.hybrid_parameters import HybridParameters, RetrievalMethod, RankingMethod
 from marqo.tensor_search.enums import SearchMethod


### PR DESCRIPTION
## Change Summary
Our perf test identified pydantic validation logic to be one of the major perf bottleneck of the search response parsing process. the core logic of Pydantic v2 is rewritten in rust and is much more performant than Pydantic v1. Upgrading to pydantic v2 helps address this perf bottleneck. In addition, after upgrading Pydantic, we can also upgrade Starlette and FastAPI to address some security issues.

Instead of a big bang change which touches all the Pydantic model class in Marqo repo. We will take baby steps and gradually migrate the model classes to v2. This is less risky. Please see [This guide](https://medium.com/codex/migrating-to-pydantic-v2-5a4b864621c3) for more details. 

In this PR
* Upgrade Pydantic dep to the latest v2 version
* Upgrade FastAPI, Starlette, Uvicorn dep to the latest version
* Replace all dep to pydantic package to pydantic.v1 so we still use the embedded v1 implementation in Pydantic v2 package. 
* Replace API method parameter with Pydantic model type with dictionary and handle the conversion from dictionary to Pydantic v1 model manually. This is due to that the latest version of FastAPI/Starllete uses Pydantic v2 and do not take v1 models as API method parameter. 
* * Please check `api.py` file and `test_api.py` file specifically for this change.
* * Please check 

In a following PR, we will
* Upgrade QueryResult to use Pydantic v2
* Upgrade SemiStructuredVespaDocument to use Pydantic v2

## Related Jira Ticket
[MOSD-365](https://s2search.atlassian.net/browse/MOSD-365)

## Checklist
<!-- Check items that apply, add items if needed -->
- [x] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)



[MOSD-365]: https://s2search.atlassian.net/browse/MOSD-365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ