### PR TITLE
Skip diff cover on push events

### DIFF
--- a/.github/workflows/run_required_checks_coverage.yml
+++ b/.github/workflows/run_required_checks_coverage.yml
@@ -97,29 +97,40 @@ jobs:
         run: |
           cd marqo
           
-          export PYTHONPATH="."
-          export BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
-          echo "Running diff-cover against branch $BASE_BRANCH"
-          git fetch origin $BASE_BRANCH:$BASE_BRANCH
-          
-          diff-cover ../unit_coverage_data/coverage.xml --html-report ../unit_coverage_data/diff_cov.html \
-            --markdown-report ../unit_coverage_data/diff_cov.md \
-            --compare-branch $BASE_BRANCH --fail-under=95
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            export PYTHONPATH="."
+            export BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
+            echo "Running diff-cover against branch $BASE_BRANCH"
+            git fetch origin $BASE_BRANCH:$BASE_BRANCH
+            
+            diff-cover ../unit_coverage_data/coverage.xml --html-report ../unit_coverage_data/diff_cov.html \
+              --markdown-report ../unit_coverage_data/diff_cov.md \
+              --compare-branch $BASE_BRANCH --fail-under=95
+          else
+            echo "Skipping diff-cover on push events"
+            echo "Skipped diff-cover on push event" > ../unit_coverage_data/diff_cov.md
+            touch ../unit_coverage_data/diff_cov.html
+          fi
 
       - name: Check diff integ test coverage (80% threshold)
         id: integ_diff_coverage
         continue-on-error: true
         run: |
           cd marqo
-          
-          export PYTHONPATH="."
-          export BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
-          echo "Running diff-cover against branch $BASE_BRANCH"
-          git fetch origin $BASE_BRANCH:$BASE_BRANCH
-          
-          diff-cover ../integ_coverage_data/coverage.xml --html-report ../integ_coverage_data/diff_cov.html \
-            --markdown-report ../integ_coverage_data/diff_cov.md \
-            --compare-branch $BASE_BRANCH --fail-under=80
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            export PYTHONPATH="."
+            export BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
+            echo "Running diff-cover against branch $BASE_BRANCH"
+            git fetch origin $BASE_BRANCH:$BASE_BRANCH
+            
+            diff-cover ../integ_coverage_data/coverage.xml --html-report ../integ_coverage_data/diff_cov.html \
+              --markdown-report ../integ_coverage_data/diff_cov.md \
+              --compare-branch $BASE_BRANCH --fail-under=80
+          else
+            echo "Skipping diff-cover on push events"
+            echo "Skipped diff-cover on push event" > ../integ_coverage_data/diff_cov.md
+            touch ../integ_coverage_data/diff_cov.html
+          fi
 
       - name: Check overall integration test coverage (78% threshold)
         id: integ_overall_coverage


### PR DESCRIPTION
## Change Summary
Diff cover on non-PR events is meaningless because there's no base branch/commit to compare with. It's currently failing on `mainline`. This PR skips diff cover unless tests are running on a feature branch (PR event).

Note these changes can't be fully tested before being merged in.

## Related Jira Ticket
N/A 

## Checklist
N/A

<!-- Special test requirements for certain changes -->
N/A