### PR TITLE
Add collapse field to attributes_to_retrieve

### DIFF
--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -80,6 +80,11 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
 
             marqo_query.attributes_to_retrieve.append(common.VESPA_FIELD_ID)
 
+            # Add collapse field if provided, this is critical for collapsing search result
+            if (isinstance(marqo_query, MarqoHybridQuery) and marqo_query.collapse_field_name
+                    and marqo_query.collapse_field_name not in marqo_query.attributes_to_retrieve):
+                marqo_query.attributes_to_retrieve.append(marqo_query.collapse_field_name)
+
             # add chunk field names for tensor fields
             marqo_query.attributes_to_retrieve.extend(
                 [self.get_marqo_index().tensor_field_map[att].chunk_field_name

--- a/tests/integ_tests/tensor_search/integ_tests/test_collapse_fields.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_collapse_fields.py
@@ -144,7 +144,7 @@ class TestCollapseFields(MarqoTestCase):
     def test_search_with_valid_collapse_field_succeeds(self):
         """Test that search with valid collapse field name succeeds"""
         
-        docs = [{"_id": f"doc{g}{i:02}", "title": f"Test document {g}{i:02}", "parent_id": f"group_{g}"}
+        docs = [{"_id": f"doc{g}{i:02}", "title": f"Test document {g}{i:02}", "parent_id": f"group_{g}", "group": g}
                 for i in range(10) for g in range(5)]
 
         self.add_documents(
@@ -177,13 +177,18 @@ class TestCollapseFields(MarqoTestCase):
                         rankingMethod=ranking_method,
                         rerankDepthTensor=10,  # tensor-tensor will have fewer hits if we do not increase this, why?
                     ),
+                    # parent id is not added here, it will be added in the query for collapsing, but not in the result
+                    attributes_to_retrieve=["title", "group"],
                     collapse_field_name="parent_id",
                     result_count=6
                 )
 
-                # Verify the search executed successfully and only contain 1 doc from each group
-                self.assertEqual(5, len(res["hits"]))  # there's only 5 groups, so at most 5 results
-                self.assertEqual(set([f"group_{g}" for g in range(5)]), set([hit['parent_id'] for hit in res["hits"]]))
+                # there's only 5 groups, so only 5 results
+                self.assertEqual(5, len(res["hits"]))
+                # only contain 1 doc from each group
+                self.assertEqual(set(range(5)), set([hit['group'] for hit in res["hits"]]))
+                # parent_id is not returned
+                self.assertTrue(all("parent_id" not in hit for hit in res["hits"]))
 
     def test_filter(self):
         """Test that filtering works with search with collapse field"""

--- a/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_semi_structured_vespa_index_to_vespa_query.py
+++ b/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_semi_structured_vespa_index_to_vespa_query.py
@@ -911,5 +911,173 @@ class TestSemiStructuredVespaIndexToVespaQueryFacets(MarqoTestCase):
                              'each(output(count()))) )', vespa_query['marqo__yql.facets'])
 
 
+class TestSemiStructuredVespaIndexCollapseFieldAttributesToRetrieve(MarqoTestCase):
+
+    def setUp(self):
+        """Set up test fixtures with a semi-structured index that supports both tensor and lexical search."""
+        # Create a semi-structured index with both lexical and tensor fields
+        marqo_index = self.semi_structured_marqo_index(
+            name='test_index',
+            lexical_field_names=['title', 'description'], 
+            tensor_field_names=['title', 'description'],
+            string_array_field_names=['tags']
+        )
+        self.vespa_index = SemiStructuredVespaIndex(marqo_index)
+
+    def test_to_vespa_query_adds_collapse_field_to_attributes_to_retrieve(self):
+        """Test that collapse field is added to attributes_to_retrieve for hybrid queries"""
+        hybrid_query = MarqoHybridQuery(
+            index_name=self.vespa_index._marqo_index.name,
+            vector_query=[0.1, 0.2, 0.3, 0.4],
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                searchableAttributesTensor=["title"],
+                searchableAttributesLexical=["title"]
+            ),
+            or_phrases=["test query"],
+            and_phrases=[],
+            attributes_to_retrieve=["title", "description"],
+            collapse_field_name="parent_id",
+            limit=10,
+            offset=0
+        )
+        
+        # Call to_vespa_query to process the query
+        vespa_query = self.vespa_index.to_vespa_query(hybrid_query)
+        
+        # Verify that collapse field was added to attributes_to_retrieve
+        self.assertIn("parent_id", hybrid_query.attributes_to_retrieve)
+        self.assertIn("parent_id", vespa_query["marqo__yql.tensor"])
+        self.assertIn("parent_id", vespa_query["marqo__yql.lexical"])
+
+        # Verify other expected attributes are still present
+        self.assertIn("title", hybrid_query.attributes_to_retrieve)
+        self.assertIn("description", hybrid_query.attributes_to_retrieve)
+
+    def test_to_vespa_query_adds_collapse_field_to_empty_attributes_to_retrieve(self):
+        """Test that collapse field is added to attributes_to_retrieve for hybrid queries"""
+        hybrid_query = MarqoHybridQuery(
+            index_name=self.vespa_index._marqo_index.name,
+            vector_query=[0.1, 0.2, 0.3, 0.4],
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                searchableAttributesTensor=["title"],
+                searchableAttributesLexical=["title"]
+            ),
+            or_phrases=["test query"],
+            and_phrases=[],
+            attributes_to_retrieve=[],
+            collapse_field_name="parent_id",
+            limit=10,
+            offset=0
+        )
+
+        # Call to_vespa_query to process the query
+        vespa_query = self.vespa_index.to_vespa_query(hybrid_query)
+
+        # Verify that collapse field was added to attributes_to_retrieve
+        self.assertIn("parent_id", hybrid_query.attributes_to_retrieve)
+        self.assertIn("parent_id", vespa_query["marqo__yql.tensor"])
+        self.assertIn("parent_id", vespa_query["marqo__yql.lexical"])
+
+    def test_to_vespa_query_does_not_duplicate_collapse_field_in_attributes_to_retrieve(self):
+        """Test that collapse field is not duplicated if already in attributes_to_retrieve"""
+        hybrid_query = MarqoHybridQuery(
+            index_name=self.vespa_index._marqo_index.name,
+            vector_query=[0.1, 0.2, 0.3, 0.4], 
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                searchableAttributesTensor=["title"],
+                searchableAttributesLexical=["title"]
+            ),
+            or_phrases=["test query"],
+            and_phrases=[],
+            attributes_to_retrieve=["title", "parent_id"],  # collapse field already present
+            collapse_field_name="parent_id",
+            limit=10,
+            offset=0
+        )
+        
+        # Call to_vespa_query to process the query
+        vespa_query = self.vespa_index.to_vespa_query(hybrid_query)
+        
+        self.assertEqual(1, hybrid_query.attributes_to_retrieve.count("parent_id"))
+        self.assertIn("parent_id", vespa_query["marqo__yql.tensor"])
+        self.assertIn("parent_id", vespa_query["marqo__yql.lexical"])
+
+    def test_to_vespa_query_does_not_add_collapse_field_to_attributes_if_not_provided(self):
+        """Test that collapse field is not added to attributes_to_retrieve if not provided"""
+        hybrid_query = MarqoHybridQuery(
+            index_name=self.vespa_index._marqo_index.name,
+            vector_query=[0.1, 0.2, 0.3, 0.4],
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                searchableAttributesTensor=["title"],
+                searchableAttributesLexical=["title"]
+            ),
+            or_phrases=["test query"],
+            and_phrases=[],
+            attributes_to_retrieve=["title"],
+            limit=10,
+            offset=0
+        )
+
+        # Call to_vespa_query to process the query
+        vespa_query = self.vespa_index.to_vespa_query(hybrid_query)
+
+        self.assertNotIn("parent_id", hybrid_query.attributes_to_retrieve)
+        self.assertNotIn("parent_id", vespa_query["marqo__yql.tensor"])
+        self.assertNotIn("parent_id", vespa_query["marqo__yql.lexical"])
+
+    def test_to_vespa_query_does_not_add_collapse_field_to_attributes_if_attributes_to_retrieve_is_none(self):
+        """Test that collapse field is not added to attributes_to_retrieve if not provided"""
+        hybrid_query = MarqoHybridQuery(
+            index_name=self.vespa_index._marqo_index.name,
+            vector_query=[0.1, 0.2, 0.3, 0.4],
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                searchableAttributesTensor=["title"],
+                searchableAttributesLexical=["title"]
+            ),
+            or_phrases=["test query"],
+            and_phrases=[],
+            collapse_field_name="parent_id",
+            limit=10,
+            offset=0
+        )
+
+        # Call to_vespa_query to process the query
+        vespa_query = self.vespa_index.to_vespa_query(hybrid_query)
+
+        self.assertIsNone(hybrid_query.attributes_to_retrieve)
+        self.assertNotIn("parent_id", vespa_query["marqo__yql.tensor"])
+        self.assertNotIn("parent_id", vespa_query["marqo__yql.lexical"])
+
+    def test_to_vespa_query_does_not_add_collapse_field_for_non_hybrid_queries(self):
+        """Test that collapse field is not added for non-hybrid queries"""
+        test_queries = [
+            MarqoTensorQuery(
+                index_name=self.vespa_index._marqo_index.name,
+                limit=10, offset=0,
+                attributes_to_retrieve=["title", "description"],
+                vector_query=[0.1, 0.2, 0.3, 0.4]
+            ),
+            MarqoLexicalQuery(
+                index_name=self.vespa_index._marqo_index.name,
+                limit=10, offset=0,
+                or_phrases=["test query"], and_phrases=[],
+                attributes_to_retrieve=["title", "description"]
+            )
+        ]
+
+        for marqo_query in test_queries:
+            with self.subTest(type=type(marqo_query)):
+                # MarqoQuery doesn't have collapse_field_name, so this should not affect attributes_to_retrieve
+                vespa_query = self.vespa_index.to_vespa_query(marqo_query)
+
+                self.assertNotIn("parent_id", vespa_query["yql"])
+                self.assertNotIn("parent_id", marqo_query.attributes_to_retrieve)
+
+
 if __name__ == '__main__':
     unittest.main() 


### PR DESCRIPTION
## Change Summary
When collapse field is not in attributes_to_retrieve, the collapsing does work since it is not retrieved to Vespa container node where collapsing happens. This change enforce collapse field in attributes_to_retrieve to work around this issue.

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [x] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

