### PR TITLE
Fix lexical filtering bug

### DIFF
--- a/src/marqo/core/structured_vespa_index/structured_vespa_index.py
+++ b/src/marqo/core/structured_vespa_index/structured_vespa_index.py
@@ -559,7 +559,7 @@ class StructuredVespaIndex(VespaIndex):
             query_inputs.update(hybrid_score_modifiers[constants.MARQO_GLOBAL_SCORE_MODIFIERS])
 
         tensor_yql = f'select {select_attributes} from {self._marqo_index.schema_name} where {tensor_term}{filter_term}'
-        lexical_yql = f'select {select_attributes} from {self._marqo_index.schema_name} where {lexical_term}{filter_term}'
+        lexical_yql = f'select {select_attributes} from {self._marqo_index.schema_name} where ({lexical_term}){filter_term}'
         facet_queries = None
 
         if marqo_query.facets or marqo_query.track_total_hits:

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.19.1"
+__version__ = "2.19.2"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/tests/integ_tests/tensor_search/integ_tests/test_hybrid_search.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_hybrid_search.py
@@ -3304,44 +3304,37 @@ class TestHybridSearch(MarqoTestCase):
         """
         Test that lexical filtering with scoreModifiersLexical works.
         """
+        for index in [self.semi_structured_default_text_index, self.structured_text_index_score_modifiers]:
+            with self.subTest(index=index):
+                doc = {
+                    "_id": "1",
+                    "text_field_1": "test",
+                    "text_field_2": "not",
+                    "add_field_1": 1.2,
+                    "text_field_3": "test",
+                }
 
-        doc = {
-            "_id": "1",
-            "text1": "test",
-            "text2": "not",
-            "score_mod": 1.2,
-            "title": "test",
-            "productname": "test",
-            "body_html_safe": "test",
-            "properties_concatenated": "test, not",
-            "mod_map": {
-                "test_mod": 1.4
-            },
-            "tags": ["t1", "t2"]
-        }
+                self.add_documents(
+                    config=self.config, add_docs_params=AddDocsParams(
+                        index_name=index.name, docs=[doc],
+                        tensor_fields=["text_field_1"] if isinstance(index, SemiStructuredMarqoIndex) else None
+                    )
+                )
 
-        self.add_documents(
-            config=self.config, add_docs_params=AddDocsParams(
-                index_name=self.semi_structured_default_text_index.name, docs=[doc],
-                tensor_fields=["text1"]
-            )
-        )
+                res = tensor_search.search(
+                    config=self.config, index_name=index.name, search_method="HYBRID", text="test",
+                    filter="text_field_1:hadhsd",
+                    score_modifiers=ScoreModifierLists(add_to_score=[{"field_name": "add_field_1", "weight": 2000}]),
+                    highlights=False,
+                    hybrid_parameters=HybridParameters(
+                        scoreModifiersLexical=ScoreModifierLists(add_to_score=[{"field_name": "add_field_1", "weight": 1}]),
+                        scoreModifiersTensor=ScoreModifierLists(add_to_score=[{"field_name": "add_field_1", "weight": 1}]),
+                        searchableAttributesLexical=[
+                            "text_field_1",
+                            "text_field_2",
+                            "text_field_3",
+                        ]
+                    )
+                )
 
-        res = tensor_search.search(
-            config=self.config, index_name=self.semi_structured_default_text_index.name, search_method="HYBRID", text="test",
-            filter="tags:hadhsd",
-            score_modifiers=ScoreModifierLists(add_to_score=[{"field_name": "mod_map.test_mod", "weight": 2000}]),
-            highlights=False,
-            hybrid_parameters=HybridParameters(
-                scoreModifiersLexical=ScoreModifierLists(add_to_score=[{"field_name": "mod_map.test_mod", "weight": 1}]),
-                scoreModifiersTensor=ScoreModifierLists(add_to_score=[{"field_name": "mod_map.test_mod", "weight": 1}]),
-                searchableAttributesLexical=[
-                    "title",
-                    "productname",
-                    "body_html_safe",
-                    "properties_concatenated",
-                ]
-            )
-        )
-
-        self.assertEqual(res["hits"], [])
+                self.assertEqual(res["hits"], [])

--- a/tests/integ_tests/tensor_search/integ_tests/test_hybrid_search.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_hybrid_search.py
@@ -3299,3 +3299,49 @@ class TestHybridSearch(MarqoTestCase):
                             rankingMethod=RankingMethod.Tensor,
                         ), result_count=5
                     )
+
+    def test_lexical_filtering_with_scoreModifiersLexical_works(self):
+        """
+        Test that lexical filtering with scoreModifiersLexical works.
+        """
+
+        doc = {
+            "_id": "1",
+            "text1": "test",
+            "text2": "not",
+            "score_mod": 1.2,
+            "title": "test",
+            "productname": "test",
+            "body_html_safe": "test",
+            "properties_concatenated": "test, not",
+            "mod_map": {
+                "test_mod": 1.4
+            },
+            "tags": ["t1", "t2"]
+        }
+
+        self.add_documents(
+            config=self.config, add_docs_params=AddDocsParams(
+                index_name=self.semi_structured_default_text_index.name, docs=[doc],
+                tensor_fields=["text1"]
+            )
+        )
+
+        res = tensor_search.search(
+            config=self.config, index_name=self.semi_structured_default_text_index.name, search_method="HYBRID", text="test",
+            filter="tags:hadhsd",
+            score_modifiers=ScoreModifierLists(add_to_score=[{"field_name": "mod_map.test_mod", "weight": 2000}]),
+            highlights=False,
+            hybrid_parameters=HybridParameters(
+                scoreModifiersLexical=ScoreModifierLists(add_to_score=[{"field_name": "mod_map.test_mod", "weight": 1}]),
+                scoreModifiersTensor=ScoreModifierLists(add_to_score=[{"field_name": "mod_map.test_mod", "weight": 1}]),
+                searchableAttributesLexical=[
+                    "title",
+                    "productname",
+                    "body_html_safe",
+                    "properties_concatenated",
+                ]
+            )
+        )
+
+        self.assertEqual(res["hits"], [])

--- a/tests/unit_tests/marqo/core/search/test_search.py
+++ b/tests/unit_tests/marqo/core/search/test_search.py
@@ -152,9 +152,6 @@ class SearchTest(unittest.TestCase):
         return yql[:-4] + ")"
 
     def get_expected_lexical_yql(self, query):
-        return f'select * from {self.current_index.schema_name} where weakAnd(default contains "{query}")'
-
-    def get_expected_lexical_yql2(self, query):
         return f'select * from {self.current_index.schema_name} where (weakAnd(default contains "{query}"))'
 
     def get_expected_lexical_yql_with_or(self, query, include_select=True):
@@ -202,7 +199,7 @@ class SearchTest(unittest.TestCase):
         tensor_search.search(self.config, "index_name", "query", search_method="lexical")
         self.vespa_client_mock.query.assert_called_once()
         call_args = self.vespa_client_mock.query.call_args[1]
-        self.assertEqual(call_args['yql'], self.get_expected_lexical_yql2("query"))
+        self.assertEqual(call_args['yql'], self.get_expected_lexical_yql("query"))
         self.assertEqual(call_args['query_features'], {'text_field_2': 1, 'text_field_1': 1})
         self.assertEqual(call_args['ranking'], 'bm25')
         self.assertEqual(call_args['hits'], 3)

--- a/tests/unit_tests/marqo/core/search/test_search.py
+++ b/tests/unit_tests/marqo/core/search/test_search.py
@@ -286,7 +286,6 @@ class SearchTest(unittest.TestCase):
         )
 
         call_args = self.vespa_client_mock.query.call_args[1]
-        print(call_args)
         self.assertEqual(
             call_args['marqo__yql.lexical'],
             'select * from unstructured_test_schema where (None contains "test" OR None contains "test") AND (((marqo__short_string_fields contains sameElement(key contains "text_field_1", value contains "hadhsd"))))'

--- a/tests/unit_tests/marqo/core/search/test_search.py
+++ b/tests/unit_tests/marqo/core/search/test_search.py
@@ -14,6 +14,7 @@ from marqo.core.models.marqo_index import (
 )
 
 from marqo.config import Config
+from marqo.tensor_search.models.score_modifiers_object import ScoreModifierLists
 from marqo.tensor_search.telemetry import RequestMetricsStore
 from marqo.version import get_version
 from marqo.vespa.models import QueryResult
@@ -66,7 +67,8 @@ class SearchTest(unittest.TestCase):
                 ), TensorField(
                     name="custom_vector_field", chunk_field_name="custom_vector_field",
                     embeddings_field_name="custom_vector_field"
-                )]
+                ),
+            ]
         )
 
         cls.legacy_unstructured_index = UnstructuredMarqoIndex(
@@ -256,6 +258,41 @@ class SearchTest(unittest.TestCase):
             call_args['marqo__yql.lexical'], self.get_expected_lexical_yql("query")
         )
         self.assertEqual(call_args['marqo__hybrid.rerankDepthGlobal'], 15)
+
+    def test_hybrid_search_with_filter_and_score_modifiers(self):
+        self.set_index_to_return(self.unstructured_index)
+        tensor_search.search(
+            config=self.config,
+            index_name="index_name",
+            text="test",
+            search_method="HYBRID",
+            filter="text_field_1:hadhsd",
+            score_modifiers=ScoreModifierLists(
+                add_to_score=[{"field_name": "add_field_1", "weight": 2000}]
+            ),
+            highlights=False,
+            hybrid_parameters=HybridParameters(
+                scoreModifiersLexical=ScoreModifierLists(
+                    add_to_score=[{"field_name": "add_field_1", "weight": 1}]
+                ),
+                scoreModifiersTensor=ScoreModifierLists(
+                    add_to_score=[{"field_name": "add_field_1", "weight": 1}]
+                ),
+                searchableAttributesLexical=[
+                    "text_field_1",
+                    "text_field_2",
+                ]
+            )
+        )
+
+        call_args = self.vespa_client_mock.query.call_args[1]
+        print(call_args)
+        self.assertEqual(
+            call_args['marqo__yql.lexical'],
+            'select * from unstructured_test_schema where (None contains "test" OR None contains "test") AND (((marqo__short_string_fields contains sameElement(key contains "text_field_1", value contains "hadhsd"))))'
+        )
+
+
 
     def test_rerank_depth_higher_than_default_ef_search_overrides_it(self):
         tensor_search.search(self.config, "index_name", "query", search_method="tensor", rerank_depth=3000)


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->
This PR fixes lexical filtering bug introduced in 2.17 that broke filters when lexical score modifiers are applied due to accidental removal of parenthesis.
## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

