### PR TITLE
Fix a bug that the relevance cut-off featuer is not blocked for `TENSOR` or `LEXICAL` search

### DIFF
--- a/src/marqo/tensor_search/models/api_models.py
+++ b/src/marqo/tensor_search/models/api_models.py
@@ -335,10 +335,10 @@ class SearchQuery(BaseMarqoModel):
     @root_validator(pre=False)
     def _validate_relevance_cutoff_only_works_for_hybrid_search(cls, values):
         """Validate that relevance cutoff is only provided for hybrid search"""
-        relevance_cutoff = values.get('relevanceCutoff')
+        relevance_cutoff = values.get('relevance_cutoff')
         search_method = values.get('searchMethod')
         if relevance_cutoff is not None and search_method.upper() != SearchMethod.HYBRID:
-            raise ValueError(f"RelevanceCutoff can only be provided for 'HYBRID' search, but "
+            raise ValueError(f"relevanceCutoff can only be provided for 'HYBRID' search, but "
                              f"received search method '{search_method}'")
         return values
 

--- a/tests/api_tests/v1/tests/api_tests/test_relevance_cutoff_feature.py
+++ b/tests/api_tests/v1/tests/api_tests/test_relevance_cutoff_feature.py
@@ -93,6 +93,33 @@ class TestRelevanceCutoffFeature(MarqoTestCase):
         ids = [hit["_id"] for hit in response["hits"]]
         self.assertEqual({'h1', 'h2'}, set(ids))
 
+    def test_relevance_cutoff_feature_is_blocked_for_lexical_or_tensor_search(self):
+        """
+        Tests that relevance cutoff feature is blocked for lexical or tensor search.
+        """
+        docs = [
+            {"_id": "h1", "content": "Machine learning algorithms in artificial intelligence enable systems"},
+        ]
+        self.client.index(self.unstructured_index_name).add_documents(
+            docs, tensor_fields=["content"]
+        )
+
+        for search_method in ["LEXICAL", "TENSOR"]:
+            with self.subTest(f"Test sort by with search method {search_method}"):
+                with self.assertRaises(MarqoWebError) as cm:
+                    self.client.index(self.unstructured_index_name).search(
+                        q="test",
+                        search_method=search_method,
+                        relevance_cutoff={
+                            "method": "gap_detection"
+                        },
+                    )
+
+            self.assertIn(
+                f"relevanceCutoff can only be provided for",
+                str(cm.exception)
+            )
+
     def test_relevance_cutoff_gap_detection_method(self):
         """
         Tests relevance cutoff with gap_detection method.

--- a/tests/api_tests/v1/tests/api_tests/test_sort_by_feature.py
+++ b/tests/api_tests/v1/tests/api_tests/test_sort_by_feature.py
@@ -62,6 +62,32 @@ class TestSortByFeature(MarqoTestCase):
             str(cm.exception)
         )
 
+    def test_sort_by_feature_is_blocked_for_lexical_or_tensor_search(self):
+        """
+        Tests that sort by feature is blocked for lexical or tensor search.
+        """
+        for search_method in ["LEXICAL", "TENSOR"]:
+            with self.subTest(f"Test sort by with search method {search_method}"):
+                with self.assertRaises(MarqoWebError) as cm:
+                    self.client.index(self.unstructured_index_name).search(
+                        q="test",
+                        search_method=search_method,
+                        sort_by={
+                            "fields": [
+                                {
+                                    "fieldName": "title",
+                                    "order": "asc",
+                                    "missing": "last"
+                                }
+                            ]
+                        }
+                    )
+
+            self.assertIn(
+                f"sortBy can only be provided for",
+                str(cm.exception)
+            )
+
     def test_sort_by_and_global_modifiers_can_not_be_used_together(self):
         """
         Tests that sort by feature cannot be used with global modifiers.

--- a/tests/integ_tests/tensor_search/integ_tests/test_search_relevance_cutoff_feature.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_search_relevance_cutoff_feature.py
@@ -1,6 +1,8 @@
 import json
 import pytest
 
+from fastapi.exceptions import RequestValidationError
+
 from marqo.core.exceptions import UnsupportedFeatureError
 from marqo.core.models.add_docs_params import AddDocsParams
 from marqo.core.models.marqo_index import *
@@ -233,6 +235,42 @@ class TestSearchRelevanceCutoffFeature(MarqoTestCase):
             )
         self.assertIn("The 'relevanceCutoff' feature is only supported for unstructured indexes created",
                       str(context.exception))
+
+    def test_relevance_cutoff_is_blocked_by_tensor_search(self):
+        """Test that relevance cutoff is blocked for tensor or lexical search."""
+        with self.assertRaises(RequestValidationError) as context:
+            _ = search(
+                index_name=self.unstructured_index_name,
+                marqo_config=self.config,
+                device="cpu",
+                search_query_dict={
+                    "q": "machine learning artificial intelligence algorithms",
+                    "searchMethod": SearchMethod.TENSOR,
+                    "relevanceCutoff": {
+                        "method": "relative_max_score",
+                        "parameters": {"relativeScoreFactor": 0.5},
+                    },
+                }
+            )
+        self.assertIn("relevanceCutoff can only be provided for", str(context.exception.errors()))
+
+    def test_relevance_cutoff_is_blocked_by_lexical_search(self):
+        """Test that relevance cutoff is blocked for lexical search."""
+        with self.assertRaises(RequestValidationError) as context:
+            _ = search(
+                index_name=self.unstructured_index_name,
+                marqo_config=self.config,
+                device="cpu",
+                search_query_dict={
+                    "q": "machine learning artificial intelligence algorithms",
+                    "searchMethod": SearchMethod.LEXICAL,
+                    "relevanceCutoff": {
+                        "method": "relative_max_score",
+                        "parameters": {"relativeScoreFactor": 0.5},
+                    },
+                }
+            )
+        self.assertIn("relevanceCutoff can only be provided for", str(context.exception.errors()))
 
     def test_relevance_cutoff_relative_max_score_low_threshold(self):
         """Test that relative_max_score cutoff with low threshold."""

--- a/tests/integ_tests/tensor_search/integ_tests/test_search_sort_by_feature.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_search_sort_by_feature.py
@@ -1,15 +1,17 @@
 import json
+import pytest
+import semver
+from unittest.mock import patch, MagicMock
 
+from fastapi.exceptions import RequestValidationError
+
+from marqo.core.exceptions import UnsupportedFeatureError
 from marqo.core.models.add_docs_params import AddDocsParams
 from marqo.core.models.marqo_index import *
+from marqo.core.models.marqo_index import MarqoIndex
 from marqo.tensor_search.api import search
 from marqo.tensor_search.enums import SearchMethod
 from tests.integ_tests.marqo_test import MarqoTestCase
-from marqo.core.exceptions import UnsupportedFeatureError
-from unittest.mock import patch, MagicMock
-from marqo.core.models.marqo_index import MarqoIndex
-import semver
-import pytest
 
 
 class TestSearchSortByFeature(MarqoTestCase):
@@ -242,6 +244,38 @@ class TestSearchSortByFeatureSort1Field(MarqoTestCase):
                 "offset": offset
             }
         ).body.decode('utf-8'))
+
+    def test_sort_by_is_blocked_by_tensor_search(self):
+        with self.assertRaises(RequestValidationError) as context:
+            _ = search(
+                index_name=self.index_name,
+                marqo_config=self.config,
+                device="cpu",
+                search_query_dict={
+                    "q": "machine learning artificial intelligence algorithms",
+                    "searchMethod": SearchMethod.TENSOR,
+                    "sortBy": {
+                        "fields": [{"fieldName": "sort_field_1"}],
+                    }
+                }
+            )
+        self.assertIn("sortBy can only be provided for", str(context.exception.errors()))
+
+    def test_sort_by_is_blocked_by_lexical_search(self):
+        with self.assertRaises(RequestValidationError) as context:
+            _ = search(
+                index_name=self.index_name,
+                marqo_config=self.config,
+                device="cpu",
+                search_query_dict={
+                    "q": "machine learning artificial intelligence algorithms",
+                    "searchMethod": SearchMethod.LEXICAL,
+                    "sortBy": {
+                        "fields": [{"fieldName": "sort_field_1"}],
+                    }
+                }
+            )
+        self.assertIn("sortBy can only be provided for", str(context.exception.errors()))
 
     def test_simple_sort_with_default_settings(self):
         """

--- a/tests/unit_tests/marqo/api/models/test_relevance_cutoff_model.py
+++ b/tests/unit_tests/marqo/api/models/test_relevance_cutoff_model.py
@@ -8,6 +8,8 @@ from marqo.tensor_search.models.relevance_cutoff_model import (
     MeanStdParameters,
     RelevanceCutoffModel
 )
+from marqo.tensor_search.models.api_models import SearchQuery
+from marqo.tensor_search.enums import SearchMethod
 
 
 class TestRelevanceCutoffModel(TestCase):
@@ -95,3 +97,36 @@ class TestRelevanceCutoffModel(TestCase):
         # stdDevFactor must be a numeric value
         with self.assertRaises(ValidationError):
             MeanStdParameters(stdDevFactor="test")
+
+    def test_relevance_cutoff_with_tensor_search_fails(self):
+        """Test that relevance cutoff fails with TENSOR search method"""
+        relevance_cutoff = RelevanceCutoffModel(
+            method=RelevanceCutoffMethod.RelativeMaxScore,
+            parameters=RelativeMaxScoreParameters(relativeScoreFactor=0.75)
+        )
+        
+        with self.assertRaises(ValidationError) as cm:
+            SearchQuery(
+                q="test query",
+                searchMethod=SearchMethod.TENSOR,
+                relevanceCutoff=relevance_cutoff
+            )
+        
+        self.assertIn("relevanceCutoff can only be provided for 'HYBRID' search", str(cm.exception))
+        self.assertIn("TENSOR", str(cm.exception))
+
+    def test_relevance_cutoff_with_lexical_search_fails(self):
+        """Test that relevance cutoff fails with LEXICAL search method"""
+        relevance_cutoff = RelevanceCutoffModel(
+            method=RelevanceCutoffMethod.GapDetection
+        )
+        
+        with self.assertRaises(ValidationError) as cm:
+            SearchQuery(
+                q="test query",
+                searchMethod=SearchMethod.LEXICAL,
+                relevanceCutoff=relevance_cutoff
+            )
+        
+        self.assertIn("relevanceCutoff can only be provided for 'HYBRID' search", str(cm.exception))
+        self.assertIn("LEXICAL", str(cm.exception))


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->
Fix a bug that the relevance cut-off feature is not blocked for `TENSOR` or `LEXICAL` search.


## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [x] Tests have been added for changes
- [x] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

