### PR TITLE
Support base64-encoded image in inference cache

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ opentelemetry-api==1.33.1
 opentelemetry-sdk==1.33.1
 
 cachetools==6.1.0
+blake3==0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ opentelemetry-api==1.33.1
 opentelemetry-sdk==1.33.1
 
 cachetools==6.1.0
-blake3==0.4.1
+blake3==1.0.5

--- a/src/marqo/inference/inference_cache/caching_inference.py
+++ b/src/marqo/inference/inference_cache/caching_inference.py
@@ -1,11 +1,13 @@
 import hashlib
-from typing import Tuple, List
+from typing import Tuple, List, Optional
 
+import blake3
 import numpy as np
 import orjson
 
 from marqo.core.inference.api import Inference, InferenceRequest, InferenceResult, Modality, \
     InferenceErrorModel
+from marqo.core.inference.modality_utils import is_base64_image
 from marqo.inference.inference_cache.marqo_inference_cache import MarqoInferenceCache
 
 
@@ -24,7 +26,12 @@ class CachingInference(Inference):
         contents_to_vectorise: List[str] = []
 
         for index, content in enumerate(request.contents):
-            embedding = self.inference_cache.get(model_cache_key, content)
+            content_cache_key = self.content_cache_key(content, request.modality)
+            if not content_cache_key:
+                contents_to_vectorise.append(content)
+                continue
+
+            embedding = self.inference_cache.get(model_cache_key, content_cache_key)
             if embedding is not None:
                 cached_result.append((index, content, embedding))
             else:
@@ -43,7 +50,9 @@ class CachingInference(Inference):
                                        f"Preprocessing config: "
                                        f"{orjson.dumps(dict(new_request.preprocessing_config)).decode('utf-8')}")
                 content, embedding = r[0]
-                self.inference_cache.set(model_cache_key, content, embedding)
+                content_cache_key = self.content_cache_key(content, request.modality)
+                if content_cache_key:
+                    self.inference_cache.set(model_cache_key, content_cache_key, embedding)
 
         # Merge result
         if cached_result:
@@ -61,10 +70,37 @@ class CachingInference(Inference):
         data = orjson.dumps(model_properties, option=orjson.OPT_SORT_KEYS)
         return hashlib.md5(data).hexdigest()
 
+    def content_cache_key(self, content: str, modality: Modality) -> Optional[str]:
+        """
+        Generate appropriate cache key for content based on modality.
+        
+        For TEXT modality: use content directly
+        For IMAGE modality: 
+            - if base64 image: use blake3 hash with prefix
+            - otherwise: use content directly (will be skipped in caching logic)
+        
+        Args:
+            content: The content string
+            modality: The modality type
+            
+        Returns:
+            Cache key string, None if it should not be cached
+        """
+        if modality == Modality.TEXT:
+            # Use original content for text and non-base64 images
+            return content
+        elif modality == Modality.IMAGE and is_base64_image(content):
+            # Use blake3 hash for base64 images to save memory
+            hash_digest = blake3.blake3(content.encode()).hexdigest()
+            return f"blake3:{hash_digest}"
+        else:
+            # should not cache non-base64-encoded images
+            return None
+
     def should_skip_cache(self, request):
         return (
             not request.use_inference_cache
             or request.device  # device is only specified to debug embedding, skip caching
-            or request.modality != Modality.TEXT  # we only support text modality for now
+            or request.modality not in [Modality.TEXT, Modality.IMAGE]  # we support text and image modalities
             or request.preprocessing_config.should_chunk  # we do not support caching chunks
         )

--- a/tests/api_tests/v1/tests/application_tests/test_env_var_changes.py
+++ b/tests/api_tests/v1/tests/application_tests/test_env_var_changes.py
@@ -79,7 +79,7 @@ class TestEnvVarChanges(marqo_test.MarqoTestCase):
         """
 
         # Restart marqo with new max values
-        new_models = ["open_clip/ViT-H-14/laion2b_s32b_b79k"]
+        new_models = ["open_clip/ViT-B-32/laion2B-s34B-b79K"]
         index_name = "test_multiple_env_vars"
         utilities.rerun_marqo_with_env_vars(
             env_vars=[

--- a/tests/api_tests/v1/tests/application_tests/test_env_var_changes.py
+++ b/tests/api_tests/v1/tests/application_tests/test_env_var_changes.py
@@ -18,17 +18,12 @@ We may test multiple different env vars in the same test case. This is because
  this test suite's runtime from growing too large.
 """
 import json
-import unittest
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Callable, Optional, List
 
-import math
-
-from tests.api_tests.v1.tests.marqo_test import TestImageUrls
+from marqo import Client
 from tests import marqo_test
 from tests import utilities
-
-from marqo import Client
 
 
 class TestEnvVarChanges(marqo_test.MarqoTestCase):
@@ -116,7 +111,7 @@ class TestEnvVarChanges(marqo_test.MarqoTestCase):
 
         # Test search query's embedding is cached when inference cache is enabled
         base64_image = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
-        image_url = TestImageUrls.HIPPO_STATUE.value
+        image_url = marqo_test.TestImageUrls.HIPPO_STATUE.value
         for query in ["test", {"random": 1, "query": 2}, base64_image]:
             with self.subTest(f"Search query: {query}"):
                 # Single query

--- a/tests/api_tests/v1/tests/application_tests/test_env_var_changes.py
+++ b/tests/api_tests/v1/tests/application_tests/test_env_var_changes.py
@@ -112,7 +112,7 @@ class TestEnvVarChanges(marqo_test.MarqoTestCase):
         # Test search query's embedding is cached when inference cache is enabled
         base64_image = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
         image_url = marqo_test.TestImageUrls.HIPPO_STATUE.value
-        for query in ["test", {"random": 1, "query": 2}, base64_image]:
+        for query in ["test", {"random": 1, "query": 2}, base64_image, image_url]:
             with self.subTest(f"Search query: {query}"):
                 # Single query
                 # First search that misses cache should take longer

--- a/tests/api_tests/v1/tests/application_tests/test_env_var_changes.py
+++ b/tests/api_tests/v1/tests/application_tests/test_env_var_changes.py
@@ -24,6 +24,7 @@ from typing import Callable, Optional, List
 
 import math
 
+from tests.api_tests.v1.tests.marqo_test import TestImageUrls
 from tests import marqo_test
 from tests import utilities
 
@@ -83,7 +84,7 @@ class TestEnvVarChanges(marqo_test.MarqoTestCase):
         """
 
         # Restart marqo with new max values
-        new_models = ["hf/e5-large-v2"]
+        new_models = ["open_clip/ViT-H-14/laion2b_s32b_b79k"]
         index_name = "test_multiple_env_vars"
         utilities.rerun_marqo_with_env_vars(
             env_vars=[
@@ -111,10 +112,12 @@ class TestEnvVarChanges(marqo_test.MarqoTestCase):
         telemetry_client = Client(**self.client_settings, return_telemetry=True)
 
         min_inference_time_ms = 8      # inference usually takes at least 8ms
-        cache_reading_time_ms = 2      # if it hits cache, it's usually less than 2ms
+        cache_reading_time_ms = 3      # if it hits cache, the pipeline should take less than 3ms
 
         # Test search query's embedding is cached when inference cache is enabled
-        for query in ["test", {"random": 1, "query": 2}]:
+        base64_image = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
+        image_url = TestImageUrls.HIPPO_STATUE.value
+        for query in ["test", {"random": 1, "query": 2}, base64_image]:
             with self.subTest(f"Search query: {query}"):
                 # Single query
                 # First search that misses cache should take longer
@@ -129,7 +132,13 @@ class TestEnvVarChanges(marqo_test.MarqoTestCase):
                 inference_latency = self._run_in_threads(
                     lambda client: client.index(index_name).search(q=query),
                     max_workers=1, count=10, telemetry_name="search.vector_inference_full_pipeline")
-                self.assertTrue(sum(inference_latency) / 10 < cache_reading_time_ms, inference_latency)
+
+                if query == image_url:
+                    # image url is not cached, so avg latency will usually be > min_inference_time_ms
+                    self.assertTrue(sum(inference_latency) / 10 > min_inference_time_ms, inference_latency)
+                else:
+                    # other queries are all cached, so avg latency should be < cache_reading_time_ms
+                    self.assertTrue(sum(inference_latency) / 10 < cache_reading_time_ms, inference_latency)
 
         # Test to ensure inference cache is not working for add_documents:
         with self.subTest("Add document"):

--- a/tests/api_tests/v1/tests/application_tests/test_env_var_changes.py
+++ b/tests/api_tests/v1/tests/application_tests/test_env_var_changes.py
@@ -79,7 +79,7 @@ class TestEnvVarChanges(marqo_test.MarqoTestCase):
         """
 
         # Restart marqo with new max values
-        new_models = ["open_clip/ViT-B-32/laion2B-s34B-b79K"]
+        new_models = ["open_clip/ViT-B-32/laion2b_s34b_b79k"]
         index_name = "test_multiple_env_vars"
         utilities.rerun_marqo_with_env_vars(
             env_vars=[

--- a/tests/integ_tests/inference/inference_cache/test_inference_cache.py
+++ b/tests/integ_tests/inference/inference_cache/test_inference_cache.py
@@ -13,7 +13,7 @@ from opentelemetry.test.globals_test import reset_metrics_globals
 from orjson import orjson
 
 from marqo.core.inference.api import InferenceRequest, Modality, ModelConfig, TextPreprocessingConfig, Inference, \
-    InferenceResult, InferenceErrorModel
+    InferenceResult, InferenceErrorModel, ImagePreprocessingConfig
 from marqo.inference.inference_cache.caching_inference import CachingInference
 
 
@@ -198,6 +198,82 @@ class TestInferenceCache(unittest.TestCase):
                 self._assert_metric_value(reader.get_metrics_data(), 'cache_size_curr', 4)  # error result not cached
 
                 provider.shutdown()
+
+    def test_base64_image_selective_caching(self):
+        """Test selective caching: base64 images cached, URL images processed normally."""
+        caching_inference = CachingInference(self.inference_local, 10, "LRU")
+
+        base64_png = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
+        base64_jpeg = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/"
+        url_image = "https://example.com/image.jpg"
+
+        # Mixed request: 2 base64 images + 1 URL
+        mixed_request = InferenceRequest(
+            modality=Modality.IMAGE,
+            contents=[base64_png, url_image, base64_jpeg],
+            model_config=ModelConfig(
+                model_name="test/clip-model",
+                model_properties={
+                    "name": "test-clip-model",
+                    "dimensions": 512,
+                    "type": "clip"
+                }
+            ),
+            preprocessing_config=ImagePreprocessingConfig(should_chunk=False),
+            use_inference_cache=True
+        )
+
+        # First call - base64 images should be cached, URL processed normally
+        result1 = caching_inference.vectorise(mixed_request)
+
+        # Verify cache contains blake3 keys for both base64 images
+        import blake3
+        model_key = caching_inference.model_cache_key(mixed_request.model_config.model_properties)
+
+        hash1 = blake3.blake3(base64_png.encode()).hexdigest()
+        hash2 = blake3.blake3(base64_jpeg.encode()).hexdigest()
+        cache_key1 = f"blake3:{hash1}"
+        cache_key2 = f"blake3:{hash2}"
+
+        cached_embedding1 = caching_inference.inference_cache.get(model_key, cache_key1)
+        cached_embedding2 = caching_inference.inference_cache.get(model_key, cache_key2)
+
+        self.assertIsNotNone(cached_embedding1, "First base64 image should be cached")
+        self.assertIsNotNone(cached_embedding2, "Second base64 image should be cached")
+
+        # Verify URL image is NOT cached
+        url_cached_embedding = caching_inference.inference_cache.get(model_key, url_image)
+        self.assertIsNone(url_cached_embedding, "URL image should not be cached")
+
+        # Verify cache size (only 2 base64 images cached)
+        self.assertEqual(caching_inference.inference_cache._cache.currsize, 2)
+
+        # Second call with same mixed content
+        result2 = caching_inference.vectorise(mixed_request)
+
+        # Base64 results should return original base64 content (not blake3 keys)
+        png_content1, png_embedding1 = result1.result[0][0]
+        png_content2, png_embedding2 = result2.result[0][0]
+
+        # Content should be original base64, embeddings should be identical (from cache)
+        self.assertEqual(png_content1, base64_png)
+        self.assertEqual(png_content2, base64_png)
+        self.assertTrue(np.array_equal(png_embedding1, png_embedding2))
+
+        jpeg_content1, jpeg_embedding1 = result1.result[2][0]
+        jpeg_content2, jpeg_embedding2 = result2.result[2][0]
+
+        # Content should be original base64, embeddings should be identical (from cache)
+        self.assertEqual(jpeg_content1, base64_jpeg)
+        self.assertEqual(jpeg_content2, base64_jpeg)
+        self.assertTrue(np.array_equal(jpeg_embedding1, jpeg_embedding2))
+
+        # URL results should be unchanged (original URL returned)
+        url_content1, url_embedding1 = result1.result[1][0]
+        url_content2, url_embedding2 = result2.result[1][0]
+        self.assertEqual(url_content1, url_image)  # Original URL unchanged
+        self.assertEqual(url_content2, url_image)  # Original URL unchanged
+        self.assertTrue(np.array_equal(url_embedding1, url_embedding2))
 
     def _assert_metric_value(self, metric_data: MetricsData, name: str, expected_value: Any):
         cache_metrics = metric_data.resource_metrics[0].scope_metrics[0].metrics

--- a/tests/unit_tests/marqo/inference/inference_cache/test_cache.py
+++ b/tests/unit_tests/marqo/inference/inference_cache/test_cache.py
@@ -1,17 +1,10 @@
-import random
-import time
 import unittest
-from concurrent.futures import ThreadPoolExecutor
-from queue import Queue
 
-import numpy as np
-
-from marqo.api.exceptions import EnvVarError
 from marqo.inference.inference_cache.marqo_lfu_cache import MarqoLFUCache
 from marqo.inference.inference_cache.marqo_lru_cache import MarqoLRUCache
 
 
-class TestLFUCache(unittest.TestCase):
+class TestCache(unittest.TestCase):
     """This class tests the LRU and LFU cache implementations."""
 
     def setUp(self):

--- a/tests/unit_tests/marqo/inference/inference_cache/test_caching_inference.py
+++ b/tests/unit_tests/marqo/inference/inference_cache/test_caching_inference.py
@@ -1,12 +1,12 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
+import blake3
 import numpy as np
 
 from marqo.core.inference.api import Inference, InferenceRequest, ModelConfig, TextPreprocessingConfig, TextChunkConfig, \
-    InferenceResult, InferenceErrorModel
+    InferenceResult, InferenceErrorModel, ImagePreprocessingConfig, Modality
 from marqo.inference.inference_cache.caching_inference import CachingInference
-from marqo.s2_inference.types import Modality
 
 
 class TestCachingInferenceModelCacheKey(TestCase):
@@ -62,9 +62,11 @@ class TestCachingInferenceShouldSkip(TestCase):
         req = self.base_request.copy(update={'device': 'cpu'})
         self.assertTrue(self.caching_inference.should_skip_cache(req))
 
-    def test_should_skip_when_non_text_modality(self):
-        req = self.base_request.copy(update={'modality': Modality.IMAGE})
-        self.assertTrue(self.caching_inference.should_skip_cache(req))
+    def test_should_skip_when_non_text_image_modality(self):
+        for modality in [Modality.VIDEO, Modality.AUDIO]:
+            with self.subTest(modality=modality):
+                req = self.base_request.copy(update={'modality': modality})
+                self.assertTrue(self.caching_inference.should_skip_cache(req))
 
     def test_should_skip_when_chunking_enabled(self):
         req = self.base_request.copy(update={'preprocessing_config': TextPreprocessingConfig(
@@ -72,8 +74,9 @@ class TestCachingInferenceShouldSkip(TestCase):
         self.assertTrue(self.caching_inference.should_skip_cache(req))
 
     def test_should_not_skip_when_all_condition_clear(self):
-        req = self.base_request
-        self.assertFalse(self.caching_inference.should_skip_cache(req))
+        for modality in [Modality.TEXT, Modality.IMAGE]:
+            req = self.base_request.copy(update={'modality': modality})
+            self.assertFalse(self.caching_inference.should_skip_cache(req))
 
 
 class TestCachingInferenceVectorise(TestCase):
@@ -186,3 +189,114 @@ class TestCachingInferenceVectorise(TestCase):
         with self.assertRaises(RuntimeError) as ctx:
             self.ci.vectorise(req)
         self.assertIn('does not support chunking', str(ctx.exception))
+
+
+class TestCachingInferenceBase64Images(TestCase):
+    def setUp(self):
+        self.mock_delegate = Mock(spec=Inference)
+        self.caching_inference = CachingInference(delegate=self.mock_delegate, cache_size=10, cache_type='LRU')
+        # Replace cache with a mock for better control
+        self.caching_inference.inference_cache = Mock()
+        # Stub model_cache_key to a fixed key
+        self.caching_inference.model_cache_key = Mock(return_value='fixed-key')
+
+        self.base64_png = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=='
+        self.base64_jpeg = 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/'
+        self.url_image = 'https://example.com/image.jpg'
+
+        # Base64 image request template
+        self.base_request = InferenceRequest(
+            contents=[self.base64_png],
+            model_config=Mock(spec=ModelConfig),
+            use_inference_cache=True,
+            device=None,
+            modality=Modality.IMAGE,
+            preprocessing_config=ImagePreprocessingConfig(should_chunk=False)
+        )
+
+    def test_vectorise_caches_base64_images_only(self):
+        """Test that only base64 images are cached, URLs are processed normally."""
+        # Cache miss for base64, no cache check for URL
+        self.caching_inference.inference_cache.get.return_value = None
+        
+        # Mock delegate response
+        embedding1 = np.array([1.0, 2.0])
+        embedding2 = np.array([3.0, 4.0])
+        delegate_result = InferenceResult(result=[[(self.base64_png, embedding1)], [(self.url_image, embedding2)]])
+        self.mock_delegate.vectorise.return_value = delegate_result
+        
+        mixed_req = self.base_request.copy(update={'contents': [self.base64_png, self.url_image]})
+        result = self.caching_inference.vectorise(mixed_req)
+        
+        # Verify cache operations
+        expected_hash = blake3.blake3(self.base64_png.encode()).hexdigest()
+        expected_cache_key = f"blake3:{expected_hash}"
+        model_key = 'fixed-key'  # Mocked in setUp
+        
+        # Should check cache only for base64 image
+        self.caching_inference.inference_cache.get.assert_called_once_with(model_key, expected_cache_key)
+        
+        # Should cache only base64 image
+        self.caching_inference.inference_cache.set.assert_called_once_with(model_key, expected_cache_key, embedding1)
+        
+        # Delegate should be called with both contents
+        called_request = self.mock_delegate.vectorise.call_args[0][0]
+        self.assertEqual(called_request.contents, [self.base64_png, self.url_image])
+        
+        # Result should contain original base64 content and URL
+        self.assertEqual(result.result[0][0], (self.base64_png, embedding1))  # Original base64 returned
+        self.assertEqual(result.result[1][0], (self.url_image, embedding2))  # URL unchanged
+
+    def test_vectorise_mixed_cache_hits_and_misses(self):
+        """Test mixed scenario: base64 cache hit, URL processed normally."""
+        # Cache hit for base64
+        cached_embedding = np.array([1.0, 2.0])
+        self.caching_inference.inference_cache.get.return_value = cached_embedding
+        
+        # Mock delegate response for URL only
+        url_embedding = np.array([3.0, 4.0])
+        delegate_result = InferenceResult(result=[[(self.url_image, url_embedding)]])
+        self.mock_delegate.vectorise.return_value = delegate_result
+        
+        mixed_req = self.base_request.copy(update={'contents': [self.base64_png, self.url_image]})
+        result = self.caching_inference.vectorise(mixed_req)
+        
+        # Should call delegate with only URL (base64 was cached)
+        called_request = self.mock_delegate.vectorise.call_args[0][0]
+        self.assertEqual(called_request.contents, [self.url_image])
+        
+        # Should not cache URL image
+        self.caching_inference.inference_cache.set.assert_not_called()
+        
+        # Final result should have original base64 for base64, original URL for URL image
+        self.assertEqual(result.result, [[(self.base64_png, cached_embedding)], [(self.url_image, url_embedding)]])
+
+    def test_vectorise_multiple_base64_images(self):
+        """Test that multiple base64 images are all cached."""
+        # Cache miss for both
+        self.caching_inference.inference_cache.get.return_value = None
+        
+        # Mock delegate response
+        embedding1 = np.array([1.0, 2.0])
+        embedding2 = np.array([3.0, 4.0])
+        delegate_result = InferenceResult(result=[[(self.base64_png, embedding1)], [(self.base64_jpeg, embedding2)]])
+        self.mock_delegate.vectorise.return_value = delegate_result
+        
+        multi_base64_req = self.base_request.copy(update={'contents': [self.base64_png, self.base64_jpeg]})
+        result = self.caching_inference.vectorise(multi_base64_req)
+        
+        # Should cache both images
+        expected_hash1 = blake3.blake3(self.base64_png.encode()).hexdigest()
+        expected_hash2 = blake3.blake3(self.base64_jpeg.encode()).hexdigest()
+        expected_key1 = f"blake3:{expected_hash1}"
+        expected_key2 = f"blake3:{expected_hash2}"
+        model_key = 'fixed-key'
+        
+        self.assertEqual(self.caching_inference.inference_cache.set.call_count, 2)
+        set_calls = self.caching_inference.inference_cache.set.call_args_list
+        self.assertIn(((model_key, expected_key1, embedding1),), set_calls)
+        self.assertIn(((model_key, expected_key2, embedding2),), set_calls)
+        
+        # Results should contain original base64 content
+        self.assertEqual(result.result[0][0], (self.base64_png, embedding1))  # Original PNG base64
+        self.assertEqual(result.result[1][0], (self.base64_jpeg, embedding2))  # Original JPEG base64


### PR DESCRIPTION
## Change Summary
The queries for the base64 search in image are from a fixed set of possible patches so it should be very cache friendly.  In this PR, we provide a solution to cache the embeddings of a base64 encoded image. We use the [BLAKE3](https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE3) hash function to generate a hash based on the encoded image, to be used as the key of the cached item. Collisions are unlikely. we tradeoff memory space with some extra CPU time. 

## Related Jira Ticket
https://s2search.atlassian.net/browse/MOSD-443

## Checklist
<!-- Check items that apply, add items if needed -->
- [x] Tests have been added for changes
- [N/A] Documentation has been updated
- [N/A] Breaking changes are clearly identified
- [N/A] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

