### PR TITLE
Fix media file chunking issue when overlap is larger than duration

### DIFF
--- a/src/marqo/inference/media_download_and_preprocess/streaming_media_processor.py
+++ b/src/marqo/inference/media_download_and_preprocess/streaming_media_processor.py
@@ -15,6 +15,62 @@ from marqo.core.models.marqo_index import *
 from marqo.inference.native_inference.embedding_models.languagebind_model import LanguagebindPreprocessor
 
 
+class ChunkTimingGenerator:
+    """Generator class to emit (chunk_start, chunk_end) pairs for media processing."""
+    
+    def __init__(self, duration: float, chunk_duration: float, overlap_duration: float):
+        """
+        Initialize the chunk timing generator.
+        
+        Args:
+            duration: Total duration of the media in seconds
+            chunk_duration: Duration of each chunk in seconds
+            overlap_duration: Overlap duration between chunks in seconds
+        """
+        self.duration = duration
+        self.chunk_duration = chunk_duration
+        self.overlap_duration = overlap_duration
+        self.total_chunks = math.ceil((duration - overlap_duration) / (chunk_duration - overlap_duration))
+    
+    def __iter__(self):
+        """Return the iterator object."""
+        return self
+    
+    def __next__(self):
+        """Generate the next chunk timing pair."""
+        if not hasattr(self, '_current_chunk'):
+            self._current_chunk = 0
+        
+        if self._current_chunk >= self.total_chunks:
+            raise StopIteration
+        
+        i = self._current_chunk
+        self._current_chunk += 1
+        
+        # For the last chunk, ensure it captures the end of the media
+        if i == self.total_chunks - 1:
+            chunk_start = max(self.duration - self.chunk_duration, 0)
+            chunk_end = self.duration
+        else:
+            chunk_start = i * (self.chunk_duration - self.overlap_duration)
+            chunk_end = min([chunk_start + self.chunk_duration, self.duration])
+        
+        return chunk_start, chunk_end
+    
+    def generate_chunks(self):
+        """Generate all chunk timing pairs as a generator."""
+        for i in range(self.total_chunks):
+            # For the last chunk, ensure it captures the end of the media
+            if i == self.total_chunks - 1:
+                chunk_start = max(self.duration - self.chunk_duration, 0)
+                chunk_end = self.duration
+            else:
+                chunk_start = i * (self.chunk_duration - self.overlap_duration)
+                chunk_end = min([chunk_start + self.chunk_duration, self.duration])
+            
+            yield chunk_start, chunk_end
+
+
 class StreamingMediaProcessor:
 
     VIDEO_CPU_TIMOUT_OUT_MULTIPLIER = 10
@@ -158,18 +214,10 @@ class StreamingMediaProcessor:
         overlap_duration = self.split_overlap
 
         with tempfile.TemporaryDirectory() as temp_dir:
-            # Calculate total number of chunks
-            total_chunks = math.ceil((self.duration - overlap_duration) / (chunk_duration - overlap_duration))
-
-            for i in range(total_chunks):
-                # For the last chunk, ensure it captures the end of the media
-                if i == total_chunks - 1:
-                    chunk_start = max(self.duration - chunk_duration, 0)
-                    chunk_end = self.duration
-                else:
-                    chunk_start = i * (chunk_duration - overlap_duration)
-                    chunk_end = min([chunk_start + chunk_duration, self.duration])
-
+            # Use the ChunkTimingGenerator to generate chunk timing pairs
+            chunk_generator = ChunkTimingGenerator(self.duration, chunk_duration, overlap_duration)
+            
+            for chunk_start, chunk_end in chunk_generator.generate_chunks():
                 output_file = self._get_output_file_path(temp_dir, chunk_start)
 
                 try:

--- a/src/marqo/inference/media_download_and_preprocess/streaming_media_processor.py
+++ b/src/marqo/inference/media_download_and_preprocess/streaming_media_processor.py
@@ -27,48 +27,34 @@ class ChunkTimingGenerator:
             chunk_duration: Duration of each chunk in seconds
             overlap_duration: Overlap duration between chunks in seconds
         """
-        self.duration = duration
-        self.chunk_duration = chunk_duration
-        self.overlap_duration = overlap_duration
-        self.total_chunks = math.ceil((duration - overlap_duration) / (chunk_duration - overlap_duration))
-    
+        self._duration = duration
+        self._chunk_duration = chunk_duration
+        self._overlap_duration = overlap_duration
+
+        self._step = chunk_duration - overlap_duration
+
+        if self._duration <= 0 or self._step <= 0:
+            pass
+
+        self._current_position = 0.0
+
     def __iter__(self):
-        """Return the iterator object."""
         return self
-    
+
     def __next__(self):
         """Generate the next chunk timing pair."""
-        if not hasattr(self, '_current_chunk'):
-            self._current_chunk = 0
-        
-        if self._current_chunk >= self.total_chunks:
+        if self._current_position >= self._duration:
             raise StopIteration
-        
-        i = self._current_chunk
-        self._current_chunk += 1
-        
-        # For the last chunk, ensure it captures the end of the media
-        if i == self.total_chunks - 1:
-            chunk_start = max(self.duration - self.chunk_duration, 0)
-            chunk_end = self.duration
+
+        chunk_end = min(self._current_position + self._chunk_duration, self._duration)
+        chunk_start = max(chunk_end - self._chunk_duration, 0)
+
+        if chunk_end == self._duration:
+            self._current_position = chunk_end
         else:
-            chunk_start = i * (self.chunk_duration - self.overlap_duration)
-            chunk_end = min([chunk_start + self.chunk_duration, self.duration])
-        
+            self._current_position = self._current_position + self._step
+
         return chunk_start, chunk_end
-    
-    def generate_chunks(self):
-        """Generate all chunk timing pairs as a generator."""
-        for i in range(self.total_chunks):
-            # For the last chunk, ensure it captures the end of the media
-            if i == self.total_chunks - 1:
-                chunk_start = max(self.duration - self.chunk_duration, 0)
-                chunk_end = self.duration
-            else:
-                chunk_start = i * (self.chunk_duration - self.overlap_duration)
-                chunk_end = min([chunk_start + self.chunk_duration, self.duration])
-            
-            yield chunk_start, chunk_end
 
 
 class StreamingMediaProcessor:
@@ -210,14 +196,8 @@ class StreamingMediaProcessor:
             MediaDownloadError: If there is an error downloading or processing the media file.
         """
         processed_chunks: list[Tuple[str, Tensor]] = []
-        chunk_duration = self.split_length
-        overlap_duration = self.split_overlap
-
         with tempfile.TemporaryDirectory() as temp_dir:
-            # Use the ChunkTimingGenerator to generate chunk timing pairs
-            chunk_generator = ChunkTimingGenerator(self.duration, chunk_duration, overlap_duration)
-            
-            for chunk_start, chunk_end in chunk_generator.generate_chunks():
+            for chunk_start, chunk_end in ChunkTimingGenerator(self.duration, self.split_length, self.split_overlap):
                 output_file = self._get_output_file_path(temp_dir, chunk_start)
 
                 try:

--- a/src/marqo/inference/media_download_and_preprocess/streaming_media_processor.py
+++ b/src/marqo/inference/media_download_and_preprocess/streaming_media_processor.py
@@ -17,11 +17,11 @@ from marqo.inference.native_inference.embedding_models.languagebind_model import
 
 class ChunkTimingGenerator:
     """Generator class to emit (chunk_start, chunk_end) pairs for media processing."""
-    
+
     def __init__(self, duration: float, chunk_duration: float, overlap_duration: float):
         """
         Initialize the chunk timing generator.
-        
+
         Args:
             duration: Total duration of the media in seconds
             chunk_duration: Duration of each chunk in seconds
@@ -30,11 +30,15 @@ class ChunkTimingGenerator:
         self._duration = duration
         self._chunk_duration = chunk_duration
         self._overlap_duration = overlap_duration
-
         self._step = chunk_duration - overlap_duration
 
-        if self._duration <= 0 or self._step <= 0:
-            pass
+        if self._duration < 0:
+            raise ValueError(f'Duration of the media file is negative: {self._duration}')
+
+        if self._step <= 0:
+            # This is already verified in the ChunkConfig validation. We check it again to avoid an infinite loop
+            raise ValueError(f'Chunking error due to chunk size ({self._chunk_duration}) <= overlap '
+                             f'({self._overlap_duration})')
 
         self._current_position = 0.0
 
@@ -50,8 +54,10 @@ class ChunkTimingGenerator:
         chunk_start = max(chunk_end - self._chunk_duration, 0)
 
         if chunk_end == self._duration:
+            # already reaches the end, so move the current position to end
             self._current_position = chunk_end
         else:
+            # otherwise, we move the current position forward by the step size
             self._current_position = self._current_position + self._step
 
         return chunk_start, chunk_end

--- a/tests/integ_tests/inference/native_inference/media_download_and_preprocess/test_streaming_media_preprcessor.py
+++ b/tests/integ_tests/inference/native_inference/media_download_and_preprocess/test_streaming_media_preprcessor.py
@@ -281,6 +281,32 @@ class TestStreamingMediaProcessor(unittest.TestCase):
                     )
                 self.assertIn("Please check your media file and try again", str(e.exception))
 
+    def test_video_chunk_generated_when_duration_smaller_than_overlap(self):
+        audio_url = TestVideoUrls.VIDEO1.value  # duration is 10s
+        preprocessing_config = self.test_video_preprocessing_config.copy(
+            update={'chunk_config': ChunkConfig(split_length=20, split_overlap=11)})
+        streaming_media_processor_object = StreamingMediaProcessor(
+            url=audio_url, preprocessors=self.test_preprocessor,
+            preprocessing_config=preprocessing_config
+        )
+
+        processed_chunks = streaming_media_processor_object.process_media()
+        self.assertEqual(1, len(processed_chunks))
+        self.assertEqual('[0.0, 10.0]', processed_chunks[0][0])
+
+    def test_audio_chunk_generated_when_duration_smaller_than_overlap(self):
+        audio_url = TestAudioUrls.AUDIO1.value  # duration is 5s
+        preprocessing_config = self.test_audio_preprocessing_config.copy(
+            update={'chunk_config': ChunkConfig(split_length=10, split_overlap=6)})
+        streaming_media_processor_object = StreamingMediaProcessor(
+            url=audio_url, preprocessors=self.test_preprocessor,
+            preprocessing_config=preprocessing_config
+        )
+
+        processed_chunks = streaming_media_processor_object.process_media()
+        self.assertEqual(1, len(processed_chunks))
+        self.assertEqual('[0.0, 5.0]', processed_chunks[0][0])
+
 
 
 

--- a/tests/unit_tests/marqo/inference/media_download_and_preprocess/test_streaming_media_processor.py
+++ b/tests/unit_tests/marqo/inference/media_download_and_preprocess/test_streaming_media_processor.py
@@ -355,14 +355,14 @@ class TestChunkTimingGenerator(unittest.TestCase):
         self.assertEqual([], chunks)
 
     def test_overlap_duration_larger_than_duration(self):
-        """Test behavior when overlap lager relative to chunk duration."""
+        """Test behavior when overlap larger relative to chunk duration."""
         generator = ChunkTimingGenerator(duration=5.0, chunk_duration=10.0, overlap_duration=6.0)
         chunks = list(generator)
         expected = [(0.0, 5.0)]
         self.assertEqual(expected, chunks)
 
     def test_overlap_duration_equals_to_duration(self):
-        """Test behavior when overlap lager relative to chunk duration."""
+        """Test behavior when overlap larger relative to chunk duration."""
         generator = ChunkTimingGenerator(duration=5.0, chunk_duration=10.0, overlap_duration=5.0)
         chunks = list(generator)
         expected = [(0.0, 5.0)]

--- a/tests/unit_tests/marqo/inference/media_download_and_preprocess/test_streaming_media_processor.py
+++ b/tests/unit_tests/marqo/inference/media_download_and_preprocess/test_streaming_media_processor.py
@@ -7,7 +7,8 @@ import torch
 
 from tests.integ_tests.marqo_test import TestAudioUrls, TestVideoUrls
 from marqo.core.inference.api import *
-from marqo.inference.media_download_and_preprocess.streaming_media_processor import StreamingMediaProcessor
+from marqo.inference.media_download_and_preprocess.streaming_media_processor import StreamingMediaProcessor, \
+    ChunkTimingGenerator
 from marqo.inference.native_inference.embedding_models.languagebind_model import LanguagebindPreprocessor
 
 
@@ -152,7 +153,7 @@ class TestStreamingMediaProcessor(unittest.TestCase):
             (20.0, 30.0) # Last chunk, note that it ends at 30.0 but starts at 20.0
         ]
 
-        self.assertEqual(len(processed_chunks), len(expected_chunk_times))
+        self.assertEqual(len(expected_chunk_times), len(processed_chunks))
 
         for (chunk_time_str, tensor), (expected_start, expected_end) in zip(processed_chunks, expected_chunk_times):
             # Validate chunk time format and values
@@ -308,3 +309,76 @@ class TestStreamingMediaProcessor(unittest.TestCase):
             # Validate tensor correctness
             self.assertIsInstance(tensor, torch.Tensor)
             self.assertEqual(tensor.shape, torch.Size([1, 10, 10]))
+
+
+class TestChunkTimingGenerator(unittest.TestCase):
+    """Unit tests for ChunkTimingGenerator class."""
+
+    def test_basic_functionality_no_overlap(self):
+        """Test basic chunking without overlap."""
+        generator = ChunkTimingGenerator(duration=10.0, chunk_duration=3.0, overlap_duration=0.0)
+        chunks = list(generator)
+        expected = [(0.0, 3.0), (3.0, 6.0), (6.0, 9.0), (7.0, 10.0)]
+        self.assertEqual(expected, chunks)
+
+    def test_basic_functionality_with_overlap(self):
+        """Test basic chunking with overlap."""
+        generator = ChunkTimingGenerator(duration=10.0, chunk_duration=3.0, overlap_duration=1.0)
+        chunks = list(generator)
+        expected = [(0.0, 3.0), (2.0, 5.0), (4.0, 7.0), (6.0, 9.0), (7.0, 10.0)]
+        self.assertEqual(expected, chunks)
+
+    def test_single_chunk_when_duration_equals_chunk_duration(self):
+        """Test single chunk when duration equals chunk duration."""
+        generator = ChunkTimingGenerator(duration=5.0, chunk_duration=5.0, overlap_duration=1.0)
+        chunks = list(generator)
+        expected = [(0.0, 5.0)]
+        self.assertEqual(expected, chunks)
+
+    def test_single_chunk_when_duration_less_than_chunk_duration(self):
+        """Test single chunk when duration is less than chunk duration."""
+        generator = ChunkTimingGenerator(duration=3.0, chunk_duration=5.0, overlap_duration=1.0)
+        chunks = list(generator)
+        expected = [(0.0, 3.0)]
+        self.assertEqual(expected, chunks)
+
+    def test_exact_fit_no_overlap(self):
+        """Test when duration divides evenly into chunks with no overlap."""
+        generator = ChunkTimingGenerator(duration=10.0, chunk_duration=5.0, overlap_duration=0.0)
+        chunks = list(generator)
+        expected = [(0.0, 5.0), (5.0, 10.0)]
+        self.assertEqual(expected, chunks)
+
+    def test_zero_duration_should_generate_empty_chunk_list(self):
+        generator = ChunkTimingGenerator(duration=0.0, chunk_duration=5.0, overlap_duration=0.0)
+        chunks = list(generator)
+        self.assertEqual([], chunks)
+
+    def test_overlap_duration_larger_than_duration(self):
+        """Test behavior when overlap lager relative to chunk duration."""
+        generator = ChunkTimingGenerator(duration=5.0, chunk_duration=10.0, overlap_duration=6.0)
+        chunks = list(generator)
+        expected = [(0.0, 5.0)]
+        self.assertEqual(expected, chunks)
+
+    def test_overlap_duration_equals_to_duration(self):
+        """Test behavior when overlap lager relative to chunk duration."""
+        generator = ChunkTimingGenerator(duration=5.0, chunk_duration=10.0, overlap_duration=5.0)
+        chunks = list(generator)
+        expected = [(0.0, 5.0)]
+        self.assertEqual(expected, chunks)
+
+    def test_negative_duration_should_raise_error(self):
+        with self.assertRaises(ValueError) as context:
+            ChunkTimingGenerator(duration=-1.0, chunk_duration=10.0, overlap_duration=5.0)
+        self.assertEqual('Duration of the media file is negative: -1.0', str(context.exception))
+
+    def test_negative_step_should_raise_error(self):
+        with self.assertRaises(ValueError) as context:
+            ChunkTimingGenerator(duration=11.0, chunk_duration=4.0, overlap_duration=5.0)
+        self.assertEqual('Chunking error due to chunk size (4.0) <= overlap (5.0)', str(context.exception))
+
+    def test_zero_step_should_raise_error(self):
+        with self.assertRaises(ValueError) as context:
+            ChunkTimingGenerator(duration=11.0, chunk_duration=5.0, overlap_duration=5.0)
+        self.assertEqual('Chunking error due to chunk size (5.0) <= overlap (5.0)', str(context.exception))


### PR DESCRIPTION
## Change Summary
Fixed the bug that generates zero chunks when `split_overlap` is larger than the duration of the media file. 

## Related Jira Ticket
https://s2search.atlassian.net/browse/MOSD-402

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [N/A] Documentation has been updated
- [N/A] Breaking changes are clearly identified
- [N/A] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [N/A] Tests cover score modifier usage of this new type
- [N/A] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

