### PR TITLE
Fix total hit count when collapse field is provided [Patch 2.23]

### DIFF
--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -187,8 +187,11 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
 
         if marqo_query.track_total_hits is not None:
             # 0 is byte representation of letter "t"
-            facet_queries.append(facets_query_skeleton % (
-            f'{base_yql}{filter_term}', f"all(group({self._TOTAL_HITS_GROUP_CONST}) each(output(count())))"))
+            if marqo_query.collapse_field_name:
+                total_hit_query = f"all(group({self._TOTAL_HITS_GROUP_CONST}) each(group({marqo_query.collapse_field_name}) output(count())))"
+            else:
+                total_hit_query = f"all(group({self._TOTAL_HITS_GROUP_CONST}) each(output(count())))"
+            facet_queries.append(facets_query_skeleton % (f'{base_yql}{filter_term}', total_hit_query))
 
         if marqo_query.facets is not None:
             facets_term = self._get_facets_term(marqo_query.facets,

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.23.1"
+__version__ = "2.23.2"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/tests/api_tests/v1/tests/api_tests/test_collapse_fields.py
+++ b/tests/api_tests/v1/tests/api_tests/test_collapse_fields.py
@@ -242,6 +242,7 @@ class TestCollapseFields(MarqoTestCase):
                         ]},
                         "color": {"type": "string"}
                     }},
+                    track_total_hits=True,
                     limit=6
                 )
 
@@ -249,6 +250,9 @@ class TestCollapseFields(MarqoTestCase):
                 self.assertDictEqual({'count': 1}, res["facets"]["price"]["0.0:2.0"])
                 self.assertDictEqual({'count': 2}, res["facets"]["price"]["2.0:4.0"])
                 self.assertDictEqual({'red': {'count': 3}, 'yellow': {'count': 3}}, res["facets"]["color"])
+
+                # Test that the hit count returns the count of unique collapse field value
+                self.assertEqual(3, res['totalHits'])
 
     def test_pagination(self):
         """Test that pagination works with search with collapse field"""

--- a/tests/integ_tests/tensor_search/integ_tests/test_collapse_fields.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_collapse_fields.py
@@ -293,6 +293,7 @@ class TestCollapseFields(MarqoTestCase):
                             "color": FieldFacetsConfiguration(type="string")
                         }
                     ),
+                    track_total_hits=True,
                     result_count=6
                 )
 
@@ -307,6 +308,9 @@ class TestCollapseFields(MarqoTestCase):
                 self.assertDictEqual({'count': 2}, res["facets"]["rating"]["2.0:4.0"])
                 # FIXME mixed int and float rating confuses Vespa, 0.0:2.0 in the float field returns 2 instead of 0
                 self.assertDictEqual({'count': 3}, res["facets"]["rating"]["0.0:2.0"])
+
+                # Test that the hit count returns the count of unique collapse field value
+                self.assertEqual(3, res['totalHits'])
 
 
 
@@ -658,4 +662,3 @@ class TestCollapseFields(MarqoTestCase):
         # Verify the search returns all docs in one group
         self.assertEqual(5, len(lexical_res["hits"]))
         self.assertEqual(set([f"doc1{i:02}" for i in range(5)]), set([hit['_id'] for hit in lexical_res["hits"]]))
-

--- a/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_semi_structured_vespa_index_to_vespa_query.py
+++ b/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_semi_structured_vespa_index_to_vespa_query.py
@@ -796,7 +796,8 @@ class TestSemiStructuredVespaIndexToVespaQueryCollapseFields(MarqoTestCase):
                     ]),
                     "color": FieldFacetsConfiguration(type="string")
                 }
-            )
+            ),
+            track_total_hits=True,
         )
         vespa_query = self.vespa_index.to_vespa_query(marqo_query)
 
@@ -815,7 +816,10 @@ class TestSemiStructuredVespaIndexToVespaQueryCollapseFields(MarqoTestCase):
                          vespa_query['marqo__ranking.tensor.lexical'])
 
         # assert facets query has an extra grouping
-        self.assertEqual('select * from test_index where (false OR False) limit 0 | all( '
+        self.assertEqual('select * from test_index where (false OR False) limit 0 | all(group(1.1) '
+                         'each(group(parent_id) output(count())))\n'
+                         '---MARQO-YQL-QUERY-DELIMITER---\n'
+                         'select * from test_index where (false OR False) limit 0 | all( '
                          'all(group(predefined(marqo__int_fields{"price"}, bucket(0.0, 1.0), '
                          'bucket(1.0, 3.0))) max(100) order(-count()) each(group(parent_id) '
                          'output(count()))) all(group(predefined(marqo__float_fields{"price"}, '
@@ -840,7 +844,8 @@ class TestSemiStructuredVespaIndexToVespaQueryCollapseFields(MarqoTestCase):
                     ]),
                     "color": FieldFacetsConfiguration(type="string")
                 }
-            )
+            ),
+            track_total_hits = True,
         )
         vespa_query = self.vespa_index.to_vespa_query(marqo_query)
 
@@ -856,7 +861,10 @@ class TestSemiStructuredVespaIndexToVespaQueryCollapseFields(MarqoTestCase):
         self.assertEqual(common.RANK_PROFILE_HYBRID_EMBEDDING_SIMILARITY_THEN_BM25,
                          vespa_query['marqo__ranking.tensor.lexical'])
 
-        self.assertEqual('select * from test_index where (false OR False) limit 0 | all( '
+        self.assertEqual('select * from test_index where (false OR False) limit 0 | all(group(1.1) '
+                         'each(output(count())))\n'
+                         '---MARQO-YQL-QUERY-DELIMITER---\n'
+                         'select * from test_index where (false OR False) limit 0 | all( '
                          'all(group(predefined(marqo__int_fields{"price"}, bucket(0.0, 1.0), '
                          'bucket(1.0, 3.0))) max(100) order(-count()) '
                          'each(output(sum(marqo__int_fields{"price"}), '


### PR DESCRIPTION
## Change Summary
Change the vespa query to group the total hit count result by collapse field when it is provided

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [x] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

