### PR TITLE
Fix a bug that causes wrong facets count when we use lexical retrieval method with filter and multiple 'OR' phrases.

### DIFF
--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -179,7 +179,7 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
             tensor_term = self._get_tensor_search_term(marqo_query)
 
         facets_lexical_term = self._get_lexical_search_term(marqo_query, is_facets_term=True)
-        base_yql = f'select {select_attributes} from {self._marqo_index.schema_name} where {facets_lexical_term}'
+        base_yql = f'select {select_attributes} from {self._marqo_index.schema_name} where ({facets_lexical_term})'
         if marqo_query.hybrid_parameters.retrievalMethod == RetrievalMethod.Disjunction:
             base_yql = f'select {select_attributes} from {self._marqo_index.schema_name} where ({facets_lexical_term} OR {tensor_term})'
         elif marqo_query.hybrid_parameters.retrievalMethod == RetrievalMethod.Tensor:

--- a/tests/integ_tests/tensor_search/integ_tests/test_facets.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_facets.py
@@ -1,29 +1,16 @@
 import copy
-import json
 import os
-import unittest
 from unittest import mock
 
-import httpx
-import numpy as np
-from fastapi.responses import ORJSONResponse
-from tests.integ_tests.marqo_test import MarqoTestCase, TestImageUrls, EXAMPLE_FASHION_DOCUMENTS
-
-import marqo.core.exceptions as core_exceptions
-import marqo.vespa.exceptions as vespa_exceptions
-from marqo.core.models.add_docs_params import AddDocsParams
-from marqo.core.models.hybrid_parameters import RetrievalMethod, RankingMethod, HybridParameters
-from marqo.core.models.marqo_index import *
-from marqo.core.models.marqo_index_request import FieldRequest
-from marqo.tensor_search import tensor_search
-from marqo.tensor_search.enums import SearchMethod
-from marqo.tensor_search.models.api_models import CustomVectorQuery
-from marqo.tensor_search.models.api_models import ScoreModifierLists
-from marqo.tensor_search.models.search import SearchContext
-from marqo.core.models.facets_parameters import FacetsParameters, FieldFacetsConfiguration, RangeConfiguration
 import pytest
 
-import unittest
+from marqo.core.models.add_docs_params import AddDocsParams
+from marqo.core.models.facets_parameters import FacetsParameters, FieldFacetsConfiguration
+from marqo.core.models.hybrid_parameters import RetrievalMethod, RankingMethod, HybridParameters
+from marqo.core.models.marqo_index import *
+from marqo.tensor_search import tensor_search
+from marqo.tensor_search.enums import SearchMethod
+from tests.integ_tests.marqo_test import MarqoTestCase, EXAMPLE_FASHION_DOCUMENTS
 
 
 class TestFacets(MarqoTestCase):
@@ -551,6 +538,30 @@ class TestFacets(MarqoTestCase):
             facets=facets
         )
         self.assertEqual(res["facets"]["non_existent_field"], {})
+
+    @pytest.mark.skip_for_multinode
+    def test_facet_count_for_lexical_retriever_with_filter_and_multiple_or_phrases(self):
+        """
+        Tests numeric facets with custom range buckets using from/to configurations.
+        """
+        self.add_fashion_docs()
+        for retrieval_method, ranking_method in (
+                (RetrievalMethod.Lexical, RankingMethod.Tensor),
+                (RetrievalMethod.Lexical, RankingMethod.Lexical),
+        ):
+            with self.subTest(retrieval_method=retrieval_method, ranking_method=ranking_method):
+                facets = FacetsParameters(fields={
+                    "brand": FieldFacetsConfiguration(type="string"),
+                })
+                res = tensor_search.search(
+                    config=self.config, index_name=self.semi_structured_default_text_index.name, text="SnugNest shirt",
+                    facets=facets, filter="price:[* to 30.0]",  # there's only one product with price less than 30.0
+                    search_method=SearchMethod.HYBRID, hybrid_parameters=HybridParameters(
+                        retrievalMethod=retrieval_method, rankingMethod=ranking_method
+                    )
+                )
+                # we should count the brand that only matches the filter
+                self.assertDictEqual({'SnugNest': {'count': 1}}, res["facets"]["brand"])
 
     @pytest.mark.skip_for_multinode
     def test_number_facets_stats_combination(self):

--- a/tests/unit_tests/marqo/core/search/test_search.py
+++ b/tests/unit_tests/marqo/core/search/test_search.py
@@ -161,7 +161,7 @@ class SearchTest(unittest.TestCase):
     def get_expected_lexical_yql_with_or(self, query, include_select=True):
         query_strings = query.split(" ")
         query_string = " OR ".join([f"default contains \"{q}\"" for q in query_strings])
-        return f'select * from {self.current_index.schema_name} where {query_string}' if include_select else query_string
+        return f'select * from {self.current_index.schema_name} where ({query_string})' if include_select else query_string
 
     def set_index_to_return(self, index):
         self.get_index_patcher.stop()

--- a/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_semi_structured_vespa_index_to_vespa_query.py
+++ b/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_semi_structured_vespa_index_to_vespa_query.py
@@ -16,6 +16,7 @@ from marqo.core.models.marqo_index import (
 from marqo.core.models.marqo_index import SemiStructuredMarqoIndex
 from marqo.core.models.marqo_query import MarqoHybridQuery, MarqoLexicalQuery
 from marqo.core.models.marqo_query import MarqoTensorQuery
+from marqo.core.search.search_filter import SearchFilter, EqualityTerm
 from marqo.core.semi_structured_vespa_index import common
 from marqo.core.semi_structured_vespa_index.semi_structured_vespa_index import SemiStructuredVespaIndex
 from marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema import SemiStructuredVespaSchema
@@ -869,6 +870,45 @@ class TestSemiStructuredVespaIndexToVespaQueryCollapseFields(MarqoTestCase):
                          'max(marqo__float_fields{"price"}), count()))) '
                          'all(group(marqo__short_string_fields{"color"}) max(100) order(-count()) '
                          'each(output(count()))) )', vespa_query['marqo__yql.facets'])
+
+
+class TestSemiStructuredVespaIndexToVespaQueryFacets(MarqoTestCase):
+
+    def setUp(self):
+        marqo_index = self.semi_structured_marqo_index("test_index")
+
+        self.vespa_index = SemiStructuredVespaIndex(marqo_index)
+
+    def test_facets_query_with_multiple_or_phrases_and_filter_for_lexical_retriever(self):
+        test_cases = [
+            ("lexical", "lexical"),
+            ("lexical", "tensor"),
+        ]
+
+        for retrieval_method, ranking_method in test_cases:
+            with self.subTest(retrieval_method=retrieval_method, ranking_method=ranking_method):
+                marqo_query = MarqoHybridQuery(
+                    index_name="test_index",
+                    limit=10,
+                    offset=0,
+                    or_phrases=["hello", "world"],
+                    and_phrases=[],
+                    hybrid_parameters=HybridParameters(
+                        retrievalMethod=retrieval_method,
+                        rankingMethod=ranking_method,
+                    ),
+                    filter=SearchFilter(root=EqualityTerm('a', 'n', 'a:n')),
+                    facets=FacetsParameters(
+                        fields={"color": FieldFacetsConfiguration(type="string")}
+                    )
+                )
+
+            vespa_query = self.vespa_index.to_vespa_query(marqo_query)
+            self.assertEqual('select * from test_index where (default contains "hello" OR default contains '
+                             '"world") AND (((marqo__short_string_fields contains sameElement(key contains '
+                             '"a", value contains "n")))) limit 0 | all( '
+                             'all(group(marqo__short_string_fields{"color"}) max(100) order(-count()) '
+                             'each(output(count()))) )', vespa_query['marqo__yql.facets'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Change Summary
The lexical term used in the facets query is missing wrapping parentheses, which will cause facets query to return wrong count when we search with filter and multiple words in the query (multiple 'OR' phrases). 
This is due to that the OR phrases without  parentheses breaks the query semantics and returns more results than expected. 
The fix is simple, just to add the parentheses around lexical term nevertheless. 

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [x] Tests have been added for changes
- [N/A] Documentation has been updated
- [N/A] Breaking changes are clearly identified
- [N/A] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

