### PR TITLE
Partially fix pagination for disjunction and relevance cutoff 

### DIFF
--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.24.1"
+__version__ = "2.24.2"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.24.2"
+__version__ = "2.24.3"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.24.3"
+__version__ = "2.24.1"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.24.0"
+__version__ = "2.24.2"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/tests/integ_tests/tensor_search/integ_tests/test_collapse_fields.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_collapse_fields.py
@@ -317,8 +317,6 @@ class TestCollapseFields(MarqoTestCase):
                 # Test that the hit count returns the count of unique collapse field value
                 self.assertEqual(3, res['totalHits'])
 
-
-
     @pytest.mark.skip_for_multinode("Pagination result is not consistent across different Vespa infrastructures")
     def test_pagination(self):
         """Test that pagination works with search with collapse field"""
@@ -335,7 +333,7 @@ class TestCollapseFields(MarqoTestCase):
         )
 
         test_cases = [
-            # (RetrievalMethod.Disjunction, RankingMethod.RRF),  # FIXME dup can only be fixed by pagination fix
+            (RetrievalMethod.Disjunction, RankingMethod.RRF),
             (RetrievalMethod.Lexical, RankingMethod.Lexical),
             # (RetrievalMethod.Lexical, RankingMethod.Tensor),  # FIXME dup and missing doc
             (RetrievalMethod.Tensor, RankingMethod.Tensor),
@@ -352,7 +350,9 @@ class TestCollapseFields(MarqoTestCase):
                     hybrid_parameters=HybridParameters(
                         retrievalMethod=retrieval_method,
                         rankingMethod=ranking_method,
-                        rerankDepthTensor=100,  # set a large value to expand the tensor retrieval set
+                        # set a large value to expand the tensor retrieval set,
+                        # this is required to make the pagination stable
+                        rerankDepthTensor=100,
                     ),
                     collapse_field_name="parent_id",
                     result_count=6

--- a/tests/integ_tests/tensor_search/integ_tests/test_search_relevance_cutoff_feature.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_search_relevance_cutoff_feature.py
@@ -195,7 +195,6 @@ class TestSearchRelevanceCutoffFeature(MarqoTestCase):
                 "retrievalMethod": "disjunction",
                 "rankingMethod": "rrf",
                 "alpha": 0.5
-
             }
 
         if index_name is None:
@@ -212,7 +211,8 @@ class TestSearchRelevanceCutoffFeature(MarqoTestCase):
                 "relevanceCutoff": relevance_cutoff,
                 "sortBy": sort_by,
                 "limit": limit,
-                "offset": offset
+                "offset": offset,
+                "showHighlights": False,
             }
         ).body.decode('utf-8'))
 
@@ -584,27 +584,40 @@ class TestSearchRelevanceCutoffFeature(MarqoTestCase):
 
     def test_relevance_cutoff_with_pagination(self):
         """Test relevance cutoff with different limit and offset values."""
-        # Test with small limit
-        result_small = self._search_helper(
+        hp_rrf = {
+            "retrievalMethod": "disjunction",
+            "rankingMethod": "rrf",
+            "alpha": 0.7
+        }
+
+        # Test first page
+        result_page1 = self._search_helper(
             relevance_cutoff={
                 "method": "relative_max_score",
                 "parameters": {"relativeScoreFactor": 0.4},
             },
-            limit=3
+            hybrid_parameters=hp_rrf,
+            limit=6,
+            offset=0,
         )
-        self.assertEqual(len(result_small["hits"]), 3, "Should respect limit")
-        self.assertIn("_relevantCandidates", result_small)
+        expected_ids_page1 = ['h3', 'h6', 'h9', 'h1', 'h2', 'h4']
+        self.assertEqual(expected_ids_page1, [h["_id"] for h in result_page1["hits"]])
+        self.assertEqual(20, result_page1["_relevantCandidates"])
         
-        # Test with offset
-        result_offset = self._search_helper(
+        # Test second page
+        result_page2 = self._search_helper(
             relevance_cutoff={
                 "method": "relative_max_score", 
                 "parameters": {"relativeScoreFactor": 0.4},
             },
-            limit=5,
-            offset=2
+            hybrid_parameters=hp_rrf,
+            limit=6,
+            offset=6
         )
-        self.assertEqual(len(result_offset["hits"]), 5, "Should respect limit with offset")
+        expected_ids_page2 = ['h10', 'h7', 'h8', 'm1', 'm7', 'm4']
+        # order of h7 and h8 is non-deterministic, so we compare with set
+        self.assertEqual(set(expected_ids_page2), set([h["_id"] for h in result_page2["hits"]]))
+        self.assertEqual(20, result_page2["_relevantCandidates"])
 
     def test_relevance_cutoff_edge_case_extreme_values(self):
         """Test edge cases with extreme parameter values."""

--- a/tests/integ_tests/tensor_search/test_pagination_rrf_fix.py
+++ b/tests/integ_tests/tensor_search/test_pagination_rrf_fix.py
@@ -1,17 +1,17 @@
-import math
 import os
-import unittest
 from unittest import mock
+
 import pytest
 
+from marqo.core.models.add_docs_params import AddDocsParams
+from marqo.core.models.hybrid_parameters import RetrievalMethod, RankingMethod, HybridParameters
 from marqo.core.models.marqo_index import *
 from marqo.tensor_search import tensor_search
-from marqo.core.models.add_docs_params import AddDocsParams
+from marqo.tensor_search.models.score_modifiers_object import ScoreModifierLists, ScoreModifierOperator
 from tests.integ_tests.marqo_test import MarqoTestCase
-from marqo.core.models.hybrid_parameters import RetrievalMethod, RankingMethod, HybridParameters
 
 
-class TestPaginationRRFFix(MarqoTestCase):
+class TestRRFPaginationPartialFix(MarqoTestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -33,6 +33,27 @@ class TestPaginationRRFFix(MarqoTestCase):
         # Any tests that call add_document, search, bulk_search need this env var
         self.device_patcher = mock.patch.dict(os.environ, {"MARQO_BEST_AVAILABLE_DEVICE": "cpu"})
         self.device_patcher.start()
+
+        # Create and add curated test documents
+        r = self.add_documents(
+            config=self.config,
+            add_docs_params=AddDocsParams(
+                index_name=self.index_unstructured.name,
+                docs=(self.create_curated_test_data()),
+                tensor_fields=['title']
+            )
+        ).dict(exclude_none=True, by_alias=True)
+        self.assertFalse(r['errors'], "Errors in add documents call")
+
+        self.hp_rrf = HybridParameters(
+            alpha=0.7,
+            rrfK=60,
+            retrievalMethod=RetrievalMethod.Disjunction,
+            rankingMethod=RankingMethod.RRF,
+            queryTensor='machine learning',
+            queryLexical='EXACT QUERY',
+            # verbose=True,
+        )
 
     def tearDown(self):
         self.device_patcher.stop()
@@ -61,7 +82,7 @@ class TestPaginationRRFFix(MarqoTestCase):
                 "_id": f"doc_T{i+1}",
                 "title": f"{tensor_terms[i]} tensor_document_{i+1}",
                 "doc_type": "tensor_only",
-                "tensor_rank": i + 1  # 1 = highest, 5 = lowest
+                "score_boost": i+1,   # the boost should reverse the order
             }
             docs.append(doc)
 
@@ -73,7 +94,7 @@ class TestPaginationRRFFix(MarqoTestCase):
                 "_id": f"doc_L{i+1}",
                 "title": f"{repeated_keywords} lexical_document_{i+1}",
                 "doc_type": "lexical_only",
-                "lexical_rank": i + 1  # 1 = highest, 5 = lowest
+                "score_boost": i+6,  # the boost should reverse the order, and this is higher than tensor match
             }
             docs.append(doc)
 
@@ -93,8 +114,7 @@ class TestPaginationRRFFix(MarqoTestCase):
                 "_id": f"doc_B{i+1}",
                 "title": f"{lexical_term} {tensor_term} both_document_{i+1}",
                 "doc_type": "both",
-                "tensor_rank": tensor_rank,
-                "lexical_rank": lexical_rank
+                "score_boost": i+11,  # the boost should reverse the order, and this is higher than tensor and lexical match
             }
             docs.append(doc)
 
@@ -214,31 +234,9 @@ class TestPaginationRRFFix(MarqoTestCase):
         doc_T4: 0.010606    (DUP)
         doc_T5: 0.010294    (DUP)
         """
-        index = self.index_unstructured
-
-        # Create and add curated test documents
-        r = self.add_documents(
-            config=self.config,
-            add_docs_params=AddDocsParams(
-                index_name=index.name,
-                docs=(self.create_curated_test_data()),
-                tensor_fields=['title']
-            )
-        ).dict(exclude_none=True, by_alias=True)
-        self.assertFalse(r['errors'], "Errors in add documents call")
-
         # Test with page size 5 for clean 3-page pagination (15 docs = 3 pages)
         page_size = 5
         all_paginated_hits = []
-
-        hp_rrf = HybridParameters(
-            alpha=0.7,
-            rrfK=60,
-            retrievalMethod=RetrievalMethod.Disjunction,
-            rankingMethod=RankingMethod.RRF,
-            queryTensor='machine learning',
-            queryLexical='EXACT QUERY',
-        )
 
         # Collect all pages
         for page_num in range(3):  # 3 pages for 15 docs with page size 5
@@ -246,9 +244,9 @@ class TestPaginationRRFFix(MarqoTestCase):
 
             page_res = tensor_search.search(
                 search_method="HYBRID",
-                hybrid_parameters=hp_rrf,
+                hybrid_parameters=self.hp_rrf,
                 config=self.config,
-                index_name=index.name,
+                index_name=self.index_unstructured.name,
                 result_count=page_size,
                 offset=offset,
                 text=None
@@ -269,27 +267,450 @@ class TestPaginationRRFFix(MarqoTestCase):
     @pytest.mark.skip_for_multinode
     def test_disjunction_rrf_pagination_with_global_modifiers_no_rerank_depth(self):
         """
-        Test pagination with various rerankDepthGlobal values.
-        Verifies the adjustment logic when needToTrimPreviousPages is true.
+        Test pagination with global score modifiers when rerankDepthGlobal is not set.
+        All results get score modifiers applied.
+
+        Lexical search score:         Tensor search score:
+        doc_B1: rank 1  boost 11      doc_B2: rank 1   boost 12
+        doc_L1: rank 2  boost 6       doc_B1: rank 2   boost 11
+        doc_L2: rank 3  boost 7       doc_T1: rank 3   boost 1
+        doc_L3: rank 4  boost 8       doc_T2: rank 4   boost 2
+        doc_L4: rank 5  boost 9       doc_T3: rank 5   boost 3
+        doc_B3: rank 6  boost 13      doc_T4: rank 6   boost 4
+        doc_L5: rank 7  boost 10      doc_B4: rank 7   boost 14
+        doc_B5: rank 8  boost 15      doc_T5: rank 8   boost 5
+        doc_B2: rank 9  boost 12      doc_B3: rank 9   boost 13
+        doc_B4: rank 10 boost 14      doc_B5: rank 10  boost 15
+                                      doc_L1: rank 11  boost 6
+                                      doc_L5: rank 12  boost 10
+                                      doc_L3: rank 13  boost 8
+                                      doc_L4: rank 14  boost 9
+                                      doc_L2: rank 15  boost 7
+
+        Pagination with page size 5: with alpha=0.7, rrf_k=60
+        tensor rrf score = alpha * (1.0 / (rank + k))
+        lexical rrf score = (1-alpha) * (1.0 / (rank + k))
+
+        ======================================================
+        Page 1:
+        Lexical search rrf score:     Tensor search rrf score:
+        doc_B1: 0.004918              doc_B2: 0.011475
+        doc_L1: 0.004839              doc_B1: 0.011290
+        doc_L2: 0.004762              doc_T1: 0.011111
+        doc_L3: 0.004688              doc_T2: 0.010938
+        doc_L4: 0.004615              doc_T3: 0.010769
+
+        After fusion and apply score modifiers for all hits:
+        doc_B2: 12.011475
+        doc_B1: 11.016208
+        doc_L4: 9.004615
+        doc_L3: 8.004688
+        doc_L2: 7.004762
+        doc_L1: 6.004839   <- Trimmed off from here
+        doc_T3: 3.010769
+        doc_T2: 2.010938
+        doc_T1: 1.011111
+
+        =======================================================
+        Page 2:
+        Lexical search rrf score:     Tensor search rrf score:
+        doc_B1: 0.004918              doc_B2: 0.011475
+        doc_L1: 0.004839              doc_B1: 0.011290
+        doc_L2: 0.004762              doc_T1: 0.011111
+        doc_L3: 0.004688              doc_T2: 0.010938
+        doc_L4: 0.004615              doc_T3: 0.010769
+        doc_B3: 0.004545              doc_T4: 0.010606
+        doc_L5: 0.004478              doc_B4: 0.010448
+        doc_B5: 0.004412              doc_T5: 0.010294
+        doc_B2: 0.004348              doc_B3: 0.010145
+        doc_B4: 0.004286              doc_B5: 0.01
+
+        After fusion:
+        doc_B5: 15.014412  (MISSED)
+        doc_B4: 14.014734  (MISSED)
+        doc_B3: 13.014690  (MISSED)
+        doc_B2: 12.015823
+        doc_B1: 11.016208
+        doc_L5: 10.004478  <- Start from here
+        doc_L4: 9.004615   (DUP)
+        doc_L3: 8.004688   (DUP)
+        doc_L2: 7.004762   (DUP)
+        doc_L1: 6.004839
+        doc_T5: 5.010294   <- Trimmed off from here
+        doc_T4: 4.010606
+        doc_T3: 3.010769
+        doc_T2: 2.010938
+        doc_T1: 1.011111
+
+        =======================================================
+        Page 3:
+        Lexical search rrf score:     Tensor search rrf score:
+        doc_B1: 0.004918              doc_B2: 0.011475
+        doc_L1: 0.004839              doc_B1: 0.011290
+        doc_L2: 0.004762              doc_T1: 0.011111
+        doc_L3: 0.004688              doc_T2: 0.010938
+        doc_L4: 0.004615              doc_T3: 0.010769
+        doc_B3: 0.004545              doc_T4: 0.010606
+        doc_L5: 0.004478              doc_B4: 0.010448
+        doc_B5: 0.004412              doc_T5: 0.010294
+        doc_B2: 0.004348              doc_B3: 0.010145
+        doc_B4: 0.004286              doc_B5: 0.01
+                                      doc_L1: 0.009859
+                                      doc_L5: 0.009722
+                                      doc_L3: 0.009589
+                                      doc_L4: 0.009459
+                                      doc_L2: 0.009333
+
+        After fusion:
+        doc_B5: 15.014412  (MISSED)
+        doc_B4: 14.014734  (MISSED)
+        doc_B3: 13.014690  (MISSED)
+        doc_B2: 12.015823
+        doc_B1: 11.016208
+        doc_L5: 10.014200
+        doc_L4: 9.014074
+        doc_L3: 8.014277
+        doc_L2: 7.014095
+        doc_L1: 6.014698
+        doc_T5: 5.010294   <- Start from here
+        doc_T4: 4.010606
+        doc_T3: 3.010769
+        doc_T2: 2.010938
+        doc_T1: 1.011111
         """
-        # TODO: Implement test
-        pass
+        # Test with page size 5 for clean 3-page pagination
+        page_size = 5
+        all_paginated_hits = []
+
+        # Collect all pages
+        for page_num in range(3):  # 3 pages for 15 docs with page size 5
+            offset = page_num * page_size
+
+            page_res = tensor_search.search(
+                search_method="HYBRID",
+                hybrid_parameters=self.hp_rrf,
+                config=self.config,
+                index_name=self.index_unstructured.name,
+                result_count=page_size,
+                offset=offset,
+                text=None,
+                score_modifiers=ScoreModifierLists(
+                    add_to_score=[
+                        ScoreModifierOperator(field_name="score_boost", weight=1)
+                    ]
+                )
+                # No rerankDepth - applies to all results
+            )
+
+            all_paginated_hits.extend(page_res["hits"])
+
+        # Page 1
+        self.assertEqual(['doc_B2', 'doc_B1', 'doc_L4', 'doc_L3', 'doc_L2'],
+                         [h['_id'] for h in all_paginated_hits[:5]])
+        # Page 2
+        self.assertEqual(['doc_L5', 'doc_L4', 'doc_L3', 'doc_L2', 'doc_L1'],
+                         [h['_id'] for h in all_paginated_hits[5:-5]])
+        # Page 3
+        self.assertEqual(['doc_T5', 'doc_T4', 'doc_T3', 'doc_T2', 'doc_T1'],
+                         [h['_id'] for h in all_paginated_hits[-5:]])
 
     @pytest.mark.skip_for_multinode
     def test_disjunction_rrf_pagination_with_global_modifiers_with_rerank_depth(self):
         """
-        Test pagination with various rerankDepthGlobal values.
-        Verifies the adjustment logic when needToTrimPreviousPages is true.
+        Test pagination with rerankDepthGlobal values. The retrieved result up to offset+rerankDepthGlobal get global
+        score modifiers applied
+
+        Lexical search score:         Tensor search score:
+        doc_B1: 1.5657032529354344    doc_B2: 0.8774912556666549
+        doc_L1: 1.5310213335683778    doc_B1: 0.8624316166639774
+        doc_L2: 1.4957020935493452    doc_T1: 0.8551202270206154
+        doc_L3: 1.4403238705575117    doc_T2: 0.8550448320679322
+        doc_L4: 1.3410214926606240    doc_T3: 0.8523972952471728
+        doc_B3: 1.2495362288065737    doc_T4: 0.8500947166713401
+        doc_L5: 1.1111902054958356    doc_B4: 0.8500164585022059
+        doc_B5: 1.0981049722627436    doc_T5: 0.8471093151792289
+        doc_B2: 0.9400916280884359    doc_B3: 0.8368122835299188
+        doc_B4: 0.4681934225728979    doc_B5: 0.8334305830362274
+                                      doc_L1: 0.8316111466678087
+                                      doc_L5: 0.8288859450924600
+                                      doc_L3: 0.8269666625377193
+                                      doc_L4: 0.8263098149586303
+                                      doc_L2: 0.8257278463225931
+
+        Pagination with page size 5: with alpha=0.7, rrf_k=60
+        tensor rrf score = alpha * (1.0 / (rank + k))
+        lexical rrf score = (1-alpha) * (1.0 / (rank + k))
+
+        ======================================================
+        Page 1:
+        Lexical search rrf score:     Tensor search rrf score:
+        doc_B1: 0.004918              doc_B2: 0.011475
+        doc_L1: 0.004839              doc_B1: 0.011290
+        doc_L2: 0.004762              doc_T1: 0.011111
+        doc_L3: 0.004688              doc_T2: 0.010938
+        doc_L4: 0.004615              doc_T3: 0.010769
+
+        After fusion:
+        doc_B2: 12.011475
+        doc_B1: 11.016208
+        doc_L2: 7.004762
+        doc_L1: 6.004839
+        doc_T3: 3.010769
+        doc_T2: 2.010938   <- Trimmed off from here
+        doc_T1: 1.011111
+        doc_L3: 0.004688   <- global reranking will not reach 8th element (rerankDepthGlobal = 7)
+        doc_L4: 0.004615
+
+        =======================================================
+        Page 2:
+        Lexical search rrf score:     Tensor search rrf score:
+        doc_B1: 0.004918              doc_B2: 0.011475
+        doc_L1: 0.004839              doc_B1: 0.011290
+        doc_L2: 0.004762              doc_T1: 0.011111
+        doc_L3: 0.004688              doc_T2: 0.010938
+        doc_L4: 0.004615              doc_T3: 0.010769
+        doc_B3: 0.004545              doc_T4: 0.010606
+        doc_L5: 0.004478              doc_B4: 0.010448
+        doc_B5: 0.004412              doc_T5: 0.010294
+        doc_B2: 0.004348              doc_B3: 0.010145
+        doc_B4: 0.004286              doc_B5: 0.01
+
+        After fusion:
+        doc_B5: 15.014412  (MISSED)
+        doc_B4: 14.014734  (MISSED)
+        doc_B3: 13.014690  (MISSED)
+        doc_B2: 12.015823
+        doc_B1: 11.016208
+        doc_L2: 7.004762   <- Start from here (DUP)
+        doc_L1: 6.004839   (DUP)
+        doc_T5: 5.010294
+        doc_T4: 4.010606
+        doc_T3: 3.010769   (DUP)
+        doc_T2: 2.010938   <- Trimmed off from here
+        doc_T1: 1.011111
+        doc_L3: 0.004688   <- global reranking will not reach 13th element (rerankDepthGlobal = 5 + 7)
+        doc_L4: 0.004615
+        doc_L5: 0.004478
+
+        =======================================================
+        Page 3:
+        Lexical search rrf score:     Tensor search rrf score:
+        doc_B1: 0.004918              doc_B2: 0.011475
+        doc_L1: 0.004839              doc_B1: 0.011290
+        doc_L2: 0.004762              doc_T1: 0.011111
+        doc_L3: 0.004688              doc_T2: 0.010938
+        doc_L4: 0.004615              doc_T3: 0.010769
+        doc_B3: 0.004545              doc_T4: 0.010606
+        doc_L5: 0.004478              doc_B4: 0.010448
+        doc_B5: 0.004412              doc_T5: 0.010294
+        doc_B2: 0.004348              doc_B3: 0.010145
+        doc_B4: 0.004286              doc_B5: 0.01
+                                      doc_L1: 0.009859
+                                      doc_L5: 0.009722
+                                      doc_L3: 0.009589
+                                      doc_L4: 0.009459
+                                      doc_L2: 0.009333
+
+        After fusion: (global score modifiers applied to all docs)
+        doc_B5: 15.014412  (MISSED)
+        doc_B4: 14.014734  (MISSED)
+        doc_B3: 13.014690  (MISSED)
+        doc_B2: 12.015823
+        doc_B1: 11.016208
+        doc_L5: 10.014200  (MISSED)
+        doc_L4: 9.014074   (MISSED)
+        doc_L3: 8.014277   (MISSED)
+        doc_L2: 7.014095
+        doc_L1: 6.014698
+        doc_T5: 5.010294   <- Start from here (DUP)
+        doc_T4: 4.010606   (DUP)
+        doc_T3: 3.010769   (DUP)
+        doc_T2: 2.010938
+        doc_T1: 1.011111
         """
-        # TODO: Implement test
-        pass
+        # Test with page size 5 for clean 3-page pagination
+        page_size = 5
+        all_paginated_hits = []
+
+        # Collect all pages
+        for page_num in range(3):  # 3 pages for 15 docs with page size 5
+            offset = page_num * page_size
+
+            page_res = tensor_search.search(
+                search_method="HYBRID",
+                hybrid_parameters=self.hp_rrf,
+                config=self.config,
+                index_name=self.index_unstructured.name,
+                result_count=page_size,
+                offset=offset,
+                text=None,
+                score_modifiers=ScoreModifierLists(
+                    add_to_score=[
+                        ScoreModifierOperator(field_name="score_boost", weight=1)
+                    ]
+                ),
+                rerank_depth=7,  # rerank 7 items
+            )
+
+            all_paginated_hits.extend(page_res["hits"])
+
+        # Page 1
+        self.assertEqual(['doc_B2', 'doc_B1', 'doc_L2', 'doc_L1', 'doc_T3'],
+                         [h['_id'] for h in all_paginated_hits[:5]])
+        # Page 2
+        self.assertEqual(['doc_L2', 'doc_L1', 'doc_T5', 'doc_T4', 'doc_T3'],
+                         [h['_id'] for h in all_paginated_hits[5:-5]])
+        # Page 3
+        self.assertEqual(['doc_T5', 'doc_T4', 'doc_T3', 'doc_T2', 'doc_T1'],
+                         [h['_id'] for h in all_paginated_hits[-5:]])
 
     @pytest.mark.skip_for_multinode
-    # TODO move to test_search_relevance_cutoff_feature.py
-    def test_relevance_cutoff_pagination(self):
+    def test_disjunction_rrf_pagination_with_global_modifiers_with_rerank_depth_small_than_limit(self):
         """
-        Test pagination with relevance cutoff enabled.
-        Verifies the fix applies to both disjunction and relevance cutoff paths.
+        Test pagination with rerankDepthGlobal values smaller than limit. The retrieved result up to
+        offset+rerankDepthGlobal get global score modifiers applied
+
+        Lexical search score:         Tensor search score:
+        doc_B1: 1.5657032529354344    doc_B2: 0.8774912556666549
+        doc_L1: 1.5310213335683778    doc_B1: 0.8624316166639774
+        doc_L2: 1.4957020935493452    doc_T1: 0.8551202270206154
+        doc_L3: 1.4403238705575117    doc_T2: 0.8550448320679322
+        doc_L4: 1.3410214926606240    doc_T3: 0.8523972952471728
+        doc_B3: 1.2495362288065737    doc_T4: 0.8500947166713401
+        doc_L5: 1.1111902054958356    doc_B4: 0.8500164585022059
+        doc_B5: 1.0981049722627436    doc_T5: 0.8471093151792289
+        doc_B2: 0.9400916280884359    doc_B3: 0.8368122835299188
+        doc_B4: 0.4681934225728979    doc_B5: 0.8334305830362274
+                                      doc_L1: 0.8316111466678087
+                                      doc_L5: 0.8288859450924600
+                                      doc_L3: 0.8269666625377193
+                                      doc_L4: 0.8263098149586303
+                                      doc_L2: 0.8257278463225931
+
+        Pagination with page size 5: with alpha=0.7, rrf_k=60
+        tensor rrf score = alpha * (1.0 / (rank + k))
+        lexical rrf score = (1-alpha) * (1.0 / (rank + k))
+
+        ======================================================
+        Page 1:
+        Lexical search rrf score:     Tensor search rrf score:
+        doc_B1: 0.004918              doc_B2: 0.011475
+        doc_L1: 0.004839              doc_B1: 0.011290
+        doc_L2: 0.004762              doc_T1: 0.011111
+        doc_L3: 0.004688              doc_T2: 0.010938
+        doc_L4: 0.004615              doc_T3: 0.010769
+
+        After fusion and applying global score modifiers
+        doc_B2: 12.011475
+        doc_B1: 11.016208
+        doc_T1: 1.011111
+        doc_T2: 0.010938  <- global reranking will not reach 4th element (rerankDepthGlobal = 3)
+        doc_T3: 0.010769
+        doc_L1: 0.004839  <- Trimmed off from here
+        doc_L2: 0.004762
+        doc_L3: 0.004688
+        doc_L4: 0.004615
+
+        =======================================================
+        Page 2:
+        Lexical search rrf score:     Tensor search rrf score:
+        doc_B1: 0.004918              doc_B2: 0.011475
+        doc_L1: 0.004839              doc_B1: 0.011290
+        doc_L2: 0.004762              doc_T1: 0.011111
+        doc_L3: 0.004688              doc_T2: 0.010938
+        doc_L4: 0.004615              doc_T3: 0.010769
+        doc_B3: 0.004545              doc_T4: 0.010606
+        doc_L5: 0.004478              doc_B4: 0.010448
+        doc_B5: 0.004412              doc_T5: 0.010294
+        doc_B2: 0.004348              doc_B3: 0.010145
+        doc_B4: 0.004286              doc_B5: 0.01
+
+        After fusion:
+        doc_B5: 15.014412  (MISSED)
+        doc_B4: 14.014734  (MISSED)
+        doc_B3: 13.014690  (MISSED)
+        doc_B2: 12.015823
+        doc_B1: 11.016208
+        doc_T3: 3.010769   <- Start from here (DUP)
+        doc_T2: 2.010938   (DUP)
+        doc_T1: 1.011111   (DUP)
+        doc_T4: 0.010606   <- global reranking will not reach 9th element (rerankDepthGlobal = 5 + 3)
+        doc_T5: 0.010294
+        doc_L1: 0.004839   <- Trimmed off from here
+        doc_L2: 0.004762
+        doc_L3: 0.004688
+        doc_L4: 0.004615
+        doc_L5: 0.004478
+
+        =======================================================
+        Page 3:
+        Lexical search rrf score:     Tensor search rrf score:
+        doc_B1: 0.004918              doc_B2: 0.011475
+        doc_L1: 0.004839              doc_B1: 0.011290
+        doc_L2: 0.004762              doc_T1: 0.011111
+        doc_L3: 0.004688              doc_T2: 0.010938
+        doc_L4: 0.004615              doc_T3: 0.010769
+        doc_B3: 0.004545              doc_T4: 0.010606
+        doc_L5: 0.004478              doc_B4: 0.010448
+        doc_B5: 0.004412              doc_T5: 0.010294
+        doc_B2: 0.004348              doc_B3: 0.010145
+        doc_B4: 0.004286              doc_B5: 0.01
+                                      doc_L1: 0.009859
+                                      doc_L5: 0.009722
+                                      doc_L3: 0.009589
+                                      doc_L4: 0.009459
+                                      doc_L2: 0.009333
+
+        After fusion: (global score modifiers applied to all docs)
+        doc_B5: 15.014412  (MISSED)
+        doc_B4: 14.014734  (MISSED)
+        doc_B3: 13.014690  (MISSED)
+        doc_B2: 12.015823
+        doc_B1: 11.016208
+        doc_L5: 10.014200  (MISSED)
+        doc_L4: 9.014074   (MISSED)
+        doc_L3: 8.014277   (MISSED)
+        doc_L2: 7.014095   (MISSED)
+        doc_L1: 6.014698   (MISSED)
+        doc_T3: 3.010769   (DUP)
+        doc_T2: 2.010938   (DUP)
+        doc_T1: 1.011111   (DUP)
+        doc_T4: 0.010606   <- global reranking will not reach 14th element (rerankDepthGlobal = 10 + 3)  (DUP)
+        doc_T5: 0.010294   (DUP)
         """
-        # TODO: Implement test
-        pass
+        # Test with page size 5 for clean 3-page pagination
+        page_size = 5
+        all_paginated_hits = []
+
+        # Collect all pages
+        for page_num in range(3):  # 3 pages for 15 docs with page size 5
+            offset = page_num * page_size
+
+            page_res = tensor_search.search(
+                search_method="HYBRID",
+                hybrid_parameters=self.hp_rrf,
+                config=self.config,
+                index_name=self.index_unstructured.name,
+                result_count=page_size,
+                offset=offset,
+                text=None,
+                score_modifiers=ScoreModifierLists(
+                    add_to_score=[
+                        ScoreModifierOperator(field_name="score_boost", weight=1)
+                    ]
+                ),
+                rerank_depth=3,  # rerank only 3 items
+            )
+
+            all_paginated_hits.extend(page_res["hits"])
+
+        # Page 1
+        self.assertEqual(['doc_B2', 'doc_B1', 'doc_T1', 'doc_T2', 'doc_T3'],
+                         [h['_id'] for h in all_paginated_hits[:5]])
+        # Page 2
+        self.assertEqual(['doc_T3', 'doc_T2', 'doc_T1', 'doc_T4', 'doc_T5'],
+                         [h['_id'] for h in all_paginated_hits[5:-5]])
+        # Page 3
+        self.assertEqual(['doc_T3', 'doc_T2', 'doc_T1', 'doc_T4', 'doc_T5'],
+                         [h['_id'] for h in all_paginated_hits[-5:]])
+        

--- a/tests/integ_tests/tensor_search/test_pagination_rrf_fix.py
+++ b/tests/integ_tests/tensor_search/test_pagination_rrf_fix.py
@@ -1,0 +1,295 @@
+import math
+import os
+import unittest
+from unittest import mock
+import pytest
+
+from marqo.core.models.marqo_index import *
+from marqo.tensor_search import tensor_search
+from marqo.core.models.add_docs_params import AddDocsParams
+from tests.integ_tests.marqo_test import MarqoTestCase
+from marqo.core.models.hybrid_parameters import RetrievalMethod, RankingMethod, HybridParameters
+
+
+class TestPaginationRRFFix(MarqoTestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+
+        # Create only unstructured index for now
+        index_request_unstructured = cls.unstructured_marqo_index_request(
+            model=Model(name='hf/e5-base-v2')
+        )
+
+        cls.indexes = cls.create_indexes([
+            index_request_unstructured
+        ])
+
+        cls.index_unstructured = cls.indexes[0]
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Any tests that call add_document, search, bulk_search need this env var
+        self.device_patcher = mock.patch.dict(os.environ, {"MARQO_BEST_AVAILABLE_DEVICE": "cpu"})
+        self.device_patcher.start()
+
+    def tearDown(self):
+        self.device_patcher.stop()
+
+    def create_curated_test_data(self):
+        """
+        Create simplified test data with deterministic rankings.
+        - 5 docs only match tensor (doc_T1 to doc_T5, ranked T1 > T2 > T3 > T4 > T5)
+        - 5 docs only match lexical (doc_L1 to doc_L5, ranked L1 > L2 > L3 > L4 > L5)
+        - 5 docs match both (doc_B1 to doc_B5, different rankings in tensor vs lexical)
+        """
+        docs = []
+
+        # 5 docs that only match TENSOR search (semantic similarity)
+        # Avoid words "EXACT", "QUERY", "machine", "learning" to prevent lexical matches
+        tensor_terms = [
+            "artificial intelligence algorithms",     # T1 - highest tensor relevance
+            "deep neural systems",                    # T2
+            "neural network models",                  # T3
+            "computational intelligence frameworks",  # T4
+            "data science tools"                      # T5 - lowest tensor relevance
+        ]
+
+        for i in range(5):
+            doc = {
+                "_id": f"doc_T{i+1}",
+                "title": f"{tensor_terms[i]} tensor_document_{i+1}",
+                "doc_type": "tensor_only",
+                "tensor_rank": i + 1  # 1 = highest, 5 = lowest
+            }
+            docs.append(doc)
+
+        # 5 docs that only match LEXICAL search (exact keyword matches)
+        for i in range(5):
+            # Use decreasing keyword repetition for deterministic TF scores
+            repeated_keywords = " ".join(["EXACT", "QUERY"] * (5 - i))  # More repetition = higher score
+            doc = {
+                "_id": f"doc_L{i+1}",
+                "title": f"{repeated_keywords} lexical_document_{i+1}",
+                "doc_type": "lexical_only",
+                "lexical_rank": i + 1  # 1 = highest, 5 = lowest
+            }
+            docs.append(doc)
+
+        # 5 docs that match BOTH tensor and lexical (for RRF fusion testing)
+        # These have DIFFERENT rankings in tensor vs lexical to test RRF properly
+        both_docs = [
+            # (tensor_keywords, lexical_keywords, tensor_rank, lexical_rank)
+            ("machine learning algorithms", " ".join(["EXACT", "QUERY"] * 10), 1, 1),  # B1: high in both
+            ("machine learning courses", "EXACT QUERY", 2, 4),                           # B2: high tensor, low lexical
+            ("computational models", "EXACT QUERY EXACT QUERY", 3, 2),          # B3: mid tensor, high lexical
+            ("data science", "EXACT", 4, 5),                                    # B4: low tensor, lowest lexical
+            ("algorithmic systems", "EXACT QUERY EXACT", 5, 3),                 # B5: lowest tensor, mid lexical
+        ]
+
+        for i, (tensor_term, lexical_term, tensor_rank, lexical_rank) in enumerate(both_docs):
+            doc = {
+                "_id": f"doc_B{i+1}",
+                "title": f"{lexical_term} {tensor_term} both_document_{i+1}",
+                "doc_type": "both",
+                "tensor_rank": tensor_rank,
+                "lexical_rank": lexical_rank
+            }
+            docs.append(doc)
+
+        return docs
+
+    @pytest.mark.skip_for_multinode
+    def test_disjunction_rrf_pagination(self):
+        """
+        Test that disjunction+RRF pagination produces no duplicates between pages.
+        Verifies ranking consistency and proper pagination behavior.
+
+        Lexical search score:         Tensor search score:
+        doc_B1: 1.5657032529354344    doc_B2: 0.8774912556666549
+        doc_L1: 1.5310213335683778    doc_B1: 0.8624316166639774
+        doc_L2: 1.4957020935493452    doc_T1: 0.8551202270206154
+        doc_L3: 1.4403238705575117    doc_T2: 0.8550448320679322
+        doc_L4: 1.3410214926606240    doc_T3: 0.8523972952471728
+        doc_B3: 1.2495362288065737    doc_T4: 0.8500947166713401
+        doc_L5: 1.1111902054958356    doc_B4: 0.8500164585022059
+        doc_B5: 1.0981049722627436    doc_T5: 0.8471093151792289
+        doc_B2: 0.9400916280884359    doc_B3: 0.8368122835299188
+        doc_B4: 0.4681934225728979    doc_B5: 0.8334305830362274
+                                      doc_L1: 0.8316111466678087
+                                      doc_L5: 0.8288859450924600
+                                      doc_L3: 0.8269666625377193
+                                      doc_L4: 0.8263098149586303
+                                      doc_L2: 0.8257278463225931
+
+        Pagination with page size 5: with alpha=0.7, rrf_k=60
+        tensor rrf score = alpha * (1.0 / (rank + k))
+        lexical rrf score = (1-alpha) * (1.0 / (rank + k))
+
+        ======================================================
+        Page 1:
+        Lexical search rrf score:     Tensor search rrf score:
+        doc_B1: 0.004918              doc_B2: 0.011475
+        doc_L1: 0.004839              doc_B1: 0.011290
+        doc_L2: 0.004762              doc_T1: 0.011111
+        doc_L3: 0.004688              doc_T2: 0.010938
+        doc_L4: 0.004615              doc_T3: 0.010769
+
+        After fusion:
+        doc_B1: 0.016208   <- In both, highest ranking
+        doc_B2: 0.011475
+        doc_T1: 0.011111
+        doc_T2: 0.010938
+        doc_T3: 0.010769
+        doc_L1: 0.004839   <- Trimmed off from here
+        doc_L2: 0.004762
+        doc_L3: 0.004688
+        doc_L4: 0.004615
+
+        =======================================================
+        Page 2:
+        Lexical search rrf score:     Tensor search rrf score:
+        doc_B1: 0.004918              doc_B2: 0.011475
+        doc_L1: 0.004839              doc_B1: 0.011290
+        doc_L2: 0.004762              doc_T1: 0.011111
+        doc_L3: 0.004688              doc_T2: 0.010938
+        doc_L4: 0.004615              doc_T3: 0.010769
+        doc_B3: 0.004545              doc_T4: 0.010606
+        doc_L5: 0.004478              doc_B4: 0.010448
+        doc_B5: 0.004412              doc_T5: 0.010294
+        doc_B2: 0.004348              doc_B3: 0.010145
+        doc_B4: 0.004286              doc_B5: 0.01
+
+        After fusion:
+        doc_B1: 0.016208
+        doc_B2: 0.015823
+        doc_B4: 0.014734   (MISSED)
+        doc_B3: 0.014690   (MISSED)
+        doc_B5: 0.014412   (MISSED)
+        doc_T1: 0.011111   <- Start from here  (DUP)
+        doc_T2: 0.010938   (DUP)
+        doc_T3: 0.010769   (DUP)
+        doc_T4: 0.010606
+        doc_T5: 0.010294
+        doc_L1: 0.004839   <- Trimmed off from here
+        doc_L2: 0.004762
+        doc_L3: 0.004688
+        doc_L4: 0.004615
+        doc_L5: 0.004478
+
+        =======================================================
+        Page 3:
+        Lexical search rrf score:     Tensor search rrf score:
+        doc_B1: 0.004918              doc_B2: 0.011475
+        doc_L1: 0.004839              doc_B1: 0.011290
+        doc_L2: 0.004762              doc_T1: 0.011111
+        doc_L3: 0.004688              doc_T2: 0.010938
+        doc_L4: 0.004615              doc_T3: 0.010769
+        doc_B3: 0.004545              doc_T4: 0.010606
+        doc_L5: 0.004478              doc_B4: 0.010448
+        doc_B5: 0.004412              doc_T5: 0.010294
+        doc_B2: 0.004348              doc_B3: 0.010145
+        doc_B4: 0.004286              doc_B5: 0.01
+                                      doc_L1: 0.009859
+                                      doc_L5: 0.009722
+                                      doc_L3: 0.009589
+                                      doc_L4: 0.009459
+                                      doc_L2: 0.009333
+
+        After fusion:
+        doc_B1: 0.016208
+        doc_B2: 0.015823
+        doc_B4: 0.014734    (MISSED)
+        doc_L1: 0.014698    (MISSED)
+        doc_B3: 0.014690    (MISSED)
+        doc_B5: 0.014412    (MISSED)
+        doc_L3: 0.014277    (MISSED)
+        doc_L5: 0.014200    (MISSED)
+        doc_L2: 0.014095    (MISSED)
+        doc_L4: 0.014074    (MISSED)
+        doc_T1: 0.011111    <- Start from here (DUP)
+        doc_T2: 0.010938    (DUP)
+        doc_T3: 0.010769    (DUP)
+        doc_T4: 0.010606    (DUP)
+        doc_T5: 0.010294    (DUP)
+        """
+        index = self.index_unstructured
+
+        # Create and add curated test documents
+        r = self.add_documents(
+            config=self.config,
+            add_docs_params=AddDocsParams(
+                index_name=index.name,
+                docs=(self.create_curated_test_data()),
+                tensor_fields=['title']
+            )
+        ).dict(exclude_none=True, by_alias=True)
+        self.assertFalse(r['errors'], "Errors in add documents call")
+
+        # Test with page size 5 for clean 3-page pagination (15 docs = 3 pages)
+        page_size = 5
+        all_paginated_hits = []
+
+        hp_rrf = HybridParameters(
+            alpha=0.7,
+            rrfK=60,
+            retrievalMethod=RetrievalMethod.Disjunction,
+            rankingMethod=RankingMethod.RRF,
+            queryTensor='machine learning',
+            queryLexical='EXACT QUERY',
+        )
+
+        # Collect all pages
+        for page_num in range(3):  # 3 pages for 15 docs with page size 5
+            offset = page_num * page_size
+
+            page_res = tensor_search.search(
+                search_method="HYBRID",
+                hybrid_parameters=hp_rrf,
+                config=self.config,
+                index_name=index.name,
+                result_count=page_size,
+                offset=offset,
+                text=None
+            )
+
+            all_paginated_hits.extend(page_res["hits"])
+
+        # TODO the result is quite broken, a lot of duplicates and missing docs. This can only be fixed by storing
+        #  pagination state or over-fetching then trimming. This bad result is also related to the data set. In reality,
+        #  we have a lot of docs matching both lexical and tensor, and with score modifiers, the result is much better.
+        # Page 1
+        self.assertEqual(['doc_B1', 'doc_B2', 'doc_T1', 'doc_T2', 'doc_T3'], [h['_id'] for h in all_paginated_hits[:5]])
+        # Page 2
+        self.assertEqual(['doc_T1', 'doc_T2', 'doc_T3', 'doc_T4', 'doc_T5'], [h['_id'] for h in all_paginated_hits[5:-5]])
+        # Page 3
+        self.assertEqual(['doc_T1', 'doc_T2', 'doc_T3', 'doc_T4', 'doc_T5'], [h['_id'] for h in all_paginated_hits[-5:]])
+
+    @pytest.mark.skip_for_multinode
+    def test_disjunction_rrf_pagination_with_global_modifiers_no_rerank_depth(self):
+        """
+        Test pagination with various rerankDepthGlobal values.
+        Verifies the adjustment logic when needToTrimPreviousPages is true.
+        """
+        # TODO: Implement test
+        pass
+
+    @pytest.mark.skip_for_multinode
+    def test_disjunction_rrf_pagination_with_global_modifiers_with_rerank_depth(self):
+        """
+        Test pagination with various rerankDepthGlobal values.
+        Verifies the adjustment logic when needToTrimPreviousPages is true.
+        """
+        # TODO: Implement test
+        pass
+
+    @pytest.mark.skip_for_multinode
+    # TODO move to test_search_relevance_cutoff_feature.py
+    def test_relevance_cutoff_pagination(self):
+        """
+        Test pagination with relevance cutoff enabled.
+        Verifies the fix applies to both disjunction and relevance cutoff paths.
+        """
+        # TODO: Implement test
+        pass

--- a/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
+++ b/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
@@ -431,6 +431,17 @@ public class HybridSearcher extends Searcher {
 
         // Validate input parameters
         if (!isRelevanceCutoffEnabled && !isSortByEnabled) {
+            // For disjunction hybrid search, we need to set offset to 0 to handle the pagination
+            // correctly
+            // TODO the logic to extract retrievalMethod is duplicated here to reduce the effort of
+            //   changing method signature. We will do a refactoring in the near future
+            String retrievalMethod =
+                    query.properties().getString("marqo__hybrid.retrievalMethod", "");
+            if ("disjunction".equalsIgnoreCase(retrievalMethod)) {
+                query.setHits(query.getOffset() + query.getHits());
+                query.setOffset(0);
+            }
+
             return query;
         }
 
@@ -943,7 +954,28 @@ public class HybridSearcher extends Searcher {
             int limit,
             int offset,
             boolean verbose) {
-        // Split original hits into 2 lists: result to rerank and excess hits
+        // Check if we need special pagination handling
+        // TODO the logic to extract retrievalMethod and relevanceCutoffMethod is duplicated here to
+        //  reduce the effort of changing method signature. We will do a refactoring in the near
+        //  future to improve this
+        String retrievalMethod = query.properties().getString("marqo__hybrid.retrievalMethod", "");
+        String relevanceCutoffMethod =
+                query.properties().getString("marqo__hybrid.relevanceCutoff.method", null);
+        boolean needsPaginationBeforeRerank =
+                "disjunction".equalsIgnoreCase(retrievalMethod) || relevanceCutoffMethod != null;
+
+        // Step 1: Apply pagination BEFORE reranking if needed
+        if (needsPaginationBeforeRerank) {
+            // We fetched (offset + limit) results from position 0
+            // Now trim to remove the first 'offset' results
+            hitsForPostProcessing.trim(offset, hitsForPostProcessing.size());
+            logIfVerbose(
+                    String.format(
+                            "Applied pre-rerank pagination: removed first %d results", offset),
+                    verbose);
+        }
+
+        // Step 2: Split original hits into 2 lists: result to rerank and excess hits
         // Excess hits will not be reranked, and will be added back after reranking the other
         // results
         HitGroup resultToRerank = new HitGroup();
@@ -974,7 +1006,7 @@ public class HybridSearcher extends Searcher {
             logHitGroup(excessHits, verbose);
         }
 
-        // Apply global score modifiers and rerank
+        // Step 3: Apply global score modifiers and rerank
         // Skip whole process if global modifier weight tensors don't exist in query
         Tensor queryMultWeightsGlobal =
                 extractTensorRankFeature(query, addQueryWrapper(QUERY_INPUT_MULT_WEIGHTS_GLOBAL));
@@ -992,11 +1024,13 @@ public class HybridSearcher extends Searcher {
         logIfVerbose("Rescored result list (UNSORTED): ", verbose);
         logHitGroup(resultToRerank, verbose);
 
+        // Step 4: Sort
         resultToRerank.sort();
 
         logIfVerbose("Reranked result list (SORTED): ", verbose);
         logHitGroup(resultToRerank, verbose);
 
+        // Step 5: Add excess hits if needed
         if (limit > rerankDepthGlobal) {
             // Add excess hits to the end of reranked results then sort
             logIfVerbose(
@@ -1007,11 +1041,8 @@ public class HybridSearcher extends Searcher {
             resultToRerank.addAll(excessHits.asList());
         }
 
-        // Paginate and/or trim
-        // Result list should always have limit length (if possible)
-        logIfVerbose(
-                String.format("Trimming result list. " + "limit: %d, offset: %d", limit, offset),
-                verbose);
+        // Step 6: Final trim to limit (pagination was already applied if needed)
+        logIfVerbose(String.format("Final trimming result list to limit: %d", limit), verbose);
         resultToRerank.trim(0, limit);
 
         logIfVerbose("Final result list (EXCESS HITS ADDED/REMOVED): ", verbose);

--- a/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
+++ b/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
@@ -961,19 +961,20 @@ public class HybridSearcher extends Searcher {
         String retrievalMethod = query.properties().getString("marqo__hybrid.retrievalMethod", "");
         String relevanceCutoffMethod =
                 query.properties().getString("marqo__hybrid.relevanceCutoff.method", null);
-        boolean needsPaginationBeforeRerank =
+        boolean needsToTrim =
                 "disjunction".equalsIgnoreCase(retrievalMethod) || relevanceCutoffMethod != null;
 
         // Step 1: Apply pagination BEFORE reranking if needed
-        if (needsPaginationBeforeRerank) {
-            // We fetched (offset + limit) results from position 0
-            // Now trim to remove the first 'offset' results
-            hitsForPostProcessing.trim(offset, hitsForPostProcessing.size());
-            logIfVerbose(
-                    String.format(
-                            "Applied pre-rerank pagination: removed first %d results", offset),
-                    verbose);
-        }
+        //        if (needsToTrim) {
+        //            // We fetched (offset + limit) results from position 0
+        //            // Now trim to remove the first 'offset' results
+        //            hitsForPostProcessing.trim(offset, hitsForPostProcessing.size() - offset);
+        //            logIfVerbose(
+        //                    String.format(
+        //                            "Applied pre-rerank pagination: removed first %d results",
+        // offset),
+        //                    verbose);
+        //        }
 
         // Step 2: Split original hits into 2 lists: result to rerank and excess hits
         // Excess hits will not be reranked, and will be added back after reranking the other
@@ -1042,8 +1043,17 @@ public class HybridSearcher extends Searcher {
         }
 
         // Step 6: Final trim to limit (pagination was already applied if needed)
-        logIfVerbose(String.format("Final trimming result list to limit: %d", limit), verbose);
-        resultToRerank.trim(0, limit);
+        if (needsToTrim) {
+            logIfVerbose(
+                    String.format(
+                            "Final trimming result list from offset %s and limit: %d",
+                            offset, limit),
+                    verbose);
+            resultToRerank.trim(offset, limit);
+        } else {
+            logIfVerbose(String.format("Final trimming result list to limit: %d", limit), verbose);
+            resultToRerank.trim(0, limit);
+        }
 
         logIfVerbose("Final result list (EXCESS HITS ADDED/REMOVED): ", verbose);
         logHitGroup(resultToRerank, verbose);

--- a/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
+++ b/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
@@ -224,6 +224,7 @@ public class HybridSearcher extends Searcher {
         // --- Update the query hits, offset and targetHits, if sort or relevance cut-off is used
         boolean isRelevanceCutoffMethodEnabled = relevanceCutoffMethod != null;
         boolean isSortByEnabled = sortByFields != null;
+        boolean isDisjunctionSearch = retrievalMethod.equals("disjunction");
 
         query =
                 updateQueryHitsOffsetsAndTargetHits(
@@ -231,10 +232,11 @@ public class HybridSearcher extends Searcher {
                         relevantCandidates,
                         sortByMinSortCandidates,
                         isRelevanceCutoffMethodEnabled,
-                        isSortByEnabled);
+                        isSortByEnabled,
+                        isDisjunctionSearch);
 
         HitGroup hitsForPostProcessing;
-        if (retrievalMethod.equals("disjunction")) {
+        if (isDisjunctionSearch) {
             Result resultLexical, resultTensor;
             Query queryLexical =
                     createSubQuery(
@@ -320,6 +322,9 @@ public class HybridSearcher extends Searcher {
             sortCandidates = hitsForPostProcessing.size();
         } else {
             // If sortBy is not set, we use the default post-processing
+            // when we do disjunction search or use relevance cutoff, the offset is set to 0, so we
+            // need to trim previous pages
+            boolean needToTrimPreviousPages = isDisjunctionSearch || isRelevanceCutoffMethodEnabled;
             processedHits =
                     postProcessResults(
                             hitsForPostProcessing,
@@ -327,6 +332,7 @@ public class HybridSearcher extends Searcher {
                             rerankDepthGlobal,
                             limit,
                             offset,
+                            needToTrimPreviousPages,
                             verbose);
         }
 
@@ -415,11 +421,13 @@ public class HybridSearcher extends Searcher {
 
     /**
      * Updates the query hits, offsets, and targetHits based on the provided parameters.
-     * @param query the query to update.
-     * @param relevantCandidates the number of relevant candidates found in the probe search.
-     * @param sortByMinSortCandidates the minimum number of candidates required for sorting, from Marqo
+     *
+     * @param query                    the query to update.
+     * @param relevantCandidates       the number of relevant candidates found in the probe search.
+     * @param sortByMinSortCandidates  the minimum number of candidates required for sorting, from Marqo
      * @param isRelevanceCutoffEnabled whether relevance cutoff is enabled.
-     * @param isSortByEnabled whether sorting is enabled.
+     * @param isSortByEnabled          whether sorting is enabled.
+     * @param isDisjunctionSearch      whether the retrieval method is disjunction
      * @return The updated query with new hits, offsets, and targetHits.
      */
     public Query updateQueryHitsOffsetsAndTargetHits(
@@ -427,17 +435,12 @@ public class HybridSearcher extends Searcher {
             Integer relevantCandidates,
             Integer sortByMinSortCandidates,
             boolean isRelevanceCutoffEnabled,
-            boolean isSortByEnabled) {
+            boolean isSortByEnabled,
+            boolean isDisjunctionSearch) {
 
         // Validate input parameters
         if (!isRelevanceCutoffEnabled && !isSortByEnabled) {
-            // For disjunction hybrid search, we need to set offset to 0 to handle the pagination
-            // correctly
-            // TODO the logic to extract retrievalMethod is duplicated here to reduce the effort of
-            //   changing method signature. We will do a refactoring in the near future
-            String retrievalMethod =
-                    query.properties().getString("marqo__hybrid.retrievalMethod", "");
-            if ("disjunction".equalsIgnoreCase(retrievalMethod)) {
+            if (isDisjunctionSearch) {
                 query.setHits(query.getOffset() + query.getHits());
                 query.setOffset(0);
             }
@@ -953,30 +956,10 @@ public class HybridSearcher extends Searcher {
             Integer rerankDepthGlobal,
             int limit,
             int offset,
+            boolean needToTrimPreviousPages,
             boolean verbose) {
-        // Check if we need special pagination handling
-        // TODO the logic to extract retrievalMethod and relevanceCutoffMethod is duplicated here to
-        //  reduce the effort of changing method signature. We will do a refactoring in the near
-        //  future to improve this
-        String retrievalMethod = query.properties().getString("marqo__hybrid.retrievalMethod", "");
-        String relevanceCutoffMethod =
-                query.properties().getString("marqo__hybrid.relevanceCutoff.method", null);
-        boolean needsToTrim =
-                "disjunction".equalsIgnoreCase(retrievalMethod) || relevanceCutoffMethod != null;
 
-        // Step 1: Apply pagination BEFORE reranking if needed
-        //        if (needsToTrim) {
-        //            // We fetched (offset + limit) results from position 0
-        //            // Now trim to remove the first 'offset' results
-        //            hitsForPostProcessing.trim(offset, hitsForPostProcessing.size() - offset);
-        //            logIfVerbose(
-        //                    String.format(
-        //                            "Applied pre-rerank pagination: removed first %d results",
-        // offset),
-        //                    verbose);
-        //        }
-
-        // Step 2: Split original hits into 2 lists: result to rerank and excess hits
+        // Step 1: Split original hits into 2 lists: result to rerank and excess hits
         // Excess hits will not be reranked, and will be added back after reranking the other
         // results
         HitGroup resultToRerank = new HitGroup();
@@ -986,6 +969,8 @@ public class HybridSearcher extends Searcher {
         // If rerank count global is not set, rerank all hits
         if (rerankDepthGlobal == null) {
             rerankDepthGlobal = hitsForPostProcessing.size();
+        } else if (needToTrimPreviousPages) {
+            rerankDepthGlobal = rerankDepthGlobal + offset;
         }
         for (Hit hit : hitsForPostProcessing) {
             if (idx < rerankDepthGlobal) {
@@ -1007,7 +992,7 @@ public class HybridSearcher extends Searcher {
             logHitGroup(excessHits, verbose);
         }
 
-        // Step 3: Apply global score modifiers and rerank
+        // Step 2: Apply global score modifiers and rerank
         // Skip whole process if global modifier weight tensors don't exist in query
         Tensor queryMultWeightsGlobal =
                 extractTensorRankFeature(query, addQueryWrapper(QUERY_INPUT_MULT_WEIGHTS_GLOBAL));
@@ -1025,13 +1010,13 @@ public class HybridSearcher extends Searcher {
         logIfVerbose("Rescored result list (UNSORTED): ", verbose);
         logHitGroup(resultToRerank, verbose);
 
-        // Step 4: Sort
+        // Step 3: Sort
         resultToRerank.sort();
 
         logIfVerbose("Reranked result list (SORTED): ", verbose);
         logHitGroup(resultToRerank, verbose);
 
-        // Step 5: Add excess hits if needed
+        // Step 4: Add excess hits if needed
         if (limit > rerankDepthGlobal) {
             // Add excess hits to the end of reranked results then sort
             logIfVerbose(
@@ -1042,8 +1027,8 @@ public class HybridSearcher extends Searcher {
             resultToRerank.addAll(excessHits.asList());
         }
 
-        // Step 6: Final trim to limit (pagination was already applied if needed)
-        if (needsToTrim) {
+        // Step 5: Final trim to limit (pagination was already applied if needed)
+        if (needToTrimPreviousPages) {
             logIfVerbose(
                     String.format(
                             "Final trimming result list from offset %s and limit: %d",

--- a/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
+++ b/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
@@ -974,14 +974,18 @@ public class HybridSearcher extends Searcher {
             // rerankDepthGlobal to make sure global score modifiers are applied to current page
             rerankDepthGlobal = rerankDepthGlobal + offset;
         }
+        // Calculate total hits needed: when needToTrimPreviousPages is true, we need offset + limit
+        // hits
+        int totalHitsNeeded = needToTrimPreviousPages ? offset + limit : limit;
+
         for (Hit hit : hitsForPostProcessing) {
             if (idx < rerankDepthGlobal) {
                 resultToRerank.add(hit);
-            } else if (idx < limit) {
-                // Total hits to return caps out at limit
+            } else if (idx < totalHitsNeeded) {
+                // Total hits to process should be offset + limit when trimming previous pages
                 excessHits.add(hit);
             } else {
-                // Ignore all hits after limit
+                // Ignore all hits after totalHitsNeeded
                 break;
             }
             idx++;

--- a/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
+++ b/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
@@ -1016,14 +1016,14 @@ public class HybridSearcher extends Searcher {
         logIfVerbose("Rescored result list (UNSORTED): ", verbose);
         logHitGroup(resultToRerank, verbose);
 
-        // Step 3: Sort
+        // Step 3: Sort  TODO should only sort after applying global score modifiers
         resultToRerank.sort();
 
         logIfVerbose("Reranked result list (SORTED): ", verbose);
         logHitGroup(resultToRerank, verbose);
 
         // Step 4: Add excess hits if needed
-        if (limit > rerankDepthGlobal) {
+        if (totalHitsNeeded > rerankDepthGlobal) {
             // Add excess hits to the end of reranked results then sort
             logIfVerbose(
                     String.format(

--- a/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
+++ b/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
@@ -970,6 +970,8 @@ public class HybridSearcher extends Searcher {
         if (rerankDepthGlobal == null) {
             rerankDepthGlobal = hitsForPostProcessing.size();
         } else if (needToTrimPreviousPages) {
+            // When previous pages are also in search result, we need to increase the original
+            // rerankDepthGlobal to make sure global score modifiers are applied to current page
             rerankDepthGlobal = rerankDepthGlobal + offset;
         }
         for (Hit hit : hitsForPostProcessing) {

--- a/vespa/src/test/java/ai/marqo/search/HybridSearcherPostProcessResultsTest.java
+++ b/vespa/src/test/java/ai/marqo/search/HybridSearcherPostProcessResultsTest.java
@@ -1,0 +1,228 @@
+package ai.marqo.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.yahoo.search.Query;
+import com.yahoo.search.result.Hit;
+import com.yahoo.search.result.HitGroup;
+import com.yahoo.tensor.Tensor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for HybridSearcher.postProcessResults method.
+ * Tests the new pagination logic controlled by needToTrimPreviousPages parameter.
+ */
+@DisplayName("HybridSearcher PostProcessResults Tests")
+class HybridSearcherPostProcessResultsTest {
+
+    private HybridSearcher hybridSearcher;
+
+    @BeforeEach
+    void setUp() {
+        hybridSearcher = new HybridSearcher();
+    }
+
+    /**
+     * Helper method to create a HitGroup with specified number of hits.
+     * Each hit has a relevance score of 1.0/(index+1) to ensure predictable sorting.
+     */
+    private HitGroup createTestHitGroup(int size) {
+        HitGroup hitGroup = new HitGroup();
+        for (int i = 0; i < size; i++) {
+            Hit hit = new Hit("hit_" + i, 1.0 / (i + 1));
+            hitGroup.add(hit);
+        }
+        return hitGroup;
+    }
+
+    /**
+     * Helper method to create a query with no global modifiers.
+     */
+    private Query createTestQuery() {
+        Query query = new Query();
+        // Ensure no global modifiers are present
+        // TODO add test coverage for global score modifier later
+        query.getRanking()
+                .getFeatures()
+                .put("query(marqo__mult_weights_global)", Tensor.from("tensor(p{}):{}"));
+        query.getRanking()
+                .getFeatures()
+                .put("query(marqo__add_weights_global)", Tensor.from("tensor(p{}):{}"));
+        return query;
+    }
+
+    @Test
+    @DisplayName("Test 1: needToTrimPreviousPages=true adjusts rerankDepthGlobal by adding offset")
+    void testPostProcessResults_NeedToTrimTrue_AdjustsRerankDepth() {
+        // Arrange
+        HitGroup inputHits = createTestHitGroup(20); // 20 hits
+        Query query = createTestQuery();
+
+        int limit = 10;
+        int offset = 5;
+        Integer rerankDepthGlobal = 10; // Should become 15 (10 + 5)
+        boolean needToTrimPreviousPages = true;
+        boolean verbose = false;
+
+        // Act
+        HitGroup result =
+                hybridSearcher.postProcessResults(
+                        inputHits,
+                        query,
+                        rerankDepthGlobal,
+                        limit,
+                        offset,
+                        needToTrimPreviousPages,
+                        verbose);
+
+        // Assert
+        // When needToTrimPreviousPages=true, rerankDepthGlobal becomes 15 (10+5)
+        // So hits 0-14 should be reranked (sorted by relevance)
+        // Final result should have 10 hits starting from offset 5
+        assertThat(result.size()).isEqualTo(10);
+
+        // Verify we get hits from positions 5-14 (after reranking adjustment)
+        // Since all hits have descending relevance scores, the first hit should be hit_0
+        assertThat(result.get(0).getId().toString()).isEqualTo("hit_5");
+    }
+
+    @Test
+    @DisplayName("Test 2: needToTrimPreviousPages=false keeps original rerankDepthGlobal")
+    void testPostProcessResults_NeedToTrimFalse_KeepsOriginalRerankDepth() {
+        // Arrange
+        HitGroup inputHits = createTestHitGroup(20); // 20 hits
+        Query query = createTestQuery();
+
+        int limit = 10;
+        int offset = 5;
+        Integer rerankDepthGlobal = 10; // Should stay 10
+        boolean needToTrimPreviousPages = false;
+        boolean verbose = false;
+
+        // Act
+        HitGroup result =
+                hybridSearcher.postProcessResults(
+                        inputHits,
+                        query,
+                        rerankDepthGlobal,
+                        limit,
+                        offset,
+                        needToTrimPreviousPages,
+                        verbose);
+
+        // Assert
+        // When needToTrimPreviousPages=false, rerankDepthGlobal stays 10
+        // So only hits 0-9 are reranked
+        // Final result should have 10 hits starting from position 0 (ignoring offset)
+        assertThat(result.size()).isEqualTo(10);
+
+        // Should get the first 10 hits after reranking (starts from 0, ignores offset)
+        assertThat(result.get(0).getId().toString()).isEqualTo("hit_0");
+    }
+
+    @Test
+    @DisplayName(
+            "Test 3: needToTrimPreviousPages=true with null rerankDepthGlobal reranks all hits")
+    void testPostProcessResults_NeedToTrimTrue_WithNullRerankDepth() {
+        // Arrange
+        HitGroup inputHits = createTestHitGroup(15); // 15 hits
+        Query query = createTestQuery();
+
+        int limit = 10;
+        int offset = 5;
+        Integer rerankDepthGlobal = null; // Should rerank all hits regardless of offset
+        boolean needToTrimPreviousPages = true;
+        boolean verbose = false;
+
+        // Act
+        HitGroup result =
+                hybridSearcher.postProcessResults(
+                        inputHits,
+                        query,
+                        rerankDepthGlobal,
+                        limit,
+                        offset,
+                        needToTrimPreviousPages,
+                        verbose);
+
+        // Assert
+        // When rerankDepthGlobal is null, all hits are reranked regardless of
+        // needToTrimPreviousPages
+        // Final result should have 10 hits starting from offset 5
+        assertThat(result.size()).isEqualTo(10);
+
+        // Verify we get hits from positions 5-14 after reranking
+        assertThat(result.get(0).getId().toString()).isEqualTo("hit_5");
+    }
+
+    @Test
+    @DisplayName("Test 4: needToTrimPreviousPages=true uses trim(offset, limit)")
+    void testPostProcessResults_NeedToTrimTrue_TrimsWithOffset() {
+        // Arrange
+        HitGroup inputHits = createTestHitGroup(20); // 20 hits
+        Query query = createTestQuery();
+
+        int limit = 5;
+        int offset = 3;
+        Integer rerankDepthGlobal = 20; // Rerank all
+        boolean needToTrimPreviousPages = true;
+        boolean verbose = false;
+
+        // Act
+        HitGroup result =
+                hybridSearcher.postProcessResults(
+                        inputHits,
+                        query,
+                        rerankDepthGlobal,
+                        limit,
+                        offset,
+                        needToTrimPreviousPages,
+                        verbose);
+
+        // Assert
+        // Should return 5 hits starting from offset 3 (positions 3,4,5,6,7)
+        assertThat(result.size()).isEqualTo(5);
+
+        // After reranking, hits are sorted by relevance (hit_0 has highest score)
+        // So result should contain hits starting from position 3
+        assertThat(result.get(0).getId().toString()).isEqualTo("hit_3");
+        assertThat(result.get(1).getId().toString()).isEqualTo("hit_4");
+        assertThat(result.get(4).getId().toString()).isEqualTo("hit_7");
+    }
+
+    @Test
+    @DisplayName("Test 5: needToTrimPreviousPages=false uses trim(0, limit)")
+    void testPostProcessResults_NeedToTrimFalse_TrimsFromZero() {
+        // Arrange
+        HitGroup inputHits = createTestHitGroup(20); // 20 hits
+        Query query = createTestQuery();
+
+        int limit = 5;
+        int offset = 3; // Should be ignored
+        Integer rerankDepthGlobal = 20; // Rerank all
+        boolean needToTrimPreviousPages = false;
+        boolean verbose = false;
+
+        // Act
+        HitGroup result =
+                hybridSearcher.postProcessResults(
+                        inputHits,
+                        query,
+                        rerankDepthGlobal,
+                        limit,
+                        offset,
+                        needToTrimPreviousPages,
+                        verbose);
+
+        // Assert
+        // Should return 5 hits starting from position 0 (ignoring offset)
+        assertThat(result.size()).isEqualTo(5);
+
+        // After reranking, should get the top 5 hits (positions 0,1,2,3,4)
+        assertThat(result.get(0).getId().toString()).isEqualTo("hit_0");
+        assertThat(result.get(1).getId().toString()).isEqualTo("hit_1");
+        assertThat(result.get(4).getId().toString()).isEqualTo("hit_4");
+    }
+}

--- a/vespa/src/test/java/ai/marqo/search/HybridSearcherPostProcessResultsTest.java
+++ b/vespa/src/test/java/ai/marqo/search/HybridSearcherPostProcessResultsTest.java
@@ -225,4 +225,44 @@ class HybridSearcherPostProcessResultsTest {
         assertThat(result.get(1).getId().toString()).isEqualTo("hit_1");
         assertThat(result.get(4).getId().toString()).isEqualTo("hit_4");
     }
+
+    @Test
+    @DisplayName("Test 6: Sufficient hits processed for pagination with offset")
+    void testPostProcessResults_PaginationBugFix_ProcessesSufficientHits() {
+        // This test verifies the fix for the pagination bug where insufficient hits
+        // were processed when needToTrimPreviousPages=true with large offset
+
+        // Arrange
+        HitGroup inputHits = createTestHitGroup(20); // 20 hits
+        Query query = createTestQuery();
+
+        int limit = 5;
+        int offset = 10; // Large offset
+        Integer rerankDepthGlobal = 8; // Small rerank depth (less than offset + limit)
+        boolean needToTrimPreviousPages = true;
+        boolean verbose = false;
+
+        // Act
+        HitGroup result =
+                hybridSearcher.postProcessResults(
+                        inputHits,
+                        query,
+                        rerankDepthGlobal,
+                        limit,
+                        offset,
+                        needToTrimPreviousPages,
+                        verbose);
+
+        // Assert
+        // Should return exactly 5 hits even with large offset
+        // Before the bug fix, this would return fewer than 5 hits because
+        // the loop was incorrectly capped at 'limit' instead of 'offset + limit'
+        assertThat(result.size()).isEqualTo(5);
+
+        // Verify we get hits from the correct range (offset 10, limit 5)
+        // After reranking with adjusted depth (8 + 10 = 18), hits should be sorted by relevance
+        assertThat(result.get(0).getId().toString()).isEqualTo("hit_10");
+        assertThat(result.get(1).getId().toString()).isEqualTo("hit_11");
+        assertThat(result.get(4).getId().toString()).isEqualTo("hit_14");
+    }
 }

--- a/vespa/src/test/java/ai/marqo/search/SortByTest.java
+++ b/vespa/src/test/java/ai/marqo/search/SortByTest.java
@@ -326,7 +326,8 @@ class SortByTest {
         verify(spy, times(1))
                 .postProcessBySort(any(HitGroup.class), anyString(), any(), anyInt(), anyInt());
         verify(spy, never())
-                .postProcessResults(any(), any(), any(), anyInt(), anyInt(), anyBoolean());
+                .postProcessResults(
+                        any(), any(), any(), anyInt(), anyInt(), anyBoolean(), anyBoolean());
     }
 
     /*
@@ -345,7 +346,8 @@ class SortByTest {
         doReturn(null).when(spy).extractTensorRankFeature(any(), contains("add_weights_global"));
         doReturn(new HitGroup())
                 .when(spy)
-                .postProcessResults(any(), any(), any(), anyInt(), anyInt(), anyBoolean());
+                .postProcessResults(
+                        any(), any(), any(), anyInt(), anyInt(), anyBoolean(), anyBoolean());
 
         Query q = new Query("?q");
         q.properties().set("hits", 1);
@@ -356,7 +358,8 @@ class SortByTest {
 
         spy.search(q, makeEmptyExec());
 
-        verify(spy, times(1)).postProcessResults(any(), eq(q), any(), eq(1), eq(0), eq(false));
+        verify(spy, times(1))
+                .postProcessResults(any(), eq(q), any(), eq(1), eq(0), eq(false), eq(false));
         verify(spy, never()).postProcessBySort(any(), anyString(), any(), anyInt(), anyInt());
     }
 
@@ -746,17 +749,31 @@ class SortByTest {
     class UpdateQueryHitsOffsetsAndTargetHitsTest {
 
         @Test
-        void shouldReturnOriginalQueryWhenNeitherFeatureEnabled() {
+        void shouldReturnOriginalQueryWhenNeitherFeatureEnabledAndNotDisjunctionSearch() {
             HybridSearcher searcher = new HybridSearcher();
             Query originalQuery = new Query("?q=test&hits=10&offset=5");
 
             Query result =
                     searcher.updateQueryHitsOffsetsAndTargetHits(
-                            originalQuery, 100, 200, false, false);
+                            originalQuery, 100, 200, false, false, false);
 
             assertThat(result).isSameAs(originalQuery);
             assertThat(result.getHits()).isEqualTo(10);
             assertThat(result.getOffset()).isEqualTo(5);
+        }
+
+        @Test
+        void shouldUpdateHitsForDisjunctionSearch() {
+            HybridSearcher searcher = new HybridSearcher();
+            Query originalQuery = new Query("?q=test&hits=10&offset=5");
+
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            originalQuery, 100, 200, false, false, true);
+
+            assertThat(result).isSameAs(originalQuery);
+            assertThat(result.getHits()).isEqualTo(15);
+            assertThat(result.getOffset()).isEqualTo(0);
         }
 
         @Test
@@ -767,7 +784,7 @@ class SortByTest {
             assertThatThrownBy(
                             () ->
                                     searcher.updateQueryHitsOffsetsAndTargetHits(
-                                            query, null, null, true, false))
+                                            query, null, null, true, false, true))
                     .isInstanceOf(RuntimeException.class)
                     .hasMessageContaining(
                             "Either relevantCandidates or sortByMinSortCandidates must be"
@@ -780,7 +797,8 @@ class SortByTest {
             Query query = new Query("?q=test&hits=10&offset=5");
 
             Query result =
-                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 20, null, true, false);
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, 20, null, true, false, true);
 
             // Should use Math.min(relevantCandidates, limit+offset) = Math.min(20, 15) = 15
             assertThat(result.getHits()).isEqualTo(15);
@@ -793,7 +811,7 @@ class SortByTest {
             Query query = new Query("?q=test&hits=10&offset=5");
 
             Query result =
-                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 8, null, true, false);
+                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 8, null, true, false, true);
 
             // Should use Math.min(relevantCandidates, limit+offset) = Math.min(8, 15) = 8
             assertThat(result.getHits()).isEqualTo(8);
@@ -806,7 +824,8 @@ class SortByTest {
             Query query = new Query("?q=test&hits=10&offset=5");
 
             Query result =
-                    searcher.updateQueryHitsOffsetsAndTargetHits(query, null, 20, false, true);
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, null, 20, false, true, true);
 
             // Should use Math.max(sortByMinSortCandidates, limit+offset) = Math.max(20, 15) = 20
             assertThat(result.getHits()).isEqualTo(20);
@@ -819,7 +838,8 @@ class SortByTest {
             Query query = new Query("?q=test&hits=10&offset=5");
 
             Query result =
-                    searcher.updateQueryHitsOffsetsAndTargetHits(query, null, 30, false, true);
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, null, 30, false, true, false);
 
             // Should use Math.max(sortByMinSortCandidates, limit+offset) = Math.max(30, 15) = 15
             assertThat(result.getHits()).isEqualTo(30);
@@ -832,7 +852,8 @@ class SortByTest {
             Query query = new Query("?q=test&hits=10&offset=5");
 
             Query result =
-                    searcher.updateQueryHitsOffsetsAndTargetHits(query, null, 8, false, true);
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, null, 8, false, true, false);
 
             // Should use Math.max(sortByMinSortCandidates, limit+offset) = Math.max(8, 15) = 15
             assertThat(result.getHits()).isEqualTo(15);
@@ -844,7 +865,8 @@ class SortByTest {
             HybridSearcher searcher = new HybridSearcher();
             Query query = new Query("?q=test&hits=10&offset=5");
 
-            Query result = searcher.updateQueryHitsOffsetsAndTargetHits(query, 30, 25, true, true);
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 30, 25, true, true, false);
 
             // Should use Math.max(relevantCandidates, sortByMinSortCandidates) = Math.max(30, 25)
             // = 30
@@ -857,7 +879,8 @@ class SortByTest {
             HybridSearcher searcher = new HybridSearcher();
             Query query = new Query("?q=test&hits=10&offset=5");
 
-            Query result = searcher.updateQueryHitsOffsetsAndTargetHits(query, 25, 30, true, true);
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 25, 30, true, true, false);
 
             // Should use Math.max(relevantCandidates, sortByMinSortCandidates) = Math.max(25, 30)
             // = 30
@@ -876,7 +899,8 @@ class SortByTest {
                                     + " hnsw.exploreAdditionalHits: 1950}");
 
             Query result =
-                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 20, null, true, false);
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, 20, null, true, false, false);
 
             // Should use Math.min(newHits, currentTensorTargetHits) = Math.min(15, 50) = 15
             String updatedYql = result.properties().getString("marqo__yql.tensor");
@@ -897,7 +921,8 @@ class SortByTest {
                                     + " hnsw.exploreAdditionalHits: 1950}");
 
             Query result =
-                    searcher.updateQueryHitsOffsetsAndTargetHits(query, null, 60, false, true);
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, null, 60, false, true, false);
 
             // Should use Math.max(newHits, currentTensorTargetHits) = Math.max(60, 50) = 60
             String updatedYql = result.properties().getString("marqo__yql.tensor");
@@ -917,7 +942,8 @@ class SortByTest {
                             "select * from sources * where {targetHits: 40,"
                                     + " hnsw.exploreAdditionalHits: 1960}");
 
-            Query result = searcher.updateQueryHitsOffsetsAndTargetHits(query, 30, 35, true, true);
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 30, 35, true, true, false);
 
             // newHits = Math.max(30, 35) = 35
             // newTensorTargetHits = Math.max(35, 40) = 40
@@ -940,7 +966,7 @@ class SortByTest {
             assertThatThrownBy(
                             () ->
                                     searcher.updateQueryHitsOffsetsAndTargetHits(
-                                            query, 20, null, true, false))
+                                            query, 20, null, true, false, false))
                     .isInstanceOf(RuntimeException.class)
                     .hasMessageContaining(
                             "The targetHits in the tensor query should not be smaller than"
@@ -955,7 +981,8 @@ class SortByTest {
             query.properties().set("marqo__yql.tensor", "");
 
             Query result =
-                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 20, null, true, false);
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, 20, null, true, false, false);
 
             assertThat(result.getHits()).isEqualTo(15);
             assertThat(result.getOffset()).isEqualTo(0);
@@ -974,7 +1001,8 @@ class SortByTest {
                                     + " hnsw.exploreAdditionalHits: 1900, param2: true}");
 
             Query result =
-                    searcher.updateQueryHitsOffsetsAndTargetHits(query, null, 150, false, true);
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, null, 150, false, true, false);
 
             String updatedYql = result.properties().getString("marqo__yql.tensor");
             assertThat(updatedYql)
@@ -996,7 +1024,8 @@ class SortByTest {
                             "select * from sources * where {targetHits: 60,"
                                     + " hnsw.exploreAdditionalHits: 1940}");
 
-            Query result = searcher.updateQueryHitsOffsetsAndTargetHits(query, 40, 45, true, true);
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 40, 45, true, true, false);
 
             // newHits = Math.max(40, 45) = 45
             // newTensorTargetHits = Math.max(45, 60) = 60 (keeps existing higher value)
@@ -1018,7 +1047,8 @@ class SortByTest {
                             "select * from sources * where {targetHits: 30,"
                                     + " hnsw.exploreAdditionalHits: 1970}");
 
-            Query result = searcher.updateQueryHitsOffsetsAndTargetHits(query, 40, 45, true, true);
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 40, 45, true, true, false);
 
             // newHits = Math.max(40, 45) = 45
             // newTensorTargetHits = Math.max(45, 30) = 45 (uses new higher value)
@@ -1035,7 +1065,8 @@ class SortByTest {
             HybridSearcher searcher = new HybridSearcher();
             Query query = new Query("?q=test&hits=5&offset=2");
 
-            Query result = searcher.updateQueryHitsOffsetsAndTargetHits(query, 40, 40, true, true);
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 40, 40, true, true, false);
 
             // Should use Math.max(40, 40) = 40
             assertThat(result.getHits()).isEqualTo(40);
@@ -1052,7 +1083,8 @@ class SortByTest {
                             "select * from sources * where {queryVector: [1,2,3], targetHits: 50,"
                                     + " hnsw.exploreAdditionalHits: 1950, threshold: 0.8}");
 
-            Query result = searcher.updateQueryHitsOffsetsAndTargetHits(query, 35, 40, true, true);
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 35, 40, true, true, false);
 
             // newHits = Math.max(35, 40) = 40
             // newTensorTargetHits = Math.max(40, 50) = 50
@@ -1069,7 +1101,8 @@ class SortByTest {
             HybridSearcher searcher = new HybridSearcher();
             Query query = new Query("?q=test&hits=1&offset=0");
 
-            Query result = searcher.updateQueryHitsOffsetsAndTargetHits(query, 1, 1, true, true);
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 1, 1, true, true, false);
 
             // Should use Math.max(1, 1) = 1
             assertThat(result.getHits()).isEqualTo(1);
@@ -1087,7 +1120,8 @@ class SortByTest {
                                     + " hnsw.exploreAdditionalHits: 1000}");
 
             Query result =
-                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 500, 750, true, true);
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, 500, 750, true, true, false);
 
             // newHits = Math.max(500, 750) = 750
             // newTensorTargetHits = Math.max(750, 1000) = 1000
@@ -1114,7 +1148,8 @@ class SortByTest {
 
             // Call with relevantCandidates = 0, which should result in hits = 0 but targetHits = 1
             Query result =
-                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 0, null, true, false);
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, 0, null, true, false, false);
 
             // Verify hits is set to 0 (original relevantCandidates value)
             assertThat(result.getHits()).isEqualTo(0);
@@ -1142,12 +1177,9 @@ class SortByTest {
             // - Uses Math.max instead of Math.min for tensorTargetHits
             Query result =
                     searcher.updateQueryHitsOffsetsAndTargetHits(
-                            query,
-                            8,
-                            12,
-                            true,
-                            true // relevantCandidates < limit+offset, but with sortBy enabled
-                            );
+                            query, 8, 12, true,
+                            true, // relevantCandidates < limit+offset, but with sortBy enabled
+                            true);
 
             // Should use Math.max(8, 12) = 12 (not Math.min like pure relevance cutoff)
             assertThat(result.getHits()).isEqualTo(12);


### PR DESCRIPTION
## Change Summary
Pagination in hybrid search - RRF has the wrong behavior. It currently implements pagination (using limit & offset) in the individual tensor and lexical searches, then performs the RRF algorithm on those 2 result lists. 

This PR fixes this behaviour by retrieving `0 to offset + limit` results in individual tensor and lexical searches, fusing them, applying global score modifiers, then trimming. In this way, we can reduce the number of duplicates and missing docs. 

The final solution to eliminate duplicates and missing docs requires storing pagination state (docs in previous pages) and excluding them from the search result. This will be addressed in [a separate PR](https://github.com/marqo-ai/marqo/pull/1234/files#top).

## Changes made in this PR
- For disjunction search without relevance cutoff or sorting, fetch offset + limit results from the beginning (offset=0) instead of applying offset before fusion.
- Increase rerankDepthGlobal by the `offset` to ensure score modifiers reach the current page's documents.
- Trim the result of disjunction search and relevance cutoff search to `(offset, offst + limit)` after applying the global modifiers

## Related Jira Ticket
https://s2search.atlassian.net/browse/MOSD-311

## Checklist
<!-- Check items that apply, add items if needed -->
- [x] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

