### PR TITLE
Fix metric emission for get-batch and delete-batch endpoints

### DIFF
--- a/src/marqo/core/monitoring/statsd_middleware.py
+++ b/src/marqo/core/monitoring/statsd_middleware.py
@@ -5,11 +5,13 @@ from typing import Dict
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
+from pathlib import PurePosixPath
 
 from marqo.core.monitoring.statsd_client import StatsDClient
 
 _DOCS_RE = re.compile(r"/indexes/[^/]+/documents$")
-_DOCUMENT_ID_RE = re.compile(r"(/documents/)[^/]+")
+
+FIXED_DOC_SUBPATHS = {"delete-batch", "get-batch"}
 
 
 class StatsDMiddleware(BaseHTTPMiddleware):
@@ -64,7 +66,10 @@ class StatsDMiddleware(BaseHTTPMiddleware):
     @staticmethod
     def _sanitize_path(path: str) -> str:
         """
-        Replace the document-id segment in …/documents/{id} with <document_id>
-        so we don’t create a high-cardinality CloudWatch dimension.
+        Replace the document-id segment in …/documents/{id} with <document_id>,
+        but skip known fixed subpaths like …/documents/delete-batch.
         """
-        return _DOCUMENT_ID_RE.sub(r"\1<document_id>", path)
+        p = PurePosixPath(path)
+        if p.parent.name == "documents" and p.name not in FIXED_DOC_SUBPATHS:
+            return str(p.parent / "<document_id>")
+        return path

--- a/tests/integ_tests/core/monitoring/test_metrics_udp.py
+++ b/tests/integ_tests/core/monitoring/test_metrics_udp.py
@@ -38,7 +38,7 @@ class _UDPSink:
                 with self._lock:
                     self.packets.append(data)
             except socket.timeout:
-                continue  # polling tick
+                continue
             except OSError:
                 break
 
@@ -101,30 +101,79 @@ class TestStatsDMiddlewareUDP(unittest.TestCase):
             statsd = sc.StatsDClient(host="127.0.0.1", port=cls.sink.port)
             app.add_middleware(sm.StatsDMiddleware, statsd_client=statsd)
 
-            @app.get("/")
-            def root():
-                return {"ok": True}
-
-            @app.get("/indexes/{name}/search")
+            # Search & related
+            @app.post("/indexes/{name}/search")
             def search(name: str):
                 return {"hits": []}
 
+            @app.post("/indexes/{name}/recommend")
+            def recommend(name: str):
+                return {"recommendations": []}
+
+            @app.post("/indexes/{name}/embed")
+            def embed(name: str):
+                return {"vectors": []}
+
+            @app.post("/indexes/bulk/search")
+            def bulk_search():
+                return {"results": []}
+
+            # Documents collection endpoints
             @app.post("/indexes/{name}/documents")
             def add_docs(name: str):
                 # Return explicit JSONResponse so we control headers precisely
                 return JSONResponse(
                     content={"indexed": 1},
-                    headers={
-                        "x-count-success": "1",
-                        "x-count-failure": "0",
-                        "x-count-error": "0",
-                    },
+                    headers={"x-count-success": "1", "x-count-failure": "0", "x-count-error": "0"},
                     status_code=200,
                 )
 
+            @app.get("/indexes/{name}/documents")
+            def get_docs(name: str):
+                return {"docs": []}
+
+            @app.patch("/indexes/{name}/documents")
+            def patch_docs(name: str):
+                return {"patched": True}
+
+            @app.post("/indexes/{name}/documents/delete-batch")
+            def delete_batch(name: str):
+                return {"deleted": 2}
+
+            @app.post("/indexes/{name}/documents/get-batch")
+            def get_batch(name: str):
+                return {"docs": [{"id": "a"}, {"id": "b"}]}
+
+            # Single document (MUST be redacted)
             @app.get("/indexes/{name}/documents/{doc_id}")
             def get_doc(name: str, doc_id: str):
                 return {"id": doc_id}
+
+            # Stats/settings
+            @app.get("/indexes/{name}/stats")
+            def stats(name: str):
+                return {"stats": {"docs": 10}}
+
+            @app.get("/indexes/{name}/settings")
+            def settings(name: str):
+                return {"settings": {"x": 1}}
+
+            # Models & devices
+            @app.get("/models")
+            def models_get():
+                return {"models": []}
+
+            @app.delete("/models")
+            def models_delete():
+                return {"deleted": True}
+
+            @app.get("/device/cuda")
+            def device_cuda():
+                return {"cuda": True}
+
+            @app.get("/device/cpu")
+            def device_cpu():
+                return {"cpu": True}
 
             return app
 
@@ -136,28 +185,74 @@ class TestStatsDMiddlewareUDP(unittest.TestCase):
         cls.client_ctx.__exit__(None, None, None)
         cls._sink_cm.__exit__(None, None, None)
 
-    def test_metrics_roundtrip(self):
-        """Test that the middleware emits expected metrics over UDP."""
-        self.client.get("/")
-        self.client.get("/indexes/foo/search")  # search timing
-        self.client.post("/indexes/foo/documents")  # index timing + headers
-        self.client.get("/indexes/foo/documents/abc123")  # redaction
+    def test_metrics_roundtrip_all_endpoints(self):
+        self.client.post("/indexes/foo/search")
+        self.client.post("/indexes/foo/recommend")
+        self.client.post("/indexes/foo/embed")
+        self.client.post("/indexes/bulk/search")
 
+        self.client.post("/indexes/foo/documents")  # emits batch counters
+        self.client.get("/indexes/foo/documents")   # collection GET
+        self.client.patch("/indexes/foo/documents") # partial update
+        self.client.get("/indexes/foo/documents/abc123")  # MUST redact id
+        self.client.post("/indexes/foo/documents/delete-batch")  # MUST NOT redact
+        self.client.post("/indexes/foo/documents/get-batch")     # MUST NOT redact
+
+        self.client.get("/indexes/foo/stats")
+        self.client.get("/indexes/foo/settings")
+
+        self.client.get("/models")
+        self.client.delete("/models")
+        self.client.get("/device/cuda")
+        self.client.get("/device/cpu")
+
+        # Expected metric patterns
         patterns = [
-            r"request\.duration_ms:\d+\|ms\|#path:/indexes/foo/search,method:GET,status_code:200",
+
+            r"request\.duration_ms:\d+\|ms\|#path:/indexes/foo/search,method:POST,status_code:200",
+            r"request\.duration_ms:\d+\|ms\|#path:/indexes/foo/recommend,method:POST,status_code:200",
+            r"request\.duration_ms:\d+\|ms\|#path:/indexes/foo/embed,method:POST,status_code:200",
+            r"request\.duration_ms:\d+\|ms\|#path:/indexes/bulk/search,method:POST,status_code:200",
+
+            # documents collection endpoints (no redaction)
             r"request\.duration_ms:\d+\|ms\|#path:/indexes/foo/documents,method:POST,status_code:200",
+            r"request\.duration_ms:\d+\|ms\|#path:/indexes/foo/documents,method:GET,status_code:200",
+            r"request\.duration_ms:\d+\|ms\|#path:/indexes/foo/documents,method:PATCH,status_code:200",
+
+            # single doc (redacted)
             r"request\.duration_ms:\d+\|ms\|#path:/indexes/foo/documents/<document_id>,method:GET,status_code:200",
+
+            # fixed subpaths (no redaction)
+            r"request\.duration_ms:\d+\|ms\|#path:/indexes/foo/documents/delete-batch,method:POST,status_code:200",
+            r"request\.duration_ms:\d+\|ms\|#path:/indexes/foo/documents/get-batch,method:POST,status_code:200",
+
+            # stats/settings
+            r"request\.duration_ms:\d+\|ms\|#path:/indexes/foo/stats,method:GET,status_code:200",
+            r"request\.duration_ms:\d+\|ms\|#path:/indexes/foo/settings,method:GET,status_code:200",
+
+            # models & devices
+            r"request\.duration_ms:\d+\|ms\|#path:/models,method:GET,status_code:200",
+            r"request\.duration_ms:\d+\|ms\|#path:/models,method:DELETE,status_code:200",
+            r"request\.duration_ms:\d+\|ms\|#path:/device/cuda,method:GET,status_code:200",
+            r"request\.duration_ms:\d+\|ms\|#path:/device/cpu,method:GET,status_code:200",
+
+            # batch counters from POST /documents (headers-driven)
             r"batch\.success:1\|c\|#path:/indexes/foo/documents,method:POST,status_code:200",
             r"batch\.failure:0\|c\|#path:/indexes/foo/documents,method:POST,status_code:200",
             r"batch\.error:0\|c\|#path:/indexes/foo/documents,method:POST,status_code:200",
         ]
 
-        # Wait until the six packets we assert on have arrived
+        # Wait for all the expected packets
         self.sink.wait(n=len(patterns))
         pkt = self.sink.decoded()
 
         for pat in patterns:
-            self.assertTrue(
-                _has(pkt, pat),
-                msg=f"Missing packet matching /{pat}/ in {pkt}",
-            )
+            self.assertTrue(_has(pkt, pat), msg=f"Missing packet /{pat}/\nSeen:\n{pkt}")
+
+    def test_idempotent_redaction(self):
+        # sanity: redaction is stable on reprocessing
+        self.client.get("/indexes/foo/documents/abc123")
+        # at least one packet with the redacted path must exist; second pass shouldn't change it
+        self.sink.wait(n=1)
+        pkt = self.sink.decoded()
+        assert _has(pkt, r"#path:/indexes/foo/documents/<document_id>,method:GET,status_code:200")

--- a/tests/integ_tests/core/monitoring/test_metrics_udp.py
+++ b/tests/integ_tests/core/monitoring/test_metrics_udp.py
@@ -185,6 +185,10 @@ class TestStatsDMiddlewareUDP(unittest.TestCase):
         cls.client_ctx.__exit__(None, None, None)
         cls._sink_cm.__exit__(None, None, None)
 
+    def _count(self, pkt: List[str], pattern: str) -> int:
+        """ Count how many packets match the given regex pattern."""
+        return sum(1 for p in pkt if re.search(pattern, p))
+
     def test_metrics_roundtrip_all_endpoints(self):
         self.client.post("/indexes/foo/search")
         self.client.post("/indexes/foo/recommend")
@@ -192,13 +196,13 @@ class TestStatsDMiddlewareUDP(unittest.TestCase):
         self.client.post("/indexes/bulk/search")
 
         self.client.post("/indexes/foo/documents")  # emits batch counters
-        self.client.get("/indexes/foo/documents")   # collection GET
-        self.client.patch("/indexes/foo/documents") # partial update
+        self.client.get("/indexes/foo/documents")  # collection GET
+        self.client.patch("/indexes/foo/documents")  # partial update
         self.client.get("/indexes/foo/documents/abc123")  # MUST redact id
         self.client.post("/indexes/foo/documents/delete-batch")  # MUST NOT redact
         self.client.post("/indexes/foo/documents/delete-batch?telemetry=true")  # MUST NOT redact (even with query)
-        self.client.post("/indexes/foo/documents/get-batch")     # MUST NOT redact
-        self.client.post("/indexes/foo/documents/get-batch?telemetry=true")     # MUST NOT redact (even with query)
+        self.client.post("/indexes/foo/documents/get-batch")  # MUST NOT redact
+        self.client.post("/indexes/foo/documents/get-batch?telemetry=true")  # MUST NOT redact (even with query)
 
         self.client.get("/indexes/foo/stats")
         self.client.get("/indexes/foo/settings")
@@ -250,6 +254,27 @@ class TestStatsDMiddlewareUDP(unittest.TestCase):
 
         for pat in patterns:
             self.assertTrue(_has(pkt, pat), msg=f"Missing packet /{pat}/\nSeen:\n{pkt}")
+
+            # 1) Query string must NEVER appear inside the #path tag.
+            # Detect any '#path:...?...,'
+            self.assertFalse(
+                any(re.search(r"#path:[^,]*\?", p) for p in pkt),
+                msg=f"Query string leaked into path tag\nSeen:\n{pkt}",
+            )
+            # 2) We sent delete-batch twice (with and without ?telemetry=true),
+            # so the normalized metric line should appear at least twice.
+            delete_batch_pat = r"request\.duration_ms:\d+\|ms\|#path:/indexes/foo/documents/delete-batch,method:POST,status_code:200"
+            self.assertEqual(
+                self._count(pkt, delete_batch_pat), 2,
+                msg=f"Expected >=2 delete-batch packets (query stripped)\nSeen:\n{pkt}",
+            )
+
+            # 3) Same for get-batch (also called twice).
+            get_batch_pat = r"request\.duration_ms:\d+\|ms\|#path:/indexes/foo/documents/get-batch,method:POST,status_code:200"
+            self.assertEqual(
+                self._count(pkt, get_batch_pat), 2,
+                msg=f"Expected >=2 get-batch packets (query stripped)\nSeen:\n{pkt}",
+            )
 
     def test_idempotent_redaction(self):
         # sanity: redaction is stable on reprocessing

--- a/tests/integ_tests/core/monitoring/test_metrics_udp.py
+++ b/tests/integ_tests/core/monitoring/test_metrics_udp.py
@@ -196,7 +196,9 @@ class TestStatsDMiddlewareUDP(unittest.TestCase):
         self.client.patch("/indexes/foo/documents") # partial update
         self.client.get("/indexes/foo/documents/abc123")  # MUST redact id
         self.client.post("/indexes/foo/documents/delete-batch")  # MUST NOT redact
+        self.client.post("/indexes/foo/documents/delete-batch?telemetry=true")  # MUST NOT redact (even with query)
         self.client.post("/indexes/foo/documents/get-batch")     # MUST NOT redact
+        self.client.post("/indexes/foo/documents/get-batch?telemetry=true")     # MUST NOT redact (even with query)
 
         self.client.get("/indexes/foo/stats")
         self.client.get("/indexes/foo/settings")
@@ -255,4 +257,5 @@ class TestStatsDMiddlewareUDP(unittest.TestCase):
         # at least one packet with the redacted path must exist; second pass shouldn't change it
         self.sink.wait(n=1)
         pkt = self.sink.decoded()
-        assert _has(pkt, r"#path:/indexes/foo/documents/<document_id>,method:GET,status_code:200")
+        self.assertTrue(_has(pkt, r"#path:/indexes/foo/documents/<document_id>,method:GET,status_code:200"),
+                        msg=f"Missing redacted packet\nSeen:\n{pkt}")

--- a/tests/integ_tests/core/monitoring/test_metrics_udp.py
+++ b/tests/integ_tests/core/monitoring/test_metrics_udp.py
@@ -186,7 +186,7 @@ class TestStatsDMiddlewareUDP(unittest.TestCase):
         cls._sink_cm.__exit__(None, None, None)
 
     def _count(self, pkt: List[str], pattern: str) -> int:
-        """ Count how many packets match the given regex pattern."""
+        """Count how many packets match the given regex pattern."""
         return sum(1 for p in pkt if re.search(pattern, p))
 
     def test_metrics_roundtrip_all_endpoints(self):
@@ -255,26 +255,30 @@ class TestStatsDMiddlewareUDP(unittest.TestCase):
         for pat in patterns:
             self.assertTrue(_has(pkt, pat), msg=f"Missing packet /{pat}/\nSeen:\n{pkt}")
 
-            # 1) Query string must NEVER appear inside the #path tag.
-            # Detect any '#path:...?...,'
-            self.assertFalse(
-                any(re.search(r"#path:[^,]*\?", p) for p in pkt),
-                msg=f"Query string leaked into path tag\nSeen:\n{pkt}",
-            )
-            # 2) We sent delete-batch twice (with and without ?telemetry=true),
-            # so the normalized metric line should appear at least twice.
-            delete_batch_pat = r"request\.duration_ms:\d+\|ms\|#path:/indexes/foo/documents/delete-batch,method:POST,status_code:200"
-            self.assertEqual(
-                self._count(pkt, delete_batch_pat), 2,
-                msg=f"Expected >=2 delete-batch packets (query stripped)\nSeen:\n{pkt}",
-            )
+        # 1) Query string must NEVER appear inside the #path tag.
+        # Detect any '#path:...?...,'
+        self.assertFalse(
+            any(re.search(r"#path:[^,]*\?", p) for p in pkt),
+            msg=f"Query string leaked into path tag\nSeen:\n{pkt}",
+        )
+        # 2) We sent delete-batch twice (with and without ?telemetry=true),
+        # so the normalized metric line should appear exactly twice.
+        delete_batch_pat = (
+            r"request\.duration_ms:\d+\|ms\|#path:/indexes/foo/documents/delete-batch,method:POST,status_code:200"
+        )
+        self.assertEqual(
+            self._count(pkt, delete_batch_pat), 2,
+            msg=f"Expected exactly 2 delete-batch packets (query stripped)\nSeen:\n{pkt}",
+        )
 
-            # 3) Same for get-batch (also called twice).
-            get_batch_pat = r"request\.duration_ms:\d+\|ms\|#path:/indexes/foo/documents/get-batch,method:POST,status_code:200"
-            self.assertEqual(
-                self._count(pkt, get_batch_pat), 2,
-                msg=f"Expected >=2 get-batch packets (query stripped)\nSeen:\n{pkt}",
-            )
+        # 3) Same for get-batch (also called twice).
+        get_batch_pat = (
+            r"request\.duration_ms:\d+\|ms\|#path:/indexes/foo/documents/get-batch,method:POST,status_code:200"
+        )
+        self.assertEqual(
+            self._count(pkt, get_batch_pat), 2,
+            msg=f"Expected exactly 2 get-batch packets (query stripped)\nSeen:\n{pkt}",
+        )
 
     def test_idempotent_redaction(self):
         # sanity: redaction is stable on reprocessing
@@ -282,5 +286,7 @@ class TestStatsDMiddlewareUDP(unittest.TestCase):
         # at least one packet with the redacted path must exist; second pass shouldn't change it
         self.sink.wait(n=1)
         pkt = self.sink.decoded()
-        self.assertTrue(_has(pkt, r"#path:/indexes/foo/documents/<document_id>,method:GET,status_code:200"),
-                        msg=f"Missing redacted packet\nSeen:\n{pkt}")
+        self.assertTrue(
+            _has(pkt, r"#path:/indexes/foo/documents/<document_id>,method:GET,status_code:200"),
+            msg=f"Missing redacted packet\nSeen:\n{pkt}",
+        )

--- a/tests/integ_tests/core/monitoring/test_metrics_udp.py
+++ b/tests/integ_tests/core/monitoring/test_metrics_udp.py
@@ -189,6 +189,15 @@ class TestStatsDMiddlewareUDP(unittest.TestCase):
         """Count how many packets match the given regex pattern."""
         return sum(1 for p in pkt if re.search(pattern, p))
 
+    def _wait_for_all_patterns(self, sink, patterns: List[str], timeout: float = 8.0) -> List[str]:
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            pkt = sink.decoded()
+            if all(any(re.search(p, x) for x in pkt) for p in patterns):
+                return pkt
+            time.sleep(0.05)
+        return sink.decoded()
+
     def test_metrics_roundtrip_all_endpoints(self):
         self.client.post("/indexes/foo/search")
         self.client.post("/indexes/foo/recommend")
@@ -249,8 +258,7 @@ class TestStatsDMiddlewareUDP(unittest.TestCase):
         ]
 
         # Wait for all the expected packets
-        self.sink.wait(n=len(patterns))
-        pkt = self.sink.decoded()
+        pkt = self._wait_for_all_patterns(self.sink, patterns, timeout=8.0)
 
         for pat in patterns:
             self.assertTrue(_has(pkt, pat), msg=f"Missing packet /{pat}/\nSeen:\n{pkt}")

--- a/tests/unit_tests/marqo/core/monitoring/test_statsd_middleware.py
+++ b/tests/unit_tests/marqo/core/monitoring/test_statsd_middleware.py
@@ -178,15 +178,19 @@ class TestStatsDMiddleware(unittest.TestCase):
         self.assertTrue(any("status_code:404" in m for m in timings))
 
     def test_sanitize_path(self):
+        """Test the _sanitize_path method for various scenarios."""
         sanitize = sm.StatsDMiddleware._sanitize_path
 
-        # Query string — current impl uses PurePosixPath on the whole string, so query is preserved
         self.assertEqual(
             sanitize("/indexes/foo/documents/abc123"),
             "/indexes/foo/documents/<document_id>",
         )
-        # Fragment — unchanged
         self.assertEqual(
             sanitize("/indexes/foo/documents/delete-batch"),
             "/indexes/foo/documents/delete-batch",
+        )
+
+        self.assertEqual(
+            sanitize("/indexes/foo/documents/get-batch"),
+            "/indexes/foo/documents/get-batch",
         )

--- a/tests/unit_tests/marqo/core/monitoring/test_statsd_middleware.py
+++ b/tests/unit_tests/marqo/core/monitoring/test_statsd_middleware.py
@@ -176,3 +176,17 @@ class TestStatsDMiddleware(unittest.TestCase):
 
         timings = _extract(self.stub, "timing", "request.duration_ms")
         self.assertTrue(any("status_code:404" in m for m in timings))
+
+    def test_sanitize_path(self):
+        sanitize = sm.StatsDMiddleware._sanitize_path
+
+        # Query string — current impl uses PurePosixPath on the whole string, so query is preserved
+        self.assertEqual(
+            sanitize("/indexes/foo/documents/abc123"),
+            "/indexes/foo/documents/<document_id>",
+        )
+        # Fragment — unchanged
+        self.assertEqual(
+            sanitize("/indexes/foo/documents/delete-batch"),
+            "/indexes/foo/documents/delete-batch",
+        )


### PR DESCRIPTION
## Change Summary
Fix metric emission for `/documents/get-batch` and `/documents/delete-batch` endpoints.  
Previously these were incorrectly treated as document-ID paths and redacted, causing missing or misclassified CloudWatch metrics.  
This change updates `_sanitize_path` to skip these fixed subpaths and adds tests to cover expected behavior.

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [x] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

