### PR TITLE
Loosen the pydantic type check to ignore extra fields for all MarqoIndex's fields

### DIFF
--- a/src/marqo/core/models/marqo_index.py
+++ b/src/marqo/core/models/marqo_index.py
@@ -10,7 +10,7 @@ from pydantic.v1 import ValidationError, validator
 from pydantic.v1.error_wrappers import ErrorWrapper
 from pydantic.v1.utils import ROOT_KEY
 
-from marqo.base_model import ImmutableStrictBaseModel, ImmutableBaseModel, StrictBaseModel
+from marqo.base_model import ImmutableStrictBaseModel, ImmutableBaseModel, StrictBaseModel, MarqoBaseModel
 from marqo.core import constants
 from marqo.exceptions import InvalidArgumentError
 from marqo.logging import get_logger
@@ -164,7 +164,7 @@ class ImagePreProcessing(ImmutableBaseModel):
     patch_method: Optional[PatchMethod] = pydantic.Field(alias='patchMethod')
 
 
-class Model(ImmutableBaseModel):
+class Model(MarqoBaseModel):
     name: str
     properties: Optional[Dict[str, Any]]
     custom: bool = False

--- a/src/marqo/core/models/marqo_index.py
+++ b/src/marqo/core/models/marqo_index.py
@@ -22,7 +22,7 @@ from marqo.s2_inference.errors import UnknownModelError, InvalidModelPropertiesE
 logger = get_logger(__name__)
 
 
-class CollapseField(StrictBaseModel):
+class CollapseField(ImmutableBaseModel):
     name: str
     min_groups: int = pydantic.Field(default=500, gt=0, alias='minGroups')
 
@@ -104,7 +104,7 @@ class PatchMethod(Enum):
     MarqoYolo = 'marqo-yolo'
 
 
-class Field(ImmutableStrictBaseModel):
+class Field(ImmutableBaseModel):
     name: str
     type: FieldType
     features: List[FieldFeature] = []
@@ -121,14 +121,14 @@ class Field(ImmutableStrictBaseModel):
         return values
 
 
-class StringArrayField(ImmutableStrictBaseModel):
+class StringArrayField(ImmutableBaseModel):
     name: str
     type: FieldType
     string_array_field_name: Optional[str]
     features: List[FieldFeature] = []
 
 
-class TensorField(ImmutableStrictBaseModel):
+class TensorField(ImmutableBaseModel):
     """
     A tensor field that has a corresponding field.
 
@@ -139,32 +139,32 @@ class TensorField(ImmutableStrictBaseModel):
     embeddings_field_name: str
 
 
-class HnswConfig(ImmutableStrictBaseModel):
+class HnswConfig(ImmutableBaseModel):
     ef_construction: int = pydantic.Field(gt=0, alias='efConstruction')
     m: int = pydantic.Field(gt=0)
 
 
-class TextPreProcessing(ImmutableStrictBaseModel):
+class TextPreProcessing(ImmutableBaseModel):
     split_length: int = pydantic.Field(gt=0, alias='splitLength')
     split_overlap: int = pydantic.Field(ge=0, alias='splitOverlap')
     split_method: TextSplitMethod = pydantic.Field(alias='splitMethod')
 
 
-class VideoPreProcessing(ImmutableStrictBaseModel):
+class VideoPreProcessing(ImmutableBaseModel):
     split_length: int = pydantic.Field(gt=0, alias='splitLength')
     split_overlap: int = pydantic.Field(ge=0, alias='splitOverlap')
 
 
-class AudioPreProcessing(ImmutableStrictBaseModel):
+class AudioPreProcessing(ImmutableBaseModel):
     split_length: int = pydantic.Field(gt=0, alias='splitLength')
     split_overlap: int = pydantic.Field(ge=0, alias='splitOverlap')
 
 
-class ImagePreProcessing(ImmutableStrictBaseModel):
+class ImagePreProcessing(ImmutableBaseModel):
     patch_method: Optional[PatchMethod] = pydantic.Field(alias='patchMethod')
 
 
-class Model(StrictBaseModel):
+class Model(ImmutableBaseModel):
     name: str
     properties: Optional[Dict[str, Any]]
     custom: bool = False

--- a/tests/unit_tests/marqo/core/models/test_marqo_index.py
+++ b/tests/unit_tests/marqo/core/models/test_marqo_index.py
@@ -2,7 +2,12 @@ import unittest
 
 from pydantic.v1 import ValidationError
 
-from marqo.core.models.marqo_index import Field, FieldType, FieldFeature, CollapseField, Stemming
+from marqo.core.models.marqo_index import (
+    Field, FieldType, FieldFeature, CollapseField, Stemming,
+    Model, TensorField, StringArrayField, HnswConfig,
+    TextPreProcessing, VideoPreProcessing, AudioPreProcessing, ImagePreProcessing,
+    TextSplitMethod, PatchMethod, VectorNumericType, DistanceMetric
+)
 from tests.unit_tests.marqo_test import MarqoTestCase
 
 
@@ -539,3 +544,141 @@ class TestSemiStructuredMarqoIndexCollapseFields(MarqoTestCase):
         index = self.semi_structured_marqo_index(name='test_index', collapse_fields=None)
         self.assertIsNone(index.collapse_fields)
         self.assertFalse(index.is_collapse_field('product_id'))
+
+
+class TestForwardCompatibility(unittest.TestCase):
+    """Test forward compatibility by ensuring models accept extra fields."""
+
+    def test_field_forward_compatibility(self):
+        """Test that Field model accepts extra fields gracefully."""
+        field = Field(
+            name="test_field",
+            type=FieldType.Text,
+            features=[FieldFeature.LexicalSearch],
+            lexical_field_name="marqo__lexical_test_field",
+            filter_field_name=None,
+            dependent_fields=None,
+            language="en",
+            stemming=Stemming.Best,
+            future_field="extra_value"  # Extra field
+        )
+        # Assert all existing fields are populated correctly
+        self.assertEqual(field.name, "test_field")
+        self.assertEqual(field.type, FieldType.Text)
+        self.assertEqual(field.features, [FieldFeature.LexicalSearch])
+        self.assertEqual(field.lexical_field_name, "marqo__lexical_test_field")
+        self.assertIsNone(field.filter_field_name)
+        self.assertIsNone(field.dependent_fields)
+        self.assertEqual(field.language, "en")
+        self.assertEqual(field.stemming, Stemming.Best)
+
+    def test_model_forward_compatibility(self):
+        """Test that Model accepts extra fields gracefully."""
+        model = Model(
+            name="test_model",
+            properties={"name": "test_model", "dimensions": 512, "tokens": 128, "type": "sbert"},  # Use valid model type
+            custom=True,
+            text_query_prefix="query:",
+            text_chunk_prefix="chunk:",
+            future_field="extra_value"  # Extra field
+        )
+        # Assert all existing fields are populated correctly
+        self.assertEqual(model.name, "test_model")
+        self.assertEqual(model.properties, {"name": "test_model", "dimensions": 512, "tokens": 128, "type": "sbert"})
+        self.assertTrue(model.custom)
+        self.assertEqual(model.text_query_prefix, "query:")
+        self.assertEqual(model.text_chunk_prefix, "chunk:")
+
+    def test_collapse_field_forward_compatibility(self):
+        """Test that CollapseField accepts extra fields gracefully."""
+        collapse_field = CollapseField(
+            name="collapse_test",
+            minGroups=100,
+            future_field="extra_value"  # Extra field
+        )
+        # Assert all existing fields are populated correctly
+        self.assertEqual(collapse_field.name, "collapse_test")
+        self.assertEqual(collapse_field.min_groups, 100)
+
+    def test_tensor_field_forward_compatibility(self):
+        """Test that TensorField accepts extra fields gracefully."""
+        tensor_field = TensorField(
+            name="tensor_field",
+            chunk_field_name="marqo__chunk_tensor_field",
+            embeddings_field_name="marqo__embeddings_tensor_field",
+            future_field="extra_value"  # Extra field
+        )
+        # Assert all existing fields are populated correctly
+        self.assertEqual(tensor_field.name, "tensor_field")
+        self.assertEqual(tensor_field.chunk_field_name, "marqo__chunk_tensor_field")
+        self.assertEqual(tensor_field.embeddings_field_name, "marqo__embeddings_tensor_field")
+
+    def test_string_array_field_forward_compatibility(self):
+        """Test that StringArrayField accepts extra fields gracefully."""
+        string_array_field = StringArrayField(
+            name="string_array_field",
+            type=FieldType.ArrayText,
+            string_array_field_name="marqo__string_array_test",
+            features=[FieldFeature.Filter],
+            future_field="extra_value"  # Extra field
+        )
+        # Assert all existing fields are populated correctly
+        self.assertEqual(string_array_field.name, "string_array_field")
+        self.assertEqual(string_array_field.type, FieldType.ArrayText)
+        self.assertEqual(string_array_field.string_array_field_name, "marqo__string_array_test")
+        self.assertEqual(string_array_field.features, [FieldFeature.Filter])
+
+    def test_hnsw_config_forward_compatibility(self):
+        """Test that HnswConfig accepts extra fields gracefully."""
+        hnsw_config = HnswConfig(
+            efConstruction=200,
+            m=16,
+            future_field="extra_value"  # Extra field
+        )
+        # Assert all existing fields are populated correctly
+        self.assertEqual(hnsw_config.ef_construction, 200)
+        self.assertEqual(hnsw_config.m, 16)
+
+    def test_text_preprocessing_forward_compatibility(self):
+        """Test that TextPreProcessing accepts extra fields gracefully."""
+        text_preprocessing = TextPreProcessing(
+            splitLength=100,
+            splitOverlap=10,
+            splitMethod=TextSplitMethod.Sentence,
+            future_field="extra_value"  # Extra field
+        )
+        # Assert all existing fields are populated correctly
+        self.assertEqual(text_preprocessing.split_length, 100)
+        self.assertEqual(text_preprocessing.split_overlap, 10)
+        self.assertEqual(text_preprocessing.split_method, TextSplitMethod.Sentence)
+
+    def test_video_preprocessing_forward_compatibility(self):
+        """Test that VideoPreProcessing accepts extra fields gracefully."""
+        video_preprocessing = VideoPreProcessing(
+            splitLength=30,
+            splitOverlap=5,
+            future_field="extra_value"  # Extra field
+        )
+        # Assert all existing fields are populated correctly
+        self.assertEqual(video_preprocessing.split_length, 30)
+        self.assertEqual(video_preprocessing.split_overlap, 5)
+
+    def test_audio_preprocessing_forward_compatibility(self):
+        """Test that AudioPreProcessing accepts extra fields gracefully."""
+        audio_preprocessing = AudioPreProcessing(
+            splitLength=60,
+            splitOverlap=10,
+            future_field="extra_value"  # Extra field
+        )
+        # Assert all existing fields are populated correctly
+        self.assertEqual(audio_preprocessing.split_length, 60)
+        self.assertEqual(audio_preprocessing.split_overlap, 10)
+
+    def test_image_preprocessing_forward_compatibility(self):
+        """Test that ImagePreProcessing accepts extra fields gracefully."""
+        image_preprocessing = ImagePreProcessing(
+            patchMethod=PatchMethod.Simple,
+            future_field="extra_value"  # Extra field
+        )
+        # Assert all existing fields are populated correctly
+        self.assertEqual(image_preprocessing.patch_method, PatchMethod.Simple)


### PR DESCRIPTION
## Change Summary
MarqoIndex model is not forward compatible since a lot of its subfields are StrictBaseModel which does not allow extra field. This causes an issue when rolling new version of Marqo out. If the index settings are changed by the new version of Marqo, any instance still with the old version is not able to load it back. The index setting cache therefore stops working. 

To solve this problem, we need to loosen the pydantic type check to ignore extra fields for all MarqoIndex's fields.

## Related Jira Ticket


## Checklist
<!-- Check items that apply, add items if needed -->
- [x] Tests have been added for changes
- [N/A] Documentation has been updated
- [N/A] Breaking changes are clearly identified
- [N/A] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

