### PR TITLE
set async client max connections to unlimited

### DIFF
--- a/src/marqo/vespa/vespa_client.py
+++ b/src/marqo/vespa/vespa_client.py
@@ -82,7 +82,7 @@ class VespaClient:
         self.async_transport = httpx.AsyncHTTPTransport(
             limits=httpx.Limits(
                 max_keepalive_connections=async_pool_size,
-                max_connections=async_pool_size),
+                max_connections=None),
             http1=True,
             http2=False  # Using http2 is slightly slower
         )

--- a/tests/integ_tests/vespa/test_vespa_client.py
+++ b/tests/integ_tests/vespa/test_vespa_client.py
@@ -1,5 +1,6 @@
 import functools
 import os
+import sys
 import unittest
 from unittest.mock import patch, Mock, AsyncMock
 
@@ -511,7 +512,9 @@ class TestFeedDocumentAsync(AsyncMarqoTestCase):
         
         # Verify connection limits are set correctly
         self.assertEqual(client.async_transport._pool._max_keepalive_connections, async_pool_size)
-        self.assertEqual(client.async_transport._pool._max_connections, async_pool_size)
+        # When max_connections=None is passed to httpx, it gets converted to sys.maxsize
+
+        self.assertEqual(client.async_transport._pool._max_connections, sys.maxsize)
         
         # Verify HTTP settings
         self.assertTrue(client.async_transport._pool._http1)
@@ -635,7 +638,8 @@ class TestFeedDocumentAsync(AsyncMarqoTestCase):
             
             # Verify default async_pool_size is used
             self.assertEqual(client.async_transport._pool._max_keepalive_connections, 10)
-            self.assertEqual(client.async_transport._pool._max_connections, 10)
+            # When max_connections=None is passed to httpx, it gets converted to sys.maxsize
+            self.assertEqual(client.async_transport._pool._max_connections, sys.maxsize)
             client.close()
         
         # Test 2: Set environment variable to custom value
@@ -648,7 +652,8 @@ class TestFeedDocumentAsync(AsyncMarqoTestCase):
                 
                 # Verify the custom async_pool_size is used
                 self.assertEqual(vespa_client.async_transport._pool._max_keepalive_connections, 25)
-                self.assertEqual(vespa_client.async_transport._pool._max_connections, 25)
+                # When max_connections=None is passed to httpx, it gets converted to sys.maxsize
+                self.assertEqual(vespa_client.async_transport._pool._max_connections, sys.maxsize)
                 
                 vespa_client.close()
 


### PR DESCRIPTION
## Change Summary
Removes hardcap on Async Client connections (used for get batch requests). Previously it used to be set to async_pool_size.

## Checklist
- [x] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

