### PR TITLE
upgrade cachetools to 6.1.0 to fix the LFU eviction efficiency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@
 
 opentelemetry-api==1.33.1
 opentelemetry-sdk==1.33.1
+
+cachetools==6.1.0


### PR DESCRIPTION
## Change Summary
The implementation eviction of LFU cache in the current version of cachetools (5.3.1) is inefficient. The latency increase linearly with the cache size, this is causing long set item latency when the cache is full. This issue is fixed in version 6.1.0. Here's the comparison of the latencies before and after the fix for a LFU of size 50000:
<img width="602" alt="image" src="https://github.com/user-attachments/assets/b019d230-ae4b-4d0e-a919-620e67f35377" />
<img width="600" alt="image" src="https://github.com/user-attachments/assets/b5ed33c9-9616-4ea9-8190-ff2961fdb76b" />


## Related Jira Ticket
https://s2search.atlassian.net/browse/MOSD-452

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [N/A] Documentation has been updated
- [N/A] Breaking changes are clearly identified
- [N/A] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [N/A] Tests cover score modifier usage of this new type
- [N/A] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

