### PR TITLE
Fix the flaky api test

### DIFF
--- a/tests/api_tests/v1/tests/application_tests/test_env_var_changes.py
+++ b/tests/api_tests/v1/tests/application_tests/test_env_var_changes.py
@@ -111,7 +111,7 @@ class TestEnvVarChanges(marqo_test.MarqoTestCase):
         telemetry_client = Client(**self.client_settings, return_telemetry=True)
 
         min_inference_time_ms = 8      # inference usually takes at least 8ms
-        cache_reading_time_ms = 2      # if it hits cache, it's usually less than 2ms
+        cache_reading_time_ms = 3      # if it hits cache, it's usually less than 3ms
 
         # Test search query's embedding is cached when inference cache is enabled
         for query in ["test", {"random": 1, "query": 2}]:


### PR DESCRIPTION
## Change Summary
### increase the cache_reading time to fix the flaky API tests
Sometimes, the latency exceeds 2ms even when cache is hit during tests. but it seldom exceeds 3ms, and we'll average 10 runs, so 3ms should be safe enough.  here's a sample failed build: https://github.com/marqo-ai/marqo/actions/runs/16867480531/job/47776381301

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [N/A] Tests have been added for changes
- [N/A] Documentation has been updated
- [N/A] Breaking changes are clearly identified
- [N/A] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

