### PR TITLE
Omit base64 in search response

### DIFF
--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -87,7 +87,7 @@ from marqo.tensor_search.models.relevance_cutoff_model import RelevanceCutoffMod
 logger = get_logger(__name__)
 
 
-def _sanitize_query_for_response(query: str):
+def _sanitize_query_for_response(query: Optional[Union[str, dict]]):
     """
     Replace base64 image content in queries with 'data:image/[omitted]' for response.
     
@@ -113,10 +113,9 @@ def _sanitize_query_for_response(query: str):
             else:
                 sanitized_query[key] = value
         return sanitized_query
-    
-    # For CustomVectorQuery or other types, return as-is
-    return query
 
+    # Should not reach here
+    raise RuntimeError('Invalid query type')
 
 def _get_marqo_document_by_id(config: Config, index_name: str, document_id: str):
     marqo_index = _get_latest_index(config, index_name)
@@ -523,11 +522,9 @@ def search(config: Config, index_name: str, text: Optional[Union[str, dict, Cust
         raise api_exceptions.InvalidArgError(f"Reranker is no longer supported in Marqo version 2.17 and later")
 
     if isinstance(text, CustomVectorQuery):
-        response_query = text.dict()  # Make object JSON serializable
+        search_result["query"] = text.dict()  # Make object JSON serializable
     else:
-        response_query = text
-
-    search_result["query"] = _sanitize_query_for_response(response_query)
+        search_result["query"] = _sanitize_query_for_response(text)
 
     search_result["limit"] = result_count
     search_result["offset"] = offset

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -48,7 +48,7 @@ from marqo.core import exceptions as core_exceptions
 from marqo.core.inference.api import Modality, TextPreprocessingConfig, ImagePreprocessingConfig, \
     AudioPreprocessingConfig, VideoPreprocessingConfig, InferenceError, Inference, InferenceRequest, ModelConfig, \
     ModelError, InferenceErrorModel
-from marqo.core.inference.modality_utils import infer_modality
+from marqo.core.inference.modality_utils import infer_modality, is_base64_image
 from marqo.core.models.facets_parameters import FacetsParameters
 from marqo.core.models.hybrid_parameters import HybridParameters
 from marqo.core.models.marqo_get_documents_by_id_response import (MarqoGetDocumentsByIdsResponse,
@@ -85,6 +85,37 @@ from marqo.tensor_search.models.sort_by_model import SortByModel
 from marqo.tensor_search.models.relevance_cutoff_model import RelevanceCutoffModel
 
 logger = get_logger(__name__)
+
+
+def _sanitize_query_for_response(query):
+    """
+    Replace base64 image content in queries with 'data:image/[omitted]' for response.
+    
+    Args:
+        query: The query object which can be a string, dict, or CustomVectorQuery
+        
+    Returns:
+        The sanitized query object with base64 content replaced
+    """
+    if query is None:
+        return query
+    
+    if isinstance(query, str):
+        if is_base64_image(query):
+            return 'data:image/[omitted]'
+        return query
+    
+    if isinstance(query, dict):
+        sanitized_query = {}
+        for key, value in query.items():
+            if is_base64_image(key):
+                sanitized_query['data:image/[omitted]'] = value
+            else:
+                sanitized_query[key] = value
+        return sanitized_query
+    
+    # For CustomVectorQuery or other types, return as-is
+    return query
 
 
 def _get_marqo_document_by_id(config: Config, index_name: str, document_id: str):
@@ -454,7 +485,7 @@ def search(config: Config, index_name: str, text: Optional[Union[str, dict, Cust
                 model_auth=model_auth, highlights=highlights, text_query_prefix=text_query_prefix,
                 rerank_depth=rerank_depth
             )
-        elif search_method.upper() == SearchMethod.HYBRID:
+        else:  # SearchMethod.HYBRID
             # TODO: Deal with circular import when all modules are refactored out.
             from marqo.core.search.hybrid_search import HybridSearch
             search_result = HybridSearch().search(
@@ -492,9 +523,11 @@ def search(config: Config, index_name: str, text: Optional[Union[str, dict, Cust
         raise api_exceptions.InvalidArgError(f"Reranker is no longer supported in Marqo version 2.17 and later")
 
     if isinstance(text, CustomVectorQuery):
-        search_result["query"] = text.dict()  # Make object JSON serializable
+        response_query = text.dict()  # Make object JSON serializable
     else:
-        search_result["query"] = text
+        response_query = text
+
+    search_result["query"] = _sanitize_query_for_response(response_query)
 
     search_result["limit"] = result_count
     search_result["offset"] = offset

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -87,7 +87,7 @@ from marqo.tensor_search.models.relevance_cutoff_model import RelevanceCutoffMod
 logger = get_logger(__name__)
 
 
-def _sanitize_query_for_response(query):
+def _sanitize_query_for_response(query: str):
     """
     Replace base64 image content in queries with 'data:image/[omitted]' for response.
     

--- a/src/marqo/tensor_search/utils.py
+++ b/src/marqo/tensor_search/utils.py
@@ -359,7 +359,7 @@ def enable_batch_apis():
         def wrapper(*args, **kwargs):
             if read_env_vars_and_defaults(EnvVars.MARQO_ENABLE_BATCH_APIS).lower() != 'true':
                 raise HTTPException(status_code=403,
-                                    detail="This API endpoint is disabled. Please set MARQO_ENABLE_BATCH_API to true to enable it.")
+                                    detail="This API endpoint is disabled. Please set MARQO_ENABLE_BATCH_APIS to true to enable it.")
             return func(*args, **kwargs)
 
         return wrapper

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.21.0"
+__version__ = "2.21.1"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/tests/api_tests/v1/tests/api_tests/test_base64_image_search.py
+++ b/tests/api_tests/v1/tests/api_tests/test_base64_image_search.py
@@ -3,7 +3,7 @@ import unittest
 
 import requests
 from marqo.errors import MarqoWebError
-from tests.api_tests.v1.tests.marqo_test import MarqoTestCase, TestImageUrls
+from tests.marqo_test import MarqoTestCase, TestImageUrls
 
 
 class TestBase64ImageSearch(MarqoTestCase):

--- a/tests/api_tests/v1/tests/api_tests/test_base64_image_search.py
+++ b/tests/api_tests/v1/tests/api_tests/test_base64_image_search.py
@@ -3,7 +3,7 @@ import unittest
 
 import requests
 from marqo.errors import MarqoWebError
-from tests.marqo_test import MarqoTestCase, TestImageUrls
+from tests.api_tests.v1.tests.marqo_test import MarqoTestCase, TestImageUrls
 
 
 class TestBase64ImageSearch(MarqoTestCase):
@@ -118,6 +118,12 @@ class TestBase64ImageSearch(MarqoTestCase):
                         self.assertAlmostEqual(
                             1.0, score, places=3,
                             msg=f"Score mismatch for {search_name} on {index_type} index"
+                        )
+
+                        # Verify query not returned in base64 search response
+                        self.assertEqual(
+                            'data:image/[omitted]', search_result.get('query'),
+                            'Base64 query should not be present in search response'
                         )
 
     def test_image_base64_search_large(self):
@@ -328,27 +334,35 @@ class TestBase64ImageSearch(MarqoTestCase):
                 self.assertFalse(add_result['errors'])
 
                 # Test tensor search with dict query: base64 image (weight 0.8) and text (weight 0.2)
-                with self.subTest(query_type="dict_mixed_weights"):
-                    search_params = {
-                        "q": {
-                            hippo_base64: 0.8,
-                            "sculpture art": 0.2  # Lower weight for text
-                        },
-                        "search_method": "TENSOR"
-                    }
+                search_params = {
+                    "q": {
+                        hippo_base64: 0.8,
+                        "sculpture art": 0.2  # Lower weight for text
+                    },
+                    "search_method": "TENSOR"
+                }
 
-                    search_result = self.client.index(index_name).search(**search_params)
+                search_result = self.client.index(index_name).search(**search_params)
 
-                    # Verify results
-                    self.assertIn('hits', search_result)
-                    self.assertGreater(len(search_result['hits']), 0)
+                # Verify results
+                self.assertIn('hits', search_result)
+                self.assertGreater(len(search_result['hits']), 0)
 
-                    # The hippo statue document should still be the first hit due to strong image match
-                    first_hit = search_result['hits'][0]
-                    self.assertEqual(first_hit['_id'], 'hippo_statue_doc')
+                # The hippo statue document should still be the first hit due to strong image match
+                first_hit = search_result['hits'][0]
+                self.assertEqual(first_hit['_id'], 'hippo_statue_doc')
 
-                    # Score should still be high due to strong image component
-                    self.assertGreater(first_hit['_score'], 0.8)
+                # Score should still be high due to strong image component
+                self.assertGreater(first_hit['_score'], 0.8)
+
+                # Verify base64 string not returned
+                self.assertEqual(
+                    {
+                        'data:image/[omitted]': 0.8,
+                        "sculpture art": 0.2
+                    },
+                    search_result.get('query')
+                )
 
     def test_invalid_base64_image_search_returns_400_error(self):
         """Test that searching with invalid base64 images returns 400 error for tensor and hybrid search."""
@@ -398,7 +412,7 @@ class TestBase64ImageSearch(MarqoTestCase):
                             )
                         assert e.exception.status_code == 400
 
-    def test_api_base64_images_rejected_in_add_documents(self):
+    def test_base64_images_rejected_in_add_documents(self):
         """Test that base64 images are properly rejected during document addition across all index types."""
 
         index_configs = [

--- a/tests/api_tests/v1/tests/api_tests/test_search_common.py
+++ b/tests/api_tests/v1/tests/api_tests/test_search_common.py
@@ -3,7 +3,9 @@ import uuid
 from marqo.client import Client
 from marqo.errors import MarqoWebError
 
-from tests.marqo_test import MarqoTestCase
+from tests.marqo_test import MarqoTestCase, TestImageUrls
+import base64
+import requests
 
 
 class TestSearchCommon(MarqoTestCase):
@@ -532,3 +534,98 @@ class TestSearchCommon(MarqoTestCase):
                     self.assertIn("'approximateThreshold'", error_msg)
                     self.assertIn("HYBRID", error_msg)
                     self.assertIn("TENSOR", error_msg)
+
+    def test_query_field_returned_and_base64_omitted_all_search_modes(self):
+        """Test that query field is returned for all search modes and base64 content is properly omitted."""
+
+        # Create base64 image data from real image URL
+        def url_to_base64(url: str):
+            """Convert an image URL to base64 data URL format."""
+            response = requests.get(url)
+            response.raise_for_status()
+            base64_data = base64.b64encode(response.content).decode('utf-8')
+            # Determine content type from response headers or default to png
+            content_type = response.headers.get('content-type', 'image/png')
+            return f"data:{content_type};base64,{base64_data}"
+        
+        base64_image = url_to_base64(TestImageUrls.HIPPO_STATUE.value)
+        
+        # Test data setup - add some documents first
+        documents = [
+            {"title": "test document", "content": "sample text content", "_id": "doc1"},
+            {"title": "another document", "content": "more text here", "_id": "doc2"}
+        ]
+        
+        # Define test cases covering all search modes and query types
+        test_cases = [
+            # (search_method, hybrid_parameters, query_types, description)
+            ("TENSOR", None, ["string", "dict"], "tensor_default"),
+            ("LEXICAL", None, ["string"], "lexical_default"),  # Lexical only supports string queries
+            ("HYBRID", {"retrievalMethod": "disjunction", "rankingMethod": "rrf"}, ["string"], "hybrid_disjunction_rrf"),  # Hybrid only supports string in q parameter
+            ("HYBRID", {"retrievalMethod": "lexical", "rankingMethod": "lexical"}, ["string"], "hybrid_lexical_lexical"),
+            ("HYBRID", {"retrievalMethod": "lexical", "rankingMethod": "tensor"}, ["string"], "hybrid_lexical_tensor"),
+            ("HYBRID", {"retrievalMethod": "tensor", "rankingMethod": "lexical"}, ["string"], "hybrid_tensor_lexical"),
+            ("HYBRID", {"retrievalMethod": "tensor", "rankingMethod": "tensor"}, ["string"], "hybrid_tensor_tensor"),
+        ]
+        
+        # Test on both structured and unstructured indexes
+        for index_name in [self.structured_text_index_name, self.unstructured_text_index_name]:
+            with self.subTest(index=index_name):
+                # Add documents
+                tensor_fields = ["title", "content"] if index_name == self.unstructured_text_index_name else None
+                res = self.client.index(index_name).add_documents(documents, tensor_fields=tensor_fields)
+                self.assertFalse(res["errors"])
+                
+                for search_method, hybrid_params, query_types, description in test_cases:
+                    with self.subTest(search_method=search_method, description=description):
+                        
+                        # Test different query types
+                        for query_type in query_types:
+                            with self.subTest(query_type=query_type):
+                                
+                                if query_type == "string":
+                                    # Test normal string query
+                                    normal_query = "sample text"
+                                    base64_query = base64_image
+                                    
+                                    queries_to_test = [
+                                        (normal_query, normal_query, "normal_string"),
+                                        (base64_query, "data:image/[omitted]", "base64_string")
+                                    ]
+                                    
+                                elif query_type == "dict":
+                                    # Test dict queries
+                                    normal_dict_query = {"sample": 0.7, "text": 0.3}
+                                    base64_dict_query = {base64_image: 0.8, "text": 0.2}
+                                    mixed_dict_query = {base64_image: 0.5, "sample": 0.3, "text": 0.2}
+                                    
+                                    queries_to_test = [
+                                        (normal_dict_query, normal_dict_query, "normal_dict"),
+                                        (base64_dict_query, {"data:image/[omitted]": 0.8, "text": 0.2}, "base64_dict"),
+                                        (mixed_dict_query, {"data:image/[omitted]": 0.5, "sample": 0.3, "text": 0.2}, "mixed_dict")
+                                    ]
+                                    
+                                
+                                # Test each query
+                                for input_query, expected_query, query_desc in queries_to_test:
+                                    with self.subTest(query_desc=query_desc):
+                                        # Skip base64 queries for lexical search (images not supported)
+                                        if search_method == "LEXICAL" and query_desc.startswith("base64"):
+                                            continue
+                                        
+                                        # Prepare search parameters
+                                        search_params = {
+                                            "q": input_query,
+                                            "search_method": search_method,
+                                            "limit": 5
+                                        }
+                                        
+                                        if hybrid_params:
+                                            search_params["hybrid_parameters"] = hybrid_params
+                                        
+                                        # Execute search
+                                        result = self.client.index(index_name).search(**search_params)
+
+                                        # Verify query field matches expected value
+                                        self.assertEqual(result["query"], expected_query,
+                                                       f"Query field mismatch for {search_method} {query_desc}")

--- a/tests/integ_tests/tensor_search/integ_tests/test_base64_image_search.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_base64_image_search.py
@@ -155,6 +155,12 @@ class TestBase64ImageSearch(MarqoTestCase):
                             msg=f"Score mismatch for {search_name} on {index_type} index"
                         )
 
+                        # Verify query not returned in base64 search response
+                        self.assertEqual(
+                            'data:image/[omitted]', search_result.get('query'),
+                            'Base64 query should not be present in search response'
+                        )
+
     def test_hybrid_search_with_base64_query_tensor_and_query_lexical(self):
         """Test hybrid search with base64 image in queryTensor and text in queryLexical across all index types."""
         # Convert real image URL to base64 for search query
@@ -238,6 +244,9 @@ class TestBase64ImageSearch(MarqoTestCase):
                     # Tensor score should be 1.0 for perfect match
                     self.assertAlmostEqual(1.0, first_hit['_tensor_score'], places=3)
 
+                    # Verify query field is None since text=None was passed
+                    self.assertIsNone(search_result.get('query'))
+
                 # Test 2: Dict queryTensor with base64 (weight 1) and text (weight 0)
                 with self.subTest(query_type="dict_base64_and_text"):
                     hybrid_params = HybridParameters(
@@ -269,6 +278,9 @@ class TestBase64ImageSearch(MarqoTestCase):
 
                     # Tensor score should be 1.0 for perfect match (text with weight 0 shouldn't affect this)
                     self.assertAlmostEqual(1.0, first_hit['_tensor_score'], places=3)
+
+                    # Verify query field is None since text=None was passed
+                    self.assertIsNone(search_result.get('query'))
 
     def test_tensor_search_with_base64_dict_query(self):
         """Test tensor search with dict query containing base64 image and text with weights across all index types."""
@@ -345,6 +357,15 @@ class TestBase64ImageSearch(MarqoTestCase):
 
                     # Score should still be high due to strong image component
                     self.assertGreater(first_hit['_score'], 0.8)
+
+                    # Verify base64 string not returned
+                    self.assertEqual(
+                        {
+                            'data:image/[omitted]': 0.8,
+                            "sculpture art": 0.2
+                        },
+                        search_result.get('query')
+                    )
 
     def test_invalid_base64_image_search_raises_error(self):
         """Test that searching with invalid base64 images raises InvalidArgError for tensor and hybrid search."""

--- a/tests/unit_tests/marqo/tensor_search/test_tensor_search.py
+++ b/tests/unit_tests/marqo/tensor_search/test_tensor_search.py
@@ -7,6 +7,7 @@ from marqo.config import Config
 from marqo.core.models.marqo_index import MarqoIndex, IndexType, Model
 from marqo.tensor_search import tensor_search
 from marqo.tensor_search.enums import SearchMethod
+from marqo.tensor_search.models.api_models import CustomVectorQuery
 from marqo.vespa.models import QueryResult
 from marqo.vespa.models.query_result import Child, Root, Coverage
 
@@ -48,37 +49,63 @@ class TestTensorSearch(unittest.TestCase):
 
         self.mock_query_result = QueryResult(root=mock_root)
 
-    @patch('marqo.tensor_search.tensor_search.index_meta_cache.get_index')
-    @patch('marqo.tensor_search.tensor_search.vespa_index_factory')
-    @patch('marqo.tensor_search.tensor_search.utils.parse_lexical_query')
-    @patch('marqo.tensor_search.tensor_search.RequestMetricsStore')
-    def test_search_lexical_method(self, mock_metrics, mock_parse_query, mock_vespa_factory, mock_get_index):
-        """Test search with lexical method returns expected results."""
-        # TODO -- there's a lot of logic in .search() that we're not covering
-        # Setup
+    def _setup_common_mocks(self, mock_metrics, mock_vespa_factory, mock_get_index):
+        """Helper method to set up common mocks used across multiple tests."""
+        # Setup index mock
         mock_get_index.return_value = self.mock_index
-        mock_parse_query.return_value = (["test"], ["query"])
-
-        # Mock vespa index
+        
+        # Setup vespa index mock
         mock_vespa_index = Mock()
-        mock_vespa_index.to_vespa_query.return_value = {"query": "test"}
+        mock_vespa_index.to_vespa_query.return_value = {"query": "test_query"}
         mock_vespa_index.to_marqo_document.return_value = {
             "_id": "doc1",
             "field1": "value1",
             "field2": "value2"
         }
         mock_vespa_factory.return_value = mock_vespa_index
-
-        # Mock metrics
+        
+        # Setup metrics mock
         mock_metrics_instance = Mock()
         mock_metrics.for_request.return_value = mock_metrics_instance
         mock_metrics_instance.start.return_value = None
         mock_metrics_instance.stop.return_value = 100.0
         mock_metrics_instance.time.return_value.__enter__ = Mock(return_value=None)
         mock_metrics_instance.time.return_value.__exit__ = Mock(return_value=None)
-
-        # Mock Vespa response
+        
+        # Setup Vespa response
         self.config.vespa_client.query.return_value = self.mock_query_result
+        
+        return mock_vespa_index
+
+    def _setup_lexical_mocks(self, mock_parse_query):
+        """Helper method to set up lexical search specific mocks."""
+        mock_parse_query.return_value = (["test"], ["query"])
+
+    def _setup_tensor_mocks(self, mock_vectorise):
+        """Helper method to set up tensor search specific mocks."""
+        mock_vectorise.return_value = {0: [0.1, 0.2, 0.3]}
+
+    def _assert_basic_search_response(self, result, expected_query, expected_limit=10, expected_offset=0):
+        """Helper method to assert basic search response structure."""
+        self.assertEqual(result['query'], expected_query)
+        self.assertEqual(result['limit'], expected_limit)
+        self.assertEqual(result['offset'], expected_offset)
+        self.assertIn('hits', result)
+        self.assertIn('processingTimeMs', result)
+        self.assertEqual(len(result['hits']), 1)
+        self.assertEqual(result['hits'][0]['_id'], 'doc1')
+        self.assertEqual(result['hits'][0]['_score'], 0.95)
+
+    @patch('marqo.tensor_search.tensor_search.index_meta_cache.get_index')
+    @patch('marqo.tensor_search.tensor_search.vespa_index_factory')
+    @patch('marqo.tensor_search.tensor_search.utils.parse_lexical_query')
+    @patch('marqo.tensor_search.tensor_search.RequestMetricsStore')
+    def test_search_lexical_method(self, mock_metrics, mock_parse_query, mock_vespa_factory, mock_get_index):
+        """Test search with lexical method returns expected results."""
+        # Setup
+        mock_vespa_index = self._setup_common_mocks(mock_metrics, mock_vespa_factory, mock_get_index)
+        self._setup_lexical_mocks(mock_parse_query)
+        mock_vespa_index.to_vespa_query.return_value = {"query": "test"}
 
         # Execute
         result = tensor_search.search(
@@ -93,14 +120,7 @@ class TestTensorSearch(unittest.TestCase):
         self.config.vespa_client.query.assert_called_once_with(query="test")
         
         # Verify search results
-        self.assertEqual(result['query'], 'test query')
-        self.assertEqual(result['limit'], 10)
-        self.assertEqual(result['offset'], 0)
-        self.assertIn('hits', result)
-        self.assertIn('processingTimeMs', result)
-        self.assertEqual(len(result['hits']), 1)
-        self.assertEqual(result['hits'][0]['_id'], 'doc1')
-        self.assertEqual(result['hits'][0]['_score'], 0.95)
+        self._assert_basic_search_response(result, 'test query')
 
     @patch('marqo.tensor_search.tensor_search.index_meta_cache.get_index')
     @patch('marqo.tensor_search.tensor_search.vespa_index_factory')
@@ -109,29 +129,9 @@ class TestTensorSearch(unittest.TestCase):
     def test_search_tensor_method(self, mock_metrics, mock_vectorise, mock_vespa_factory, mock_get_index):
         """Test search with tensor method returns expected results."""
         # Setup
-        mock_get_index.return_value = self.mock_index
-        mock_vectorise.return_value = {0: [0.1, 0.2, 0.3]}
-
-        # Mock vespa index
-        mock_vespa_index = Mock()
+        mock_vespa_index = self._setup_common_mocks(mock_metrics, mock_vespa_factory, mock_get_index)
+        self._setup_tensor_mocks(mock_vectorise)
         mock_vespa_index.to_vespa_query.return_value = {"query": "vector_query"}
-        mock_vespa_index.to_marqo_document.return_value = {
-            "_id": "doc1",
-            "field1": "value1",
-            "field2": "value2"
-        }
-        mock_vespa_factory.return_value = mock_vespa_index
-
-        # Mock metrics
-        mock_metrics_instance = Mock()
-        mock_metrics.for_request.return_value = mock_metrics_instance
-        mock_metrics_instance.start.return_value = None
-        mock_metrics_instance.stop.return_value = 100.0
-        mock_metrics_instance.time.return_value.__enter__ = Mock(return_value=None)
-        mock_metrics_instance.time.return_value.__exit__ = Mock(return_value=None)
-
-        # Mock Vespa response
-        self.config.vespa_client.query.return_value = self.mock_query_result
 
         # Execute
         result = tensor_search.search(
@@ -146,14 +146,7 @@ class TestTensorSearch(unittest.TestCase):
         self.config.vespa_client.query.assert_called_once_with(query="vector_query")
         
         # Verify search results
-        self.assertEqual(result['query'], 'test query')
-        self.assertEqual(result['limit'], 10)
-        self.assertEqual(result['offset'], 0)
-        self.assertIn('hits', result)
-        self.assertIn('processingTimeMs', result)
-        self.assertEqual(len(result['hits']), 1)
-        self.assertEqual(result['hits'][0]['_id'], 'doc1')
-        self.assertEqual(result['hits'][0]['_score'], 0.95)
+        self._assert_basic_search_response(result, 'test query')
 
     @patch('marqo.tensor_search.tensor_search.index_meta_cache.get_index')
     @patch('marqo.core.search.hybrid_search.HybridSearch')
@@ -187,6 +180,50 @@ class TestTensorSearch(unittest.TestCase):
         self.assertEqual(result['offset'], 0)
         self.assertIn('hits', result)
         self.assertIn('processingTimeMs', result)
+
+    @patch('marqo.tensor_search.tensor_search.index_meta_cache.get_index')
+    @patch('marqo.tensor_search.tensor_search.vespa_index_factory')
+    @patch('marqo.tensor_search.tensor_search.run_vectorise_pipeline')
+    @patch('marqo.tensor_search.tensor_search.RequestMetricsStore')
+    def test_search_with_base64_query_omitted_in_response(self, mock_metrics, mock_vectorise, mock_vespa_factory, mock_get_index):
+        """Test that search with base64 content in query returns sanitized query in response."""
+        # Setup
+        mock_vespa_index = self._setup_common_mocks(mock_metrics, mock_vespa_factory, mock_get_index)
+        self._setup_tensor_mocks(mock_vectorise)
+        mock_vespa_index.to_vespa_query.return_value = {"query": "vector_query"}
+
+        test_cases = [
+            {
+                "name": "base64_image_string",
+                "query": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ...",
+                "expected": "data:image/[omitted]"
+            },
+            {
+                "name": "dict_with_base64_key",
+                "query": {
+                    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34...": 0.8,
+                    "regular_field": 0.2
+                },
+                "expected": {
+                    "data:image/[omitted]": 0.8,
+                    "regular_field": 0.2
+                }
+            }
+        ]
+
+        for case in test_cases:
+            with self.subTest(case=case["name"]):
+                # Execute search with test case query
+                result = tensor_search.search(
+                    config=self.config,
+                    index_name="test-index",
+                    text=case["query"],
+                    result_count=10,
+                    search_method=SearchMethod.TENSOR
+                )
+
+                # Verify search results including sanitized query
+                self._assert_basic_search_response(result, case["expected"])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Change Summary
Base64 queries can be large and returning these in the search response could create unnecessarily large responses. This change replaces base64 queries with a fixed string, including as part of a dict.

## Related Jira Ticket
N/A

## Checklist
<!-- Check items that apply, add items if needed -->
- [x] Tests have been added for changes
- [ ] Documentation has been updated
- [x] Breaking changes are clearly identified
- [x] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [x] Tests cover score modifier usage of this new type
- [x] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

