### PR TITLE
Load clip model with weight_only=False if weights only load fails

### DIFF
--- a/src/marqo/inference/native_inference/embedding_models/open_clip_model.py
+++ b/src/marqo/inference/native_inference/embedding_models/open_clip_model.py
@@ -148,7 +148,8 @@ class OpenCLIPModel(AbstractCLIPModel):
 
         return aggregated_image_preprocess_config
 
-    def _load_model_and_image_preprocessor_from_checkpoint(self) -> Tuple[torch.nn.Module, Compose]:
+    def _load_model_and_image_preprocessor_from_checkpoint(self, weights_only: bool = True) \
+            -> Tuple[torch.nn.Module, Compose]:
         """Load the model and image preprocessor from a checkpoint file.
 
         The checkpoint file can be provided through a URL or a model_location object.
@@ -181,12 +182,19 @@ class OpenCLIPModel(AbstractCLIPModel):
                 pretrained=self.model_path,
                 precision=self.model_properties.precision,
                 device=self.device,
-                cache_dir=ModelCache.clip_cache_path
+                cache_dir=ModelCache.clip_cache_path,
+                load_weights_only=weights_only,
             )
             return model, preprocess
         except Exception as e:
+            if weights_only and isinstance(e, UnpicklingError) and "Weights only load failed" in str(e):
+                logger.warning(f'Marqo encountered an error when loading only weights of custom open_clip model '
+                               f'{self.model_properties.name} with model properties = {self.model_properties.dict()}.'
+                               f'Will load again with `weights_only = False`')
+                return self._load_model_and_image_preprocessor_from_checkpoint(weights_only=False)
+
             # RuntimeError is raised by torch 1.12.1, UnpicklingError is raised by torch 1.13.1
-            if (isinstance(e, (RuntimeError, UnpicklingError)) and "The file might be corrupted" in str(e)):
+            if isinstance(e, (RuntimeError, UnpicklingError)) and "The file might be corrupted" in str(e):
                 try:
                     os.remove(self.model_path)
                 except Exception as remove_e:

--- a/src/marqo/inference/native_inference/embedding_models/open_clip_model.py
+++ b/src/marqo/inference/native_inference/embedding_models/open_clip_model.py
@@ -148,8 +148,7 @@ class OpenCLIPModel(AbstractCLIPModel):
 
         return aggregated_image_preprocess_config
 
-    def _load_model_and_image_preprocessor_from_checkpoint(self, weights_only: bool = True) \
-            -> Tuple[torch.nn.Module, Compose]:
+    def _load_model_and_image_preprocessor_from_checkpoint(self) -> Tuple[torch.nn.Module, Compose]:
         """Load the model and image preprocessor from a checkpoint file.
 
         The checkpoint file can be provided through a URL or a model_location object.
@@ -176,23 +175,9 @@ class OpenCLIPModel(AbstractCLIPModel):
         try:
             self.image_preprocessor_config = self._aggregate_image_preprocessor_config()
             preprocess = image_transform_v2(self.image_preprocessor_config, is_train=False)
-            model = open_clip.create_model(
-                model_name=self.model_properties.name,
-                jit=self.model_properties.jit,
-                pretrained=self.model_path,
-                precision=self.model_properties.precision,
-                device=self.device,
-                cache_dir=ModelCache.clip_cache_path,
-                load_weights_only=weights_only,
-            )
+            model = self._create_model()
             return model, preprocess
         except Exception as e:
-            if weights_only and isinstance(e, UnpicklingError) and "Weights only load failed" in str(e):
-                logger.warning(f'Marqo encountered an error when loading only weights of custom open_clip model '
-                               f'{self.model_properties.name} with model properties = {self.model_properties.dict()}.'
-                               f'Will load again with `weights_only = False`')
-                return self._load_model_and_image_preprocessor_from_checkpoint(weights_only=False)
-
             # RuntimeError is raised by torch 1.12.1, UnpicklingError is raised by torch 1.13.1
             if isinstance(e, (RuntimeError, UnpicklingError)) and "The file might be corrupted" in str(e):
                 try:
@@ -232,6 +217,34 @@ class OpenCLIPModel(AbstractCLIPModel):
                     f"Please check and update your model properties and retry. "
                     f"You can find more details at {marqo_docs.bring_your_own_model()}"
                 )
+
+    def _create_model(self):
+        try:
+            return open_clip.create_model(
+                model_name=self.model_properties.name,
+                jit=self.model_properties.jit,
+                pretrained=self.model_path,
+                precision=self.model_properties.precision,
+                device=self.device,
+                cache_dir=ModelCache.clip_cache_path,
+            )
+        except Exception as e:
+            if isinstance(e, UnpicklingError) and "Weights only load failed" in str(e):
+                logger.warning(f'Marqo encountered an error when loading only weights of custom open_clip model '
+                               f'{self.model_properties.name} with model properties = {self.model_properties.dict()}.'
+                               f'Will load again with `weights_only = False`')
+
+                return open_clip.create_model(
+                    model_name=self.model_properties.name,
+                    jit=self.model_properties.jit,
+                    pretrained=self.model_path,
+                    precision=self.model_properties.precision,
+                    device=self.device,
+                    cache_dir=ModelCache.clip_cache_path,
+                    load_weights_only=False,
+                )
+            else:
+                raise e
 
     def _load_model_and_image_preprocessor_from_hf_repo(self) -> Tuple[torch.nn.Module, Compose]:
         """Load the model and image preprocessor from a hf_repo.

--- a/src/marqo/inference/native_inference/embedding_models/open_clip_model.py
+++ b/src/marqo/inference/native_inference/embedding_models/open_clip_model.py
@@ -228,8 +228,8 @@ class OpenCLIPModel(AbstractCLIPModel):
                 device=self.device,
                 cache_dir=ModelCache.clip_cache_path,
             )
-        except Exception as e:
-            if isinstance(e, UnpicklingError) and "Weights only load failed" in str(e):
+        except UnpicklingError as e:
+            if "Weights only load failed" in str(e):
                 logger.warning(f'Marqo encountered an error when loading only weights of custom open_clip model '
                                f'{self.model_properties.name} with model properties = {self.model_properties.dict()}.'
                                f'Will load again with `weights_only = False`')

--- a/tests/unit_tests/marqo/inference/native_inference/test_handling_corrupt_files_open_clip.py
+++ b/tests/unit_tests/marqo/inference/native_inference/test_handling_corrupt_files_open_clip.py
@@ -1,6 +1,6 @@
 import unittest
 from pickle import UnpicklingError
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 from marqo.s2_inference.errors import InvalidModelPropertiesError
 from marqo.s2_inference.s2_inference import _load_model
@@ -16,22 +16,22 @@ class TestCorruptFileInOpenCLIP(unittest.TestCase):
             "model_name": "test-corrupted-open-clip-model",
             "device": "cpu",
             "model_auth": None,
-            "calling_func" : "unit_test"
+            "calling_func": "unit_test"
         }
         self.dummy_model_properties = [
             {
                 # from url
                 "name": "ViT-B-32",
-                "dimensions" : 512,
+                "dimensions": 512,
                 "url": "https://a-url-to-a-corrupted-model.pt",
                 "type": "open_clip",
             },
             {
                 # from s3
                 "name": "ViT-B-32",
-                "dimensions" : 512,
+                "dimensions": 512,
                 "model_location": {
-                    "s3":{
+                    "s3": {
                         "Bucket": "a-bucket",
                         "Key": "a-path-to-a-corrupted-model.pt"},
                         },
@@ -43,7 +43,7 @@ class TestCorruptFileInOpenCLIP(unittest.TestCase):
                 "dimensions": 512,
                 "model_location": {
                     "hf": {
-                        "repo_id" : "a-dummy-repo",
+                        "repo_id": "a-dummy-repo",
                         "filename": "a-path-to-a-corrupted-model.pt"},
                         },
                 "type": "open_clip",
@@ -105,6 +105,29 @@ class TestCorruptFileInOpenCLIP(unittest.TestCase):
 
                 # Reset the mock
                 mock_os_remove.reset_mock()
+
+    @patch('open_clip.create_model', autospec=True)
+    @patch('marqo.inference.native_inference.embedding_models.open_clip_model.download_model', autospec=True)
+    def test_handling_unpickling_error_with_weights_only_true(self, mock_download, mock_create_model):
+        # Setup
+        mock_download.return_value = self.dummpy_corrupted_file
+
+        for model_properties in self.dummy_model_properties:
+            mock_create_model.reset_mock()
+            mock_download.reset_mock()
+            # first call raises a UnpicklingError, second returns a model
+            mock_create_model.side_effect = [UnpicklingError("Weights only load failed"), Mock()]
+
+            # Execute and Verify
+            _ = _load_model(**self.load_parameters, model_properties=model_properties, max_retries=1)
+
+            self.assertEqual(mock_create_model.call_count, 2)
+            # assert the first create_model call does not provide `load_weights_only` parameter
+            self.assertNotIn("load_weights_only", mock_create_model.call_args_list[0][1])
+            # assert the second create_model call specifies `load_weights_only=False`
+            self.assertEqual(mock_create_model.call_args_list[1][1]["load_weights_only"], False)
+            # assert download_model only called once
+            mock_download.assert_called_once()
 
     @patch('open_clip.create_model', autospec=True)
     @patch('os.remove', autospec=True)

--- a/tests/unit_tests/marqo/inference/native_inference/test_handling_corrupt_files_open_clip.py
+++ b/tests/unit_tests/marqo/inference/native_inference/test_handling_corrupt_files_open_clip.py
@@ -50,7 +50,7 @@ class TestCorruptFileInOpenCLIP(unittest.TestCase):
             }
         ]
 
-        self.dummpy_corrupted_file = "/path/to/corrupted/file.pt"
+        self.dummy_corrupted_file = "/path/to/corrupted/file.pt"
 
     @patch('open_clip.create_model', autospec=True)
     @patch('os.remove', autospec=True)
@@ -59,12 +59,12 @@ class TestCorruptFileInOpenCLIP(unittest.TestCase):
         mock_create_model_and_transforms.side_effect = RuntimeError("The file might be corrupted")
         for model_properties in self.dummy_model_properties:
             with patch("marqo.inference.native_inference.embedding_models.open_clip_model.download_model",
-                       return_value = self.dummpy_corrupted_file):
+                       return_value = self.dummy_corrupted_file):
                 with self.assertRaises(InvalidModelPropertiesError) as context:
                     _ = _load_model(**self.load_parameters, model_properties=model_properties, max_retries=1)
                 # Verify
                 self.assertIn("Marqo encountered a corrupted file when loading open_clip file", str(context.exception))
-                mock_os_remove.assert_called_once_with(self.dummpy_corrupted_file)
+                mock_os_remove.assert_called_once_with(self.dummy_corrupted_file)
 
                 # Reset the mock
                 mock_os_remove.reset_mock()
@@ -76,12 +76,12 @@ class TestCorruptFileInOpenCLIP(unittest.TestCase):
         mock_create_model_and_transforms.side_effect = UnpicklingError("The file might be corrupted")
         for model_properties in self.dummy_model_properties:
             with patch("marqo.inference.native_inference.embedding_models.open_clip_model.download_model",
-                       return_value=self.dummpy_corrupted_file):
+                       return_value=self.dummy_corrupted_file):
                 with self.assertRaises(InvalidModelPropertiesError) as context:
                     _ = _load_model(**self.load_parameters, model_properties=model_properties, max_retries=1)
                 # Verify
                 self.assertIn("Marqo encountered a corrupted file when loading open_clip file", str(context.exception))
-                mock_os_remove.assert_called_once_with(self.dummpy_corrupted_file)
+                mock_os_remove.assert_called_once_with(self.dummy_corrupted_file)
 
                 # Reset the mock
                 mock_os_remove.reset_mock()
@@ -93,14 +93,14 @@ class TestCorruptFileInOpenCLIP(unittest.TestCase):
         mock_create_model_and_transforms.side_effect = RuntimeError("The file might be corrupted")
         mock_os_remove.side_effect = OSError("Permission denied")
         with patch("marqo.inference.native_inference.embedding_models.open_clip_model.download_model",
-                   return_value = self.dummpy_corrupted_file):
+                   return_value = self.dummy_corrupted_file):
             for model_properties in self.dummy_model_properties:
                 # Execute and Verify
                 with self.assertRaises(RuntimeError) as context:
                     _ = _load_model(**self.load_parameters, model_properties=model_properties, max_retries=1)
                 self.assertIn("Marqo encountered an error while attempting to delete a corrupted file",
                               str(context.exception))
-                mock_os_remove.assert_called_with(self.dummpy_corrupted_file)
+                mock_os_remove.assert_called_with(self.dummy_corrupted_file)
                 self.assertEqual(mock_os_remove.call_count, 1)
 
                 # Reset the mock
@@ -110,7 +110,7 @@ class TestCorruptFileInOpenCLIP(unittest.TestCase):
     @patch('marqo.inference.native_inference.embedding_models.open_clip_model.download_model', autospec=True)
     def test_handling_unpickling_error_with_weights_only_true(self, mock_download, mock_create_model):
         # Setup
-        mock_download.return_value = self.dummpy_corrupted_file
+        mock_download.return_value = self.dummy_corrupted_file
 
         for model_properties in self.dummy_model_properties:
             mock_create_model.reset_mock()
@@ -135,7 +135,7 @@ class TestCorruptFileInOpenCLIP(unittest.TestCase):
         # Setup
         mock_create_model_and_transforms.side_effect = Exception("An error occurred")
         with patch("marqo.inference.native_inference.embedding_models.open_clip_model.download_model",
-                   return_value = self.dummpy_corrupted_file):
+                   return_value = self.dummy_corrupted_file):
             for model_properties in self.dummy_model_properties:
                 # Execute and Verify
                 with self.assertRaises(RuntimeError) as context:
@@ -150,7 +150,7 @@ class TestCorruptFileInOpenCLIP(unittest.TestCase):
         mock_create_model_and_transforms.side_effect = Exception(
             "This could be because the operator doesn't exist for this backend")
         with patch("marqo.inference.native_inference.embedding_models.open_clip_model.download_model",
-                   return_value=self.dummpy_corrupted_file):
+                   return_value=self.dummy_corrupted_file):
             for model_properties in self.dummy_model_properties:
                 # Execute and Verify
                 with self.assertRaises(InvalidModelPropertiesError) as context:


### PR DESCRIPTION
## Change Summary
After the upgrade to torch 1.13.1 and open_clip 2.32.0, some models trained/fine-tuned using torch 1.12.1 cannot be loaded since it contains more than weight change. If the model cannot be loaded due to this reason, we'll try to load it with weights_only set to False again.

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [x] Tests have been added for changes
- [ ] Documentation has been updated (N/A)
- [ ] Breaking changes are clearly identified (N/A)
- [ ] Python client changes linked or N/A (N/A)

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

