### PR TITLE
Fix httpx client read timeout for search

### DIFF
--- a/src/marqo/core/structured_vespa_index/structured_vespa_index.py
+++ b/src/marqo/core/structured_vespa_index/structured_vespa_index.py
@@ -409,7 +409,7 @@ class StructuredVespaIndex(VespaIndex):
             'yql': f'select {common.FIELD_VECTOR_COUNT} from {self._marqo_index.schema_name} '
                    f'where true limit 0 | all(group(1) each(output(sum({common.FIELD_VECTOR_COUNT}))))',
             'model_restrict': self._marqo_index.schema_name,
-            'timeout': '5s'
+            'timeout': 5000
         }
 
     def _to_vespa_tensor_query(self, marqo_query: MarqoTensorQuery) -> Dict[str, Any]:

--- a/src/marqo/core/unstructured_vespa_index/unstructured_vespa_index.py
+++ b/src/marqo/core/unstructured_vespa_index/unstructured_vespa_index.py
@@ -391,7 +391,7 @@ class UnstructuredVespaIndex(VespaIndex):
             'yql': f'select {unstructured_common.FIELD_VECTOR_COUNT} from {self._marqo_index.schema_name} '
                    f'where true limit 0 | all(group(1) each(output(sum({unstructured_common.FIELD_VECTOR_COUNT}))))',
             'model_restrict': self._marqo_index.schema_name,
-            'timeout': '5s'
+            'timeout': 5000
         }
 
     @classmethod

--- a/src/marqo/vespa/vespa_client.py
+++ b/src/marqo/vespa/vespa_client.py
@@ -241,12 +241,10 @@ class VespaClient:
             **kwargs
         }
 
-        vespa_timeout_ms: int = timeout if timeout else self.default_search_timeout_ms
         # Use default timeout if not already set.
-        if timeout:
-            query['timeout'] = f"{vespa_timeout_ms}ms"
-        else:
-            query['timeout'] = f"{vespa_timeout_ms}ms"
+        vespa_timeout_ms = timeout if timeout is not None else self.default_search_timeout_ms
+        query['timeout'] = f"{vespa_timeout_ms}ms"
+
         # Set httpx timeout to be slightly longer than Vespa timeout to avoid early termination of the request.
         # However, we set it to be at least 5 seconds to avoid any regression.
         httpx_read_timeout_second = max((vespa_timeout_ms + 1000) / 1000, 5.0)

--- a/src/marqo/vespa/vespa_client.py
+++ b/src/marqo/vespa/vespa_client.py
@@ -242,7 +242,7 @@ class VespaClient:
         }
 
         # Use default timeout if not already set.
-        vespa_timeout_ms = timeout if timeout is not None else self.default_search_timeout_ms
+        vespa_timeout_ms = timeout if timeout else self.default_search_timeout_ms
         query['timeout'] = f"{vespa_timeout_ms}ms"
 
         # Set httpx timeout to be slightly longer than Vespa timeout to avoid early termination of the request.

--- a/src/marqo/vespa/vespa_client.py
+++ b/src/marqo/vespa/vespa_client.py
@@ -240,18 +240,23 @@ class VespaClient:
             **kwargs
         }
 
+        vespa_timeout_ms = timeout if timeout else self.default_search_timeout_ms
         # Use default timeout if not already set.
         if timeout:
-            query['timeout'] = f"{timeout}ms"
+            query['timeout'] = f"{vespa_timeout_ms}ms"
         else:
-            query['timeout'] = f"{self.default_search_timeout_ms}ms"
+            query['timeout'] = f"{vespa_timeout_ms}ms"
+        # Set httpx timeout to be slightly longer than Vespa timeout to avoid early termination of the request.
+        # However, we set it to be at least 5 seconds to avoid any regression.
+        httpx_read_timeout_second = max((vespa_timeout_ms + 1000) / 1000, 5.0)
+        httpx_client_timeout = httpx.Timeout(5.0, read=httpx_read_timeout_second)
 
         query = {key: value for key, value in query.items() if value is not None}
 
         logger.debug(f'Query: {query}')
 
         try:
-            resp = self.http_client.post(f'{self.query_url}/search/', json=query)
+            resp = self.http_client.post(f'{self.query_url}/search/', json=query, timeout=httpx_client_timeout)
         except httpx.HTTPError as e:
             raise VespaError(e) from e
 

--- a/src/marqo/vespa/vespa_client.py
+++ b/src/marqo/vespa/vespa_client.py
@@ -214,7 +214,7 @@ class VespaClient:
                          f"The convergence status is {self._get_convergence_status()}")
 
     def query(self, yql: str, hits: int = 10, ranking: str = None, model_restrict: str = None,
-              query_features: Dict[str, Any] = None, timeout: float = None, **kwargs) -> QueryResult:
+              query_features: Dict[str, Any] = None, timeout: Optional[float] = None, **kwargs) -> QueryResult:
         """
         Query Vespa.
         Args:
@@ -223,6 +223,7 @@ class VespaClient:
             ranking: Ranking profile to use
             model_restrict: Schema to restrict the query to
             query_features: Query features
+            timeout: The Vespa query timeout in milliseconds. If not set, the default timeout will be used.
             **kwargs: Additional query parameters
         Returns:
             Query result as a VespaQueryResult object
@@ -240,7 +241,7 @@ class VespaClient:
             **kwargs
         }
 
-        vespa_timeout_ms = timeout if timeout else self.default_search_timeout_ms
+        vespa_timeout_ms: int = timeout if timeout else self.default_search_timeout_ms
         # Use default timeout if not already set.
         if timeout:
             query['timeout'] = f"{vespa_timeout_ms}ms"

--- a/tests/integ_tests/vespa/test_vespa_client.py
+++ b/tests/integ_tests/vespa/test_vespa_client.py
@@ -1,9 +1,10 @@
 import asyncio
 import functools
+import json
 import os
-import sys
+import time
 import unittest
-from unittest.mock import patch, Mock, AsyncMock, ANY
+from unittest.mock import Mock, patch
 
 import httpcore
 import httpx
@@ -13,13 +14,13 @@ import vespa.application as pyvespa
 from marqo.tensor_search.api import generate_config
 from marqo.tensor_search.enums import EnvVars
 from marqo.vespa import concurrency
-from marqo.vespa.exceptions import VespaError, VespaStatusError, VespaTimeoutError, VespaNotConvergedError
-from marqo.vespa.models import VespaDocument, QueryResult
-from marqo.vespa.models.get_document_response import GetBatchResponse, GetBatchDocumentResponse, Document
+from marqo.vespa.exceptions import (VespaError, VespaNotConvergedError,
+                                    VespaStatusError, VespaTimeoutError)
+from marqo.vespa.models import QueryResult, VespaDocument
 from marqo.vespa.models.application_metrics import ApplicationMetrics
 from marqo.vespa.models.query_result import Error
 from marqo.vespa.vespa_client import VespaClient
-from tests.integ_tests.marqo_test import AsyncMarqoTestCase, MarqoTestCase
+from tests.integ_tests.marqo_test import AsyncMarqoTestCase
 
 
 class TestVespaClient(AsyncMarqoTestCase):
@@ -838,3 +839,30 @@ class TestVespaClient(AsyncMarqoTestCase):
                 )
 
         assert mock_delete.call_count == 1
+
+    def test_httpx_client_should_not_timeout_before_vespa_timeout(self):
+        """Test that httpx client will not time out before Vespa timeout"""
+        def delayed_vespa_504(*args, **kwargs):
+            time.sleep(7)  # emulate Vespa taking ~7s
+            payload = {
+                "root": {
+                    "relevance": 0.0,
+                    "errors": [{
+                        "code": 8,
+                        "summary": "Error in search reply.",
+                        "message": "Search request soft doomed during query setup and initialization."
+                    }]
+                }
+            }
+            req = httpx.Request("POST", "http://dummy/search/")
+            return httpx.Response(status_code=504, content=json.dumps(payload).encode(), request=req)
+
+        query_client = VespaClient("http://localhost:8080","http://localhost:8080",
+                                   "http://localhost:8080","content_default")
+
+        with patch.object(httpx.Client, "post", side_effect=delayed_vespa_504):
+            with self.assertRaisesStrict(VespaTimeoutError):
+                query_client.query(
+                    yql="select * from sources * where title contains 'Title 1';",
+                    timeout=7000 # 7 seconds Vespa timeout, 8 seconds httpx timeout
+                )

--- a/tests/unit_tests/vespa/test_vespa_client.py
+++ b/tests/unit_tests/vespa/test_vespa_client.py
@@ -27,8 +27,6 @@ class TestVespaClient(unittest.TestCase):
             # Verify that close was called
             mock_close.assert_called_once()
 
-
-
     def test_get_content_url_single_path(self):
         """Test get_content_url with single path component"""
         
@@ -137,21 +135,24 @@ class TestVespaClient(unittest.TestCase):
             return mock_response
 
         test_cases = [
-            (1000, 5.0, "Vespa timeout 1000ms -> httpx timeout 5.0s"),
-            (1, 5.0, "Vespa timeout 1ms -> httpx timeout 5.0s"),
-            (6000, 7.0, "Vespa timeout 6000ms -> httpx timeout 7.0s"),
-            (None, 5.0, "Vespa timeout None -> Default to 1000 -> httpx timeout 5.0s"),
+            (1000, 5.0, "1000ms", "Vespa timeout 1000ms -> httpx timeout 5.0s"),
+            (1, 5.0, "1ms", "Vespa timeout 1ms -> httpx timeout 5.0s"),
+            (6000, 7.0, "6000ms", "Vespa timeout 6000ms -> httpx timeout 7.0s"),
+            (None, 5.0, "1000ms", "Vespa timeout None -> Default to 1000 -> httpx timeout 5.0s"),
+            (0, 5.0, "1000ms", "Vespa timeout 0ms -> Default to 1000 -> httpx timeout 5.0s"),
         ]
 
-        for vespa_timeout_ms, httpx_read_timeout_second, msg in test_cases:
+        for provided_vespa_timeout_ms, httpx_read_timeout_second, sent_vespa_timeout_ms, msg in test_cases:
             with self.subTest(msg=msg):
                 with patch.object(httpx.Client, 'post', side_effect=mock_post) as mock_query:
                     self.vespa_client.query(
                         yql="select * from sources * where test;",
-                        timeout=vespa_timeout_ms
+                        timeout=provided_vespa_timeout_ms
                     )
 
                     timeout_obj = mock_query.call_args.kwargs["timeout"]
+                    vespa_time_out = mock_query.call_args.kwargs["json"]["timeout"]
+                    self.assertEqual(sent_vespa_timeout_ms, vespa_time_out)
                     self.assertEqual(timeout_obj.read, httpx_read_timeout_second)
                     self.assertEqual(5.0, timeout_obj.connect)
                     self.assertEqual(5.0, timeout_obj.write)

--- a/tests/unit_tests/vespa/test_vespa_client.py
+++ b/tests/unit_tests/vespa/test_vespa_client.py
@@ -1,5 +1,6 @@
 import unittest
-from unittest.mock import Mock, patch, AsyncMock
+from unittest.mock import Mock, patch
+import httpx
 from marqo.vespa.vespa_client import VespaClient
 
 
@@ -125,6 +126,36 @@ class TestVespaClient(unittest.TestCase):
         # Should return empty response without making any requests
         self.assertEqual(len(result.responses), 0)
         self.assertFalse(result.errors)
+
+    def test_query_httpx_timeout_configuration_small_vespa_timeout(self):
+        """Test that httpx read timeout is set to max(5.0, (vespa_timeout + 1000) / 1000) for Vespa timeouts"""
+        def mock_post(*args, **kwargs):
+            # Return a mock response
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.text = '{"root": {"id": "test", "relevance": 1.0, "children": []}}'
+            return mock_response
+
+        test_cases = [
+            (1000, 5.0, "Vespa timeout 1000ms -> httpx timeout 5.0s"),
+            (1, 5.0, "Vespa timeout 1ms -> httpx timeout 5.0s"),
+            (6000, 7.0, "Vespa timeout 6000ms -> httpx timeout 7.0s"),
+            (None, 5.0, "Vespa timeout None -> Default to 1000 -> httpx timeout 5.0s"),
+        ]
+
+        for vespa_timeout_ms, httpx_read_timeout_second, msg in test_cases:
+            with self.subTest(msg=msg):
+                with patch.object(httpx.Client, 'post', side_effect=mock_post) as mock_query:
+                    self.vespa_client.query(
+                        yql="select * from sources * where test;",
+                        timeout=vespa_timeout_ms
+                    )
+
+                    timeout_obj = mock_query.call_args.kwargs["timeout"]
+                    self.assertEqual(timeout_obj.read, httpx_read_timeout_second)
+                    self.assertEqual(5.0, timeout_obj.connect)
+                    self.assertEqual(5.0, timeout_obj.write)
+                    self.assertEqual(5.0, timeout_obj.pool)
 
 
 if __name__ == '__main__':

--- a/tests/unit_tests/vespa/test_vespa_client.py
+++ b/tests/unit_tests/vespa/test_vespa_client.py
@@ -142,7 +142,7 @@ class TestVespaClient(unittest.TestCase):
             (0, 5.0, "1000ms", "Vespa timeout 0ms -> Default to 1000 -> httpx timeout 5.0s"),
         ]
 
-        for provided_vespa_timeout_ms, httpx_read_timeout_second, sent_vespa_timeout_ms, msg in test_cases:
+        for provided_vespa_timeout_ms, httpx_read_timeout_second, expected_vespa_timeout_ms, msg in test_cases:
             with self.subTest(msg=msg):
                 with patch.object(httpx.Client, 'post', side_effect=mock_post) as mock_query:
                     self.vespa_client.query(
@@ -152,8 +152,8 @@ class TestVespaClient(unittest.TestCase):
 
                     timeout_obj = mock_query.call_args.kwargs["timeout"]
                     vespa_time_out = mock_query.call_args.kwargs["json"]["timeout"]
-                    self.assertEqual(sent_vespa_timeout_ms, vespa_time_out)
-                    self.assertEqual(timeout_obj.read, httpx_read_timeout_second)
+                    self.assertEqual(expected_vespa_timeout_ms, vespa_time_out)
+                    self.assertEqual(httpx_read_timeout_second, timeout_obj.read)
                     self.assertEqual(5.0, timeout_obj.connect)
                     self.assertEqual(5.0, timeout_obj.write)
                     self.assertEqual(5.0, timeout_obj.pool)


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->
This pull request improves the timeout handling logic between Vespa and the underlying `httpx` client to ensure that client-side timeouts do not occur before the Vespa server timeout.

The read timeout is set to `max(5, vespa_search_timeout_second + 1)`, where vespa_search_timeout_second can be configured by an environment variable.

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

