### PR TITLE
Pin the log level of metrics (cache) to INFO

### DIFF
--- a/src/marqo/logging.py
+++ b/src/marqo/logging.py
@@ -107,6 +107,11 @@ LOGGING_CONFIG = {
             "handlers": ["default"],  # change this to a different handler if security is a concern
             "level": "WARNING",  # slow query at warning level, failed query at error level
             "propagate": False,
+        },
+        "metrics": {
+            "handlers": ["default"],
+            "level": "INFO",  # Always log out metrics in INFO level, ignoring the root log level.
+            "propagate": False,
         }
     },
     "root": {

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.24.0"
+__version__ = "2.24.1"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/tests/integ_tests/core/index_management/test_index_management.py
+++ b/tests/integ_tests/core/index_management/test_index_management.py
@@ -173,15 +173,16 @@ class TestIndexManagement(MarqoTestCase):
         app._service_xml.add_schema(index_with_230_version.schema_name)
         app._store.save_file(app._service_xml.to_xml(), app._SERVICES_XML_FILE)
         app._persist_index_settings()
+        app._marqo_config_store.update_version(index_with_230_version.marqo_version)
+        app._store.save_file(app._marqo_config_store.get().json(), app._MARQO_CONFIG_FILE)
         app._deploy()
 
         index = self.index_management.get_index(index_with_230_version.name)
         self.assertIsNone(index.typeahead_schema_name)
 
         # Now bootstrap again - this should add the missing typeahead schema
-        with patch('marqo.version.get_version', return_value='2.24.1'):
-            bootstrapped = self.index_management.bootstrap_vespa()
-            self.assertTrue(bootstrapped)
+        bootstrapped = self.index_management.bootstrap_vespa()
+        self.assertTrue(bootstrapped)
         
         # Verify that the typeahead schema was added
         downloaded_app = self.vespa_client.download_application()

--- a/tests/unit_tests/marqo/test_logging.py
+++ b/tests/unit_tests/marqo/test_logging.py
@@ -99,13 +99,22 @@ class TestLoggingConfig(unittest.TestCase):
                 self.assertEqual(LOGGING_CONFIG['loggers']['httpx']['level'], expected_level)
 
     def test_access_log_level_changes_with_root_log_level(self):
-        """Test that access log level is always INFO"""
+        """Test that access log level changes with the root log level"""
         for level in ['debug', 'info', 'warning', 'error']:
             with patch.dict(os.environ, {'MARQO_LOG_LEVEL': level, 'MARQO_LOG_FORMAT': 'plain'}):
                 importlib.reload(marqo_logging)
                 from marqo.logging import LOGGING_CONFIG
 
                 self.assertEqual(level.upper(), LOGGING_CONFIG['loggers']['uvicorn.access']['level'])
+
+    def test_metric_log_level_is_fixed(self):
+        """Test that metrics log level is always INFO"""
+        for level in ['debug', 'info', 'warning', 'error']:
+            with patch.dict(os.environ, {'MARQO_LOG_LEVEL': level, 'MARQO_LOG_FORMAT': 'plain'}):
+                importlib.reload(marqo_logging)
+                from marqo.logging import LOGGING_CONFIG
+
+                self.assertEqual("INFO", LOGGING_CONFIG['loggers']['metrics']['level'])
 
     def test_plain_format_output(self):
         """Test the exact plain text format output"""


### PR DESCRIPTION
## Change Summary
The log level of 'metrics' logger (which we used to log out embedding cache metrics) follows the root log level. This is not expected since we always want the metrics logger to log out info level log. This change will make sure the log level of `metrics` logger is pinned to `INFO`.

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

