### PR TITLE
Change telemetry key of image downloading to media_download.image

### DIFF
--- a/src/marqo/inference/media_download_and_preprocess/image_download.py
+++ b/src/marqo/inference/media_download_and_preprocess/image_download.py
@@ -162,7 +162,7 @@ def load_image_from_path(image_path: str, media_download_headers: dict, timeout_
         img = Image.open(image_path)
     elif validators.url(image_path):
         if metrics_obj is not None:
-            metrics_obj.start(f"image_download.{image_path}")
+            metrics_obj.start(f"media_download.image.{image_path}")
         try:
             img_io: BytesIO = download_image_from_url(image_path, media_download_headers, timeout_ms)
             img = Image.open(img_io)
@@ -178,7 +178,7 @@ def load_image_from_path(image_path: str, media_download_headers: dict, timeout_
                 raise e
         finally:
             if metrics_obj is not None:
-                metrics_obj.stop(f"image_download.{image_path}")
+                metrics_obj.stop(f"media_download.image.{image_path}")
     else:
         raise UnidentifiedImageError(f"Input str of {image_path} is not a local file or a valid url. "
                                      f"If you are using Marqo Cloud, please note that images can only be downloaded "


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->
Fix an issue where the telemetry key in the image downloading function is still using the old prefix `image_download`. We are using `media_download.{modality}` now.

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

