### PR TITLE
Fix Python testing warnings

### DIFF
--- a/tests/unit_tests/marqo/inference/native_inference/remote/server/test_inference_api.py
+++ b/tests/unit_tests/marqo/inference/native_inference/remote/server/test_inference_api.py
@@ -89,7 +89,7 @@ class TestInferenceAPI(unittest.TestCase):
         self.assertEqual(response.status_code, HTTP_422_UNPROCESSABLE_ENTITY)
         unpacked_response = msgpack.unpackb(response.content, raw=False)
         self.assertIn("detail", unpacked_response)
-        self.assertEquals({'loc': ['modality'], 'msg': 'field required', 'type': 'value_error.missing'},
+        self.assertEqual({'loc': ['modality'], 'msg': 'field required', 'type': 'value_error.missing'},
                           unpacked_response["detail"][0])
 
     def test_vectorise_raise_inference_error(self):


### PR DESCRIPTION
## Change Summary
This small PR migrates from `unittest.assertEquals` to `unittest.assertEqual` which is deprecated from Python2.7:
```python
DeprecationWarning: Please use assertEqual instead.
```

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

