### PR TITLE
[releases/2.19] Fix lexical search required items string

### DIFF
--- a/src/marqo/core/structured_vespa_index/structured_vespa_index.py
+++ b/src/marqo/core/structured_vespa_index/structured_vespa_index.py
@@ -918,6 +918,12 @@ class StructuredVespaIndex(VespaIndex):
         Generate required terms for the given phrases and search attributes. If search attributes are not provided,
         we use 'default' as the search attribute.
 
+        Examples:
+            if we have phrases = ["required 1", "required 2"] and search_attributes = ["field1", "field2"],
+            we should return '(field1 contains "required 1" OR field2 contains "required 1") AND
+            (field1 contains "required 2" OR field2 contains "required 2")'. The required phrases do not have to be
+            in the same field, but must be in the same document.
+
         Returns:
             str: The generated and(required) terms for the phrases and search attributes.
         """
@@ -925,17 +931,15 @@ class StructuredVespaIndex(VespaIndex):
         if search_attributes is None:
             return ' AND '.join([f'default contains "{phrase}"' for phrase in phrases])
 
-        if not isinstance(search_attributes, list):
-            raise InternalError(f'Expected list[str] of searchable attributes, but found {type(search_attributes)}')
-
-        per_field_terms = [
-            "(" + ' AND '.join([
+        # Each element in the list is a string of the form '(field1 contains "phrase" AND field2 contains "phrase")'
+        per_phrase_term_list = [
+            "(" + ' OR '.join([
                 f'{self._marqo_index.field_map[field].lexical_field_name} contains "{phrase}"'
-                for phrase in phrases
-            ]) + ")" for field in search_attributes
+                for field in search_attributes
+            ]) + ")" for phrase in phrases
         ]
 
-        return ' OR '.join(per_field_terms)
+        return ' AND '.join(per_phrase_term_list)
 
     def _get_lexical_contains_term(self, phrase, query: MarqoQuery) -> str:
         if isinstance(query, MarqoHybridQuery):

--- a/src/marqo/core/structured_vespa_index/structured_vespa_index.py
+++ b/src/marqo/core/structured_vespa_index/structured_vespa_index.py
@@ -897,16 +897,45 @@ class StructuredVespaIndex(VespaIndex):
 
         # Required tokens
         if marqo_query.and_phrases:
-            and_terms = ' AND '.join([
-                self._get_lexical_contains_term(phrase, marqo_query) for phrase in marqo_query.and_phrases
-            ])
+            if isinstance(marqo_query, MarqoHybridQuery):
+                searchable_attributes: Union[None, list[str]] = marqo_query.hybrid_parameters.searchableAttributesLexical
+            else:
+                searchable_attributes: Union[None, list[str]] = marqo_query.searchable_attributes
+
+            and_terms = self._get_and_terms_for_required_phrase(
+                marqo_query.and_phrases, searchable_attributes
+            )
+
             if or_terms:
                 or_terms = f'({or_terms})'
                 and_terms = f' AND ({and_terms})'
         else:
             and_terms = ''
-
         return f'{or_terms}{and_terms}'
+
+    def _get_and_terms_for_required_phrase(self, phrases: List[str], search_attributes: Union[None, List[str]]) -> str:
+        """
+        Generate required terms for the given phrases and search attributes. If search attributes are not provided,
+        we use 'default' as the search attribute.
+
+        Returns:
+            str: The generated and(required) terms for the phrases and search attributes.
+        """
+
+        if search_attributes is None:
+            return ' AND '.join([f'default contains "{phrase}"' for phrase in phrases])
+
+        if not isinstance(search_attributes, list):
+            raise InternalError(f'Expected list[str] of searchable attributes, but found {type(search_attributes)}')
+
+        per_field_terms = [
+            "(" + ' AND '.join([
+                f'{self._marqo_index.field_map[field].lexical_field_name} contains "{phrase}"'
+                for phrase in phrases
+            ]) + ")" for field in search_attributes
+        ]
+
+        return ' OR '.join(per_field_terms)
 
     def _get_lexical_contains_term(self, phrase, query: MarqoQuery) -> str:
         if isinstance(query, MarqoHybridQuery):

--- a/src/marqo/core/structured_vespa_index/structured_vespa_index.py
+++ b/src/marqo/core/structured_vespa_index/structured_vespa_index.py
@@ -897,61 +897,28 @@ class StructuredVespaIndex(VespaIndex):
 
         # Required tokens
         if marqo_query.and_phrases:
-            if isinstance(marqo_query, MarqoHybridQuery):
-                searchable_attributes: Union[None, list[str]] = marqo_query.hybrid_parameters.searchableAttributesLexical
-            else:
-                searchable_attributes: Union[None, list[str]] = marqo_query.searchable_attributes
-
-            and_terms = self._get_and_terms_for_required_phrase(
-                marqo_query.and_phrases, searchable_attributes
-            )
-
+            and_terms = ' AND '.join([
+                self._get_lexical_contains_term(phrase, marqo_query) for phrase in marqo_query.and_phrases
+            ])
             if or_terms:
                 or_terms = f'({or_terms})'
                 and_terms = f' AND ({and_terms})'
         else:
             and_terms = ''
+
         return f'{or_terms}{and_terms}'
 
-    def _get_and_terms_for_required_phrase(self, phrases: List[str], search_attributes: Union[None, List[str]]) -> str:
-        """
-        Generate required terms for the given phrases and search attributes. If search attributes are not provided,
-        we use 'default' as the search attribute.
-
-        Examples:
-            if we have phrases = ["required 1", "required 2"] and search_attributes = ["field1", "field2"],
-            we should return '(field1 contains "required 1" OR field2 contains "required 1") AND
-            (field1 contains "required 2" OR field2 contains "required 2")'. The required phrases do not have to be
-            in the same field, but must be in the same document.
-
-        Returns:
-            str: The generated and(required) terms for the phrases and search attributes.
-        """
-
-        if search_attributes is None:
-            return ' AND '.join([f'default contains "{phrase}"' for phrase in phrases])
-
-        # Each element in the list is a string of the form '(field1 contains "phrase" AND field2 contains "phrase")'
-        per_phrase_term_list = [
-            "(" + ' OR '.join([
-                f'{self._marqo_index.field_map[field].lexical_field_name} contains "{phrase}"'
-                for field in search_attributes
-            ]) + ")" for phrase in phrases
-        ]
-
-        return ' AND '.join(per_phrase_term_list)
-
-    def _get_lexical_contains_term(self, phrase, query: MarqoQuery) -> str:
+    def _get_lexical_contains_term(self, phrase:str, query: MarqoQuery) -> str:
         if isinstance(query, MarqoHybridQuery):
             searchable_attributes = query.hybrid_parameters.searchableAttributesLexical
         else:
             searchable_attributes = query.searchable_attributes
 
         if searchable_attributes is not None:
-            return ' OR '.join([
+            return "("+' OR '.join([
                 f'{self._marqo_index.field_map[field].lexical_field_name} contains "{phrase}"'
                 for field in searchable_attributes
-            ])
+            ])+")"
         else:
             return f'default contains "{phrase}"'
 

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.19.2"
+__version__ = "2.19.3"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/tests/integ_tests/tensor_search/integ_tests/test_search_combined.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_search_combined.py
@@ -1021,11 +1021,6 @@ class TestSearch(MarqoTestCase):
 
         for index, method_name in indexes_to_test:
             with self.subTest(index_type=type(index).__name__):
-                # Mock the _get_lexical_contains_term method for StructuredVespaIndex
-                if isinstance(index, StructuredVespaIndex):
-                    index._get_lexical_contains_term = mock.MagicMock(
-                        side_effect=lambda phrase, query: f'contains("{phrase}")')
-
                 # Test cases
                 test_cases = [
                     # Test with score modifiers (should use OR)
@@ -1037,7 +1032,7 @@ class TestSearch(MarqoTestCase):
                             and_phrases=[],
                             score_modifiers=[ScoreModifier(field="field1", weight=1.0, type=ScoreModifierType.Multiply)]
                         ),
-                        'contains("term1") OR contains("term2")' if isinstance(index, StructuredVespaIndex)
+                        'default contains "term1" OR default contains "term2"' if isinstance(index, StructuredVespaIndex)
                         else '(default contains "term1" OR default contains "term2")'
                     ),
                     # Test without score modifiers (should use weakAnd)
@@ -1048,7 +1043,7 @@ class TestSearch(MarqoTestCase):
                             or_phrases=["term1", "term2"],
                             and_phrases=[]
                         ),
-                        'weakAnd(contains("term1"), contains("term2"))' if isinstance(index, StructuredVespaIndex)
+                        'weakAnd(default contains "term1", default contains "term2")' if isinstance(index, StructuredVespaIndex)
                         else '(weakAnd(default contains "term1", default contains "term2"))'
                     ),
                     # Test with both OR and AND phrases
@@ -1059,7 +1054,8 @@ class TestSearch(MarqoTestCase):
                             or_phrases=["term1", "term2"],
                             and_phrases=["term3", "term4"]
                         ),
-                        '(weakAnd(contains("term1"), contains("term2"))) AND (contains("term3") AND contains("term4"))'
+                        '(weakAnd(default contains "term1", default contains "term2")) AND '
+                        '(default contains "term3" AND default contains "term4")'
                         if isinstance(index, StructuredVespaIndex)
                         else '((weakAnd(default contains "term1", default contains "term2")) '
                              'AND (default contains "term3" AND default contains "term4"))'

--- a/tests/integ_tests/tensor_search/integ_tests/test_search_structured.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_search_structured.py
@@ -1319,7 +1319,10 @@ class TestSearchStructured(MarqoTestCase):
             # Exact phrase no match
             ('"term4 term3"', None, []),  # Wrong order — phrase not found
             # Required tokens in non-overlapping fields
-            ('"term1" "term4"', None, ["1", "2"])  # spread across field_1 and field_5
+            ('"term1" "term4"', None, ["1", "2"]),  # spread across field_1 and field_5
+            # Swap searchable attributes order
+            ('"term5"', ["text_field_1", "text_field_2"], ["1", "3"]),  # both in 1 and 3
+            ('"term5"', ["text_field_2", "text_field_1"], ["1", "3"]),  # both in 1 and 3
         ]
 
         self.add_documents(

--- a/tests/integ_tests/tensor_search/integ_tests/test_search_structured.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_search_structured.py
@@ -1301,28 +1301,37 @@ class TestSearchStructured(MarqoTestCase):
         ]
 
         test_cases = [
-            # Original cases
-            ('"term1 term2"', None, ["1", "2"]),  # exact phrase match across fields
-            ('"term1" "term2"', ["text_field_1"], ["1"]),  # both in field_1
-            ('"term1" "term2" word5', None, ["1"]),  # word5 in field_3
-            ('"term5 term6 term7 word5"', None, ["1"]),  # full span across field_3
-            # All required terms in one doc across multiple fields
-            ('"term3" "term4" "term5"', None, ["1"]),  # term3/4/5 in field_2
-            # Phrase only in doc 2
-            ('"term1 term2"', ["text_field_4"], ["2"]),
-            # Field restriction excludes valid hits
-            ('"term5"', ["text_field_4"], []),  # term5 only in field_2/3
-            # Match across field_1 and field_2
-            ('"term5" "word5"', None, ["1", "3"]),  # both in 1 and 3
-            # Match only document 4
-            ('"term7" "word7"', None, ["4"]),  # both appear in doc 4
-            # Exact phrase no match
-            ('"term4 term3"', None, []),  # Wrong order — phrase not found
-            # Required tokens in non-overlapping fields
-            ('"term1" "term4"', None, ["1", "2"]),  # spread across field_1 and field_5
-            # Swap searchable attributes order
-            ('"term5"', ["text_field_1", "text_field_2"], ["1", "3"]),  # both in 1 and 3
-            ('"term5"', ["text_field_2", "text_field_1"], ["1", "3"]),  # both in 1 and 3
+            # ─── Phrase Matching ─────────────────────────────────────────────
+            ('"term1 term2"', None, ["1", "2"]),  # match phrase across fields
+            ('"term1 term2"', ["text_field_4"], ["2"]),  # phrase match restricted to field
+            ('"term7 term8"', ["text_field_1"], ["4"]),  # phrase match in single field
+            ('"term4 term3"', None, []),  # phrase order matters (should not match)
+
+            # ─── Token Matching ──────────────────────────────────────────────
+            ('"term1" "term2"', None, ["1", "2"]),  # terms in multiple fields
+            ('"term1" "term2"', ["text_field_1"], ["1"]),  # both in same field
+            ('"term1" "term4"', None, ["1", "2"]),  # terms spread across fields
+            ('"term5" "word5"', None, ["1", "3"]),  # match across or within fields
+            ('"word1" "word6"', None, ["1"]),  # span across different fields in one doc
+
+            # ─── Field Filtering ─────────────────────────────────────────────
+            ('"term5"', ["text_field_1", "text_field_2"], ["1", "3"]),
+            ('"term5"', ["text_field_4"], []),  # valid term excluded due to field filter
+            ('"term7"', ["text_field_2"], []),  # term exists but outside filtered field
+            ('"term7"', ["text_field_1"], ["4"]),  # valid in allowed field
+
+            # ─── Matching Logic ──────────────────────────────────────────────
+            ('"term5 term6 term7 word5"', None, ["1"]),  # all terms appear in one doc
+            ('"term5 term6"', ["text_field_1"], ["3"]),  # single field match
+            ('"term1 TERM2"', None, ["1", "2"]),  # mixed case — case-insensitive
+            ('"term5" "term5"', None, ["1", "3"]),  # duplicate terms
+            ('"term999"', None, []),  # nonexistent term
+            ('"the of and"', None, []),  # stopwords
+            ('', None, []),  # empty query
+
+            # ─── Control Cases ───────────────────────────────────────────────
+            ('"term1" "term2" word5', None, ["1"]),  # combo of phrase + token
+            ('"word5 term8"', None, []),  # required terms in diff docs
         ]
 
         self.add_documents(

--- a/tests/integ_tests/tensor_search/integ_tests/test_search_structured.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_search_structured.py
@@ -1274,3 +1274,69 @@ class TestSearchStructured(MarqoTestCase):
         # Assert that no characters fail
         self.assertEqual(failed_characters, [],
                          f"Expected no characters to fail, but got: {failed_characters}")
+
+    def test_lexical_search_with_required_terms_results(self):
+        docs = [
+            {
+                "_id": "1",
+                "text_field_1": "term1 term2 term3 word1 word2",
+                "text_field_2": "term3 term4 term5 word3 word4",
+                "text_field_3": "term5 term6 term7 word5 word6"
+            },
+            {
+                "_id": "2",
+                "text_field_4": "term1 term2",
+                "text_field_5": "term3 term4",
+            },
+            {
+                "_id": "3",
+                "text_field_1": "term5 term6",
+                "text_field_2": "word5",
+            },
+            {
+                "_id": "4",
+                "text_field_1": "term7 term8",
+                "text_field_2": "word7 word8",
+            }
+        ]
+
+        test_cases = [
+            # Original cases
+            ('"term1 term2"', None, ["1", "2"]),  # exact phrase match across fields
+            ('"term1" "term2"', ["text_field_1"], ["1"]),  # both in field_1
+            ('"term1" "term2" word5', None, ["1"]),  # word5 in field_3
+            ('"term5 term6 term7 word5"', None, ["1"]),  # full span across field_3
+            # All required terms in one doc across multiple fields
+            ('"term3" "term4" "term5"', None, ["1"]),  # term3/4/5 in field_2
+            # Phrase only in doc 2
+            ('"term1 term2"', ["text_field_4"], ["2"]),
+            # Field restriction excludes valid hits
+            ('"term5"', ["text_field_4"], []),  # term5 only in field_2/3
+            # Match across field_1 and field_2
+            ('"term5" "word5"', None, ["1", "3"]),  # both in 1 and 3
+            # Match only document 4
+            ('"term7" "word7"', None, ["4"]),  # both appear in doc 4
+            # Exact phrase no match
+            ('"term4 term3"', None, []),  # Wrong order — phrase not found
+            # Required tokens in non-overlapping fields
+            ('"term1" "term4"', None, ["1", "2"])  # spread across field_1 and field_5
+        ]
+
+        self.add_documents(
+            config=self.config,
+            add_docs_params=AddDocsParams(
+                index_name=self.default_text_index,
+                docs=docs,
+            )
+        )
+
+        for query, searchable_attributes, expected_docs_ids in test_cases:
+            with self.subTest(f"{query}, {searchable_attributes}, {expected_docs_ids}"):
+                res = tensor_search.search(
+                    config=self.config,
+                    index_name=self.default_text_index,
+                    text=query,
+                    searchable_attributes=searchable_attributes,
+                    search_method=SearchMethod.LEXICAL
+                )
+                self.assertEqual(set(expected_docs_ids), {hit["_id"] for hit in res["hits"]})

--- a/tests/unit_tests/marqo/core/search/test_search.py
+++ b/tests/unit_tests/marqo/core/search/test_search.py
@@ -287,11 +287,9 @@ class SearchTest(unittest.TestCase):
 
         call_args = self.vespa_client_mock.query.call_args[1]
         self.assertEqual(
-            call_args['marqo__yql.lexical'],
-            'select * from unstructured_test_schema where (None contains "test" OR None contains "test") AND (((marqo__short_string_fields contains sameElement(key contains "text_field_1", value contains "hadhsd"))))'
+            'select * from unstructured_test_schema where ((None contains "test" OR None contains "test")) AND (((marqo__short_string_fields contains sameElement(key contains "text_field_1", value contains "hadhsd"))))',
+            call_args['marqo__yql.lexical']
         )
-
-
 
     def test_rerank_depth_higher_than_default_ef_search_overrides_it(self):
         tensor_search.search(self.config, "index_name", "query", search_method="tensor", rerank_depth=3000)

--- a/tests/unit_tests/marqo/core/structured_vespa_index/test_structured_add_documents_handler.py
+++ b/tests/unit_tests/marqo/core/structured_vespa_index/test_structured_add_documents_handler.py
@@ -10,7 +10,7 @@ from marqo.vespa.vespa_client import VespaClient
 from unit_tests.marqo_test import MarqoTestCase
 
 
-class TestUnstructuredAddDocumentsHandler(MarqoTestCase):
+class TestStructuredAddDocumentsHandler(MarqoTestCase):
     IMAGE_URL = 'https://sample.com/abcd.png'
     AUDIO_URL = 'https://sample.com/abcd.wav'
     VIDEO_URL = 'https://sample.com/abcd.mp4'

--- a/tests/unit_tests/marqo/core/structured_vespa_index/test_structured_index_build_search_query.py
+++ b/tests/unit_tests/marqo/core/structured_vespa_index/test_structured_index_build_search_query.py
@@ -91,6 +91,16 @@ class TestStructuredIndexBuildLexicalSearchQuery(MarqoTestCase):
                 ["term1", "term2"], None,
                 'default contains "term1" AND default contains "term2"',
                 "2 required terms, no fields"
+            ),
+            (
+                ["term1", "term2", "term3", "term4"], ['lexical_field_1', 'lexical_field_2', 'lexical_field_3'],
+                '(marqo__lexical_lexical_field_1 contains "term1" OR marqo__lexical_lexical_field_2 contains "term1" '
+                'OR marqo__lexical_lexical_field_3 contains "term1") AND (marqo__lexical_lexical_field_1 contains "term2" '
+                'OR marqo__lexical_lexical_field_2 contains "term2" OR marqo__lexical_lexical_field_3 contains "term2") AND '
+                '(marqo__lexical_lexical_field_1 contains "term3" OR marqo__lexical_lexical_field_2 contains "term3" OR '
+                'marqo__lexical_lexical_field_3 contains "term3") AND (marqo__lexical_lexical_field_1 contains "term4" '
+                'OR marqo__lexical_lexical_field_2 contains "term4" OR marqo__lexical_lexical_field_3 contains "term4")',
+                "4 required terms, 3 fields"
             )
         ]
         for required_phrases, searchable_attributes, expected_and_terms, msg in test_cases:

--- a/tests/unit_tests/marqo/core/structured_vespa_index/test_structured_index_build_search_query.py
+++ b/tests/unit_tests/marqo/core/structured_vespa_index/test_structured_index_build_search_query.py
@@ -51,23 +51,23 @@ class TestStructuredIndexBuildLexicalSearchQuery(MarqoTestCase):
             ),
             (
                 ["required_1", "required_2"], ['lexical_field_1'],
-                '(marqo__lexical_lexical_field_1 contains "required_1" '
-                'AND marqo__lexical_lexical_field_1 contains "required_2")',
+                '(marqo__lexical_lexical_field_1 contains "required_1") AND '
+                '(marqo__lexical_lexical_field_1 contains "required_2")',
                 "2 required terms, 1 field"
             ),
             (
                 ["required_1", "required_2"], ['lexical_field_1', 'lexical_field_2'],
                 '(marqo__lexical_lexical_field_1 contains "required_1" '
-                'AND marqo__lexical_lexical_field_1 contains "required_2") OR '
-                '(marqo__lexical_lexical_field_2 contains "required_1" '
-                'AND marqo__lexical_lexical_field_2 contains "required_2")',
+                'OR marqo__lexical_lexical_field_2 contains "required_1") AND '
+                '(marqo__lexical_lexical_field_1 contains "required_2" '
+                'OR marqo__lexical_lexical_field_2 contains "required_2")',
                 "2 required terms, 2 fields"
             ),
             (
                 ["long required phrase", "short required phrase"], ['lexical_field_1', 'lexical_field_4'],
                 '(marqo__lexical_lexical_field_1 contains "long required phrase" '
-                'AND marqo__lexical_lexical_field_1 contains "short required phrase") OR '
-                '(marqo__lexical_lexical_field_4 contains "long required phrase" AND '
+                'OR marqo__lexical_lexical_field_4 contains "long required phrase") AND '
+                '(marqo__lexical_lexical_field_1 contains "short required phrase" OR '
                 'marqo__lexical_lexical_field_4 contains "short required phrase")',
                 "2 multiple words required phrases, 2 fields"
             ),

--- a/tests/unit_tests/marqo/core/structured_vespa_index/test_structured_index_build_search_query.py
+++ b/tests/unit_tests/marqo/core/structured_vespa_index/test_structured_index_build_search_query.py
@@ -1,3 +1,4 @@
+from magic import Magic
 from unittest.mock import MagicMock
 
 from marqo.core.exceptions import AddDocumentsError
@@ -10,6 +11,7 @@ from marqo.vespa.vespa_client import VespaClient
 from unit_tests.marqo_test import MarqoTestCase
 from marqo.core.models.marqo_index import *
 from marqo.core.structured_vespa_index.structured_vespa_index import StructuredVespaIndex
+from marqo.core.models.marqo_query import MarqoLexicalQuery
 
 
 
@@ -38,6 +40,20 @@ class TestStructuredIndexBuildLexicalSearchQuery(MarqoTestCase):
                 ],
                 tensor_fields=[]
             )
+        )
+
+    def _help_create_test_lexical_query_object(self, or_phrases: List[str], and_phrases: List[str],
+                                               searchable_attributes: List[str] = None) -> MarqoLexicalQuery:
+        """
+        Helper function to create a MarqoLexicalQuery object with the given parameters.
+        """
+        return MarqoLexicalQuery(
+            index_name='index1',
+            limit=10,
+            offset=0,
+            searchable_attributes=searchable_attributes,
+            or_phrases=or_phrases,
+            and_phrases=and_phrases
         )
 
     def test_generate_and_terms_for_lexical_search(self):
@@ -79,8 +95,12 @@ class TestStructuredIndexBuildLexicalSearchQuery(MarqoTestCase):
         ]
         for required_phrases, searchable_attributes, expected_and_terms, msg in test_cases:
             with self.subTest(f"{msg}"):
-                generated_and_terms = self.structured_vespa_index._get_and_terms_for_required_phrase(
-                    required_phrases,
-                    searchable_attributes
+                test_marqo_query = self._help_create_test_lexical_query_object(
+                    or_phrases=[],
+                    and_phrases=required_phrases,
+                    searchable_attributes=searchable_attributes
+                )
+                generated_and_terms = self.structured_vespa_index._get_lexical_search_term(
+                    test_marqo_query
                 )
                 self.assertEqual(generated_and_terms, expected_and_terms)

--- a/tests/unit_tests/marqo/core/structured_vespa_index/test_structured_index_build_search_query.py
+++ b/tests/unit_tests/marqo/core/structured_vespa_index/test_structured_index_build_search_query.py
@@ -1,0 +1,86 @@
+from unittest.mock import MagicMock
+
+from marqo.core.exceptions import AddDocumentsError
+from marqo.core.inference.api import Inference, Modality
+from marqo.core.inference.tensor_fields_container import TensorField
+from marqo.core.models.add_docs_params import AddDocsParams
+from marqo.core.models.marqo_index import FieldType
+from marqo.core.structured_vespa_index.structured_add_document_handler import StructuredAddDocumentsHandler
+from marqo.vespa.vespa_client import VespaClient
+from unit_tests.marqo_test import MarqoTestCase
+from marqo.core.models.marqo_index import *
+from marqo.core.structured_vespa_index.structured_vespa_index import StructuredVespaIndex
+
+
+
+class TestStructuredIndexBuildLexicalSearchQuery(MarqoTestCase):
+    """
+    Test the build_lexical_search_query method of StructuredVespaIndex.
+    Note that this method is also used in semi-structured Vespa index.
+    """
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.maxDiff = None
+        cls.structured_vespa_index = StructuredVespaIndex(
+            marqo_index=cls.structured_marqo_index(
+                name='index1',
+                schema_name='index1',
+                fields=[
+                    Field(name='lexical_field_1', type=FieldType.Text, features=[FieldFeature.LexicalSearch],
+                          lexical_field_name='marqo__lexical_lexical_field_1'),
+                    Field(name='lexical_field_2', type=FieldType.Text, features=[FieldFeature.LexicalSearch],
+                          lexical_field_name='marqo__lexical_lexical_field_2'),
+                    Field(name='lexical_field_3', type=FieldType.Text, features=[FieldFeature.LexicalSearch],
+                          lexical_field_name='marqo__lexical_lexical_field_3'),
+                    Field(name='lexical_field_4', type=FieldType.Text, features=[FieldFeature.LexicalSearch],
+                          lexical_field_name='marqo__lexical_lexical_field_4')
+                ],
+                tensor_fields=[]
+            )
+        )
+
+    def test_generate_and_terms_for_lexical_search(self):
+        """Test to ensure that the AND terms are correctly built when searchable attributes are specified.
+        """
+        test_cases = [
+            (
+                ["required_1"], ['lexical_field_1'],
+                '(marqo__lexical_lexical_field_1 contains "required_1")',
+                "Simple 1 required term, 1 field"
+            ),
+            (
+                ["required_1", "required_2"], ['lexical_field_1'],
+                '(marqo__lexical_lexical_field_1 contains "required_1" '
+                'AND marqo__lexical_lexical_field_1 contains "required_2")',
+                "2 required terms, 1 field"
+            ),
+            (
+                ["required_1", "required_2"], ['lexical_field_1', 'lexical_field_2'],
+                '(marqo__lexical_lexical_field_1 contains "required_1" '
+                'AND marqo__lexical_lexical_field_1 contains "required_2") OR '
+                '(marqo__lexical_lexical_field_2 contains "required_1" '
+                'AND marqo__lexical_lexical_field_2 contains "required_2")',
+                "2 required terms, 2 fields"
+            ),
+            (
+                ["long required phrase", "short required phrase"], ['lexical_field_1', 'lexical_field_4'],
+                '(marqo__lexical_lexical_field_1 contains "long required phrase" '
+                'AND marqo__lexical_lexical_field_1 contains "short required phrase") OR '
+                '(marqo__lexical_lexical_field_4 contains "long required phrase" AND '
+                'marqo__lexical_lexical_field_4 contains "short required phrase")',
+                "2 multiple words required phrases, 2 fields"
+            ),
+            (
+                ["term1", "term2"], None,
+                'default contains "term1" AND default contains "term2"',
+                "2 required terms, no fields"
+            )
+        ]
+        for required_phrases, searchable_attributes, expected_and_terms, msg in test_cases:
+            with self.subTest(f"{msg}"):
+                generated_and_terms = self.structured_vespa_index._get_and_terms_for_required_phrase(
+                    required_phrases,
+                    searchable_attributes
+                )
+                self.assertEqual(generated_and_terms, expected_and_terms)


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->
This pull request fixes a bug when generating lexical queries for required items. 

For a lexical query `'"required_1" "required_2"'` with searchable attributes `['lexical_field_1', 'lexical_field_2']`,
Previously, we have:
```python
'marqo__lexical_lexical_field_1 contains "required_1" 
OR marqo__lexical_lexical_field_2 contains "required_1" 
AND marqo__lexical_lexical_field_1 contains "required_2" 
OR marqo__lexical_lexical_field_2 contains "required_2"'
```

Now we have:
```python
'(marqo__lexical_lexical_field_1 contains "required_1" \
OR marqo__lexical_lexical_field_2 contains "required_1") \
AND (marqo__lexical_lexical_field_1 contains "required_2" \
OR marqo__lexical_lexical_field_1 contains "required_2")'
```

This fix applies to lexical search and hybrid search, for both structured index and semi-structured index.

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [x] Tests have been added for changes
- [n/a] Documentation has been updated
- [n/a] Breaking changes are clearly identified
- [n/a] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

