### PR TITLE
Fix verbose log in hybrid searcher

### DIFF
--- a/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
+++ b/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
@@ -919,7 +919,7 @@ public class HybridSearcher extends Searcher {
         return null;
     }
 
-    HitGroup collectErrorsFromResults(Result resultLexical, Result resultTensor, Boolean verbose) {
+    HitGroup collectErrorsFromResults(Result resultLexical, Result resultTensor, boolean verbose) {
         // Return errors if either result list has an error. Make sure all errors are returned.
         HitGroup combinedErrors = new HitGroup();
         logIfVerbose(

--- a/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
+++ b/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
@@ -263,7 +263,8 @@ public class HybridSearcher extends Searcher {
             }
 
             // Collect errors from lexical and tensor results.
-            HitGroup combinedErrors = collectErrorsFromResults(resultLexical, resultTensor, verbose);
+            HitGroup combinedErrors =
+                    collectErrorsFromResults(resultLexical, resultTensor, verbose);
             if (combinedErrors.getError() != null) {
                 return new Result(query, combinedErrors);
             }
@@ -925,7 +926,8 @@ public class HybridSearcher extends Searcher {
         logIfVerbose(
                 String.format("Tensor Errors found: %s", resultTensor.hits().getError()), verbose);
         logIfVerbose(
-                String.format("Lexical Errors found: %s", resultLexical.hits().getError()), verbose);
+                String.format("Lexical Errors found: %s", resultLexical.hits().getError()),
+                verbose);
         combinedErrors.addErrorsFrom(resultTensor.hits());
         combinedErrors.addErrorsFrom(resultLexical.hits());
         return combinedErrors;

--- a/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
+++ b/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
@@ -263,7 +263,7 @@ public class HybridSearcher extends Searcher {
             }
 
             // Collect errors from lexical and tensor results.
-            HitGroup combinedErrors = collectErrorsFromResults(resultLexical, resultTensor);
+            HitGroup combinedErrors = collectErrorsFromResults(resultLexical, resultTensor, verbose);
             if (combinedErrors.getError() != null) {
                 return new Result(query, combinedErrors);
             }
@@ -919,13 +919,13 @@ public class HybridSearcher extends Searcher {
         return null;
     }
 
-    HitGroup collectErrorsFromResults(Result resultLexical, Result resultTensor) {
+    HitGroup collectErrorsFromResults(Result resultLexical, Result resultTensor, Boolean verbose) {
         // Return errors if either result list has an error. Make sure all errors are returned.
         HitGroup combinedErrors = new HitGroup();
         logIfVerbose(
-                String.format("Tensor Errors found: %s", resultTensor.hits().getError()), true);
+                String.format("Tensor Errors found: %s", resultTensor.hits().getError()), verbose);
         logIfVerbose(
-                String.format("Lexical Errors found: %s", resultLexical.hits().getError()), true);
+                String.format("Lexical Errors found: %s", resultLexical.hits().getError()), verbose);
         combinedErrors.addErrorsFrom(resultTensor.hits());
         combinedErrors.addErrorsFrom(resultLexical.hits());
         return combinedErrors;

--- a/vespa/src/test/java/ai/marqo/search/HybridSearcherTest.java
+++ b/vespa/src/test/java/ai/marqo/search/HybridSearcherTest.java
@@ -445,7 +445,7 @@ class HybridSearcherTest {
                             ErrorMessage.createInternalServerError("Example lexical error"));
             Result resultTensor = new Result(new Query());
             HitGroup combinedErrors =
-                    hybridSearcher.collectErrorsFromResults(resultLexical, resultTensor);
+                    hybridSearcher.collectErrorsFromResults(resultLexical, resultTensor, true);
 
             assertThat(combinedErrors.getError().getDetailedMessage())
                     .contains("Example lexical error");
@@ -459,7 +459,7 @@ class HybridSearcherTest {
                             new Query(),
                             ErrorMessage.createInternalServerError("Example tensor error"));
             HitGroup combinedErrors =
-                    hybridSearcher.collectErrorsFromResults(resultLexical, resultTensor);
+                    hybridSearcher.collectErrorsFromResults(resultLexical, resultTensor, true);
 
             assertThat(combinedErrors.getError().getDetailedMessage())
                     .contains("Example tensor error");
@@ -476,7 +476,7 @@ class HybridSearcherTest {
                             new Query(),
                             ErrorMessage.createInternalServerError("Example tensor error"));
             HitGroup combinedErrors =
-                    hybridSearcher.collectErrorsFromResults(resultLexical, resultTensor);
+                    hybridSearcher.collectErrorsFromResults(resultLexical, resultTensor, true);
 
             Iterator<ErrorMessage> iterator = combinedErrors.getErrorHit().errors().iterator();
             assertThat(iterator.next().getDetailedMessage()).contains("Example tensor error");
@@ -488,7 +488,7 @@ class HybridSearcherTest {
             Result resultLexical = new Result(new Query());
             Result resultTensor = new Result(new Query());
             HitGroup combinedErrors =
-                    hybridSearcher.collectErrorsFromResults(resultLexical, resultTensor);
+                    hybridSearcher.collectErrorsFromResults(resultLexical, resultTensor, true);
             assertThat(combinedErrors.getError()).isNull();
         }
     }


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->
Fix a bug that the method `collectErrorsFromResults` does not respect the verbose value and always logs the errors.

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

