### PR TITLE
remove context docs concurrency parameter

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,18 @@
+# Release 2.22.0
+
+## New features
+- Search result sorting and relevance cutoff ([#1246](https://github.com/marqo-ai/marqo/pull/1246)). You can now sort search results by up to 3 fields with the `sortBy` parameter. Customize further with field sort `order` and `missing`, which determines placement of documents without said fields. You can also exclude results that do not meet a certain relevance threshhold with `relevanceCutoff`. Check [here](https://docs.marqo.ai/latest/other-resources/cookbook/tips-and-tricks/sort-and-relevance-cutoff/) for detailed usage.
+- Personalization with context documents ([#1254](https://github.com/marqo-ai/marqo/pull/1254)). You can now search using existing documents in your index in combination with a query by using `documents` in the `context` search parameter. Marqo will interpolate all vectors from your query, context tensors (if any), and context documents using `interpolationMethod`. This is a more robust form of the `recommend` endpoint. Check [here](https://docs.marqo.ai/latest/reference/api/search/search/#using-context-documents) for detailed usage.
+- Query logging for slow or failed queries ([#1247](https://github.com/marqo-ai/marqo/pull/1247)). Marqo now logs the sanitized query and E2E latency for slow queries (configurable with `MARQO_VESPA_SLOW_QUERY_THRESHOLD_MS`). Failed queries are also logged along with the exception that caused it.
+
+## Bug Fixes and Minor Changes
+- Fixed bug where no chunks are generated when `split_overlap` is larger than the duration of the media file ([#1255](https://github.com/marqo-ai/marqo/pull/1255)).
+- Upgraded `cachetools` to 6.1.0 which fixes the LFU cache eviction efficiency issue ([#1262](https://github.com/marqo-ai/marqo/pull/1262)).
+- Emit `StatsD` metrics from Marqo ([#1260](https://github.com/marqo-ai/marqo/pull/1260)).
+
+## Performance Improvements
+- Optimized `recommend` endpoint, resulting in up to 34.9% improvement in latency ([#1254](https://github.com/marqo-ai/marqo/pull/1254)).
+
 # Release 2.21.1
 
 ## Bug fixes and minor changes
@@ -9,6 +24,7 @@
 - Search with base64-encoded images ([#1236](https://github.com/marqo-ai/marqo/pull/1236)). You can now submit image data as a Base64 string (starting with `"data:image/…"`) when querying any image-compatible index. Marqo will decode and vectorize the image on the fly. This an alternative to supplying an external image URL for search. Check [here](https://docs.marqo.ai/2.21/reference/api/search/search/#query-q) for detailed usage.
 
 - Set language for lexical fields and search ([#1242](https://github.com/marqo-ai/marqo/pull/1242)). When you add a new text field or send a query, you can specify its language to optimize tokenization and parsing. Lexical searches over that field will honour your language setting, delivering more accurate search results. This feature is available for unstructured indexes created with Marqo 2.16 or later. Check [here](https://docs.marqo.ai/2.21/reference/api/documents/add-or-replace-documents/#example-language-mappings) for adding documents and [here](https://docs.marqo.ai/2.21/reference/api/search/search/#language) for searching.
+
 
 # Release 2.20.0
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,15 @@
+# Release 2.21.1
+
+## Bug fixes and minor changes
+- Omit base64 image strings in the search response to avoid returning unnecessarily large responses ([#1256](https://github.com/marqo-ai/marqo/pull/1256)).
+
+# Release 2.21.0
+
+## New features
+- Search with base64-encoded images ([#1236](https://github.com/marqo-ai/marqo/pull/1236)). You can now submit image data as a Base64 string (starting with `"data:image/…"`) when querying any image-compatible index. Marqo will decode and vectorize the image on the fly. This an alternative to supplying an external image URL for search. Check [here](https://docs.marqo.ai/2.21/reference/api/search/search/#query-q) for detailed usage.
+
+- Set language for lexical fields and search ([#1242](https://github.com/marqo-ai/marqo/pull/1242)). When you add a new text field or send a query, you can specify its language to optimize tokenization and parsing. Lexical searches over that field will honour your language setting, delivering more accurate search results. This feature is available for unstructured indexes created with Marqo 2.16 or later. Check [here](https://docs.marqo.ai/2.21/reference/api/documents/add-or-replace-documents/#example-language-mappings) for adding documents and [here](https://docs.marqo.ai/2.21/reference/api/search/search/#language) for searching.
+
 # Release 2.20.0
 
 ## New features

--- a/src/marqo/core/search/recommender.py
+++ b/src/marqo/core/search/recommender.py
@@ -26,8 +26,7 @@ class Recommender:
     def get_doc_vectors_from_ids(self,
                   index_name: str,
                   documents: Union[List[str], Dict[str, float]],
-                  tensor_fields: Optional[List[str]] = None,
-                  concurrency: Optional[int] = None) -> Dict[str, List[List[float]]]:
+                  tensor_fields: Optional[List[str]] = None) -> Dict[str, List[List[float]]]:
         """
         This method gets documents from Vespa using their IDs, removes any unnecessary data, checks for
         lack of vectors, then returns a list of document vectors. Can be used internally (in recommend)
@@ -37,7 +36,6 @@ class Recommender:
             index_name: Name of the index to search
             documents: A list of document IDs or a dictionary where the keys are document IDs and the values are weights
             tensor_fields: List of tensor fields to use for recommendation (can include text, image, audio, and video fields)
-            concurrency: Max number of concurrent requests to use when fetching documents by batch
 
         Returns:
             A dictionary mapping document IDs to lists of vector embeddings. This is flattened to 1 list per document
@@ -90,8 +88,7 @@ class Recommender:
             config.Config(self.vespa_client, inference=self.inference),
             index_name, 
             document_ids, 
-            tensor_fields=tensor_fields,
-            concurrency=concurrency
+            tensor_fields=tensor_fields
         )
 
         # Check that all documents were found

--- a/src/marqo/tensor_search/models/search.py
+++ b/src/marqo/tensor_search/models/search.py
@@ -69,7 +69,6 @@ class SearchContextTensor(BaseModel):
 class SearchContextDocumentsParameters(BaseModel):
     tensor_fields: Optional[List[str]] = Field(None, alias='tensorFields')
     exclude_input_documents: bool = Field(True, alias='excludeInputDocuments')
-    concurrency: Optional[int] = None
 
     @validator('tensor_fields', pre=True, always=True)
     def check_tensor_fields_not_empty(cls, v):

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -943,8 +943,7 @@ def get_query_vectors_from_jobs(
                                             context_doc_vectors = config.recommender.get_doc_vectors_from_ids(
                             index_name=q.index.name,
                             documents=context_documents.ids,
-                            tensor_fields=context_documents.parameters.tensor_fields,
-                            concurrency=context_documents.parameters.concurrency
+                            tensor_fields=context_documents.parameters.tensor_fields
                         )
 
                 # Update weights and vectors list
@@ -1354,7 +1353,6 @@ def get_doc_vectors_per_tensor_field_by_ids(
     index_name: str, 
     document_ids: List[str],
     tensor_fields: Optional[List[str]] = None,
-    concurrency: Optional[int] = None
 ) -> Dict[str, Dict[str, List[List[float]]]]:
     """
     Get only the embeddings for documents by their IDs.
@@ -1383,8 +1381,7 @@ def get_doc_vectors_per_tensor_field_by_ids(
         batch_get = config.vespa_client.get_batch(
             document_ids,
             marqo_index.schema_name,
-            fields=fields_to_retrieve,
-            concurrency=concurrency
+            fields=fields_to_retrieve
         )
     
     vespa_index = vespa_index_factory(marqo_index)

--- a/tests/compatibility_tests/docker_manager.py
+++ b/tests/compatibility_tests/docker_manager.py
@@ -393,7 +393,7 @@ class DockerManager:
             container = self.docker_client.containers.get(container_name)
 
             # Stop the container
-            container.stop()
+            container.stop(timeout=60)  # Increase the timeout from default 10 seconds to 60 seconds
             self.logger.debug(f"Successfully stopped container {container_name}")
 
         except NotFound:

--- a/tests/integ_tests/tensor_search/search/test_search_with_context.py
+++ b/tests/integ_tests/tensor_search/search/test_search_with_context.py
@@ -933,59 +933,6 @@ class TestSearchWithContext(MarqoTestCase):
                             # But we should still have embeddings
                             self.assertGreater(len(doc_embeddings), 0)
 
-    def test_search_with_context_documents_concurrency_parameter_controls_vespa_concurrency(self):
-        """Test that context.documents.parameters.concurrency is passed to vespa_client.get_batch."""
-        index = self.structured_default_text_index
-        
-        # Add documents to the index
-        docs = [
-            {"_id": "doc1", "text_field_1": "Test document 1"},
-            {"_id": "doc2", "text_field_1": "Test document 2"}
-        ]
-
-        self.add_documents(
-            config=self.config,
-            add_docs_params=AddDocsParams(
-                index_name=index.name,
-                docs=docs,
-                tensor_fields=None
-            )
-        )
-
-        # Mock vespa_client.get_batch to capture the concurrency parameter
-        original_get_batch = self.config.vespa_client.get_batch
-        captured_concurrency = []
-
-        def mock_get_batch(*args, **kwargs):
-            captured_concurrency.append(kwargs.get('concurrency'))
-            return original_get_batch(*args, **kwargs)
-
-        with mock.patch.object(self.config.vespa_client, 'get_batch', side_effect=mock_get_batch):
-            # Create search context with specific concurrency
-            search_context = SearchContext(
-                documents=SearchContextDocuments(
-                    ids={"doc1": 1.0, "doc2": 1.0},
-                    parameters=SearchContextDocumentsParameters(
-                        tensorFields=["text_field_1"],
-                        excludeInputDocuments=False,
-                        concurrency=5  # Test with concurrency=5
-                    )
-                )
-            )
-
-            # Perform search with context documents
-            tensor_search.search(
-                config=self.config,
-                index_name=index.name,
-                text=None,
-                context=search_context,
-                result_count=5
-            )
-
-            # Verify that get_batch was called with the correct concurrency parameter
-            self.assertEqual(len(captured_concurrency), 1, "get_batch should have been called")
-            self.assertEqual(captured_concurrency[0], 5, "get_batch should be called with concurrency=5")
-
     def test_search_with_context_documents_max_search_context_docs_env_var(self):
         """Test that MARQO_MAX_SEARCH_CONTEXT_DOCS environment variable controls the limit for context documents."""
 

--- a/tests/integ_tests/tensor_search/test_api_query_logging_integration.py
+++ b/tests/integ_tests/tensor_search/test_api_query_logging_integration.py
@@ -170,8 +170,7 @@ class TestAPIQueryLoggingIntegration(MarqoTestCase):
                     },
                     "parameters": {
                         "tensorFields": ["text_field_1"],
-                        "excludeInputDocuments": False,
-                        "concurrency": 5,
+                        "excludeInputDocuments": False
                     }
                 }
             },
@@ -251,8 +250,7 @@ class TestAPIQueryLoggingIntegration(MarqoTestCase):
                     },
                     "parameters": {
                         "tensorFields": ["text_field_1"],
-                        "excludeInputDocuments": False,
-                        "concurrency": 5,
+                        "excludeInputDocuments": False
                     }
                 }
             },

--- a/tests/unit_tests/core/search/test_recommender_vectors.py
+++ b/tests/unit_tests/core/search/test_recommender_vectors.py
@@ -77,7 +77,7 @@ class TestRecommenderGetDocVectorsFromIds(unittest.TestCase):
         
         # Verify tensor_search function was called correctly
         mock_get_vectors.assert_called_once_with(
-            mock_config, "test_index", ["doc1", "doc2"], tensor_fields=None, concurrency=None
+            mock_config, "test_index", ["doc1", "doc2"], tensor_fields=None
         )
     
     @patch('marqo.tensor_search.index_meta_cache.get_index')
@@ -117,7 +117,7 @@ class TestRecommenderGetDocVectorsFromIds(unittest.TestCase):
         
         # Verify tensor_search function was called with non-zero weight docs only
         mock_get_vectors.assert_called_once_with(
-            mock_config, "test_index", ["doc1", "doc3"], tensor_fields=None, concurrency=None
+            mock_config, "test_index", ["doc1", "doc3"], tensor_fields=None
         )
     
     @patch('marqo.tensor_search.index_meta_cache.get_index')
@@ -155,7 +155,7 @@ class TestRecommenderGetDocVectorsFromIds(unittest.TestCase):
         
         # Verify tensor_search function was called with specific fields
         mock_get_vectors.assert_called_once_with(
-            mock_config, "test_index", ["doc1"], tensor_fields=["title", "content"], concurrency=None
+            mock_config, "test_index", ["doc1"], tensor_fields=["title", "content"]
         )
     
     @patch('marqo.tensor_search.index_meta_cache.get_index')

--- a/tests/unit_tests/marqo/tensor_search/models/test_api_models.py
+++ b/tests/unit_tests/marqo/tensor_search/models/test_api_models.py
@@ -564,16 +564,6 @@ class TestSearchContextDocuments(unittest.TestCase):
         docs = SearchContextDocuments(ids={"doc1": 1.0, "doc2": 0.5})
         self.assertEqual(docs.ids, {"doc1": 1.0, "doc2": 0.5})
 
-    def test_concurrency_validation(self):
-        """Test concurrency parameter validation"""
-        # Valid positive integer
-        params = SearchContextDocumentsParameters(concurrency=5)
-        self.assertEqual(params.concurrency, 5)
-
-        # None should be valid
-        params = SearchContextDocumentsParameters(concurrency=None)
-        self.assertIsNone(params.concurrency)
-
     def test_exclude_input_documents_boolean_validation(self):
         """Test excludeInputDocuments boolean validation"""
         # Valid boolean values
@@ -594,13 +584,11 @@ class TestSearchContextDocuments(unittest.TestCase):
         params = SearchContextDocumentsParameters(
             tensorFields=["field1"],
             excludeInputDocuments=False,
-            concurrency=10
         )
         docs = SearchContextDocuments(ids={"doc1": 1.0}, parameters=params)
 
         self.assertEqual(docs.parameters.tensor_fields, ["field1"])
         self.assertFalse(docs.parameters.exclude_input_documents)
-        self.assertEqual(docs.parameters.concurrency, 10)
 
     def test_search_context_documents_with_invalid_weight_types(self):
         """Test that invalid weight types are handled by pydantic"""

--- a/tests/unit_tests/marqo/tensor_search/test_api_query_logging.py
+++ b/tests/unit_tests/marqo/tensor_search/test_api_query_logging.py
@@ -648,8 +648,7 @@ class TestAPIQueryLogging(MarqoTestCase):
                         },
                         "parameters": {
                             "tensorFields": ["description"],
-                            "excludeInputDocuments": False,
-                            "concurrency": 5,
+                            "excludeInputDocuments": False
                         }
                     }
                 },
@@ -732,8 +731,7 @@ class TestAPIQueryLogging(MarqoTestCase):
                         },
                         "parameters": {
                             "tensorFields": ["description"],
-                            "excludeInputDocuments": False,
-                            "concurrency": 5,
+                            "excludeInputDocuments": False
                         }
                     }
                 },

--- a/tests/unit_tests/marqo/tensor_search/test_tensor_search_doc_vectors.py
+++ b/tests/unit_tests/marqo/tensor_search/test_tensor_search_doc_vectors.py
@@ -196,7 +196,7 @@ class TestGetDocVectorsPerTensorFieldByIds(unittest.TestCase):
         # Verify get_batch was called with correct fields
         expected_fields = [structured_common.FIELD_ID, "emb_title", "emb_desc"]
         self.mock_vespa_client.get_batch.assert_called_once_with(
-            ["doc1"], "test_schema", fields=expected_fields, concurrency=None
+            ["doc1"], "test_schema", fields=expected_fields
         )
     
     @patch('marqo.tensor_search.tensor_search.RequestMetricsStore')
@@ -350,7 +350,7 @@ class TestGetDocVectorsPerTensorFieldByIds(unittest.TestCase):
         # Verify get_batch was called with empty document list
         expected_fields = [structured_common.FIELD_ID, "emb_title"]
         self.mock_vespa_client.get_batch.assert_called_once_with(
-            [], "test_schema", fields=expected_fields, concurrency=None
+            [], "test_schema", fields=expected_fields
         )
 
     @patch('marqo.tensor_search.tensor_search.RequestMetricsStore')
@@ -567,5 +567,5 @@ class TestGetDocVectorsPerTensorFieldByIds(unittest.TestCase):
         # Verify get_batch was called with correct fields
         expected_fields = [structured_common.FIELD_ID, "emb_field1", "emb_field2", "emb_field3"]
         self.mock_config.vespa_client.get_batch.assert_called_once_with(
-            ["doc1", "doc2", "doc3"], "test_schema", fields=expected_fields, concurrency=None
+            ["doc1", "doc2", "doc3"], "test_schema", fields=expected_fields
         )


### PR DESCRIPTION
## Change Summary
remove `context.docs.parameters.concurrency`

## Related Jira Ticket
https://s2search.atlassian.net/jira/polaris/projects/MOSD/ideas/view/4863474?selectedIssue=MOSD-461&issueViewLayout=sidebar&issueViewSection=overview&atlOrigin=eyJpIjoiZGY2Y2Q3YTA1OTY2NDRlMzg5NTBkYzQxMDg3MTgyMjUiLCJwIjoiaiJ9

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

