### PR TITLE
[Releases/2.22] Add new parameters for context documents and ease queryTensor restriction

### DIFF
--- a/src/marqo/api/models/recommend_query.py
+++ b/src/marqo/api/models/recommend_query.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Union, Optional
 
 from marqo.core.models.interpolation_method import InterpolationMethod
 from marqo.tensor_search.models.api_models import BaseMarqoModel
-from pydantic.v1 import root_validator
+from pydantic.v1 import root_validator, Field
 from marqo.tensor_search.models.score_modifiers_object import ScoreModifierLists
 
 
@@ -22,6 +22,8 @@ class RecommendQuery(BaseMarqoModel):
     attributesToRetrieve: Union[None, List[str]] = None
     scoreModifiers: Optional[ScoreModifierLists] = None
     rerankDepth: Optional[int] = None
+    allow_missing_documents: bool = Field(default=False, alias="allowMissingDocuments")
+    allow_missing_embeddings: bool = Field(default=False, alias="allowMissingEmbeddings")
 
     @root_validator(pre=False)
     def validate_rerank_depth(cls, values):

--- a/src/marqo/core/models/hybrid_parameters.py
+++ b/src/marqo/core/models/hybrid_parameters.py
@@ -99,14 +99,6 @@ class HybridParameters(StrictBaseModel):
             if values.get('rankingMethod') not in [RankingMethod.Lexical, RankingMethod.Tensor]:
                 raise ValueError("For retrievalMethod: tensor or lexical, rankingMethod must be: tensor or lexical")
 
-        # if tensor query is an empty dict
-        if isinstance(values.get('queryTensor'), dict):
-            if not len(values.get('queryTensor')):
-                raise ValueError(
-                    "Multi-term query for queryTensor requires at least one query. Received empty dictionary"
-                )
-
-
         return values
 
     @validator('alpha')

--- a/src/marqo/core/search/hybrid_search.py
+++ b/src/marqo/core/search/hybrid_search.py
@@ -198,10 +198,11 @@ class HybridSearch:
             tensor_query = query
             lexical_query = query
 
-        if (tensor_query is None) != (lexical_query is None):
+        if lexical_query is None:
+            # We could allow queryTensor to be None as tensors might be provided with context
             if hybrid_parameters.retrievalMethod == RetrievalMethod.Disjunction:
                 raise core_exceptions.InvalidArgumentError(
-                    "Either both of 'hybridParameters.queryLexical' and 'hybridParameters.queryTensor' or just 'q'"
+                    "Either 'hybridParameters.queryLexical' or just 'q'"
                     "must be present when 'disjunction' retrieval method is used."
                 )
 

--- a/src/marqo/core/search/recommender.py
+++ b/src/marqo/core/search/recommender.py
@@ -95,6 +95,7 @@ class Recommender:
                                                     f'Available tensor fields: {", ".join(valid_tensor_fields)}')
 
         # Use the new optimized method to get only embeddings
+        # TODO - Consolidate these two method into one place
         doc_embeddings_by_field = tensor_search.get_doc_vectors_per_tensor_field_by_ids(
             config.Config(self.vespa_client, inference=self.inference),
             index_name, 

--- a/src/marqo/core/search/recommender.py
+++ b/src/marqo/core/search/recommender.py
@@ -46,6 +46,11 @@ class Recommender:
         Returns:
             A dictionary mapping document IDs to lists of vector embeddings. This is flattened to 1 list per document
                 ID (not separated by tensor field). Order of embeddings is not guaranteed.
+
+        Raises:
+            InvalidArgumentError:
+                - If any document IDs are not found and allow_missing_documents is False
+                - If any document IDs does not have embeddings and allow_missing_embeddings is False
         """
 
         # TODO - Extract search and get_docs from tensor_search and refactor this
@@ -207,7 +212,9 @@ class Recommender:
                   filter: str = None,
                   attributes_to_retrieve: Optional[List[str]] = None,
                   score_modifiers: Optional[ScoreModifierLists] = None,
-                  rerank_depth: Optional[int] = None
+                  rerank_depth: Optional[int] = None,
+                  allow_missing_documents: bool = False,
+                  allow_missing_embeddings: bool = False,
                   ):
         """
         Recommend documents similar to the provided documents.
@@ -248,7 +255,9 @@ class Recommender:
         doc_vectors = self.get_doc_vectors_from_ids(
             index_name=index_name,
             documents=documents,
-            tensor_fields=tensor_fields
+            tensor_fields=tensor_fields,
+            allow_missing_documents=allow_missing_documents,
+            allow_missing_embeddings=allow_missing_embeddings,
         )
 
         # Save original document IDs for filtering
@@ -265,8 +274,15 @@ class Recommender:
                 weight = documents[document_id]
             else:
                 weight = 1
+
             vectors.extend(vector_list)
             weights.extend([weight] * len(vector_list))
+
+        if len(vectors) == 0:
+            raise InvalidArgumentError(
+                "Marqo could not collect any valid vector from the documents. "
+                "Please check if the provided documents exist or if the documents have valid embeddings. "
+            )
 
         try:
             interpolated_vector = vector_interpolation.interpolate(
@@ -310,7 +326,7 @@ class Recommender:
             attributes_to_retrieve=attributes_to_retrieve,
             score_modifiers=score_modifiers,
             processing_start=t0,
-            rerank_depth=rerank_depth
+            rerank_depth=rerank_depth,
         )
 
         return results

--- a/src/marqo/core/search/recommender.py
+++ b/src/marqo/core/search/recommender.py
@@ -23,10 +23,14 @@ class Recommender:
         self.index_management = index_management
         self.inference = inference
 
-    def get_doc_vectors_from_ids(self,
-                  index_name: str,
-                  documents: Union[List[str], Dict[str, float]],
-                  tensor_fields: Optional[List[str]] = None) -> Dict[str, List[List[float]]]:
+    def get_doc_vectors_from_ids(
+            self,
+            index_name: str,
+            documents: Union[List[str], Dict[str, float]],
+            tensor_fields: Optional[List[str]] = None,
+            allow_missing_documents: bool = False,
+            allow_missing_embeddings: bool = False
+    ) -> Dict[str, List[List[float]]]:
         """
         This method gets documents from Vespa using their IDs, removes any unnecessary data, checks for
         lack of vectors, then returns a list of document vectors. Can be used internally (in recommend)
@@ -36,6 +40,8 @@ class Recommender:
             index_name: Name of the index to search
             documents: A list of document IDs or a dictionary where the keys are document IDs and the values are weights
             tensor_fields: List of tensor fields to use for recommendation (can include text, image, audio, and video fields)
+            allow_missing_documents: If True, will not raise an error if some document IDs are not found
+            allow_missing_embeddings: If True, will not raise an error if some documents do not have embeddings
 
         Returns:
             A dictionary mapping document IDs to lists of vector embeddings. This is flattened to 1 list per document
@@ -88,50 +94,101 @@ class Recommender:
             config.Config(self.vespa_client, inference=self.inference),
             index_name, 
             document_ids, 
-            tensor_fields=tensor_fields
+            tensor_fields=tensor_fields,
+            allow_missing_documents=allow_missing_documents,
         )
 
-        # Check that all documents were found
-        not_found = []
-        for doc_id in document_ids:
-            if doc_id not in doc_embeddings_by_field:
-                not_found.append(doc_id)
+        return self._sanitize_doc_embeddins_by_field(
+            all_documents_ids = document_ids,
+            marqo_index=marqo_index,
+            doc_embeddings_by_field=doc_embeddings_by_field,
+            tensor_fields=tensor_fields,
+            allow_missing_documents=allow_missing_documents,
+            allow_missing_embeddings=allow_missing_embeddings,
+        )
 
-        if len(not_found) > 0:
-            raise InvalidArgumentError(f'The following document IDs were not found: {", ".join(not_found)}')
+    def _sanitize_doc_embeddins_by_field(
+            self,
+            all_documents_ids: List[str],
+            marqo_index: MarqoIndex,
+            doc_embeddings_by_field: Dict[str, Dict[str, List[List[float]]]],
+            tensor_fields: Optional[List[str]],
+            allow_missing_documents: bool,
+            allow_missing_embeddings: bool
+    ) -> Dict[str, List[List[float]]]:
+        """
+        Sanitize the document embeddings by checking for missing documents and embeddings,
+        and flattening the structure to a simple mapping of document ID to list of embeddings.
+
+        If allow_missing_documents is False, raises an error if any document IDs are not found.
+        If allow_missing_embeddings is False, raises an error if any documents do not have embeddings.
+
+        Documents with no embeddings are removed from the result.
+        Args:
+            all_documents_ids: The list of all document IDs that were requested
+            marqo_index: The marqo index object containing metadata about the index
+            doc_embeddings_by_field: The document embeddings by field returned from
+                tensor_search.get_doc_vectors_per_tensor_field_by_ids
+            tensor_fields: tensor fields to include in the result. If None, all fields are included.
+            allow_missing_documents: If True, will not raise an error if some document IDs are not found.
+            allow_missing_embeddings: If True, will not raise an error if some documents do not have embeddings.
+
+        Returns:
+            A dictionary mapping document IDs to lists of vector embeddings.
+            E.g.,
+            {
+                "doc1": [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]],
+                "doc2": [[0.7, 0.8, 0.9]]
+            }
+            where each list contains embeddings from all tensor fields where order of embeddings is not preserved.
+
+        Raises:
+            InvalidArgumentError: If any document IDs are not found and allow_missing_documents is False,
+                                  or if any documents do not have embeddings and allow_missing_embeddings is False.
+        """
+
+        # Check that all documents were found
+        not_found_docs = []
+        for doc_id in all_documents_ids:
+            if doc_id not in doc_embeddings_by_field:
+                not_found_docs.append(doc_id)
+
+        if len(not_found_docs) > 0 and not allow_missing_documents:
+            raise InvalidArgumentError(f'The following document IDs were not found: {", ".join(not_found_docs)}')
 
         # Flatten the embeddings structure to match the expected return format
-        # Convert from Dict[doc_id, Dict[field_name, List[List[float]]]] 
+        # Convert from Dict[doc_id, Dict[field_name, List[List[float]]]]
         # to Dict[doc_id, List[List[float]]]
         doc_vectors: Dict[str, List[List[float]]] = {}
         docs_without_vectors = []
-        
+
         for doc_id, field_embeddings in doc_embeddings_by_field.items():
             vectors: List[List[float]] = []
-            
+
             # Flatten all embeddings from all fields for this document
             for field_name, embedding_list in field_embeddings.items():
                 # For legacy unstructured indices, field_name will be "marqo__embeddings"
                 # and we should include all embeddings regardless of tensor_fields filter
                 # since all embeddings are stored together in marqo__embeddings
-                if (tensor_fields is None or 
+                if (tensor_fields is None or
                     field_name in tensor_fields or
                     (marqo_index.type == IndexType.Unstructured and
                      field_name == unstructured_common.VESPA_DOC_EMBEDDINGS)):
                     vectors.extend(embedding_list)
-            
+
             doc_vectors[doc_id] = vectors
 
             if len(vectors) == 0:
                 docs_without_vectors.append(doc_id)
 
-        if len(docs_without_vectors) > 0:
+
+        if len(docs_without_vectors) > 0 and not allow_missing_embeddings:
             raise InvalidArgumentError(
                 f'The following documents do not have embeddings: {", ".join(docs_without_vectors)}'
             )
-
+        for doc_id in docs_without_vectors:
+            del doc_vectors[doc_id]
         return doc_vectors
-
 
     def recommend(self,
                   index_name: str,

--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -479,7 +479,9 @@ def recommend(query_dict: dict, index_name: str,
             filter=query.filter,
             attributes_to_retrieve=query.attributesToRetrieve,
             score_modifiers=query.scoreModifiers,
-            rerank_depth=query.rerankDepth
+            rerank_depth=query.rerankDepth,
+            allow_missing_documents=query.allow_missing_documents,
+            allow_missing_embeddings=query.allow_missing_embeddings,
         )
 
 

--- a/src/marqo/tensor_search/models/search.py
+++ b/src/marqo/tensor_search/models/search.py
@@ -69,6 +69,8 @@ class SearchContextTensor(BaseModel):
 class SearchContextDocumentsParameters(BaseModel):
     tensor_fields: Optional[List[str]] = Field(None, alias='tensorFields')
     exclude_input_documents: bool = Field(True, alias='excludeInputDocuments')
+    allow_missing_documents: bool = Field(False, alias='allowMissingDocuments')
+    allow_missing_embeddings: bool = Field(False, alias='allowMissingEmbeddings')
 
     @validator('tensor_fields', pre=True, always=True)
     def check_tensor_fields_not_empty(cls, v):

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -970,13 +970,14 @@ def get_query_vectors_from_jobs(
             # Use interpolation to combine all vectors
             vector_interpolation = from_interpolation_method(interpolation_method)
             with RequestMetricsStore.for_request().time(f"search.vectorise.interpolate_vectors"):
-                merged_vector = vector_interpolation.interpolate(
-                    vectors=collected_vectors,
-                    weights=collected_weights
-                )
-
-            result[qidx] = list(merged_vector)
-
+                if collected_vectors:
+                    merged_vector = vector_interpolation.interpolate(
+                        vectors=collected_vectors,
+                        weights=collected_weights
+                    )
+                    result[qidx] = list(merged_vector)
+                else:
+                    result[qidx] = []
         elif isinstance(q.q, str):
             if q.context:
                 raise core_exceptions.InvalidArgumentError(
@@ -990,6 +991,13 @@ def get_query_vectors_from_jobs(
             )
         else:
             raise ValueError(f"Unexpected query type: {type(q.q).__name__}")
+
+        if not result[qidx]:
+            raise api_exceptions.InvalidArgError(
+                f"Marqo could not collect any vectors from the search query '{q.q}'. "
+                f"Please check the provided query and context (if any). "
+            )
+
     return result
 
 
@@ -1366,7 +1374,6 @@ def get_doc_vectors_per_tensor_field_by_ids(
         document_ids: List of document IDs to fetch
         tensor_fields: Specific tensor fields to get. If None, get all tensor fields.
         allow_missing_documents: If True, will not raise an error if a document is not found
-        allow_missing_embeddings: If True, will not raise an error if an embedding field is not found
     
     Returns:
         Dict mapping document_id to field_name to list of embedding vectors
@@ -1430,10 +1437,10 @@ def get_doc_vectors_per_tensor_field_by_ids(
                 else:
                     # Otherwise, field is empty list
                     result[doc_id][marqo_tensor_field_name] = []
-        else:
-            if response.status == 404 and allow_missing_documents:
+        elif response.status == 404 and allow_missing_documents:
                 # If the document is not found and we are allowing missing documents, continue to next response
                 continue
+        else:
             # If the response is not successful, error out
             raise core_exceptions.InvalidArgumentError(
                 f"Failed to retrieve document {document_ids[res_idx]} from index {index_name}. "

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -887,7 +887,7 @@ def get_query_vectors_from_jobs(
 ) -> Dict[Qidx, List[float]]:
     """
     Retrieve the vectorised content associated to each query from the set of batch vectorise jobs.
-    Handles multi-modal queries, by weighting and combining queries into a single vector
+    Handles multi-modal queries, by weighting and combining queries into a single vector.
 
     Args:
         - queries: Original search queries.
@@ -895,6 +895,8 @@ def get_query_vectors_from_jobs(
         - job_to_vectors: inference output from each VectorisedJob
         - config: standard Marqo config.
 
+    Raises:
+        api_exceptions.InvalidArgError: If this method can not collect a valid vector from the query
     """
     result: Dict[Qidx, List[float]] = defaultdict(list)
     for qidx, ptrs in qidx_to_job.items():
@@ -994,7 +996,8 @@ def get_query_vectors_from_jobs(
 
         if not result[qidx]:
             raise api_exceptions.InvalidArgError(
-                f"Marqo could not collect any vectors from the search query '{q.q}'. "
+                f"Marqo could not collect any vectors from the search query but the retrieval or ranking method requires "
+                f"at least one valid vector. "
                 f"Please check the provided query and context (if any). "
             )
 
@@ -1079,7 +1082,7 @@ def add_prefix_to_queries(queries: List[BulkSearchQueryEntity]) -> List[BulkSear
 def run_vectorise_pipeline(config: Config, queries: List[BulkSearchQueryEntity], device: Union[Device, str],
                            interpolation_method: InterpolationMethod = None) -> Dict[
     Qidx, List[float]]:
-    """Run the query vectorisation process
+    """Run the query vectorisation process. This is a pipeline used for both Tensor search and Hybrid search.
 
     Raise:
         api_exceptions.InvalidArgError: If the vectorisation process fails or if the media cannot be downloaded.

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -943,7 +943,9 @@ def get_query_vectors_from_jobs(
                                             context_doc_vectors = config.recommender.get_doc_vectors_from_ids(
                             index_name=q.index.name,
                             documents=context_documents.ids,
-                            tensor_fields=context_documents.parameters.tensor_fields
+                            tensor_fields=context_documents.parameters.tensor_fields,
+                            allow_missing_documents=context_documents.parameters.allow_missing_documents,
+                            allow_missing_embeddings= context_documents.parameters.allow_missing_embeddings
                         )
 
                 # Update weights and vectors list
@@ -1353,6 +1355,7 @@ def get_doc_vectors_per_tensor_field_by_ids(
     index_name: str, 
     document_ids: List[str],
     tensor_fields: Optional[List[str]] = None,
+    allow_missing_documents: bool = False,
 ) -> Dict[str, Dict[str, List[List[float]]]]:
     """
     Get only the embeddings for documents by their IDs.
@@ -1362,9 +1365,19 @@ def get_doc_vectors_per_tensor_field_by_ids(
         index_name: Name of the index
         document_ids: List of document IDs to fetch
         tensor_fields: Specific tensor fields to get. If None, get all tensor fields.
+        allow_missing_documents: If True, will not raise an error if a document is not found
+        allow_missing_embeddings: If True, will not raise an error if an embedding field is not found
     
     Returns:
         Dict mapping document_id to field_name to list of embedding vectors
+        E.g.,
+        {
+            "doc_id_1": {
+                "field_name_1": [[0.1, 0.2, ...], ...],
+                "field_name_2": [[0.3, 0.4, ...], ...],
+            },
+            "doc_id_2": {"field_name_1": [[0.5, 0.6, ...], ...]}
+         }
     """
 
     # We can just use the cache here since we refresh every 1s.
@@ -1418,6 +1431,9 @@ def get_doc_vectors_per_tensor_field_by_ids(
                     # Otherwise, field is empty list
                     result[doc_id][marqo_tensor_field_name] = []
         else:
+            if response.status == 404 and allow_missing_documents:
+                # If the document is not found and we are allowing missing documents, continue to next response
+                continue
             # If the response is not successful, error out
             raise core_exceptions.InvalidArgumentError(
                 f"Failed to retrieve document {document_ids[res_idx]} from index {index_name}. "

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -1198,6 +1198,9 @@ def _vector_text_search(
         qidx_to_vectors: Dict[Qidx, List[float]] = run_vectorise_pipeline(config, queries, device, interpolation_method)
     vectorised_text = list(qidx_to_vectors.values())[0]
 
+    if not vectorised_text: # pragma: no cover
+        raise InternalError(f"No vector is generated for the tensor query: {query}. ")
+
     marqo_query = MarqoTensorQuery(
         index_name=index_name,
         vector_query=vectorised_text,

--- a/src/marqo/tensor_search/tensor_search.py
+++ b/src/marqo/tensor_search/tensor_search.py
@@ -998,7 +998,7 @@ def get_query_vectors_from_jobs(
             raise api_exceptions.InvalidArgError(
                 f"Marqo could not collect any vectors from the search query but the retrieval or ranking method requires "
                 f"at least one valid vector. "
-                f"Please check the provided query and context (if any). "
+                f"Please check the provided query, context (if any), or queryTensor(for Hybrid search) "
             )
 
     return result

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.22.1"
+__version__ = "2.22.2"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/tests/api_tests/v1/tests/api_tests/test_recommend.py
+++ b/tests/api_tests/v1/tests/api_tests/test_recommend.py
@@ -272,3 +272,152 @@ class TestRecommend(MarqoTestCase):
                         self.client.index(index_name).recommend(
                             documents=["doc_0", "doc_1"], limit=10, offset=0, rerank_depth=-1
                         )
+
+    def test_recommend_allow_missing_documents_true(self):
+        """Test recommend with allow_missing_documents=True allows missing documents"""
+        docs = [
+            {
+                "_id": "1",
+                "title": "Red orchid",
+                "tags": ["flower", "orchid"],
+            },
+            {
+                "_id": "2", 
+                "title": "Red rose",
+                "tags": ["flower"],
+            },
+            {
+                "_id": "3",
+                "title": "Europe",
+                "tags": ["continent"],
+            },
+        ]
+
+        for index_name in [self.structured_index_name, self.unstructured_index_name]:
+            with self.subTest(index_name):
+                tensor_fields = ["title"] if index_name == self.unstructured_index_name else None
+                add_docs_results = self.client.index(index_name).add_documents(docs, tensor_fields=tensor_fields)
+
+                if add_docs_results["errors"]:
+                    raise Exception(f"Failed to add documents to index {index_name}")
+
+                # Should succeed even with missing document "missing_doc"
+                res = self.client.index(index_name).recommend(
+                    documents=['1', '2', 'missing_doc'],
+                    allow_missing_documents=True
+                )
+                
+                # Should return results based on available documents
+                ids = [doc["_id"] for doc in res["hits"]]
+                self.assertEqual(set(ids), {"3"})
+
+    def test_recommend_allow_missing_embeddings_true(self):
+        """Test recommend with allow_missing_embeddings=True allows documents without embeddings"""
+        docs = [
+            {
+                "_id": "1",
+                "title": "Red orchid",
+                "tags": ["flower", "orchid"],
+            },
+            {
+                "_id": "2",
+                "title": "Red rose", 
+                "tags": ["flower"],
+                "content": "test"
+            },
+            {
+                "_id": "3",
+                "title": "Europe",
+                "tags": ["continent"],
+            },
+        ]
+
+        for index_name in [self.structured_index_name, self.unstructured_index_name]:
+            with self.subTest(index_name):
+                # For structured: use content field but only doc 2 has content (docs 1,3 lack embeddings)
+                # For unstructured: use content field but only doc 2 has content
+                tensor_fields = ["content"] if index_name == self.unstructured_index_name else None
+                add_docs_results = self.client.index(index_name).add_documents(docs, tensor_fields=tensor_fields)
+
+                if add_docs_results["errors"]:
+                    raise Exception(f"Failed to add documents to index {index_name}")
+
+                # Should succeed even when documents 1 and 3 lack embeddings for content field
+                res = self.client.index(index_name).recommend(
+                    documents=['1', '2', '3'],
+                    tensor_fields=["content"],
+                    allow_missing_embeddings=True
+                )
+
+    def test_recommend_allow_missing_both_true(self):
+        """Test recommend with both allow_missing_documents=True and allow_missing_embeddings=True"""
+        docs = [
+            {
+                "_id": "1",
+                "title": "Red orchid",
+                "tags": ["flower", "orchid"],
+            },
+            {
+                "_id": "2",
+                "title": "Red rose",
+                "tags": ["flower"],
+                "content": "test"
+            },
+            {
+                "_id": "3", 
+                "title": "Europe",
+                "tags": ["continent"],
+            },
+        ]
+
+        for index_name in [self.structured_index_name, self.unstructured_index_name]:
+            with self.subTest(index_name):
+                tensor_fields = ["content"] if index_name == self.unstructured_index_name else None
+                add_docs_results = self.client.index(index_name).add_documents(docs, tensor_fields=tensor_fields)
+
+                if add_docs_results["errors"]:
+                    raise Exception(f"Failed to add documents to index {index_name}")
+
+                # Should succeed with both missing documents and missing embeddings
+                res = self.client.index(index_name).recommend(
+                    documents=['1', '2', '3', 'missing_doc'],
+                    tensor_fields=["content"],
+                    allow_missing_documents=True,
+                    allow_missing_embeddings=True
+                )
+
+    def test_recommend_failed_to_collect_vectors_error(self):
+        """Test recommend raises error when no valid vectors available and allow_missing_embeddings=False"""
+        docs = [
+            {
+                "_id": "1",
+                "title": "Red orchid",
+                "tags": ["flower", "orchid"],
+            },
+            {
+                "_id": "2",
+                "title": "Red rose",
+                "tags": ["flower"],
+            },
+            {
+                "_id": "3",
+                "content": "test",
+            }
+        ]
+
+        for index_name in [self.structured_index_name, self.unstructured_index_name]:
+            with self.subTest(index_name):
+                tensor_fields = ["content"] if index_name == self.unstructured_index_name else None
+                add_docs_results = self.client.index(index_name).add_documents(docs, tensor_fields=tensor_fields)
+
+                if add_docs_results["errors"]:
+                    raise Exception(f"Failed to add documents to index {index_name}")
+
+                # Should fail when all documents lack embeddings and allow_missing_embeddings=False
+                with self.assertRaises(MarqoWebError) as e:
+                    self.client.index(index_name).recommend(
+                        documents=['1', '2'],
+                        tensor_fields=["content"],  # Documents don't have content embeddings
+                        allow_missing_embeddings=True
+                    )
+                self.assertIn("Marqo could not collect any valid vector from the documents.", str(e.exception))

--- a/tests/api_tests/v1/tests/api_tests/test_recommend.py
+++ b/tests/api_tests/v1/tests/api_tests/test_recommend.py
@@ -413,7 +413,7 @@ class TestRecommend(MarqoTestCase):
                 if add_docs_results["errors"]:
                     raise Exception(f"Failed to add documents to index {index_name}")
 
-                # Should fail when all documents lack embeddings and allow_missing_embeddings=False
+                # Should fail when all documents lack embeddings and allow_missing_embeddings=True
                 with self.assertRaises(MarqoWebError) as e:
                     self.client.index(index_name).recommend(
                         documents=['1', '2'],

--- a/tests/api_tests/v1/tests/api_tests/test_search_common.py
+++ b/tests/api_tests/v1/tests/api_tests/test_search_common.py
@@ -809,3 +809,213 @@ class TestSearchCommon(MarqoTestCase):
                     self.assertIsNotNone(result)
                     self.assertIn("hits", result)
 
+    def test_search_context_allow_missing_documents_true(self):
+        """Test search with context and allow_missing_documents=True allows missing context documents"""
+        docs = [
+            {
+                "_id": "1",
+                "title": "Red orchid",
+                "content": "flower content",
+            },
+            {
+                "_id": "2", 
+                "title": "Red rose",
+                "content": "flower content",
+            },
+            {
+                "_id": "3",
+                "title": "Europe",
+                "content": "continent content",
+            },
+        ]
+
+        for index_name in [self.structured_text_index_name, self.unstructured_text_index_name]:
+            for search_method in ["TENSOR", "HYBRID"]:
+                hybrid_parameters = {"retrievalMethod": "tensor", "rankingMethod": "tensor"} \
+                    if search_method == "HYBRID" else None
+                with self.subTest(f"index_name={index_name}, search_method={search_method}"):
+                    tensor_fields = ["title", "content"] if index_name == self.unstructured_text_index_name else None
+                    add_docs_results = self.client.index(index_name).add_documents(docs, tensor_fields=tensor_fields)
+
+                    if add_docs_results["errors"]:
+                        raise Exception(f"Failed to add documents to index {index_name}")
+
+                    # Should succeed even with missing context document "missing_doc"
+                    context = {
+                        "documents": {
+                            "ids": {"1": 1.0, "2": 1.0, "missing_doc": 1.0},
+                            "parameters": {
+                                "tensorFields": ["title"],
+                                "excludeInputDocuments": True,
+                                "allowMissingDocuments": True
+                            }
+                        }
+                    }
+
+                    res = self.client.index(index_name).search(
+                        q=None,
+                        context=context,
+                        search_method=search_method,
+                        hybrid_parameters=hybrid_parameters
+                    )
+
+                    # Should return results based on available context documents
+                    ids = [doc["_id"] for doc in res["hits"]]
+                    self.assertIn("3", ids)
+
+    def test_search_context_allow_missing_embeddings_true(self):
+        """Test search with context and allow_missing_embeddings=True allows context documents without embeddings"""
+        docs = [
+            {
+                "_id": "1",
+                "title": "Red orchid",
+            },
+            {
+                "_id": "2",
+                "title": "Red rose", 
+                "content": "flower content",
+            },
+            {
+                "_id": "3",
+                "title": "Europe",
+                "content": "continent content",
+            },
+        ]
+
+        for index_name in [self.structured_text_index_name, self.unstructured_text_index_name]:
+            for search_method in ["TENSOR", "HYBRID"]:
+                hybrid_parameters = {"retrievalMethod": "tensor", "rankingMethod": "tensor"} \
+                    if search_method == "HYBRID" else None
+                with self.subTest(f"index_name={index_name}, search_method={search_method}"):
+                    tensor_fields = ["content", "title"] if index_name == self.unstructured_text_index_name else None
+                    add_docs_results = self.client.index(index_name).add_documents(docs, tensor_fields=tensor_fields)
+
+                    if add_docs_results["errors"]:
+                        raise Exception(f"Failed to add documents to index {index_name}")
+
+                    # Should succeed even when context documents 1 and 2 lack embeddings for title field
+                    context = {
+                        "documents": {
+                            "ids": {"1": 1.0, "2": 1.0},
+                            "parameters": {
+                                # doc '1' does not have content
+                                "tensorFields": ["content"],
+                                "excludeInputDocuments": True,
+                                "allowMissingEmbeddings": True
+                            }
+                        }
+                    }
+
+                    res = self.client.index(index_name).search(
+                        q=None,
+                        context=context,
+                        search_method=search_method,
+                        hybrid_parameters=hybrid_parameters
+                    )
+
+                    self.assertEqual("3", res["hits"][0]["_id"])
+
+    def test_search_context_allow_missing_both_true(self):
+        """Test search with context and both allow_missing_documents=True and allow_missing_embeddings=True"""
+        docs = [
+            {
+                "_id": "1",
+                "content": "flower content",
+            },
+            {
+                "_id": "2",
+                "title": "Red rose",
+                "content": "flower content",
+            },
+            {
+                "_id": "3", 
+                "title": "Europe",
+                "content": "continent content",
+            },
+        ]
+
+        for index_name in [self.structured_text_index_name, self.unstructured_text_index_name]:
+            for search_method in ["TENSOR", "HYBRID"]:
+                hybrid_parameters = {"retrievalMethod": "tensor", "rankingMethod": "tensor"} \
+                    if search_method == "HYBRID" else None
+                with self.subTest(f"index_name={index_name}, search_method={search_method}"):
+                    tensor_fields = ["content", "title"] if index_name == self.unstructured_text_index_name else None
+                    add_docs_results = self.client.index(index_name).add_documents(docs, tensor_fields=tensor_fields)
+
+                    if add_docs_results["errors"]:
+                        raise Exception(f"Failed to add documents to index {index_name}")
+
+                    # Should succeed with both missing context documents and missing embeddings
+                    context = {
+                        "documents": {
+                            # doc '1' has no title embeddings
+                            "ids": {"1": 1.0, "2": 1.0, "missing_doc": 1.0},
+                            "parameters": {
+                                "tensorFields": ["title"],
+                                "excludeInputDocuments": True,
+                                "allowMissingDocuments": True,
+                                "allowMissingEmbeddings": True
+                            }
+                        }
+                    }
+
+                    res = self.client.index(index_name).search(
+                        q=None,
+                        context=context,
+                        search_method=search_method,
+                        hybrid_parameters=hybrid_parameters
+                    )
+
+                    self.assertEqual("3", res["hits"][0]["_id"])
+
+    def test_search_context_failed_to_collect_vectors_error(self):
+        """Test search with context and both allow_missing_documents=True and allow_missing_embeddings=True"""
+        docs = [
+            {
+                "_id": "1",
+                "content": "flower content",
+            },
+            {
+                "_id": "2",
+                "title": "Red rose",
+                "content": "flower content",
+            },
+            {
+                "_id": "3",
+                "title": "Europe",
+                "content": "continent content",
+            },
+        ]
+
+        for index_name in [self.structured_text_index_name, self.unstructured_text_index_name]:
+            for search_method in ["TENSOR", "HYBRID"]:
+                hybrid_parameters = {"retrievalMethod": "tensor", "rankingMethod": "tensor"} \
+                    if search_method == "HYBRID" else None
+                with self.subTest(f"index_name={index_name}, search_method={search_method}"):
+                    tensor_fields = ["content", "title"] if index_name == self.unstructured_text_index_name else None
+                    add_docs_results = self.client.index(index_name).add_documents(docs, tensor_fields=tensor_fields)
+
+                    if add_docs_results["errors"]:
+                        raise Exception(f"Failed to add documents to index {index_name}")
+
+                    # Should succeed with both missing context documents and missing embeddings
+                    context = {
+                        "documents": {
+                            # doc '1' has no title embeddings
+                            "ids": {"1": 1.0, "missing_doc": 1.0},
+                            "parameters": {
+                                "tensorFields": ["title"],
+                                "excludeInputDocuments": True,
+                                "allowMissingDocuments": True,
+                                "allowMissingEmbeddings": True
+                            }
+                        }
+                    }
+                    with self.assertRaises(MarqoWebError) as e:
+                        _ = self.client.index(index_name).search(
+                            q=None,
+                            context=context,
+                            search_method=search_method,
+                            hybrid_parameters=hybrid_parameters
+                        )
+                    self.assertIn("Marqo could not collect any vectors from the search query", str(e.exception))

--- a/tests/api_tests/v1/tests/api_tests/test_search_common.py
+++ b/tests/api_tests/v1/tests/api_tests/test_search_common.py
@@ -324,7 +324,7 @@ class TestSearchCommon(MarqoTestCase):
                             }
                         )
                     assert e.exception.status_code == 400
-                    assert "Either both of 'hybridParameters.queryLexical' and 'hybridParameters.queryTensor'" in str(e.exception)
+                    assert "Either 'hybridParameters.queryLexical' or just 'q'" in str(e.exception)
                     with self.assertRaises(MarqoWebError) as e:
                         self.client.index(index_name).search(
                             search_method="HYBRID",
@@ -333,7 +333,7 @@ class TestSearchCommon(MarqoTestCase):
                             }
                         )
                     assert e.exception.status_code == 400
-                    assert "Either both of 'hybridParameters.queryLexical' and 'hybridParameters.queryTensor'" in str(e.exception)
+                    assert "Marqo could not collect any vectors from the search query" in str(e.exception)
 
                 with self.subTest(
                         "Hybrid search without query and with queryTensor/queryLexical should not raise an error"):

--- a/tests/integ_tests/core/search/test_recommender.py
+++ b/tests/integ_tests/core/search/test_recommender.py
@@ -766,6 +766,203 @@ class TestRecommender(MarqoTestCase):
                     expected = {"doc1": [[0.1, 0.2, 0.3]]}
                     self.assertEqual(result, expected)
 
+    def test_recommend_allow_missing_documents_true_success(self):
+        """Test that allowMissingDocuments=True allows missing documents and only uses existing ones"""
+        for index in [self.unstructured_text_index, self.structured_text_index]:
+            with self.subTest(type=index.type):
+                self._populate_index(index)
+
+                # Should succeed with allowMissingDocuments=True and only use existing documents
+                res = self.recommender.recommend(
+                    index_name=index.name,
+                    documents=["1", "non_existent_doc", "2", "another_missing_doc"],
+                    allow_missing_documents=True,
+                    exclude_input_documents=False
+                )
+
+                # Verify search was successful
+                self.assertIn("hits", res)
+                self.assertGreater(len(res["hits"]), 0)
+
+                # Verify that existing documents are included in results
+                result_ids = [hit["_id"] for hit in res["hits"]]
+                self.assertIn("1", result_ids)
+                self.assertIn("2", result_ids)
+
+    def test_recommend_allow_missing_embeddings_true_success(self):
+        """Test that allowMissingEmbeddings=True allows documents with missing embeddings"""
+        # Create documents where some have embeddings for specific fields and others don't
+        docs = [
+            {
+                "_id": "doc_with_title",
+                "title": "Document with title embedding",
+                "description": "Also has description"
+            },
+            {
+                "_id": "doc_with_content", 
+                "content": "Document with only content embedding",
+                "tags": ["test"]
+            },
+            {
+                "_id": "doc_mixed",
+                "title": "Mixed document",
+                "content": "Has both title and content"
+            }
+        ]
+
+        for index in [self.unstructured_text_index, self.structured_text_index]:
+            with self.subTest(type=index.type):
+                # For unstructured, specify which fields to vectorize
+                if isinstance(index, UnstructuredMarqoIndex):
+                    tensor_fields = ["title", "description"]  # Don't vectorize content
+                else:
+                    tensor_fields = None
+
+                self.add_documents(
+                    self.config,
+                    add_docs_params=AddDocsParams(
+                        index_name=index.name,
+                        docs=docs,
+                        tensor_fields=tensor_fields
+                    )
+                )
+
+                # Should succeed with allowMissingEmbeddings=True, using only docs with required embeddings
+                res = self.recommender.recommend(
+                    index_name=index.name,
+                    documents=["doc_with_title", "doc_with_content", "doc_mixed"],
+                    tensor_fields=["title"],
+                    allow_missing_embeddings=True,
+                    exclude_input_documents=False
+                )
+
+                # Verify search was successful
+                self.assertIn("hits", res)
+                self.assertGreater(len(res["hits"]), 0)
+
+                # Verify that documents with required embeddings are included
+                result_ids = [hit["_id"] for hit in res["hits"]]
+                self.assertIn("doc_with_title", result_ids)
+                self.assertIn("doc_mixed", result_ids)
+
+    def test_recommend_allow_both_missing_parameters_true_success(self):
+        """Test that both allowMissingDocuments=True and allowMissingEmbeddings=True work together"""
+        # Create documents with various scenarios
+        docs = [
+            {
+                "_id": "complete_doc",
+                "title": "Complete document",
+                "description": "Has both title and description"
+            },
+            {
+                "_id": "partial_doc",
+                "content": "Document with only content",
+                "tags": ["partial"]
+            }
+        ]
+
+        for index in [self.unstructured_text_index, self.structured_text_index]:
+            with self.subTest(type=index.type):
+                # For unstructured, specify which fields to vectorize
+                if isinstance(index, UnstructuredMarqoIndex):
+                    tensor_fields = ["title", "description"]  # Don't vectorize content
+                else:
+                    tensor_fields = None
+
+                self.add_documents(
+                    self.config,
+                    add_docs_params=AddDocsParams(
+                        index_name=index.name,
+                        docs=docs,
+                        tensor_fields=tensor_fields
+                    )
+                )
+
+                # Should succeed with both parameters=True, handling missing docs and missing embeddings
+                res = self.recommender.recommend(
+                    index_name=index.name,
+                    documents=[
+                        "complete_doc",           # Exists, has required embeddings
+                        "non_existent_doc",       # Doesn't exist (should be ignored)
+                        "partial_doc",            # Exists, but missing required embeddings (should be ignored)
+                        "another_missing_doc"     # Doesn't exist (should be ignored)
+                    ],
+                    tensor_fields=["title"],
+                    allow_missing_documents=True,
+                    allow_missing_embeddings=True,
+                    exclude_input_documents=False
+                )
+
+                # Verify search was successful
+                self.assertIn("hits", res)
+                self.assertGreater(len(res["hits"]), 0)
+
+                # Verify that only the document with required embeddings is used for context
+                result_ids = [hit["_id"] for hit in res["hits"]]
+                self.assertIn("complete_doc", result_ids)
+
+    def test_recommend_all_documents_missing_with_allow_missing_documents_true_fails(self):
+        """Test that when allowMissingDocuments=True but ALL documents are missing, it should fail"""
+        for index in [self.unstructured_text_index, self.structured_text_index]:
+            with self.subTest(type=index.type):
+                self._populate_index(index)
+
+                # Should still fail when no documents are available at all
+                with self.assertRaisesStrict(InvalidArgumentError) as cm:
+                    self.recommender.recommend(
+                        index_name=index.name,
+                        documents=["non_existent_1", "non_existent_2", "non_existent_3"],
+                        allow_missing_documents=True
+                    )
+
+                self.assertIn("Marqo could not collect any valid vector from the documents", str(cm.exception))
+
+    def test_recommend_all_documents_missing_embeddings_with_allow_missing_embeddings_true_fails(self):
+        """Test that when allowMissingEmbeddings=True but ALL documents lack embeddings, it should fail"""
+        # Create documents that all lack a specific embedding field
+        docs = [
+            {
+                "_id": "doc1",
+                "content": "Document 1 with only content"
+            },
+            {
+                "_id": "doc2", 
+                "content": "Document 2 with only content"
+            },
+            {
+                "_id": "doc3",
+                "title": "Document 3",
+            }
+        ]
+
+        for index in [self.unstructured_text_index, self.structured_text_index]:
+            with self.subTest(type=index.type):
+                # For unstructured, only vectorize content (not title)
+                if isinstance(index, UnstructuredMarqoIndex):
+                    tensor_fields = ["content", "title"]
+                else:
+                    tensor_fields = None
+
+                self.add_documents(
+                    self.config,
+                    add_docs_params=AddDocsParams(
+                        index_name=index.name,
+                        docs=docs,
+                        tensor_fields=tensor_fields
+                    )
+                )
+
+                # Should still fail when no documents have the required embeddings
+                with self.assertRaisesStrict(InvalidArgumentError) as cm:
+                    self.recommender.recommend(
+                        index_name=index.name,
+                        documents=["doc1", "doc2"],
+                        tensor_fields=["title"],  # Request field that no documents have
+                        allow_missing_embeddings=True
+                    )
+
+                self.assertIn("Marqo could not collect any valid vector from the documents", str(cm.exception))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/integ_tests/tensor_search/integ_tests/test_hybrid_search.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_hybrid_search.py
@@ -20,6 +20,7 @@ from marqo.tensor_search.enums import SearchMethod
 from marqo.tensor_search.models.api_models import CustomVectorQuery
 from marqo.tensor_search.models.api_models import ScoreModifierLists
 from marqo.tensor_search.models.search import SearchContext
+import marqo.api.exceptions as api_exception
 from marqo.core.models.facets_parameters import FacetsParameters, FieldFacetsConfiguration, RangeConfiguration
 import pytest
 
@@ -2357,9 +2358,7 @@ class TestHybridSearch(MarqoTestCase):
         """
         Test that hybrid search with a None query and wrong retrieval or ranking method fails.
         """
-        custom_vector = [0.655 for _ in range(16)]
         test_cases = [
-            (RetrievalMethod.Disjunction, RankingMethod.RRF),
             (RetrievalMethod.Tensor, RankingMethod.Lexical),
             (RetrievalMethod.Lexical, RankingMethod.Tensor),
             (RetrievalMethod.Lexical, RankingMethod.Lexical)
@@ -2382,6 +2381,51 @@ class TestHybridSearch(MarqoTestCase):
                                 )
                             )
                         self.assertIn("retrievalMethod and rankingMethod are both 'tensor'", str(e.exception))
+
+    def test_hybrid_search_none_query_wrong_retrieval_or_ranking_fails_for_disjunction(self):
+        """
+        Test that hybrid search with a None query will raise error for disjunction and rrf.
+        """
+        for index in [self.structured_index_with_no_model, self.unstructured_index_with_no_model]:
+            with self.subTest(index=index.name):
+                with self.assertRaises(InvalidArgumentError) as e:
+                    tensor_search.search(
+                        config=self.config,
+                        index_name=index.name,
+                        text=None,
+                        search_method="HYBRID",
+                        hybrid_parameters=HybridParameters(
+                            retrievalMethod=RetrievalMethod.Disjunction,
+                            rankingMethod=RankingMethod.RRF,
+                            verbose=True
+                        )
+                    )
+                self.assertIn("Either 'hybridParameters.queryLexical' or just 'q'", str(e.exception))
+
+    def test_hybrid_search_none_query_tensor_without_text_raises_error(self):
+        """
+        Test that hybrid search with none query tensor and no context will raise an error.
+        """
+        for index in [self.structured_index_with_no_model, self.unstructured_index_with_no_model]:
+            with self.subTest(index=index.name):
+                with self.assertRaises(api_exception.InvalidArgError) as e:
+                    tensor_search.search(
+                        config=self.config,
+                        text=None,
+                        index_name=index.name,
+                        search_method="HYBRID",
+                        hybrid_parameters=HybridParameters(
+                            queryLexical="test",
+                            queryTensor=None,
+                            retrievalMethod=RetrievalMethod.Disjunction,
+                            rankingMethod=RankingMethod.RRF,
+                            verbose=True
+                        )
+                    )
+                self.assertIn(
+                    "Marqo could not collect any vectors from the search query but the retrieval or ranking method",
+                              str(e.exception)
+                )
 
     def test_hybrid_search_none_query_with_context_vectors_passes(self):
         """Test to ensure that context vectors work with no_model by setting query as None and providing context
@@ -3006,7 +3050,7 @@ class TestHybridSearch(MarqoTestCase):
                 assert res["hits"][0]["_id"] == res_reverse["hits"][-1]["_id"]
 
     def test_empty_tensor_query_dict(self):
-        """Ensure empty tensor query dict does not raise errors and behaves correctly."""
+        """Ensure empty tensor query dict can be provided in the API but downstream errors will be raised."""
         for index in [self.structured_text_index_score_modifiers, self.semi_structured_default_text_index]:
             with self.subTest(index=index.type):
                 self.add_documents(
@@ -3016,7 +3060,7 @@ class TestHybridSearch(MarqoTestCase):
                     )
                 )
 
-                with self.assertRaises(ValueError):
+                with self.assertRaises(api_exception.InvalidArgError) as e:
                     tensor_search.search(
                         config=self.config, index_name=index.name, text=None, search_method="HYBRID",
                         hybrid_parameters=HybridParameters(
@@ -3025,6 +3069,10 @@ class TestHybridSearch(MarqoTestCase):
                             rankingMethod=RankingMethod.RRF
                         ), result_count=5
                     )
+                self.assertIn(
+                    "Marqo could not collect any vectors from the search query but the retrieval or ranking method",
+                    str(e.exception)
+                )
 
     def test_query_tensor_as_string_equivalent_to_single_query(self):
         """String tensor query should work like dict with one key."""
@@ -3189,28 +3237,6 @@ class TestHybridSearch(MarqoTestCase):
                         hybrid_parameters=HybridParameters(
                             queryTensor="dogs",
                             queryLexical=None,
-                            retrievalMethod=RetrievalMethod.Disjunction,
-                            rankingMethod=RankingMethod.RRF
-                        ), result_count=5
-                    )
-
-    def test_none_query_tensor_disjunction_retrieval(self):
-        """Ensure that a None query tensor and lexical with disjunction retrieval raises an error."""
-        for index in [self.structured_text_index_score_modifiers, self.semi_structured_default_text_index]:
-            with self.subTest(index=index.type):
-                self.add_documents(
-                    config=self.config, add_docs_params=AddDocsParams(
-                        index_name=index.name, docs=self.docs_list,
-                        tensor_fields=["text_field_1"] if isinstance(index, UnstructuredMarqoIndex) else None
-                    )
-                )
-
-                with self.assertRaises(InvalidArgumentError):
-                    tensor_search.search(
-                        config=self.config, index_name=index.name, search_method="HYBRID", text=None,
-                        hybrid_parameters=HybridParameters(
-                            queryTensor=None,
-                            queryLexical="dogs",
                             retrievalMethod=RetrievalMethod.Disjunction,
                             rankingMethod=RankingMethod.RRF
                         ), result_count=5

--- a/tests/integ_tests/tensor_search/integ_tests/test_hybrid_search.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_hybrid_search.py
@@ -19,7 +19,7 @@ from marqo.tensor_search import tensor_search
 from marqo.tensor_search.enums import SearchMethod
 from marqo.tensor_search.models.api_models import CustomVectorQuery
 from marqo.tensor_search.models.api_models import ScoreModifierLists
-from marqo.tensor_search.models.search import SearchContext
+from marqo.tensor_search.models.search import SearchContext, SearchContextDocuments
 import marqo.api.exceptions as api_exception
 from marqo.core.models.facets_parameters import FacetsParameters, FieldFacetsConfiguration, RangeConfiguration
 import pytest
@@ -2477,6 +2477,94 @@ class TestHybridSearch(MarqoTestCase):
 
                 self.assertEqual("1", r["hits"][1]["_id"])
                 self.assertTrue(r["hits"][1]["_score"], r["hits"][0]["_score"])
+
+    def test_hybrid_search_query_tensor_none_with_context_vectors_passes(self):
+        """Test to ensure that context vectors work with queryTensor=None, and a different queryLexical.
+        """
+        custom_vector = [0.655 for _ in range(16)]
+
+        docs = [
+            {
+                "_id": "1",
+                "custom_field_1":
+                    {
+                        "content": "test custom field content_1",
+                        "vector": np.random.rand(16).tolist()
+                    }
+            },
+            {
+                "_id": "2",
+                "custom_field_1":
+                    {
+                        "content": "test custom field content_2",
+                        "vector": custom_vector
+                    }
+            }
+        ]
+
+        for index in [self.structured_index_with_no_model, self.semi_structured_index_with_no_model]:
+            with (self.subTest(index_name=index.name)):
+                add_docs_params = AddDocsParams(index_name=index.name,
+                                                docs=docs,
+                                                tensor_fields=["custom_field_1"] \
+                                                    if isinstance(index, UnstructuredMarqoIndex) else None,
+                                                mappings={"custom_field_1": {"type": "custom_vector"}} \
+                                                    if isinstance(index, UnstructuredMarqoIndex) else None)
+                _ = self.add_documents(config=self.config,
+                                       add_docs_params=add_docs_params)
+
+                r = tensor_search.search(
+                    config=self.config, index_name=index.name, text=None,
+                    search_method="hybrid",
+                    hybrid_parameters=HybridParameters(
+                        retrievalMethod=RetrievalMethod.Disjunction,
+                        rankingMethod=RankingMethod.RRF,
+                        queryTensor=None,
+                        queryLexical="test",
+                        verbose=True
+                    ),
+                    context=SearchContext(**{"tensor": [{"vector": custom_vector,
+                                                         "weight": 1}], })
+                )
+                self.assertEqual(2, len(r["hits"]))
+
+    def test_hybrid_search_query_tensor_none_with_context_docs_passes(self):
+        """Test to ensure that context documents work with queryTensor=None, and a different queryLexical.
+        """
+        docs = [
+            {
+                "_id": "1",
+                "text_field_1": "Some content 1"
+            },
+            {
+                "_id": "2",
+                "text_field_1": "Some content 2"
+            }
+        ]
+
+        for index in [self.structured_text_index_score_modifiers, self.semi_structured_default_text_index]:
+            with (self.subTest(index_name=index.name)):
+                add_docs_params = AddDocsParams(index_name=index.name,
+                                                docs=docs,
+                                                tensor_fields=["text_field_1"] \
+                                                    if isinstance(index, UnstructuredMarqoIndex) else None)
+                _ = self.add_documents(config=self.config,
+                                       add_docs_params=add_docs_params)
+
+                r = tensor_search.search(
+                    config=self.config, index_name=index.name, text=None,
+                    search_method="hybrid",
+                    hybrid_parameters=HybridParameters(
+                        retrievalMethod=RetrievalMethod.Disjunction,
+                        rankingMethod=RankingMethod.RRF,
+                        queryTensor=None,
+                        queryLexical="test",
+                        verbose=True
+                    ),
+                    context=SearchContext(documents=SearchContextDocuments(ids={"1": 1}))
+                )
+                ids = [hit["_id"] for hit in r["hits"]]
+                self.assertEqual(["2"], ids)
 
     def test_hybrid_search_unstructured_with_searchable_attributes_fails(self):
         """

--- a/tests/integ_tests/tensor_search/search/test_search_with_context.py
+++ b/tests/integ_tests/tensor_search/search/test_search_with_context.py
@@ -1428,7 +1428,7 @@ class TestSearchWithContext(MarqoTestCase):
                             ids={"doc1": 2.0, "doc3": 0.1, "not_exists_doc": 1},
                             parameters=SearchContextDocumentsParameters(
                                 tensorFields=["text_field_1"],
-                                exclueInputDocuments=True,
+                                excludeInputDocuments=True,
                                 allowMissingEmbeddings=True,
                                 allowMissingDocuments=True
                             )
@@ -1481,7 +1481,7 @@ class TestSearchWithContext(MarqoTestCase):
                             ids={"doc3": 0.1, "not_exists_doc": 1},
                             parameters=SearchContextDocumentsParameters(
                                 tensorFields=["text_field_1"],
-                                exclueInputDocuments=True,
+                                excludeInputDocuments=True,
                                 allowMissingEmbeddings=True,
                                 allowMissingDocuments=True
                             )
@@ -1537,7 +1537,7 @@ class TestSearchWithContext(MarqoTestCase):
                             ids={"doc1": 2.0, "doc3": 0.1, "not_exists_doc": 1},
                             parameters=SearchContextDocumentsParameters(
                                 tensorFields=["text_field_1"],
-                                exclueInputDocuments=True,
+                                excludeInputDocuments=True,
                                 allowMissingEmbeddings=True,
                                 allowMissingDocuments=True
                             )
@@ -1596,7 +1596,7 @@ class TestSearchWithContext(MarqoTestCase):
                             ids={"doc3": 0.1, "not_exists_doc": 1},
                             parameters=SearchContextDocumentsParameters(
                                 tensorFields=["text_field_1"],
-                                exclueInputDocuments=True,
+                                excludeInputDocuments=True,
                                 allowMissingEmbeddings=True,
                                 allowMissingDocuments=True
                             )

--- a/tests/integ_tests/tensor_search/search/test_search_with_context.py
+++ b/tests/integ_tests/tensor_search/search/test_search_with_context.py
@@ -1,6 +1,8 @@
 import os
 import unittest
 from unittest import mock
+
+from marqo.marqo_docs import hybrid_parameters
 from marqo.tensor_search.enums import EnvVars
 from pydantic.v1.error_wrappers import ValidationError
 from marqo.core.exceptions import InvalidFieldNameError, UnsupportedFeatureError
@@ -1286,3 +1288,220 @@ class TestSearchWithContext(MarqoTestCase):
                             # Verify the expected document is returned as the top result
                             self.assertEqual(res["hits"][0]["_id"], "d1")
 
+    def test_search_with_context_documents_allow_missing_documents_true(self):
+        """Test that search with context documents succeeds when allowMissingDocuments=True and some documents don't exist."""
+        for index in [self.unstructured_default_text_index, self.structured_default_text_index]:
+            for search_method in ["TENSOR", "HYBRID"]:
+                hybrid_parameters = HybridParameters(retrievalMethod="tensor", rankingMethod="tensor") \
+                        if search_method == "HYBRID" else None
+                with self.subTest(f"index={index.type}, search_method={search_method}"):
+                    # Add some documents
+                    docs = [
+                        {"_id": "doc1", "text_field_1": "Machine learning and artificial intelligence"},
+                        {"_id": "doc2", "text_field_1": "Deep learning neural networks"},
+                        {"_id": "doc3", "text_field_1": "Natural language processing"}
+                    ]
+
+                    self.add_documents(
+                        config=self.config,
+                        add_docs_params=AddDocsParams(
+                            index_name=index.name,
+                            docs=docs,
+                            tensor_fields=["text_field_1"] if isinstance(index, UnstructuredMarqoIndex) else None
+                        )
+                    )
+
+                    # Create search context with mix of existing and non-existent documents
+                    search_context = SearchContext(
+                        documents=SearchContextDocuments(
+                            ids={"doc1": 2.0, "non_existent_doc": 1.0, "doc2": 1.5, "another_missing_doc": 0.5},
+                            parameters=SearchContextDocumentsParameters(
+                                tensorFields=["text_field_1"],
+                                excludeInputDocuments=False,
+                                allowMissingDocuments=True
+                            )
+                        )
+                    )
+
+                    # Should succeed and only use existing documents (doc1 and doc2)
+                    results = tensor_search.search(
+                        config=self.config,
+                        index_name=index.name,
+                        text=None,
+                        context=search_context,
+                        result_count=5,
+                        search_method=search_method,
+                        hybrid_parameters=hybrid_parameters
+                    )
+
+                    # Verify search was successful
+                    self.assertIn("hits", results)
+                    self.assertGreater(len(results["hits"]), 0)
+
+                    # Verify that existing documents are still included in results
+                    result_ids = [hit["_id"] for hit in results["hits"]]
+                    self.assertIn("doc1", result_ids)
+                    self.assertIn("doc2", result_ids)
+
+    def test_search_with_context_documents_allow_missing_embeddings_true(self):
+        """Test that search with context documents succeeds when allowMissingEmbeddings=True and some documents lack required embeddings."""
+        for index in [self.unstructured_default_text_index, self.structured_default_text_index]:
+            for search_method in ["TENSOR", "HYBRID"]:
+                hybrid_parameters = HybridParameters(retrievalMethod="tensor", rankingMethod="tensor") \
+                    if search_method == "HYBRID" else None
+                with self.subTest(f"index={index.type}, search_method={search_method}"):
+                    # Add some documents
+                    docs = [
+                        {"_id": "doc1", "text_field_1": "Machine learning and artificial intelligence"},
+                        {"_id": "doc2", "text_field_1": "Deep learning neural networks"},
+                        {"_id": "doc3", "text_field_2": "Natural language processing"}
+                    ]
+
+                    self.add_documents(
+                        config=self.config,
+                        add_docs_params=AddDocsParams(
+                            index_name=index.name,
+                            docs=docs,
+                            tensor_fields=["text_field_1", "text_field_2"] if isinstance(index, UnstructuredMarqoIndex) else None
+                        )
+                    )
+
+                    # Create search context with mix of existing and non-existent documents
+                    search_context = SearchContext(
+                        documents=SearchContextDocuments(
+                            # doc3 does not have "text_field_1"
+                            ids={"doc1": 2.0, "doc3": 0.1},
+                            parameters=SearchContextDocumentsParameters(
+                                tensorFields=["text_field_1"],
+                                excludeInputDocuments=False,
+                                allowMissingEmbeddings=True
+                            )
+                        )
+                    )
+
+                    # Should succeed and only use existing documents (doc1 and doc2)
+                    results = tensor_search.search(
+                        config=self.config,
+                        index_name=index.name,
+                        text=None,
+                        context=search_context,
+                        result_count=5,
+                        search_method=search_method,
+                        hybrid_parameters=hybrid_parameters
+                    )
+
+                    # Verify search was successful
+                    self.assertIn("hits", results)
+                    self.assertGreater(len(results["hits"]), 0)
+
+                    # Verify that existing documents are still included in results
+                    result_ids = [hit["_id"] for hit in results["hits"]]
+                    self.assertIn("doc1", result_ids)
+                    self.assertIn("doc2", result_ids)
+                    self.assertIn("doc3", result_ids)
+
+    def test_search_with_context_documents_allow_missing_both_parameters(self):
+        """Test that search works when both allowMissingDocuments=True and allowMissingEmbeddings=True with mixed scenarios."""
+        # This test only works with structured index as it has defined tensor fields
+        for index in [self.unstructured_default_text_index, self.structured_default_text_index]:
+            for search_method in ["TENSOR", "HYBRID"]:
+                hybrid_parameters = HybridParameters(retrievalMethod="tensor", rankingMethod="tensor") \
+                    if search_method == "HYBRID" else None
+                with self.subTest(f"index={index.type}, search_method={search_method}"):
+                    # Add some documents
+                    docs = [
+                        {"_id": "doc1", "text_field_1": "Machine learning and artificial intelligence"},
+                        {"_id": "doc2", "text_field_1": "Deep learning neural networks"},
+                        {"_id": "doc3", "text_field_2": "Natural language processing"}
+                    ]
+
+                    self.add_documents(
+                        config=self.config,
+                        add_docs_params=AddDocsParams(
+                            index_name=index.name,
+                            docs=docs,
+                            tensor_fields=["text_field_1"] if isinstance(index, UnstructuredMarqoIndex) else None
+                        )
+                    )
+
+                    # Create search context with mix of existing and non-existent documents
+                    search_context = SearchContext(
+                        documents=SearchContextDocuments(
+                            # doc3 does not have "text_field_1"
+                            ids={"doc1": 2.0, "doc3": 0.1, "not_exists_doc": 1},
+                            parameters=SearchContextDocumentsParameters(
+                                tensorFields=["text_field_1"],
+                                exclueInputDocuments=True,
+                                allowMissingEmbeddings=True,
+                                allowMissingDocuments=True
+                            )
+                        )
+                    )
+
+                    # Should succeed and only use existing documents (doc1 and doc2)
+                    results = tensor_search.search(
+                        config=self.config,
+                        index_name=index.name,
+                        text=None,
+                        context=search_context,
+                        result_count=5,
+                        search_method=search_method,
+                        hybrid_parameters=hybrid_parameters
+                    )
+
+                    # Verify search was successful
+                    self.assertIn("hits", results)
+                    self.assertGreater(len(results["hits"]), 0)
+                    self.assertNotIn("doc1", results["hits"][0]["_id"])
+                    self.assertNotIn("doc3", results["hits"][0]["_id"])
+                    self.assertIn("doc2", results["hits"][0]["_id"])
+
+    def test_a_proper_error_is_raised_if_marqo_can_not_collect_any_vector(self):
+        for index in [self.unstructured_default_text_index, self.structured_default_text_index]:
+            for search_method in ["TENSOR", "HYBRID"]:
+                hybrid_parameters = HybridParameters(retrievalMethod="tensor", rankingMethod="tensor") \
+                    if search_method == "HYBRID" else None
+                with self.subTest(f"index={index.type}, search_method={search_method}"):
+                    # Add some documents
+                    docs = [
+                        {"_id": "doc1", "text_field_1": "Machine learning and artificial intelligence"},
+                        {"_id": "doc2", "text_field_1": "Deep learning neural networks"},
+                        {"_id": "doc3", "text_field_2": "Natural language processing"}
+                    ]
+
+                    self.add_documents(
+                        config=self.config,
+                        add_docs_params=AddDocsParams(
+                            index_name=index.name,
+                            docs=docs,
+                            tensor_fields=["text_field_1"] if isinstance(index, UnstructuredMarqoIndex) else None
+                        )
+                    )
+
+                    # Create search context with mix of existing and non-existent documents
+                    search_context = SearchContext(
+                        documents=SearchContextDocuments(
+                            # doc3 does not have "text_field_1"
+                            ids={"doc3": 0.1, "not_exists_doc": 1},
+                            parameters=SearchContextDocumentsParameters(
+                                tensorFields=["text_field_1"],
+                                exclueInputDocuments=True,
+                                allowMissingEmbeddings=True,
+                                allowMissingDocuments=True
+                            )
+                        )
+                    )
+
+                    # Should succeed and only use existing documents (doc1 and doc2)
+                    with self.assertRaises(InvalidArgError) as e:
+                        results = tensor_search.search(
+                            config=self.config,
+                            index_name=index.name,
+                            text=None,
+                            context=search_context,
+                            result_count=5,
+                            search_method=search_method,
+                            hybrid_parameters=hybrid_parameters
+                        )
+
+                    self.assertIn("Marqo could not collect any vectors from the search query", str(e.exception))

--- a/tests/integ_tests/tensor_search/search/test_search_with_context.py
+++ b/tests/integ_tests/tensor_search/search/test_search_with_context.py
@@ -2,7 +2,6 @@ import os
 import unittest
 from unittest import mock
 
-from marqo.marqo_docs import hybrid_parameters
 from marqo.tensor_search.enums import EnvVars
 from pydantic.v1.error_wrappers import ValidationError
 from marqo.core.exceptions import InvalidFieldNameError, UnsupportedFeatureError
@@ -1509,7 +1508,9 @@ class TestSearchWithContext(MarqoTestCase):
         for index in [self.unstructured_default_text_index, self.structured_default_text_index]:
             hybrid_parameters_test_cases = (
                 {"queryLexical": "*", "queryTensor": None, "retrievalMethod": "disjunction", "rankingMethod": "rrf"},
-                {"queryTensor": None, "retrievalMethod": "tensor", "rankingMethod": "tensor"}
+                {"queryLexical": "*", "queryTensor": {}, "retrievalMethod": "disjunction", "rankingMethod": "rrf"},
+                {"queryTensor": None, "retrievalMethod": "tensor", "rankingMethod": "tensor"},
+                {"queryTensor": {}, "retrievalMethod": "tensor", "rankingMethod": "tensor"}
             )
             for hybrid_parameters in hybrid_parameters_test_cases:
                 with self.subTest(f"index={index.type}, hybrid_parameters={hybrid_parameters_test_cases}"):
@@ -1559,3 +1560,59 @@ class TestSearchWithContext(MarqoTestCase):
                     self.assertGreater(len(results["hits"]), 0)
                     result_ids = set([hit["_id"] for hit in results["hits"]])
                     self.assertEqual({"doc2"}, result_ids)
+
+    def test_search_with_context_documents_raise_vector_collect_errors_with_disjunction(self):
+        """Test that search works when both allowMissingDocuments=True and allowMissingEmbeddings=True with mixed scenarios,
+        with different hybrid parameters"""
+        for index in [self.unstructured_default_text_index, self.structured_default_text_index]:
+            hybrid_parameters_test_cases = (
+                {"queryLexical": "*", "queryTensor": None, "retrievalMethod": "disjunction", "rankingMethod": "rrf"},
+                {"queryLexical": "*", "queryTensor": {}, "retrievalMethod": "disjunction", "rankingMethod": "rrf"},
+                {"queryTensor": None, "retrievalMethod": "tensor", "rankingMethod": "tensor"},
+                {"queryTensor": {}, "retrievalMethod": "tensor", "rankingMethod": "tensor"}
+            )
+            for hybrid_parameters in hybrid_parameters_test_cases:
+                with self.subTest(f"index={index.type}, hybrid_parameters={hybrid_parameters_test_cases}"):
+                    # Add some documents
+                    docs = [
+                        {"_id": "doc1", "text_field_1": "Machine learning and artificial intelligence"},
+                        {"_id": "doc2", "text_field_1": "Deep learning neural networks"},
+                        {"_id": "doc3", "text_field_2": "Natural language processing"}
+                    ]
+
+                    self.add_documents(
+                        config=self.config,
+                        add_docs_params=AddDocsParams(
+                            index_name=index.name,
+                            docs=docs,
+                            tensor_fields=["text_field_1"] if isinstance(index, UnstructuredMarqoIndex) else None
+                        )
+                    )
+
+                    # Create search context with mix of existing and non-existent documents
+                    search_context = SearchContext(
+                        documents=SearchContextDocuments(
+                            # doc3 does not have "text_field_1"
+                            ids={"doc3": 0.1, "not_exists_doc": 1},
+                            parameters=SearchContextDocumentsParameters(
+                                tensorFields=["text_field_1"],
+                                exclueInputDocuments=True,
+                                allowMissingEmbeddings=True,
+                                allowMissingDocuments=True
+                            )
+                        )
+                    )
+
+                    with self.assertRaises(InvalidArgError) as e:
+                        _ = tensor_search.search(
+                            config=self.config,
+                            index_name=index.name,
+                            text=None,
+                            context=search_context,
+                            result_count=5,
+                            search_method="HYBRID",
+                            hybrid_parameters=HybridParameters(**hybrid_parameters)
+                        )
+                    self.assertIn("Marqo could not collect any vectors from the search query", str(e.exception))
+                    self.assertIn("Please check the provided query, context (if any), "
+                                  "or queryTensor(for Hybrid search)", str(e.exception))

--- a/tests/integ_tests/tensor_search/search/test_search_with_context.py
+++ b/tests/integ_tests/tensor_search/search/test_search_with_context.py
@@ -1502,3 +1502,60 @@ class TestSearchWithContext(MarqoTestCase):
                         )
 
                     self.assertIn("Marqo could not collect any vectors from the search query", str(e.exception))
+
+    def test_search_with_context_documents_allow_missing_both_parameters_for_different_hybrid_parameters(self):
+        """Test that search works when both allowMissingDocuments=True and allowMissingEmbeddings=True with mixed scenarios,
+        with different hybrid parameters"""
+        for index in [self.unstructured_default_text_index, self.structured_default_text_index]:
+            hybrid_parameters_test_cases = (
+                {"queryLexical": "*", "queryTensor": None, "retrievalMethod": "disjunction", "rankingMethod": "rrf"},
+                {"queryTensor": None, "retrievalMethod": "tensor", "rankingMethod": "tensor"}
+            )
+            for hybrid_parameters in hybrid_parameters_test_cases:
+                with self.subTest(f"index={index.type}, hybrid_parameters={hybrid_parameters_test_cases}"):
+                    # Add some documents
+                    docs = [
+                        {"_id": "doc1", "text_field_1": "Machine learning and artificial intelligence"},
+                        {"_id": "doc2", "text_field_1": "Deep learning neural networks"},
+                        {"_id": "doc3", "text_field_2": "Natural language processing"}
+                    ]
+
+                    self.add_documents(
+                        config=self.config,
+                        add_docs_params=AddDocsParams(
+                            index_name=index.name,
+                            docs=docs,
+                            tensor_fields=["text_field_1"] if isinstance(index, UnstructuredMarqoIndex) else None
+                        )
+                    )
+
+                    # Create search context with mix of existing and non-existent documents
+                    search_context = SearchContext(
+                        documents=SearchContextDocuments(
+                            # doc3 does not have "text_field_1"
+                            ids={"doc1": 2.0, "doc3": 0.1, "not_exists_doc": 1},
+                            parameters=SearchContextDocumentsParameters(
+                                tensorFields=["text_field_1"],
+                                exclueInputDocuments=True,
+                                allowMissingEmbeddings=True,
+                                allowMissingDocuments=True
+                            )
+                        )
+                    )
+
+                    # Should succeed and only use existing documents (doc1 and doc2)
+                    results = tensor_search.search(
+                        config=self.config,
+                        index_name=index.name,
+                        text=None,
+                        context=search_context,
+                        result_count=5,
+                        search_method="HYBRID",
+                        hybrid_parameters=HybridParameters(**hybrid_parameters)
+                    )
+
+                    # Verify search was successful
+                    self.assertIn("hits", results)
+                    self.assertGreater(len(results["hits"]), 0)
+                    result_ids = set([hit["_id"] for hit in results["hits"]])
+                    self.assertEqual({"doc2"}, result_ids)

--- a/tests/integ_tests/tensor_search/search/test_search_with_context.py
+++ b/tests/integ_tests/tensor_search/search/test_search_with_context.py
@@ -1395,10 +1395,8 @@ class TestSearchWithContext(MarqoTestCase):
                     self.assertGreater(len(results["hits"]), 0)
 
                     # Verify that existing documents are still included in results
-                    result_ids = [hit["_id"] for hit in results["hits"]]
-                    self.assertIn("doc1", result_ids)
-                    self.assertIn("doc2", result_ids)
-                    self.assertIn("doc3", result_ids)
+                    result_ids = set([hit["_id"] for hit in results["hits"]])
+                    self.assertEqual({"doc1", "doc2", "doc3"}, result_ids)
 
     def test_search_with_context_documents_allow_missing_both_parameters(self):
         """Test that search works when both allowMissingDocuments=True and allowMissingEmbeddings=True with mixed scenarios."""
@@ -1452,9 +1450,8 @@ class TestSearchWithContext(MarqoTestCase):
                     # Verify search was successful
                     self.assertIn("hits", results)
                     self.assertGreater(len(results["hits"]), 0)
-                    self.assertNotIn("doc1", results["hits"][0]["_id"])
-                    self.assertNotIn("doc3", results["hits"][0]["_id"])
-                    self.assertIn("doc2", results["hits"][0]["_id"])
+                    result_ids = set([hit["_id"] for hit in results["hits"]])
+                    self.assertEqual({"doc2"}, result_ids)
 
     def test_a_proper_error_is_raised_if_marqo_can_not_collect_any_vector(self):
         for index in [self.unstructured_default_text_index, self.structured_default_text_index]:

--- a/tests/integ_tests/tensor_search/search/test_search_with_context.py
+++ b/tests/integ_tests/tensor_search/search/test_search_with_context.py
@@ -1616,3 +1616,58 @@ class TestSearchWithContext(MarqoTestCase):
                     self.assertIn("Marqo could not collect any vectors from the search query", str(e.exception))
                     self.assertIn("Please check the provided query, context (if any), "
                                   "or queryTensor(for Hybrid search)", str(e.exception))
+
+    def test_search_with_context_if_context_vectors_exist_documents_can_have_no_embeddings(self):
+        """Test that if context vector is provided, even if marqo can not collect any vectors from the documents,
+        the search can still proceed when allow_missing_documents=True, allowing_missing_embeddings=True"""
+        for index in [self.unstructured_default_text_index, self.structured_default_text_index]:
+            hybrid_parameters_test_cases = (
+                {"queryLexical": "*", "queryTensor": None, "retrievalMethod": "disjunction", "rankingMethod": "rrf"},
+                {"queryLexical": "*", "queryTensor": {}, "retrievalMethod": "disjunction", "rankingMethod": "rrf"},
+                {"queryTensor": None, "retrievalMethod": "tensor", "rankingMethod": "tensor"},
+                {"queryTensor": {}, "retrievalMethod": "tensor", "rankingMethod": "tensor"}
+            )
+            for hybrid_parameters in hybrid_parameters_test_cases:
+                with self.subTest(f"index={index.type}, hybrid_parameters={hybrid_parameters_test_cases}"):
+                    # Add some documents
+                    docs = [
+                        {"_id": "doc1", "text_field_1": "Machine learning and artificial intelligence"},
+                        {"_id": "doc2", "text_field_1": "Deep learning neural networks"},
+                        {"_id": "doc3", "text_field_2": "Natural language processing"}
+                    ]
+
+                    self.add_documents(
+                        config=self.config,
+                        add_docs_params=AddDocsParams(
+                            index_name=index.name,
+                            docs=docs,
+                            tensor_fields=["text_field_1"] if isinstance(index, UnstructuredMarqoIndex) else None
+                        )
+                    )
+
+                    # Create search context with mix of existing and non-existent documents
+                    search_context = SearchContext(
+                        documents=SearchContextDocuments(
+                            # doc3 does not have "text_field_1"
+                            ids={"doc3": 0.1, "not_exists_doc": 1},
+                            parameters=SearchContextDocumentsParameters(
+                                tensorFields=["text_field_1"],
+                                excludeInputDocuments=True,
+                                allowMissingEmbeddings=True,
+                                allowMissingDocuments=True
+                            )
+                        ),
+                        tensor=[SearchContextTensor(vector=[0.01] * 384, weight=1)]
+                    )
+
+                    r = tensor_search.search(
+                        config=self.config,
+                        index_name=index.name,
+                        text=None,
+                        context=search_context,
+                        result_count=5,
+                        search_method="HYBRID",
+                        hybrid_parameters=HybridParameters(**hybrid_parameters)
+                    )
+
+                    self.assertEqual(2, len(r["hits"]))

--- a/tests/unit_tests/core/search/test_recommender_vectors.py
+++ b/tests/unit_tests/core/search/test_recommender_vectors.py
@@ -77,7 +77,7 @@ class TestRecommenderGetDocVectorsFromIds(unittest.TestCase):
         
         # Verify tensor_search function was called correctly
         mock_get_vectors.assert_called_once_with(
-            mock_config, "test_index", ["doc1", "doc2"], tensor_fields=None
+            mock_config, "test_index", ["doc1", "doc2"], tensor_fields=None, allow_missing_documents=False
         )
     
     @patch('marqo.tensor_search.index_meta_cache.get_index')
@@ -117,7 +117,7 @@ class TestRecommenderGetDocVectorsFromIds(unittest.TestCase):
         
         # Verify tensor_search function was called with non-zero weight docs only
         mock_get_vectors.assert_called_once_with(
-            mock_config, "test_index", ["doc1", "doc3"], tensor_fields=None
+            mock_config, "test_index", ["doc1", "doc3"], tensor_fields=None, allow_missing_documents=False
         )
     
     @patch('marqo.tensor_search.index_meta_cache.get_index')
@@ -155,7 +155,7 @@ class TestRecommenderGetDocVectorsFromIds(unittest.TestCase):
         
         # Verify tensor_search function was called with specific fields
         mock_get_vectors.assert_called_once_with(
-            mock_config, "test_index", ["doc1"], tensor_fields=["title", "content"]
+            mock_config, "test_index", ["doc1"], tensor_fields=["title", "content"], allow_missing_documents=False
         )
     
     @patch('marqo.tensor_search.index_meta_cache.get_index')

--- a/tests/unit_tests/core/search/test_recommender_vectors.py
+++ b/tests/unit_tests/core/search/test_recommender_vectors.py
@@ -677,4 +677,112 @@ class TestRecommenderGetDocVectorsFromIds(unittest.TestCase):
         
         error_message = str(cm.exception)
         self.assertIn("Duplicate document IDs found", error_message)
-        self.assertIn("doc1", error_message) 
+        self.assertIn("doc1", error_message)
+
+    @patch('marqo.tensor_search.index_meta_cache.get_index')
+    @patch('marqo.tensor_search.tensor_search.get_doc_vectors_per_tensor_field_by_ids')
+    @patch('marqo.config.Config')
+    def test_get_doc_vectors_allow_missing_documents_true(self, mock_config_class, mock_get_vectors, mock_get_index):
+        """Test that allowMissingDocuments=True allows missing documents and only returns existing ones"""
+        
+        # Mock dependencies
+        mock_get_index.return_value = self.mock_structured_index
+        mock_config = Mock()
+        mock_config_class.return_value = mock_config
+        
+        # Mock response with only some documents (simulating missing documents ignored)
+        mock_get_vectors.return_value = {
+            "doc1": {"title": [[0.1, 0.2, 0.3]]},
+            "doc3": {"title": [[0.7, 0.8, 0.9]]}
+            # doc2 and doc4 are missing but should be ignored due to allowMissingDocuments=True
+        }
+        
+        # Should succeed with allowMissingDocuments=True
+        result = self.recommender.get_doc_vectors_from_ids(
+            index_name="test_index",
+            documents=["doc1", "doc2", "doc3", "doc4"],
+            allow_missing_documents=True
+        )
+        
+        # Should only return vectors for existing documents
+        expected = {
+            "doc1": [[0.1, 0.2, 0.3]],
+            "doc3": [[0.7, 0.8, 0.9]]
+        }
+        self.assertEqual(result, expected)
+        
+        # Verify tensor_search function was called with allowMissingDocuments=True
+        mock_get_vectors.assert_called_once_with(
+            mock_config, "test_index", ["doc1", "doc2", "doc3", "doc4"], tensor_fields=None, allow_missing_documents=True
+        )
+
+    @patch('marqo.tensor_search.index_meta_cache.get_index')
+    @patch('marqo.tensor_search.tensor_search.get_doc_vectors_per_tensor_field_by_ids')
+    @patch('marqo.config.Config')
+    def test_get_doc_vectors_allow_missing_embeddings_true(self, mock_config_class, mock_get_vectors, mock_get_index):
+        """Test that allowMissingEmbeddings=True allows documents with missing embeddings"""
+
+        # Mock dependencies
+        mock_get_index.return_value = self.mock_structured_index
+        mock_config = Mock()
+        mock_config_class.return_value = mock_config
+
+        # Mock response where one document has no embeddings for requested field
+        mock_get_vectors.return_value = {
+            "doc1": {"title": [[0.1, 0.2, 0.3]]},
+            "doc2": {}  # No embeddings for the requested field
+        }
+
+        r = self.recommender.get_doc_vectors_from_ids(
+            index_name="test_index",
+            documents=["doc1", "doc2"],
+            tensor_fields=["title"],
+            allow_missing_embeddings=True
+        )
+
+        self.assertEqual(
+            {"doc1": [[0.1, 0.2, 0.3]]}, r
+        )
+
+        mock_get_vectors.assert_called_once_with(
+            mock_config, "test_index", ["doc1", "doc2"], tensor_fields=["title"],
+            allow_missing_documents=False
+        )
+
+    @patch('marqo.tensor_search.index_meta_cache.get_index')
+    @patch('marqo.tensor_search.tensor_search.get_doc_vectors_per_tensor_field_by_ids')
+    @patch('marqo.config.Config')
+    def test_get_doc_vectors_allow_both_missing_parameters_true(self, mock_config_class, mock_get_vectors, mock_get_index):
+        """Test that both allowMissingDocuments=True and allowMissingEmbeddings=True work together"""
+        
+        # Mock dependencies
+        mock_get_index.return_value = self.mock_structured_index
+        mock_config = Mock()
+        mock_config_class.return_value = mock_config
+        
+        # Mock response where some documents are missing and others lack embeddings
+        mock_get_vectors.return_value = {
+            "doc1": {"title": [[0.1, 0.2, 0.3]]},
+            "doc4": {},
+            # doc2 missing entirely, doc3 exists but has no title embeddings
+        }
+        
+        # Should succeed with both parameters set to True
+        result = self.recommender.get_doc_vectors_from_ids(
+            index_name="test_index",
+            documents=["doc1", "doc2", "doc3", "doc4"],
+            tensor_fields=["title"],
+            allow_missing_documents=True,
+            allow_missing_embeddings=True
+        )
+        
+        # Should only return vectors for documents that exist and have embeddings
+        expected = {
+            "doc1": [[0.1, 0.2, 0.3]],
+        }
+        self.assertEqual(result, expected)
+        
+        # Verify tensor_search function was called with both parameters=True
+        mock_get_vectors.assert_called_once_with(
+            mock_config, "test_index", ["doc1", "doc2", "doc3", "doc4"], tensor_fields=["title"], allow_missing_documents=True
+        )

--- a/tests/unit_tests/marqo/tensor_search/test_tensor_search.py
+++ b/tests/unit_tests/marqo/tensor_search/test_tensor_search.py
@@ -1,5 +1,6 @@
 import unittest
-from unittest.mock import Mock, patch
+from magic import Magic
+from unittest.mock import Mock, patch, MagicMock
 
 from marqo import version
 from marqo.api import exceptions as api_exceptions
@@ -7,7 +8,7 @@ from marqo.config import Config
 from marqo.core.models.marqo_index import MarqoIndex, IndexType, Model, StructuredMarqoIndex, SemiStructuredMarqoIndex
 from marqo.tensor_search import tensor_search
 from marqo.tensor_search.enums import SearchMethod
-from marqo.tensor_search.models.search import VectorisedJobPointer, JHash
+from marqo.tensor_search.models.search import VectorisedJobPointer, JHash, Qidx, SearchContextDocuments
 from marqo.tensor_search.models.api_models import CustomVectorQuery
 from marqo.vespa.models import QueryResult
 from marqo.vespa.models.query_result import Child, Root, Coverage
@@ -533,6 +534,51 @@ class TestTensorSearchValidation(unittest.TestCase):
                 document_ids=["doc1", "doc2", "doc3"]
             )
         self.assertIn("documents were requested, which is more than the allowed limit", str(cm.exception))
+
+
+class TestGetQueryVectorFromJobs(unittest.TestCase):
+
+    def test_get_query_vector_from_jobs_fails_if_no_vector_is_collected(self):
+        """Test that get_query_vectors_from_jobs raises InvalidArgError when no vector is collected"""
+        # Create a mock index
+        mock_index = Mock(spec=SemiStructuredMarqoIndex)
+        mock_index.model = Mock()
+        mock_index.model.get_dimension.return_value = 3
+        mock_index.name = "test-index"
+        mock_index.type = IndexType.SemiStructured
+        
+        # Create a multimodal query (dict) that will result in no vector being collected
+        # This will go through the multimodal path and can result in empty vectors
+        query = BulkSearchQueryEntity(
+            q=None,
+            index=mock_index,
+            searchMethod=SearchMethod.TENSOR,
+            limit=10,
+            offset=0,
+            showHighlights=False,
+            context=MagicMock(spec=SearchContext)
+        )
+
+        mock_recommender = MagicMock()
+        mock_config = MagicMock(spec=Config)
+        mock_config.recommender = mock_recommender
+
+        mock_recommender.get_doc_vectors_from_ids.return_value = {}
+        mock_recommender.get_default_interpolation_method.return_value="slerp"
+
+        with self.assertRaises(api_exceptions.InvalidArgError) as cm:
+            with patch("marqo.tensor_search.telemetry.RequestMetricsStore.for_request") as mock_telemetry:
+                r = tensor_search.get_query_vectors_from_jobs(
+                    queries=[query],
+                    qidx_to_job={0: []},
+                    job_to_vectors=dict(),
+                    config= mock_config,
+                    jobs = dict(),
+                    interpolation_method=None
+                )
+        self.assertIn("Marqo could not collect any vectors from the search query but the retrieval "
+                      "or ranking method requires at least one valid vector", str(cm.exception))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->
This pull request introduces improved handling of missing documents and embeddings in recommendation and search workflows. It adds new parameters to allow the API to optionally skip errors when documents or their embeddings are missing. 

In addition, we ease the restriction on the hybrid parameters `queryTensor`. It can now be either `None`, `{}` or even nothing. Marqo will raise an error if it can not collect any vector from the inputs while a vector is needed.

Py-marqo PR: https://github.com/marqo-ai/py-marqo/pull/299

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

[MOSD-483](https://s2search.atlassian.net/browse/MOSD-483?atlOrigin=eyJpIjoiNzk5MjRkZmQ5ZmYwNGRlNGE0NmI1NGIzNmI1Y2NkYjciLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

## Checklist
<!-- Check items that apply, add items if needed -->
- [x] Tests have been added for changes
- [ ] Documentation has been updated
- [x] Breaking changes are clearly identified
- [x] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)



[MOSD-483]: https://s2search.atlassian.net/browse/MOSD-483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ