### PR TITLE
Increase docker stop timeout in backwards compatibility tests to 60s

### DIFF
--- a/tests/compatibility_tests/docker_manager.py
+++ b/tests/compatibility_tests/docker_manager.py
@@ -393,7 +393,7 @@ class DockerManager:
             container = self.docker_client.containers.get(container_name)
 
             # Stop the container
-            container.stop()
+            container.stop(timeout=60)  # Increase the timeout from default 10 seconds to 60 seconds
             self.logger.debug(f"Successfully stopped container {container_name}")
 
         except NotFound:


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->
Increase the Docker stop timeout in backwards compatibility tests from 10 seconds to 60 seconds. Previously, the tests were flaky. 

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->
https://s2search.atlassian.net/jira/polaris/projects/MOSD/ideas/view/4863474?selectedIssue=MOSD-383&issueViewLayout=sidebar&issueViewSection=overview&atlOrigin=eyJpIjoiZDhmNjk5MGFiMTIxNDZlOTkwOWNjMzc0ZDk3NWZlNzQiLCJwIjoiaiJ9

## Checklist
<!-- Check items that apply, add items if needed -->
- [x] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

