### PR TITLE
Infer modality based on field type for structured index

### DIFF
--- a/examples/ClothingCLI/simple_marqo_demo.py
+++ b/examples/ClothingCLI/simple_marqo_demo.py
@@ -27,7 +27,7 @@ def load_index(index_name: str, number_data: int) -> None:
 
         settings = {
             "treatUrlsAndPointersAsImages": True,  # allows us to find an image file and index it
-            "model": "ViT-B/16"
+            "model": "open_clip/ViT-B-16/openai"
         }
 
         mq.create_index(index_name, settings_dict=settings)

--- a/examples/ClothingStreamlit/streamlit_marqo_demo.py
+++ b/examples/ClothingStreamlit/streamlit_marqo_demo.py
@@ -28,7 +28,7 @@ def load_index(number_data):
             
         settings = {
             "treatUrlsAndPointersAsImages":True,   # allows us to find an image file and index it
-            "model":"ViT-B/16"
+            "model": "open_clip/ViT-B-16/openai"
         }
          
         mq.create_index("demo-search-index", settings_dict=settings)

--- a/src/marqo/core/structured_vespa_index/structured_add_document_handler.py
+++ b/src/marqo/core/structured_vespa_index/structured_add_document_handler.py
@@ -27,6 +27,13 @@ MODALITY_FIELD_TYPE_MAP = {
     Modality.AUDIO: FieldType.AudioPointer,
 }
 
+FIELD_TYPE_MODALITY_MAP = {
+    FieldType.Text: Modality.TEXT,
+    FieldType.ImagePointer: Modality.IMAGE,
+    FieldType.VideoPointer: Modality.VIDEO,
+    FieldType.AudioPointer: Modality.AUDIO
+}
+
 
 class StructuredAddDocumentsHandler(AddDocumentsHandler):
     def __init__(self, marqo_index: StructuredMarqoIndex, add_docs_params: AddDocsParams, vespa_client: VespaClient,
@@ -74,20 +81,22 @@ class StructuredAddDocumentsHandler(AddDocumentsHandler):
         marqo_doc[field_name] = content
 
     def _infer_modality(self, tensor_field: TensorField) -> Modality:
+        """
+        Infer modality based on tensor field type specified in the definition of structured index. Please note we
+        do not infer the modality from the content of the field here, any modality mismatch is detected later when
+        we download and preprocess the media content.
+        """
         if tensor_field.field_type == FieldType.Text:
             return Modality.TEXT
-
-        url = tensor_field.field_content
-        try:
-            modality = infer_modality(url, self.add_docs_params.media_download_headers)
-        except MediaDownloadError as err:
-            raise AddDocumentsError(f"Error processing {tensor_field.field_name}: {err.message}") from err
-
-        if MODALITY_FIELD_TYPE_MAP[modality] != tensor_field.field_type:
-            raise AddDocumentsError(f"Error processing {tensor_field.field_name}, detected as {modality.value}, "
-                                    f"but expected field type is {tensor_field.field_type}")
-
-        return modality
+        elif tensor_field.field_type == FieldType.ImagePointer:
+            return Modality.IMAGE
+        elif tensor_field.field_type == FieldType.VideoPointer:
+            return Modality.VIDEO
+        elif tensor_field.field_type == FieldType.AudioPointer:
+            return Modality.AUDIO
+        else:
+            raise AddDocumentsError(f"Error processing {tensor_field.field_name}, tensor field type "
+                                    f"{tensor_field.field_type} is not supported")
 
     def _validate_field(self, field_name: str, field_content: Any) -> None:
         try:

--- a/src/marqo/core/vespa_index/add_documents_handler.py
+++ b/src/marqo/core/vespa_index/add_documents_handler.py
@@ -166,7 +166,8 @@ class AddDocumentsHandler(ABC):
                 self._populate_existing_tensors(existing_vespa_docs)
 
             # vectorise tensor fields
-            self._vectorise_tensor_fields()
+            with RequestMetricsStore.for_request().time("add_documents.inference.all"):
+                self._vectorise_tensor_fields()
 
         with RequestMetricsStore.for_request().time("add_documents.vespa.to_vespa_docs"):
             vespa_docs = self._convert_to_vespa_docs()
@@ -285,7 +286,8 @@ class AddDocumentsHandler(ABC):
         3. The result will be then populated to the tensor field. Individual errors happened during preprocessing
             and vectorisation will also be returned and collected by the `add_docs_response_collector`
         """
-        modalities = self._infer_modalities()
+        with RequestMetricsStore.for_request().time("add_documents.inference.infer_modality"):
+            modalities = self._infer_modalities()
 
         for modality in modalities:
             self._vectorise_fields(modality, for_top_level_field=True)
@@ -340,7 +342,9 @@ class AddDocumentsHandler(ABC):
 
         # This method could raise InferenceError, we'll allow it propagate to the API layer and convert to proper
         # error response to return to users
-        inference_result = self.inference.vectorise(request)
+        with RequestMetricsStore.for_request().time(f"add_documents.inference.{modality}."
+                                                    f"is_subfield_{not for_top_level_field}.size_{len(tensor_fields)}"):
+            inference_result = self.inference.vectorise(request)
 
         if len(tensor_fields) != len(inference_result.result):
             raise InternalError(f'Inference result contains chunks and embeddings for {len(inference_result.result)} '

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.18.1"
+__version__ = "2.18.2"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/tests/integ_tests/tensor_search/integ_tests/test_add_documents_structured.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_add_documents_structured.py
@@ -938,5 +938,4 @@ class TestAddDocumentsStructured(MarqoTestCase):
         for item in r.items:
             self.assertEqual(400, item.status)
             # modality mismatch
-            self.assertIn("Error processing image_field, detected as language, "
-                          "but expected field type is image_pointer", item.message)
+            self.assertIn("is not a local file or a valid url", item.message)

--- a/tests/integ_tests/tensor_search/integ_tests/test_add_documents_structured.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_add_documents_structured.py
@@ -125,7 +125,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
                 )
             ],
             tensor_fields=['image_field', 'image_field_2'],
-            model=Model(name='ViT-B/16')
+            model=Model(name='open_clip/ViT-B-16/openai')
         )
         index_request_img_chunking = cls.structured_marqo_index_request(
             fields=[
@@ -141,7 +141,7 @@ class TestAddDocumentsStructured(MarqoTestCase):
                 )
             ],
             tensor_fields=['image_field'],
-            model=Model(name='ViT-B/16'),
+            model=Model(name='open_clip/ViT-B-16/openai'),
             normalize_embeddings=True,
             image_preprocessing=ImagePreProcessing(patch_method=PatchMethod.Frcnn)
         )

--- a/tests/unit_tests/marqo/core/structured_vespa_index/test_structured_add_documents_handler.py
+++ b/tests/unit_tests/marqo/core/structured_vespa_index/test_structured_add_documents_handler.py
@@ -1,53 +1,28 @@
-import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-# TODO should I move utility method from integ_tests.MarqoTestCase to MarqoTestCase?
-from integ_tests.marqo_test import MarqoTestCase
 from marqo.core.exceptions import AddDocumentsError
-from marqo.core.inference.api import Inference, Modality, MediaDownloadError
+from marqo.core.inference.api import Inference, Modality
 from marqo.core.inference.tensor_fields_container import TensorField
 from marqo.core.models.add_docs_params import AddDocsParams
 from marqo.core.models.marqo_index import FieldType
 from marqo.core.structured_vespa_index.structured_add_document_handler import StructuredAddDocumentsHandler
 from marqo.vespa.vespa_client import VespaClient
+from unit_tests.marqo_test import MarqoTestCase
 
 
-class TestUnstructuredAddDocumentsHandler(unittest.TestCase):
+class TestUnstructuredAddDocumentsHandler(MarqoTestCase):
     IMAGE_URL = 'https://sample.com/abcd.png'
     AUDIO_URL = 'https://sample.com/abcd.wav'
     VIDEO_URL = 'https://sample.com/abcd.mp4'
-    INVALID_URL = 'https://invalid_url'
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.vespa_client = MagicMock(spec=VespaClient)
-        cls.inference = MagicMock(spec=Inference)
-        MarqoTestCase.configure_request_metrics()
+        super().setUpClass()
 
-    def setUp(self):
-        patcher = patch("marqo.core.structured_vespa_index.structured_add_document_handler.infer_modality")
-        self.mock_infer_modality = patcher.start()
-        self.addCleanup(patcher.stop)
-
-        def infer_modality_side_effect(url: str, media_download_header) -> Modality:
-            if url == self.IMAGE_URL:
-                return Modality.IMAGE
-            elif url == self.AUDIO_URL:
-                return Modality.AUDIO
-            elif url == self.VIDEO_URL:
-                return Modality.VIDEO
-            elif url == self.INVALID_URL:
-                raise MediaDownloadError(f"Error downloading media file {url}")
-            else:
-                return Modality.TEXT
-
-        self.mock_infer_modality.side_effect = infer_modality_side_effect
-
-    def _get_handler(self):
-        return StructuredAddDocumentsHandler(
-            vespa_client=self.vespa_client,
-            inference=self.inference,
-            marqo_index=MarqoTestCase.structured_marqo_index(
+        cls.handler = StructuredAddDocumentsHandler(
+            vespa_client=MagicMock(spec=VespaClient),
+            inference=MagicMock(spec=Inference),
+            marqo_index=cls.structured_marqo_index(
                 'index1', 'index1',
                 fields=[], tensor_fields=[]
             ),
@@ -56,71 +31,50 @@ class TestUnstructuredAddDocumentsHandler(unittest.TestCase):
             ),
         )
 
-    def test_infer_modality_should_return_text_when_field_type_is_text(self):
-        handler = self._get_handler()
-
+    def test_infer_modality_should_return_modality_based_on_field_type(self):
         test_cases = [
-            (self.AUDIO_URL, FieldType.Text, "audio url should be treated as text", Modality.TEXT),
-            (self.VIDEO_URL, FieldType.Text, "video url should be treated as text", Modality.TEXT),
-            (self.IMAGE_URL, FieldType.Text, "image url should be treated as text", Modality.TEXT),
+            ('Hello World', FieldType.Text, "string should be inferred as text", Modality.TEXT),
+            (self.AUDIO_URL, FieldType.AudioPointer, "audio url should be inferred as audio", Modality.AUDIO),
+            (self.VIDEO_URL, FieldType.VideoPointer, "video url should be inferred as video", Modality.VIDEO),
+            (self.IMAGE_URL, FieldType.ImagePointer, "image url should be inferred as image", Modality.IMAGE),
         ]
-        for url, field_type, test_case, expected_modality in test_cases:
+        for content, field_type, test_case, expected_modality in test_cases:
             with self.subTest(msg=test_case):
-                modality = handler._infer_modality(
-                    TensorField(doc_id='1', field_name='field1', field_content=url,
-                                is_top_level_tensor_field=True, field_type=field_type))
-                self.assertEqual(expected_modality, modality)
-                self.mock_infer_modality.assert_not_called()
-
-    def test_infer_modality_should_succeed_when_modality_matches_field_type(self):
-        handler = self._get_handler()
-
-        test_cases = [
-            (self.AUDIO_URL, FieldType.AudioPointer, "audio url should be treated as audio", Modality.AUDIO),
-            (self.VIDEO_URL, FieldType.VideoPointer, "video url should be treated as video", Modality.VIDEO),
-            (self.IMAGE_URL, FieldType.ImagePointer, "image url should be treated as image", Modality.IMAGE),
-        ]
-        for url, field_type, test_case, expected_modality in test_cases:
-            with self.subTest(msg=test_case):
-                modality = handler._infer_modality(
-                    TensorField(doc_id='1', field_name='field1', field_content=url,
+                modality = self.handler._infer_modality(
+                    TensorField(doc_id='1', field_name='field1', field_content=content,
                                 is_top_level_tensor_field=True, field_type=field_type))
                 self.assertEqual(expected_modality, modality)
 
-    def test_infer_modality_should_raise_error_when_fails_to_download_file(self):
-        handler = self._get_handler()
-
-        with self.assertRaises(AddDocumentsError) as context:
-            handler._infer_modality(
-                TensorField(doc_id='1', field_name='field1', field_content=self.INVALID_URL,
-                            is_top_level_tensor_field=True, field_type=FieldType.ImagePointer))
-        self.assertIn(f'Error processing field1: Error downloading media file {self.INVALID_URL}',
-                      str(context.exception))
-
-    def test_infer_modality_should_raise_error_when_inferred_modality_does_not_match_field_type(self):
-        handler = self._get_handler()
-
+    def test_infer_modality_should_ignore_content(self):
         test_cases = [
-            (self.AUDIO_URL, FieldType.ImagePointer, "audio url does not match image modality", Modality.AUDIO),
-            (self.AUDIO_URL, FieldType.VideoPointer, "audio url does not match video modality", Modality.AUDIO),
-
-            (self.VIDEO_URL, FieldType.ImagePointer, "video url does not match image modality", Modality.VIDEO),
-            (self.VIDEO_URL, FieldType.AudioPointer, "video url does not match audio modality", Modality.VIDEO),
-
-            (self.IMAGE_URL, FieldType.VideoPointer, "image url does not match video modality", Modality.IMAGE),
-            (self.IMAGE_URL, FieldType.AudioPointer, "image url does not match audio modality", Modality.IMAGE),
-
-            ('some text', FieldType.VideoPointer, "text does not match video modality", Modality.TEXT),
-            ('some text', FieldType.AudioPointer, "text does not match video modality", Modality.TEXT),
-            ('some text', FieldType.ImagePointer, "text does not match video modality", Modality.TEXT),
-
+            (self.AUDIO_URL, FieldType.Text, "audio url should be inferred as text", Modality.TEXT),
+            (self.IMAGE_URL, FieldType.Text, "image url should be inferred as text", Modality.TEXT),
+            (self.VIDEO_URL, FieldType.Text, "audio url should be inferred as text", Modality.TEXT),
+            (self.IMAGE_URL, FieldType.AudioPointer, "image url should be inferred as audio", Modality.AUDIO),
+            (self.VIDEO_URL, FieldType.AudioPointer, "video url should be inferred as audio", Modality.AUDIO),
+            (self.IMAGE_URL, FieldType.VideoPointer, "image url should be inferred as video", Modality.VIDEO),
+            (self.AUDIO_URL, FieldType.VideoPointer, "audio url should be inferred as video", Modality.VIDEO),
+            (self.VIDEO_URL, FieldType.ImagePointer, "video url should be inferred as image", Modality.IMAGE),
+            (self.AUDIO_URL, FieldType.ImagePointer, "audio url should be inferred as image", Modality.IMAGE),
         ]
-        for url, field_type, test_case, expected_modality in test_cases:
+        for content, field_type, test_case, expected_modality in test_cases:
             with self.subTest(msg=test_case):
+                modality = self.handler._infer_modality(
+                    TensorField(doc_id='1', field_name='field1', field_content=content,
+                                is_top_level_tensor_field=True, field_type=field_type))
+                self.assertEqual(expected_modality, modality)
+
+    def test_infer_modality_should_raise_error_for_unsupported_field_type(self):
+        supported_types = [FieldType.Text, FieldType.ImagePointer, FieldType.AudioPointer, FieldType.VideoPointer]
+
+        test_cases = [field_type for field_type in FieldType if field_type not in supported_types] + [None]
+
+        for unsupported_type in test_cases:
+            with self.subTest(msg=unsupported_type):
                 with self.assertRaises(AddDocumentsError) as context:
-                    handler._infer_modality(
-                        TensorField(doc_id='1', field_name='field1', field_content=url,
-                                    is_top_level_tensor_field=True, field_type=field_type))
+                    self.handler._infer_modality(
+                        TensorField(doc_id='1', field_name='field1', field_content='Some content',
+                                    is_top_level_tensor_field=True, field_type=unsupported_type))
 
-                self.assertIn(f'Error processing field1, detected as {expected_modality.value}, '
-                              f'but expected field type is {field_type.value}', str(context.exception))
+                self.assertIn(f'Error processing field1, tensor field type {unsupported_type} '
+                              f'is not supported', str(context.exception))

--- a/tests/unit_tests/marqo_test.py
+++ b/tests/unit_tests/marqo_test.py
@@ -1,7 +1,13 @@
+import time
+from typing import List
 from unittest import TestCase
 from unittest.mock import patch, Mock
 
+from marqo.core.models.marqo_index import Field, TensorField, Model, TextPreProcessing, TextSplitMethod, \
+    ImagePreProcessing, VideoPreProcessing, AudioPreProcessing, DistanceMetric, VectorNumericType, HnswConfig, \
+    StructuredMarqoIndex
 from marqo.tensor_search.telemetry import RequestMetricsStore
+from marqo.version import get_version
 
 
 class MarqoTestCase(TestCase):
@@ -18,3 +24,62 @@ class MarqoTestCase(TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.configure_request_metrics()
+
+    @classmethod
+    def structured_marqo_index(
+            cls,
+            name: str,
+            schema_name: str,
+            fields: List[Field] = None,
+            tensor_fields: List[TensorField] = None,
+            model: Model = Model(name='hf/all_datasets_v4_MiniLM-L6'),
+            normalize_embeddings: bool = True,
+            text_preprocessing: TextPreProcessing = TextPreProcessing(
+                split_length=2,
+                split_overlap=0,
+                split_method=TextSplitMethod.Sentence
+            ),
+            image_preprocessing: ImagePreProcessing = ImagePreProcessing(
+                patch_method=None
+            ),
+            video_preprocessing: VideoPreProcessing = VideoPreProcessing(
+                split_length=20,
+                split_overlap=1,
+            ),
+            audio_preprocessing: AudioPreProcessing = AudioPreProcessing(
+                split_length=20,
+                split_overlap=1,
+            ),
+            distance_metric: DistanceMetric = DistanceMetric.Angular,
+            vector_numeric_type: VectorNumericType = VectorNumericType.Float,
+            hnsw_config: HnswConfig = HnswConfig(
+                ef_construction=128,
+                m=16
+            ),
+            marqo_version=get_version(),
+            created_at=int(time.time()),
+            updated_at=int(time.time()),
+            version=None
+    ) -> StructuredMarqoIndex:
+        """
+        Helper method that provides reasonable defaults for StructuredMarqoIndex.
+        """
+        return StructuredMarqoIndex(
+            name=name,
+            schema_name=schema_name,
+            model=model,
+            normalize_embeddings=normalize_embeddings,
+            text_preprocessing=text_preprocessing,
+            image_preprocessing=image_preprocessing,
+            video_preprocessing=video_preprocessing,
+            audio_preprocessing=audio_preprocessing,
+            distance_metric=distance_metric,
+            vector_numeric_type=vector_numeric_type,
+            hnsw_config=hnsw_config,
+            fields=fields,
+            tensor_fields=tensor_fields,
+            marqo_version=marqo_version,
+            created_at=created_at,
+            updated_at=updated_at,
+            version=version
+        )


### PR DESCRIPTION
## Change Summary
* Infer modality based on the field type for structured index
* Add more telemetry data point for add_document process

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

