### PR TITLE
Add a modality check in streaming media preprocessor

### DIFF
--- a/src/marqo/core/inference/api/exceptions.py
+++ b/src/marqo/core/inference/api/exceptions.py
@@ -29,3 +29,8 @@ class UnsupportedModalityError(InferenceError):
 class MediaExceedsMaxSizeError(InferenceError):
     """Raised when the media exceeds the maximum size limit"""
     pass
+
+
+class MediaMisMatchError(InferenceError):
+    """Raised when the media does not match the expected type"""
+    pass

--- a/src/marqo/core/inference/api/exceptions.py
+++ b/src/marqo/core/inference/api/exceptions.py
@@ -31,6 +31,6 @@ class MediaExceedsMaxSizeError(InferenceError):
     pass
 
 
-class MediaMisMatchError(InferenceError):
+class MediaMismatchError(InferenceError):
     """Raised when the media does not match the expected type"""
     pass

--- a/src/marqo/inference/media_download_and_preprocess/streaming_media_processor.py
+++ b/src/marqo/inference/media_download_and_preprocess/streaming_media_processor.py
@@ -47,7 +47,7 @@ class StreamingMediaProcessor:
         self.total_size, self.duration, self.probed_modality = self._fetch_file_metadata()
 
         if self.modality != self.probed_modality:
-            raise MediaMisMatchError(
+            raise MediaMismatchError(
                 f"Error processing media file {self.url}. The provided modality {self.modality} does not match the "
                 f"detected modality {self.probed_modality}. Please check your media file and try again. If you are using"
                 f"a structured index, check if your media file matches the field type"

--- a/src/marqo/inference/media_download_and_preprocess/streaming_media_processor.py
+++ b/src/marqo/inference/media_download_and_preprocess/streaming_media_processor.py
@@ -127,8 +127,8 @@ class StreamingMediaProcessor:
 
             size = int(probe['format'].get('size', 0))
             duration = float(probe['format'].get('duration', 0))
-            format_name = probe['format'].get('format_name', None)
-            modality_list = [codec_type.get('codec_type', None) for codec_type in probe['streams']]
+            format_name = probe['format'].get('format_name', "")
+            modality_list = [codec_type.get('codec_type', "") for codec_type in probe['streams']]
             modality = self._infer_modality_from_probe(modality_list, format_name)
 
             return size, duration, modality

--- a/src/marqo/inference/media_download_and_preprocess/streaming_media_processor.py
+++ b/src/marqo/inference/media_download_and_preprocess/streaming_media_processor.py
@@ -44,7 +44,14 @@ class StreamingMediaProcessor:
         self.modality = preprocessing_config.modality
         
         self.media_download_header = self._convert_headers_to_cli_format(preprocessing_config.download_header)
-        self.total_size, self.duration = self._fetch_file_metadata()
+        self.total_size, self.duration, self.probed_modality = self._fetch_file_metadata()
+
+        if self.modality != self.probed_modality:
+            raise MediaMisMatchError(
+                f"Error processing media file {self.url}. The provided modality {self.modality} does not match the "
+                f"detected modality {self.probed_modality}. Please check your media file and try again. If you are using"
+                f"a structured index, check if your media file matches the field type"
+            )
 
         if self.total_size > preprocessing_config.max_media_size_bytes:
             raise MediaExceedsMaxSizeError(
@@ -81,11 +88,34 @@ class StreamingMediaProcessor:
             raise InternalError("media_download_headers should be a dictionary")
         return "\r\n".join([f"{key}: {value}" for key, value in raw_media_download_headers.items()])
 
-    def _fetch_file_metadata(self) -> Tuple[float, float]:
+    def _infer_modality_from_probe(self, modality_list: list[str], format_name: Optional[str]) -> Optional[Modality]:
+        """
+        Infer the modality from the probed media file. This is used to determine whether the media is audio or video.
+        """
+        if Modality.VIDEO in modality_list:
+            if "image" in format_name:
+                return Modality.IMAGE
+            else:
+                return Modality.VIDEO
+        elif Modality.AUDIO in modality_list:
+            return Modality.AUDIO
+        else:
+            return None
+
+    def _fetch_file_metadata(self) -> Tuple[float, float, Optional[Modality]]:
+        """
+        Fetch the metadata of the media file using ffmpeg. This includes the size, duration, and modality of the
+        media file.
+
+        Returns:
+            Tuple[float, float, str]: A tuple containing the size (in bytes), duration (in seconds), and modality of the
+            media file.
+
+        """
         try:
             probe_options = {
                 'v': 'error',
-                'show_entries': 'format=size,duration',
+                'show_entries': 'stream=codec_type,format=size,duration,format_name',
                 'of': 'json',
                 'probesize': '256K',  # Probe only the first 256KB
             }
@@ -97,8 +127,11 @@ class StreamingMediaProcessor:
 
             size = int(probe['format'].get('size', 0))
             duration = float(probe['format'].get('duration', 0))
+            format_name = probe['format'].get('format_name', None)
+            modality_list = [codec_type.get('codec_type', None) for codec_type in probe['streams']]
+            modality = self._infer_modality_from_probe(modality_list, format_name)
 
-            return size, duration
+            return size, duration, modality
 
         except ffmpeg.Error as e:
             raise MediaDownloadError(f"Error fetching metadata: {e.stderr.decode()}") from e

--- a/src/marqo/inference/media_download_and_preprocess/streaming_media_processor.py
+++ b/src/marqo/inference/media_download_and_preprocess/streaming_media_processor.py
@@ -49,7 +49,7 @@ class StreamingMediaProcessor:
         if self.modality != self.probed_modality:
             raise MediaMismatchError(
                 f"Error processing media file {self.url}. The provided modality {self.modality} does not match the "
-                f"detected modality {self.probed_modality}. Please check your media file and try again. If you are using"
+                f"detected modality {self.probed_modality}. Please check your media file and try again. If you are using "
                 f"a structured index, check if your media file matches the field type"
             )
 
@@ -93,7 +93,7 @@ class StreamingMediaProcessor:
         Infer the modality from the probed media file. This is used to determine whether the media is audio or video.
         """
         if Modality.VIDEO in modality_list:
-            if "image" in format_name:
+            if "image" in format_name or "png" in format_name:
                 return Modality.IMAGE
             else:
                 return Modality.VIDEO

--- a/tests/integ_tests/inference/native_inference/media_download_and_preprocess/test_streaming_media_preprcessor.py
+++ b/tests/integ_tests/inference/native_inference/media_download_and_preprocess/test_streaming_media_preprcessor.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import torch
 from pytest import mark
 
-from integ_tests.marqo_test import TestVideoUrls, TestAudioUrls
+from integ_tests.marqo_test import TestVideoUrls, TestAudioUrls, TestImageUrls
 from marqo.core.inference.api import *
 from marqo.inference.media_download_and_preprocess.streaming_media_processor import StreamingMediaProcessor
 from marqo.inference.native_inference.embedding_models.languagebind_model import LanguagebindPreprocessor
@@ -163,7 +163,7 @@ class TestStreamingMediaProcessor(unittest.TestCase):
             url=valid_url, preprocessors=self.test_preprocessor,
             preprocessing_config=self.test_video_preprocessing_config
         )
-        size, duration = streaming_media_processor_object._fetch_file_metadata()
+        size, duration, _ = streaming_media_processor_object._fetch_file_metadata()
 
         self.assertEqual(2971504, size) # Hardcoded value
         self.assertEqual(10.01, duration) # Hardcoded value
@@ -215,11 +215,72 @@ class TestStreamingMediaProcessor(unittest.TestCase):
         with patch("marqo.inference.media_download_and_preprocess"
                    ".streaming_media_processor.StreamingMediaProcessor._fetch_file_metadata") \
                 as mock_fetch_file_metadata:
-            mock_fetch_file_metadata.return_value = (2971504, 10.01)
+            mock_fetch_file_metadata.return_value = (2971504, 10.01, Modality.VIDEO)
             streaming_media_processor_object = StreamingMediaProcessor(
-                url=TestAudioUrls.AUDIO1.value, preprocessors=self.test_preprocessor,
+                url=TestVideoUrls.VIDEO1.value, preprocessors=self.test_preprocessor,
                 preprocessing_config=test_video_preprocessing_config
             )
 
         expected = "Authorization: Bearer token\r\nUser-Agent: Test"
         self.assertEqual(streaming_media_processor_object.media_download_header, expected)
+
+    def test_prob_modality_correct_video(self):
+        for url in [
+            TestVideoUrls.VIDEO1.value, TestVideoUrls.VIDEO2.value, TestVideoUrls.VIDEO3.value,
+            TestVideoUrls.MKV_VIDEO1.value, TestVideoUrls.WEBM_VIDEO1.value, TestVideoUrls.AVI_VIDEO1.value
+        ]:
+            with self.subTest(url=url):
+                streaming_media_processor_object = StreamingMediaProcessor(
+                    url=url, preprocessors=self.test_preprocessor,
+                    preprocessing_config=self.test_video_preprocessing_config
+                )
+                self.assertEqual(Modality.VIDEO, streaming_media_processor_object.probed_modality)
+
+    def test_prob_modality_correct_audio(self):
+        for url in [
+            TestAudioUrls.AUDIO1.value, TestAudioUrls.AUDIO2.value, TestAudioUrls.AUDIO3.value,
+            TestAudioUrls.MP3_AUDIO1.value, TestAudioUrls.MP3_AUDIO1.value, TestAudioUrls.ACC_AUDIO1.value,
+            TestAudioUrls.OGG_AUDIO1.value, TestAudioUrls.FLAC_AUDIO1.value
+        ]:
+            with self.subTest(url=url):
+                streaming_media_processor_object = StreamingMediaProcessor(
+                    url=url, preprocessors=self.test_preprocessor,
+                    preprocessing_config=self.test_audio_preprocessing_config
+                )
+                self.assertEqual(Modality.AUDIO, streaming_media_processor_object.probed_modality)
+
+    def test_prob_modality_correct_image(self):
+        """Ensure that the probed modality is correct for various image formats. Note that
+        an error is raised as StreamingMediaProcessor is not designed to handle images."""
+        for url in [
+            TestImageUrls.IMAGE1.value, TestImageUrls.IMAGE2.value, TestImageUrls.IMAGE3.value,
+            TestImageUrls.COCO.value
+        ]:
+            with self.subTest(url=url):
+                with self.assertRaises(MediaMisMatchError) as e:
+                    _ = StreamingMediaProcessor(
+                        url=url, preprocessors=self.test_preprocessor,
+                        preprocessing_config=self.test_video_preprocessing_config
+                    )
+                self.assertIn('the detected modality image', str(e.exception))
+
+
+    def test_incorrect_modality_between_audio_and_video_will_raise_an_error(self):
+        test_cases = [
+            (TestVideoUrls.VIDEO1.value, self.test_audio_preprocessing_config,
+             "The url is video, but the preprocessing config is audio"),
+            (TestAudioUrls.AUDIO1.value, self.test_video_preprocessing_config,
+             "The url is audio, but the preprocessing config is video")
+        ]
+        for url, processing_config, msg in test_cases:
+            with self.subTest(msg):
+                with self.assertRaises(MediaMisMatchError) as e:
+                    _ = StreamingMediaProcessor(
+                        url=url, preprocessors=self.test_preprocessor,
+                        preprocessing_config=processing_config
+                    )
+                self.assertIn("Please check your media file and try again", str(e.exception))
+
+
+
+

--- a/tests/integ_tests/inference/native_inference/media_download_and_preprocess/test_streaming_media_preprcessor.py
+++ b/tests/integ_tests/inference/native_inference/media_download_and_preprocess/test_streaming_media_preprcessor.py
@@ -257,7 +257,7 @@ class TestStreamingMediaProcessor(unittest.TestCase):
             TestImageUrls.COCO.value
         ]:
             with self.subTest(url=url):
-                with self.assertRaises(MediaMisMatchError) as e:
+                with self.assertRaises(MediaMismatchError) as e:
                     _ = StreamingMediaProcessor(
                         url=url, preprocessors=self.test_preprocessor,
                         preprocessing_config=self.test_video_preprocessing_config
@@ -274,7 +274,7 @@ class TestStreamingMediaProcessor(unittest.TestCase):
         ]
         for url, processing_config, msg in test_cases:
             with self.subTest(msg):
-                with self.assertRaises(MediaMisMatchError) as e:
+                with self.assertRaises(MediaMismatchError) as e:
                     _ = StreamingMediaProcessor(
                         url=url, preprocessors=self.test_preprocessor,
                         preprocessing_config=processing_config

--- a/tests/unit_tests/marqo/inference/media_download_and_preprocess/test_streaming_media_processor.py
+++ b/tests/unit_tests/marqo/inference/media_download_and_preprocess/test_streaming_media_processor.py
@@ -69,7 +69,7 @@ class TestStreamingMediaProcessor(unittest.TestCase):
     @patch(
         "marqo.inference.media_download_and_preprocess.streaming_media_processor.StreamingMediaProcessor.fetch_audio_chunk")
     def test_process_audio_media_chunks(self, mock_fetch_audio_chunk, mock_fetch_file_metadata):
-        mock_fetch_file_metadata.return_value = (1000000, 30.0)  # size, duration
+        mock_fetch_file_metadata.return_value = (1000000, 30.0, Modality.AUDIO)  # size, duration
         mock_fetch_audio_chunk.side_effect = lambda start_time, duration, output_file: output_file
 
         processor = StreamingMediaProcessor(
@@ -97,7 +97,7 @@ class TestStreamingMediaProcessor(unittest.TestCase):
     @patch(
         "marqo.inference.media_download_and_preprocess.streaming_media_processor.StreamingMediaProcessor.fetch_audio_chunk")
     def test_last_chunk_alignment(self, mock_fetch_audio_chunk, mock_fetch_file_metadata):
-        mock_fetch_file_metadata.return_value = (1000000, 23.5)  # Non-divisible duration
+        mock_fetch_file_metadata.return_value = (1000000, 23.5, Modality.AUDIO)  # Non-divisible duration
         mock_fetch_audio_chunk.side_effect = lambda start_time, duration, output_file: output_file
 
         processor = StreamingMediaProcessor(
@@ -122,7 +122,7 @@ class TestStreamingMediaProcessor(unittest.TestCase):
         "marqo.inference.media_download_and_preprocess.streaming_media_processor.StreamingMediaProcessor.fetch_audio_chunk")
     def test_explicit_audio_chunk_times(self, mock_fetch_audio_chunk, mock_fetch_file_metadata):
         # Set up media duration exactly 30s
-        mock_fetch_file_metadata.return_value = (1000000, 30.0)
+        mock_fetch_file_metadata.return_value = (1000000, 30.0, Modality.AUDIO)
         mock_fetch_audio_chunk.side_effect = lambda start_time, duration, output_file: output_file
 
         overlap_config = AudioPreprocessingConfig(
@@ -171,7 +171,7 @@ class TestStreamingMediaProcessor(unittest.TestCase):
     @patch(
         "marqo.inference.media_download_and_preprocess.streaming_media_processor.StreamingMediaProcessor.fetch_audio_chunk")
     def test_short_media_duration(self, mock_fetch_audio_chunk, mock_fetch_file_metadata):
-        mock_fetch_file_metadata.return_value = (1000000, 5.0)  # Shorter than split_length
+        mock_fetch_file_metadata.return_value = (1000000, 5.0, Modality.AUDIO)  # Shorter than split_length
         mock_fetch_audio_chunk.side_effect = lambda start_time, duration, output_file: output_file
 
         processor = StreamingMediaProcessor(
@@ -193,7 +193,7 @@ class TestStreamingMediaProcessor(unittest.TestCase):
         "marqo.inference.media_download_and_preprocess.streaming_media_processor.StreamingMediaProcessor.fetch_audio_chunk")
     def test_media_download_error_is_raised(self, mock_fetch_audio_chunk, mock_fetch_file_metadata):
 
-        mock_fetch_file_metadata.return_value = (1000000, 10.0)
+        mock_fetch_file_metadata.return_value = (1000000, 10.0, Modality.AUDIO)
         mock_fetch_audio_chunk.side_effect = MediaDownloadError("Failed downloading audio")
 
         processor = StreamingMediaProcessor(
@@ -209,7 +209,7 @@ class TestStreamingMediaProcessor(unittest.TestCase):
         "marqo.inference.media_download_and_preprocess.streaming_media_processor.StreamingMediaProcessor.fetch_audio_chunk")
     def test_media_exceeds_max_size_error_is_raised(self, mock_fetch_audio_chunk, mock_fetch_file_metadata):
 
-        mock_fetch_file_metadata.return_value = (1e10, 10.0)
+        mock_fetch_file_metadata.return_value = (1e10, 10.0, Modality.AUDIO)
         mock_fetch_audio_chunk.side_effect = MediaDownloadError("Failed downloading audio")
 
         with self.assertRaises(MediaExceedsMaxSizeError) as context:
@@ -224,7 +224,7 @@ class TestStreamingMediaProcessor(unittest.TestCase):
     @patch(
         "marqo.inference.media_download_and_preprocess.streaming_media_processor.StreamingMediaProcessor.fetch_video_chunk")
     def test_explicit_video_chunk_times_with_overlaps(self, mock_fetch_audio_chunk, mock_fetch_file_metadata):
-        mock_fetch_file_metadata.return_value = (1000000, 41.0)
+        mock_fetch_file_metadata.return_value = (1000000, 41.0, Modality.VIDEO)
         mock_fetch_audio_chunk.side_effect = lambda start_time, duration, output_file: output_file
 
         overlap_config = VideoPreprocessingConfig(
@@ -272,7 +272,7 @@ class TestStreamingMediaProcessor(unittest.TestCase):
     @patch(
         "marqo.inference.media_download_and_preprocess.streaming_media_processor.StreamingMediaProcessor.fetch_video_chunk")
     def test_explicit_video_chunk_times_without_chunk(self, mock_fetch_audio_chunk, mock_fetch_file_metadata):
-        mock_fetch_file_metadata.return_value = (1000000, 41.0)
+        mock_fetch_file_metadata.return_value = (1000000, 41.0, Modality.VIDEO)
         mock_fetch_audio_chunk.side_effect = lambda start_time, duration, output_file: output_file
 
         overlap_config = VideoPreprocessingConfig(


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->

Add a modality check in the streaming media preprocessor, ensuring that the detected media type matches the expected type. This could happen in a structured index as the given modality is inferred from the field type instead of the file itself. Without this detection, ffmpeg will silently process the given video file even if the file is in an audio format.

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

