### PR TITLE
Merge changes on relaeses/2.24 branch to mainline

### DIFF
--- a/src/marqo/core/structured_vespa_index/structured_vespa_index.py
+++ b/src/marqo/core/structured_vespa_index/structured_vespa_index.py
@@ -409,7 +409,7 @@ class StructuredVespaIndex(VespaIndex):
             'yql': f'select {common.FIELD_VECTOR_COUNT} from {self._marqo_index.schema_name} '
                    f'where true limit 0 | all(group(1) each(output(sum({common.FIELD_VECTOR_COUNT}))))',
             'model_restrict': self._marqo_index.schema_name,
-            'timeout': '5s'
+            'timeout': 5000
         }
 
     def _to_vespa_tensor_query(self, marqo_query: MarqoTensorQuery) -> Dict[str, Any]:

--- a/src/marqo/core/typeahead/typeahead.py
+++ b/src/marqo/core/typeahead/typeahead.py
@@ -4,7 +4,7 @@ from typing import List, Dict, Any
 
 import blake3
 
-from marqo.core.constants import MARQO_TYPEAHEAD_SCHEMA_MINIMUM_VERSION
+from marqo.core.constants import MARQO_TYPEAHEAD_SCHEMA_MINIMUM_VERSION, CHARACTERS_TO_BE_ESCAPED_IN_VESPA
 from marqo.core.index_management.index_management import IndexManagement
 from marqo.core.models.typeahead import (
     TypeaheadRequest, TypeaheadResponse, TypeaheadSuggestion,
@@ -66,19 +66,20 @@ class Typeahead:
             retrieval_terms = []
             ranking_terms = []
             for token in tokens:
+                escaped_token = self._escape_token(token)
                 if len(token) < request.min_fuzzy_match_length:
                     # Use exact prefix matching for short tokens
                     retrieval_terms.append(
-                        f"query_words contains ({{prefix:true}}\"{token}\")"
+                        f"query_words contains ({{prefix:true}}\"{escaped_token}\")"
                     )
                 else:
                     # Use fuzzy matching for longer tokens
                     retrieval_terms.append(
                         f"query_words contains "
-                        f"({{maxEditDistance:{request.fuzzy_edit_distance}, prefix:true}}fuzzy(\"{token}\"))"
+                        f"({{maxEditDistance:{request.fuzzy_edit_distance}, prefix:true}}fuzzy(\"{escaped_token}\"))"
                     )
 
-                ranking_terms.append(f"query_index contains \"{token}\"")
+                ranking_terms.append(f"query_index contains \"{escaped_token}\"")
 
             # Create single YQL query that ORs all token conditions
             yql_retrieval = " OR ".join(retrieval_terms)
@@ -308,6 +309,23 @@ class Typeahead:
                 query_results.append(TypeaheadQuery(**fields))
         
         return TypeaheadGetQueriesResponse(queries=query_results)
+
+    def _escape_token(self, token: str) -> str:
+        """Escape special characters in a token for Vespa YQL queries.
+
+        Args:
+            token: The token to escape
+
+        Returns:
+            The escaped token
+        """
+        escaped = []
+        for char in token:
+            if char in CHARACTERS_TO_BE_ESCAPED_IN_VESPA:
+                escaped.append('\\' + char)
+            else:
+                escaped.append(char)
+        return ''.join(escaped)
 
     def _generate_query_hash(self, query: str) -> str:
         """Generate a 128-bit blake3 hash for a query string.

--- a/src/marqo/core/unstructured_vespa_index/unstructured_vespa_index.py
+++ b/src/marqo/core/unstructured_vespa_index/unstructured_vespa_index.py
@@ -391,7 +391,7 @@ class UnstructuredVespaIndex(VespaIndex):
             'yql': f'select {unstructured_common.FIELD_VECTOR_COUNT} from {self._marqo_index.schema_name} '
                    f'where true limit 0 | all(group(1) each(output(sum({unstructured_common.FIELD_VECTOR_COUNT}))))',
             'model_restrict': self._marqo_index.schema_name,
-            'timeout': '5s'
+            'timeout': 5000
         }
 
     @classmethod

--- a/src/marqo/logging.py
+++ b/src/marqo/logging.py
@@ -107,6 +107,11 @@ LOGGING_CONFIG = {
             "handlers": ["default"],  # change this to a different handler if security is a concern
             "level": "WARNING",  # slow query at warning level, failed query at error level
             "propagate": False,
+        },
+        "metrics": {
+            "handlers": ["default"],
+            "level": "INFO",  # Always log out metrics in INFO level, ignoring the root log level.
+            "propagate": False,
         }
     },
     "root": {

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.24.1"
+__version__ = "2.24.2"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.24.0"
+__version__ = "2.24.1"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/src/marqo/vespa/vespa_client.py
+++ b/src/marqo/vespa/vespa_client.py
@@ -214,7 +214,7 @@ class VespaClient:
                          f"The convergence status is {self._get_convergence_status()}")
 
     def query(self, yql: str, hits: int = 10, ranking: str = None, model_restrict: str = None,
-              query_features: Dict[str, Any] = None, timeout: float = None, **kwargs) -> QueryResult:
+              query_features: Dict[str, Any] = None, timeout: Optional[float] = None, **kwargs) -> QueryResult:
         """
         Query Vespa.
         Args:
@@ -223,6 +223,7 @@ class VespaClient:
             ranking: Ranking profile to use
             model_restrict: Schema to restrict the query to
             query_features: Query features
+            timeout: The Vespa query timeout in milliseconds. If not set, the default timeout will be used.
             **kwargs: Additional query parameters
         Returns:
             Query result as a VespaQueryResult object
@@ -241,17 +242,20 @@ class VespaClient:
         }
 
         # Use default timeout if not already set.
-        if timeout:
-            query['timeout'] = f"{timeout}ms"
-        else:
-            query['timeout'] = f"{self.default_search_timeout_ms}ms"
+        vespa_timeout_ms = timeout if timeout else self.default_search_timeout_ms
+        query['timeout'] = f"{vespa_timeout_ms}ms"
+
+        # Set httpx timeout to be slightly longer than Vespa timeout to avoid early termination of the request.
+        # However, we set it to be at least 5 seconds to avoid any regression.
+        httpx_read_timeout_second = max((vespa_timeout_ms + 1000) / 1000, 5.0)
+        httpx_client_timeout = httpx.Timeout(5.0, read=httpx_read_timeout_second)
 
         query = {key: value for key, value in query.items() if value is not None}
 
         logger.debug(f'Query: {query}')
 
         try:
-            resp = self.http_client.post(f'{self.query_url}/search/', json=query)
+            resp = self.http_client.post(f'{self.query_url}/search/', json=query, timeout=httpx_client_timeout)
         except httpx.HTTPError as e:
             raise VespaError(e) from e
 

--- a/tests/integ_tests/core/index_management/test_index_management.py
+++ b/tests/integ_tests/core/index_management/test_index_management.py
@@ -173,15 +173,16 @@ class TestIndexManagement(MarqoTestCase):
         app._service_xml.add_schema(index_with_230_version.schema_name)
         app._store.save_file(app._service_xml.to_xml(), app._SERVICES_XML_FILE)
         app._persist_index_settings()
+        app._marqo_config_store.update_version(index_with_230_version.marqo_version)
+        app._store.save_file(app._marqo_config_store.get().json(), app._MARQO_CONFIG_FILE)
         app._deploy()
 
         index = self.index_management.get_index(index_with_230_version.name)
         self.assertIsNone(index.typeahead_schema_name)
 
         # Now bootstrap again - this should add the missing typeahead schema
-        with patch('marqo.version.get_version', return_value='2.24.1'):
-            bootstrapped = self.index_management.bootstrap_vespa()
-            self.assertTrue(bootstrapped)
+        bootstrapped = self.index_management.bootstrap_vespa()
+        self.assertTrue(bootstrapped)
         
         # Verify that the typeahead schema was added
         downloaded_app = self.vespa_client.download_application()

--- a/tests/integ_tests/core/typeahead/test_typeahead_integration.py
+++ b/tests/integ_tests/core/typeahead/test_typeahead_integration.py
@@ -456,6 +456,47 @@ class TestTypeaheadIntegration(MarqoTestCase):
 
         self._assert_version_error_message(context.exception, self.index_220_name, "2.22.0")
 
+    # G. Special Character Handling Tests
+    def test_typeahead_with_special_characters_in_user_input(self):
+        """Test typeahead search handles special characters in user input without causing Vespa 500 errors."""
+        self._index_test_queries()
+
+        # Test user input queries with special characters that should NOT cause Vespa 500 errors
+        user_input_test_cases = [
+            # Single special characters
+            '"',
+            '\\',
+            # Queries with quotes
+            'a"b"c',
+            'a"b"',
+            '"b"c',
+            '"bc',
+            'bc"',
+            # Queries with backslashes
+            'Path\\to\\file',
+            '\\',
+            '\\\\',
+            'a\\b',
+            '\\a',
+            'b\\',
+            # Mixed special characters
+            'Program "with spaces"\\folder',
+            '"\\',
+            '\\"',
+        ]
+
+        for user_query in user_input_test_cases:
+            with self.subTest(user_query=user_query):
+                request = TypeaheadRequest(q=user_query, limit=10)
+                # This should NOT raise a 500 error from Vespa (main goal of the fix)
+                try:
+                    response = self.config.typeahead.get_suggestions(self.test_index_name, request)
+                    # Just verify we get a response without error
+                    self.assertIsNotNone(response)
+                    self.assertGreaterEqual(len(response.suggestions), 0)
+                except Exception as e:
+                    self.fail(f"User input query '{user_query}' caused an error: {e}")
+
     def _assert_version_error_message(self, exception: UnsupportedFeatureError, index_name: str, version: str):
         """Helper method to verify the error message contains expected information."""
         error_message = str(exception)

--- a/tests/integ_tests/tensor_search/integ_tests/test_collapse_fields.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_collapse_fields.py
@@ -317,8 +317,6 @@ class TestCollapseFields(MarqoTestCase):
                 # Test that the hit count returns the count of unique collapse field value
                 self.assertEqual(3, res['totalHits'])
 
-
-
     @pytest.mark.skip_for_multinode("Pagination result is not consistent across different Vespa infrastructures")
     def test_pagination(self):
         """Test that pagination works with search with collapse field"""
@@ -335,7 +333,7 @@ class TestCollapseFields(MarqoTestCase):
         )
 
         test_cases = [
-            # (RetrievalMethod.Disjunction, RankingMethod.RRF),  # FIXME dup can only be fixed by pagination fix
+            (RetrievalMethod.Disjunction, RankingMethod.RRF),
             (RetrievalMethod.Lexical, RankingMethod.Lexical),
             # (RetrievalMethod.Lexical, RankingMethod.Tensor),  # FIXME dup and missing doc
             (RetrievalMethod.Tensor, RankingMethod.Tensor),
@@ -352,7 +350,9 @@ class TestCollapseFields(MarqoTestCase):
                     hybrid_parameters=HybridParameters(
                         retrievalMethod=retrieval_method,
                         rankingMethod=ranking_method,
-                        rerankDepthTensor=100,  # set a large value to expand the tensor retrieval set
+                        # set a large value to expand the tensor retrieval set,
+                        # this is required to make the pagination stable
+                        rerankDepthTensor=100,
                     ),
                     collapse_field_name="parent_id",
                     result_count=6

--- a/tests/integ_tests/tensor_search/integ_tests/test_search_relevance_cutoff_feature.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_search_relevance_cutoff_feature.py
@@ -195,7 +195,6 @@ class TestSearchRelevanceCutoffFeature(MarqoTestCase):
                 "retrievalMethod": "disjunction",
                 "rankingMethod": "rrf",
                 "alpha": 0.5
-
             }
 
         if index_name is None:
@@ -212,7 +211,8 @@ class TestSearchRelevanceCutoffFeature(MarqoTestCase):
                 "relevanceCutoff": relevance_cutoff,
                 "sortBy": sort_by,
                 "limit": limit,
-                "offset": offset
+                "offset": offset,
+                "showHighlights": False,
             }
         ).body.decode('utf-8'))
 
@@ -584,27 +584,40 @@ class TestSearchRelevanceCutoffFeature(MarqoTestCase):
 
     def test_relevance_cutoff_with_pagination(self):
         """Test relevance cutoff with different limit and offset values."""
-        # Test with small limit
-        result_small = self._search_helper(
+        hp_rrf = {
+            "retrievalMethod": "disjunction",
+            "rankingMethod": "rrf",
+            "alpha": 0.7
+        }
+
+        # Test first page
+        result_page1 = self._search_helper(
             relevance_cutoff={
                 "method": "relative_max_score",
                 "parameters": {"relativeScoreFactor": 0.4},
             },
-            limit=3
+            hybrid_parameters=hp_rrf,
+            limit=6,
+            offset=0,
         )
-        self.assertEqual(len(result_small["hits"]), 3, "Should respect limit")
-        self.assertIn("_relevantCandidates", result_small)
+        expected_ids_page1 = ['h3', 'h6', 'h9', 'h1', 'h2', 'h4']
+        self.assertEqual(expected_ids_page1, [h["_id"] for h in result_page1["hits"]])
+        self.assertEqual(20, result_page1["_relevantCandidates"])
         
-        # Test with offset
-        result_offset = self._search_helper(
+        # Test second page
+        result_page2 = self._search_helper(
             relevance_cutoff={
                 "method": "relative_max_score", 
                 "parameters": {"relativeScoreFactor": 0.4},
             },
-            limit=5,
-            offset=2
+            hybrid_parameters=hp_rrf,
+            limit=6,
+            offset=6
         )
-        self.assertEqual(len(result_offset["hits"]), 5, "Should respect limit with offset")
+        expected_ids_page2 = ['h10', 'h7', 'h8', 'm1', 'm7', 'm4']
+        # order of h7 and h8 is non-deterministic, so we compare with set
+        self.assertEqual(set(expected_ids_page2), set([h["_id"] for h in result_page2["hits"]]))
+        self.assertEqual(20, result_page2["_relevantCandidates"])
 
     def test_relevance_cutoff_edge_case_extreme_values(self):
         """Test edge cases with extreme parameter values."""

--- a/tests/integ_tests/tensor_search/test_pagination_rrf_fix.py
+++ b/tests/integ_tests/tensor_search/test_pagination_rrf_fix.py
@@ -1,0 +1,716 @@
+import os
+from unittest import mock
+
+import pytest
+
+from marqo.core.models.add_docs_params import AddDocsParams
+from marqo.core.models.hybrid_parameters import RetrievalMethod, RankingMethod, HybridParameters
+from marqo.core.models.marqo_index import *
+from marqo.tensor_search import tensor_search
+from marqo.tensor_search.models.score_modifiers_object import ScoreModifierLists, ScoreModifierOperator
+from tests.integ_tests.marqo_test import MarqoTestCase
+
+
+class TestRRFPaginationPartialFix(MarqoTestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+
+        # Create only unstructured index for now
+        index_request_unstructured = cls.unstructured_marqo_index_request(
+            model=Model(name='hf/e5-base-v2')
+        )
+
+        cls.indexes = cls.create_indexes([
+            index_request_unstructured
+        ])
+
+        cls.index_unstructured = cls.indexes[0]
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Any tests that call add_document, search, bulk_search need this env var
+        self.device_patcher = mock.patch.dict(os.environ, {"MARQO_BEST_AVAILABLE_DEVICE": "cpu"})
+        self.device_patcher.start()
+
+        # Create and add curated test documents
+        r = self.add_documents(
+            config=self.config,
+            add_docs_params=AddDocsParams(
+                index_name=self.index_unstructured.name,
+                docs=(self.create_curated_test_data()),
+                tensor_fields=['title']
+            )
+        ).dict(exclude_none=True, by_alias=True)
+        self.assertFalse(r['errors'], "Errors in add documents call")
+
+        self.hp_rrf = HybridParameters(
+            alpha=0.7,
+            rrfK=60,
+            retrievalMethod=RetrievalMethod.Disjunction,
+            rankingMethod=RankingMethod.RRF,
+            queryTensor='machine learning',
+            queryLexical='EXACT QUERY',
+            # verbose=True,
+        )
+
+    def tearDown(self):
+        self.device_patcher.stop()
+
+    def create_curated_test_data(self):
+        """
+        Create simplified test data with deterministic rankings.
+        - 5 docs only match tensor (doc_T1 to doc_T5, ranked T1 > T2 > T3 > T4 > T5)
+        - 5 docs only match lexical (doc_L1 to doc_L5, ranked L1 > L2 > L3 > L4 > L5)
+        - 5 docs match both (doc_B1 to doc_B5, different rankings in tensor vs lexical)
+        """
+        docs = []
+
+        # 5 docs that only match TENSOR search (semantic similarity)
+        # Avoid words "EXACT", "QUERY", "machine", "learning" to prevent lexical matches
+        tensor_terms = [
+            "artificial intelligence algorithms",     # T1 - highest tensor relevance
+            "deep neural systems",                    # T2
+            "neural network models",                  # T3
+            "computational intelligence frameworks",  # T4
+            "data science tools"                      # T5 - lowest tensor relevance
+        ]
+
+        for i in range(5):
+            doc = {
+                "_id": f"doc_T{i+1}",
+                "title": f"{tensor_terms[i]} tensor_document_{i+1}",
+                "doc_type": "tensor_only",
+                "score_boost": i+1,   # the boost should reverse the order
+            }
+            docs.append(doc)
+
+        # 5 docs that only match LEXICAL search (exact keyword matches)
+        for i in range(5):
+            # Use decreasing keyword repetition for deterministic TF scores
+            repeated_keywords = " ".join(["EXACT", "QUERY"] * (5 - i))  # More repetition = higher score
+            doc = {
+                "_id": f"doc_L{i+1}",
+                "title": f"{repeated_keywords} lexical_document_{i+1}",
+                "doc_type": "lexical_only",
+                "score_boost": i+6,  # the boost should reverse the order, and this is higher than tensor match
+            }
+            docs.append(doc)
+
+        # 5 docs that match BOTH tensor and lexical (for RRF fusion testing)
+        # These have DIFFERENT rankings in tensor vs lexical to test RRF properly
+        both_docs = [
+            # (tensor_keywords, lexical_keywords, tensor_rank, lexical_rank)
+            ("machine learning algorithms", " ".join(["EXACT", "QUERY"] * 10), 1, 1),  # B1: high in both
+            ("machine learning courses", "EXACT QUERY", 2, 4),                           # B2: high tensor, low lexical
+            ("computational models", "EXACT QUERY EXACT QUERY", 3, 2),          # B3: mid tensor, high lexical
+            ("data science", "EXACT", 4, 5),                                    # B4: low tensor, lowest lexical
+            ("algorithmic systems", "EXACT QUERY EXACT", 5, 3),                 # B5: lowest tensor, mid lexical
+        ]
+
+        for i, (tensor_term, lexical_term, tensor_rank, lexical_rank) in enumerate(both_docs):
+            doc = {
+                "_id": f"doc_B{i+1}",
+                "title": f"{lexical_term} {tensor_term} both_document_{i+1}",
+                "doc_type": "both",
+                "score_boost": i+11,  # the boost should reverse the order, and this is higher than tensor and lexical match
+            }
+            docs.append(doc)
+
+        return docs
+
+    @pytest.mark.skip_for_multinode
+    def test_disjunction_rrf_pagination(self):
+        """
+        Test that disjunction+RRF pagination produces no duplicates between pages.
+        Verifies ranking consistency and proper pagination behavior.
+
+        Lexical search score:         Tensor search score:
+        doc_B1: 1.5657032529354344    doc_B2: 0.8774912556666549
+        doc_L1: 1.5310213335683778    doc_B1: 0.8624316166639774
+        doc_L2: 1.4957020935493452    doc_T1: 0.8551202270206154
+        doc_L3: 1.4403238705575117    doc_T2: 0.8550448320679322
+        doc_L4: 1.3410214926606240    doc_T3: 0.8523972952471728
+        doc_B3: 1.2495362288065737    doc_T4: 0.8500947166713401
+        doc_L5: 1.1111902054958356    doc_B4: 0.8500164585022059
+        doc_B5: 1.0981049722627436    doc_T5: 0.8471093151792289
+        doc_B2: 0.9400916280884359    doc_B3: 0.8368122835299188
+        doc_B4: 0.4681934225728979    doc_B5: 0.8334305830362274
+                                      doc_L1: 0.8316111466678087
+                                      doc_L5: 0.8288859450924600
+                                      doc_L3: 0.8269666625377193
+                                      doc_L4: 0.8263098149586303
+                                      doc_L2: 0.8257278463225931
+
+        Pagination with page size 5: with alpha=0.7, rrf_k=60
+        tensor rrf score = alpha * (1.0 / (rank + k))
+        lexical rrf score = (1-alpha) * (1.0 / (rank + k))
+
+        ======================================================
+        Page 1:
+        Lexical search rrf score:     Tensor search rrf score:
+        doc_B1: 0.004918              doc_B2: 0.011475
+        doc_L1: 0.004839              doc_B1: 0.011290
+        doc_L2: 0.004762              doc_T1: 0.011111
+        doc_L3: 0.004688              doc_T2: 0.010938
+        doc_L4: 0.004615              doc_T3: 0.010769
+
+        After fusion:
+        doc_B1: 0.016208   <- In both, highest ranking
+        doc_B2: 0.011475
+        doc_T1: 0.011111
+        doc_T2: 0.010938
+        doc_T3: 0.010769
+        doc_L1: 0.004839   <- Trimmed off from here
+        doc_L2: 0.004762
+        doc_L3: 0.004688
+        doc_L4: 0.004615
+
+        =======================================================
+        Page 2:
+        Lexical search rrf score:     Tensor search rrf score:
+        doc_B1: 0.004918              doc_B2: 0.011475
+        doc_L1: 0.004839              doc_B1: 0.011290
+        doc_L2: 0.004762              doc_T1: 0.011111
+        doc_L3: 0.004688              doc_T2: 0.010938
+        doc_L4: 0.004615              doc_T3: 0.010769
+        doc_B3: 0.004545              doc_T4: 0.010606
+        doc_L5: 0.004478              doc_B4: 0.010448
+        doc_B5: 0.004412              doc_T5: 0.010294
+        doc_B2: 0.004348              doc_B3: 0.010145
+        doc_B4: 0.004286              doc_B5: 0.01
+
+        After fusion:
+        doc_B1: 0.016208
+        doc_B2: 0.015823
+        doc_B4: 0.014734   (MISSED)
+        doc_B3: 0.014690   (MISSED)
+        doc_B5: 0.014412   (MISSED)
+        doc_T1: 0.011111   <- Start from here  (DUP)
+        doc_T2: 0.010938   (DUP)
+        doc_T3: 0.010769   (DUP)
+        doc_T4: 0.010606
+        doc_T5: 0.010294
+        doc_L1: 0.004839   <- Trimmed off from here
+        doc_L2: 0.004762
+        doc_L3: 0.004688
+        doc_L4: 0.004615
+        doc_L5: 0.004478
+
+        =======================================================
+        Page 3:
+        Lexical search rrf score:     Tensor search rrf score:
+        doc_B1: 0.004918              doc_B2: 0.011475
+        doc_L1: 0.004839              doc_B1: 0.011290
+        doc_L2: 0.004762              doc_T1: 0.011111
+        doc_L3: 0.004688              doc_T2: 0.010938
+        doc_L4: 0.004615              doc_T3: 0.010769
+        doc_B3: 0.004545              doc_T4: 0.010606
+        doc_L5: 0.004478              doc_B4: 0.010448
+        doc_B5: 0.004412              doc_T5: 0.010294
+        doc_B2: 0.004348              doc_B3: 0.010145
+        doc_B4: 0.004286              doc_B5: 0.01
+                                      doc_L1: 0.009859
+                                      doc_L5: 0.009722
+                                      doc_L3: 0.009589
+                                      doc_L4: 0.009459
+                                      doc_L2: 0.009333
+
+        After fusion:
+        doc_B1: 0.016208
+        doc_B2: 0.015823
+        doc_B4: 0.014734    (MISSED)
+        doc_L1: 0.014698    (MISSED)
+        doc_B3: 0.014690    (MISSED)
+        doc_B5: 0.014412    (MISSED)
+        doc_L3: 0.014277    (MISSED)
+        doc_L5: 0.014200    (MISSED)
+        doc_L2: 0.014095    (MISSED)
+        doc_L4: 0.014074    (MISSED)
+        doc_T1: 0.011111    <- Start from here (DUP)
+        doc_T2: 0.010938    (DUP)
+        doc_T3: 0.010769    (DUP)
+        doc_T4: 0.010606    (DUP)
+        doc_T5: 0.010294    (DUP)
+        """
+        # Test with page size 5 for clean 3-page pagination (15 docs = 3 pages)
+        page_size = 5
+        all_paginated_hits = []
+
+        # Collect all pages
+        for page_num in range(3):  # 3 pages for 15 docs with page size 5
+            offset = page_num * page_size
+
+            page_res = tensor_search.search(
+                search_method="HYBRID",
+                hybrid_parameters=self.hp_rrf,
+                config=self.config,
+                index_name=self.index_unstructured.name,
+                result_count=page_size,
+                offset=offset,
+                text=None
+            )
+
+            all_paginated_hits.extend(page_res["hits"])
+
+        # TODO the result is quite broken, a lot of duplicates and missing docs. This can only be fixed by storing
+        #  pagination state or over-fetching then trimming. This bad result is also related to the data set. In reality,
+        #  we have a lot of docs matching both lexical and tensor, and with score modifiers, the result is much better.
+        # Page 1
+        self.assertEqual(['doc_B1', 'doc_B2', 'doc_T1', 'doc_T2', 'doc_T3'], [h['_id'] for h in all_paginated_hits[:5]])
+        # Page 2
+        self.assertEqual(['doc_T1', 'doc_T2', 'doc_T3', 'doc_T4', 'doc_T5'], [h['_id'] for h in all_paginated_hits[5:-5]])
+        # Page 3
+        self.assertEqual(['doc_T1', 'doc_T2', 'doc_T3', 'doc_T4', 'doc_T5'], [h['_id'] for h in all_paginated_hits[-5:]])
+
+    @pytest.mark.skip_for_multinode
+    def test_disjunction_rrf_pagination_with_global_modifiers_no_rerank_depth(self):
+        """
+        Test pagination with global score modifiers when rerankDepthGlobal is not set.
+        All results get score modifiers applied.
+
+        Lexical search score:         Tensor search score:
+        doc_B1: rank 1  boost 11      doc_B2: rank 1   boost 12
+        doc_L1: rank 2  boost 6       doc_B1: rank 2   boost 11
+        doc_L2: rank 3  boost 7       doc_T1: rank 3   boost 1
+        doc_L3: rank 4  boost 8       doc_T2: rank 4   boost 2
+        doc_L4: rank 5  boost 9       doc_T3: rank 5   boost 3
+        doc_B3: rank 6  boost 13      doc_T4: rank 6   boost 4
+        doc_L5: rank 7  boost 10      doc_B4: rank 7   boost 14
+        doc_B5: rank 8  boost 15      doc_T5: rank 8   boost 5
+        doc_B2: rank 9  boost 12      doc_B3: rank 9   boost 13
+        doc_B4: rank 10 boost 14      doc_B5: rank 10  boost 15
+                                      doc_L1: rank 11  boost 6
+                                      doc_L5: rank 12  boost 10
+                                      doc_L3: rank 13  boost 8
+                                      doc_L4: rank 14  boost 9
+                                      doc_L2: rank 15  boost 7
+
+        Pagination with page size 5: with alpha=0.7, rrf_k=60
+        tensor rrf score = alpha * (1.0 / (rank + k))
+        lexical rrf score = (1-alpha) * (1.0 / (rank + k))
+
+        ======================================================
+        Page 1:
+        Lexical search rrf score:     Tensor search rrf score:
+        doc_B1: 0.004918              doc_B2: 0.011475
+        doc_L1: 0.004839              doc_B1: 0.011290
+        doc_L2: 0.004762              doc_T1: 0.011111
+        doc_L3: 0.004688              doc_T2: 0.010938
+        doc_L4: 0.004615              doc_T3: 0.010769
+
+        After fusion and apply score modifiers for all hits:
+        doc_B2: 12.011475
+        doc_B1: 11.016208
+        doc_L4: 9.004615
+        doc_L3: 8.004688
+        doc_L2: 7.004762
+        doc_L1: 6.004839   <- Trimmed off from here
+        doc_T3: 3.010769
+        doc_T2: 2.010938
+        doc_T1: 1.011111
+
+        =======================================================
+        Page 2:
+        Lexical search rrf score:     Tensor search rrf score:
+        doc_B1: 0.004918              doc_B2: 0.011475
+        doc_L1: 0.004839              doc_B1: 0.011290
+        doc_L2: 0.004762              doc_T1: 0.011111
+        doc_L3: 0.004688              doc_T2: 0.010938
+        doc_L4: 0.004615              doc_T3: 0.010769
+        doc_B3: 0.004545              doc_T4: 0.010606
+        doc_L5: 0.004478              doc_B4: 0.010448
+        doc_B5: 0.004412              doc_T5: 0.010294
+        doc_B2: 0.004348              doc_B3: 0.010145
+        doc_B4: 0.004286              doc_B5: 0.01
+
+        After fusion:
+        doc_B5: 15.014412  (MISSED)
+        doc_B4: 14.014734  (MISSED)
+        doc_B3: 13.014690  (MISSED)
+        doc_B2: 12.015823
+        doc_B1: 11.016208
+        doc_L5: 10.004478  <- Start from here
+        doc_L4: 9.004615   (DUP)
+        doc_L3: 8.004688   (DUP)
+        doc_L2: 7.004762   (DUP)
+        doc_L1: 6.004839
+        doc_T5: 5.010294   <- Trimmed off from here
+        doc_T4: 4.010606
+        doc_T3: 3.010769
+        doc_T2: 2.010938
+        doc_T1: 1.011111
+
+        =======================================================
+        Page 3:
+        Lexical search rrf score:     Tensor search rrf score:
+        doc_B1: 0.004918              doc_B2: 0.011475
+        doc_L1: 0.004839              doc_B1: 0.011290
+        doc_L2: 0.004762              doc_T1: 0.011111
+        doc_L3: 0.004688              doc_T2: 0.010938
+        doc_L4: 0.004615              doc_T3: 0.010769
+        doc_B3: 0.004545              doc_T4: 0.010606
+        doc_L5: 0.004478              doc_B4: 0.010448
+        doc_B5: 0.004412              doc_T5: 0.010294
+        doc_B2: 0.004348              doc_B3: 0.010145
+        doc_B4: 0.004286              doc_B5: 0.01
+                                      doc_L1: 0.009859
+                                      doc_L5: 0.009722
+                                      doc_L3: 0.009589
+                                      doc_L4: 0.009459
+                                      doc_L2: 0.009333
+
+        After fusion:
+        doc_B5: 15.014412  (MISSED)
+        doc_B4: 14.014734  (MISSED)
+        doc_B3: 13.014690  (MISSED)
+        doc_B2: 12.015823
+        doc_B1: 11.016208
+        doc_L5: 10.014200
+        doc_L4: 9.014074
+        doc_L3: 8.014277
+        doc_L2: 7.014095
+        doc_L1: 6.014698
+        doc_T5: 5.010294   <- Start from here
+        doc_T4: 4.010606
+        doc_T3: 3.010769
+        doc_T2: 2.010938
+        doc_T1: 1.011111
+        """
+        # Test with page size 5 for clean 3-page pagination
+        page_size = 5
+        all_paginated_hits = []
+
+        # Collect all pages
+        for page_num in range(3):  # 3 pages for 15 docs with page size 5
+            offset = page_num * page_size
+
+            page_res = tensor_search.search(
+                search_method="HYBRID",
+                hybrid_parameters=self.hp_rrf,
+                config=self.config,
+                index_name=self.index_unstructured.name,
+                result_count=page_size,
+                offset=offset,
+                text=None,
+                score_modifiers=ScoreModifierLists(
+                    add_to_score=[
+                        ScoreModifierOperator(field_name="score_boost", weight=1)
+                    ]
+                )
+                # No rerankDepth - applies to all results
+            )
+
+            all_paginated_hits.extend(page_res["hits"])
+
+        # Page 1
+        self.assertEqual(['doc_B2', 'doc_B1', 'doc_L4', 'doc_L3', 'doc_L2'],
+                         [h['_id'] for h in all_paginated_hits[:5]])
+        # Page 2
+        self.assertEqual(['doc_L5', 'doc_L4', 'doc_L3', 'doc_L2', 'doc_L1'],
+                         [h['_id'] for h in all_paginated_hits[5:-5]])
+        # Page 3
+        self.assertEqual(['doc_T5', 'doc_T4', 'doc_T3', 'doc_T2', 'doc_T1'],
+                         [h['_id'] for h in all_paginated_hits[-5:]])
+
+    @pytest.mark.skip_for_multinode
+    def test_disjunction_rrf_pagination_with_global_modifiers_with_rerank_depth(self):
+        """
+        Test pagination with rerankDepthGlobal values. The retrieved result up to offset+rerankDepthGlobal get global
+        score modifiers applied
+
+        Lexical search score:         Tensor search score:
+        doc_B1: 1.5657032529354344    doc_B2: 0.8774912556666549
+        doc_L1: 1.5310213335683778    doc_B1: 0.8624316166639774
+        doc_L2: 1.4957020935493452    doc_T1: 0.8551202270206154
+        doc_L3: 1.4403238705575117    doc_T2: 0.8550448320679322
+        doc_L4: 1.3410214926606240    doc_T3: 0.8523972952471728
+        doc_B3: 1.2495362288065737    doc_T4: 0.8500947166713401
+        doc_L5: 1.1111902054958356    doc_B4: 0.8500164585022059
+        doc_B5: 1.0981049722627436    doc_T5: 0.8471093151792289
+        doc_B2: 0.9400916280884359    doc_B3: 0.8368122835299188
+        doc_B4: 0.4681934225728979    doc_B5: 0.8334305830362274
+                                      doc_L1: 0.8316111466678087
+                                      doc_L5: 0.8288859450924600
+                                      doc_L3: 0.8269666625377193
+                                      doc_L4: 0.8263098149586303
+                                      doc_L2: 0.8257278463225931
+
+        Pagination with page size 5: with alpha=0.7, rrf_k=60
+        tensor rrf score = alpha * (1.0 / (rank + k))
+        lexical rrf score = (1-alpha) * (1.0 / (rank + k))
+
+        ======================================================
+        Page 1:
+        Lexical search rrf score:     Tensor search rrf score:
+        doc_B1: 0.004918              doc_B2: 0.011475
+        doc_L1: 0.004839              doc_B1: 0.011290
+        doc_L2: 0.004762              doc_T1: 0.011111
+        doc_L3: 0.004688              doc_T2: 0.010938
+        doc_L4: 0.004615              doc_T3: 0.010769
+
+        After fusion:
+        doc_B2: 12.011475
+        doc_B1: 11.016208
+        doc_L2: 7.004762
+        doc_L1: 6.004839
+        doc_T3: 3.010769
+        doc_T2: 2.010938   <- Trimmed off from here
+        doc_T1: 1.011111
+        doc_L3: 0.004688   <- global reranking will not reach 8th element (rerankDepthGlobal = 7)
+        doc_L4: 0.004615
+
+        =======================================================
+        Page 2:
+        Lexical search rrf score:     Tensor search rrf score:
+        doc_B1: 0.004918              doc_B2: 0.011475
+        doc_L1: 0.004839              doc_B1: 0.011290
+        doc_L2: 0.004762              doc_T1: 0.011111
+        doc_L3: 0.004688              doc_T2: 0.010938
+        doc_L4: 0.004615              doc_T3: 0.010769
+        doc_B3: 0.004545              doc_T4: 0.010606
+        doc_L5: 0.004478              doc_B4: 0.010448
+        doc_B5: 0.004412              doc_T5: 0.010294
+        doc_B2: 0.004348              doc_B3: 0.010145
+        doc_B4: 0.004286              doc_B5: 0.01
+
+        After fusion:
+        doc_B5: 15.014412  (MISSED)
+        doc_B4: 14.014734  (MISSED)
+        doc_B3: 13.014690  (MISSED)
+        doc_B2: 12.015823
+        doc_B1: 11.016208
+        doc_L2: 7.004762   <- Start from here (DUP)
+        doc_L1: 6.004839   (DUP)
+        doc_T5: 5.010294
+        doc_T4: 4.010606
+        doc_T3: 3.010769   (DUP)
+        doc_T2: 2.010938   <- Trimmed off from here
+        doc_T1: 1.011111
+        doc_L3: 0.004688   <- global reranking will not reach 13th element (rerankDepthGlobal = 5 + 7)
+        doc_L4: 0.004615
+        doc_L5: 0.004478
+
+        =======================================================
+        Page 3:
+        Lexical search rrf score:     Tensor search rrf score:
+        doc_B1: 0.004918              doc_B2: 0.011475
+        doc_L1: 0.004839              doc_B1: 0.011290
+        doc_L2: 0.004762              doc_T1: 0.011111
+        doc_L3: 0.004688              doc_T2: 0.010938
+        doc_L4: 0.004615              doc_T3: 0.010769
+        doc_B3: 0.004545              doc_T4: 0.010606
+        doc_L5: 0.004478              doc_B4: 0.010448
+        doc_B5: 0.004412              doc_T5: 0.010294
+        doc_B2: 0.004348              doc_B3: 0.010145
+        doc_B4: 0.004286              doc_B5: 0.01
+                                      doc_L1: 0.009859
+                                      doc_L5: 0.009722
+                                      doc_L3: 0.009589
+                                      doc_L4: 0.009459
+                                      doc_L2: 0.009333
+
+        After fusion: (global score modifiers applied to all docs)
+        doc_B5: 15.014412  (MISSED)
+        doc_B4: 14.014734  (MISSED)
+        doc_B3: 13.014690  (MISSED)
+        doc_B2: 12.015823
+        doc_B1: 11.016208
+        doc_L5: 10.014200  (MISSED)
+        doc_L4: 9.014074   (MISSED)
+        doc_L3: 8.014277   (MISSED)
+        doc_L2: 7.014095
+        doc_L1: 6.014698
+        doc_T5: 5.010294   <- Start from here (DUP)
+        doc_T4: 4.010606   (DUP)
+        doc_T3: 3.010769   (DUP)
+        doc_T2: 2.010938
+        doc_T1: 1.011111
+        """
+        # Test with page size 5 for clean 3-page pagination
+        page_size = 5
+        all_paginated_hits = []
+
+        # Collect all pages
+        for page_num in range(3):  # 3 pages for 15 docs with page size 5
+            offset = page_num * page_size
+
+            page_res = tensor_search.search(
+                search_method="HYBRID",
+                hybrid_parameters=self.hp_rrf,
+                config=self.config,
+                index_name=self.index_unstructured.name,
+                result_count=page_size,
+                offset=offset,
+                text=None,
+                score_modifiers=ScoreModifierLists(
+                    add_to_score=[
+                        ScoreModifierOperator(field_name="score_boost", weight=1)
+                    ]
+                ),
+                rerank_depth=7,  # rerank 7 items
+            )
+
+            all_paginated_hits.extend(page_res["hits"])
+
+        # Page 1
+        self.assertEqual(['doc_B2', 'doc_B1', 'doc_L2', 'doc_L1', 'doc_T3'],
+                         [h['_id'] for h in all_paginated_hits[:5]])
+        # Page 2
+        self.assertEqual(['doc_L2', 'doc_L1', 'doc_T5', 'doc_T4', 'doc_T3'],
+                         [h['_id'] for h in all_paginated_hits[5:-5]])
+        # Page 3
+        self.assertEqual(['doc_T5', 'doc_T4', 'doc_T3', 'doc_T2', 'doc_T1'],
+                         [h['_id'] for h in all_paginated_hits[-5:]])
+
+    @pytest.mark.skip_for_multinode
+    def test_disjunction_rrf_pagination_with_global_modifiers_with_rerank_depth_small_than_limit(self):
+        """
+        Test pagination with rerankDepthGlobal values smaller than limit. The retrieved result up to
+        offset+rerankDepthGlobal get global score modifiers applied
+
+        Lexical search score:         Tensor search score:
+        doc_B1: 1.5657032529354344    doc_B2: 0.8774912556666549
+        doc_L1: 1.5310213335683778    doc_B1: 0.8624316166639774
+        doc_L2: 1.4957020935493452    doc_T1: 0.8551202270206154
+        doc_L3: 1.4403238705575117    doc_T2: 0.8550448320679322
+        doc_L4: 1.3410214926606240    doc_T3: 0.8523972952471728
+        doc_B3: 1.2495362288065737    doc_T4: 0.8500947166713401
+        doc_L5: 1.1111902054958356    doc_B4: 0.8500164585022059
+        doc_B5: 1.0981049722627436    doc_T5: 0.8471093151792289
+        doc_B2: 0.9400916280884359    doc_B3: 0.8368122835299188
+        doc_B4: 0.4681934225728979    doc_B5: 0.8334305830362274
+                                      doc_L1: 0.8316111466678087
+                                      doc_L5: 0.8288859450924600
+                                      doc_L3: 0.8269666625377193
+                                      doc_L4: 0.8263098149586303
+                                      doc_L2: 0.8257278463225931
+
+        Pagination with page size 5: with alpha=0.7, rrf_k=60
+        tensor rrf score = alpha * (1.0 / (rank + k))
+        lexical rrf score = (1-alpha) * (1.0 / (rank + k))
+
+        ======================================================
+        Page 1:
+        Lexical search rrf score:     Tensor search rrf score:
+        doc_B1: 0.004918              doc_B2: 0.011475
+        doc_L1: 0.004839              doc_B1: 0.011290
+        doc_L2: 0.004762              doc_T1: 0.011111
+        doc_L3: 0.004688              doc_T2: 0.010938
+        doc_L4: 0.004615              doc_T3: 0.010769
+
+        After fusion and applying global score modifiers
+        doc_B2: 12.011475
+        doc_B1: 11.016208
+        doc_T1: 1.011111
+        doc_T2: 0.010938  <- global reranking will not reach 4th element (rerankDepthGlobal = 3)
+        doc_T3: 0.010769
+        doc_L1: 0.004839  <- Trimmed off from here
+        doc_L2: 0.004762
+        doc_L3: 0.004688
+        doc_L4: 0.004615
+
+        =======================================================
+        Page 2:
+        Lexical search rrf score:     Tensor search rrf score:
+        doc_B1: 0.004918              doc_B2: 0.011475
+        doc_L1: 0.004839              doc_B1: 0.011290
+        doc_L2: 0.004762              doc_T1: 0.011111
+        doc_L3: 0.004688              doc_T2: 0.010938
+        doc_L4: 0.004615              doc_T3: 0.010769
+        doc_B3: 0.004545              doc_T4: 0.010606
+        doc_L5: 0.004478              doc_B4: 0.010448
+        doc_B5: 0.004412              doc_T5: 0.010294
+        doc_B2: 0.004348              doc_B3: 0.010145
+        doc_B4: 0.004286              doc_B5: 0.01
+
+        After fusion:
+        doc_B5: 15.014412  (MISSED)
+        doc_B4: 14.014734  (MISSED)
+        doc_B3: 13.014690  (MISSED)
+        doc_B2: 12.015823
+        doc_B1: 11.016208
+        doc_T3: 3.010769   <- Start from here (DUP)
+        doc_T2: 2.010938   (DUP)
+        doc_T1: 1.011111   (DUP)
+        doc_T4: 0.010606   <- global reranking will not reach 9th element (rerankDepthGlobal = 5 + 3)
+        doc_T5: 0.010294
+        doc_L1: 0.004839   <- Trimmed off from here
+        doc_L2: 0.004762
+        doc_L3: 0.004688
+        doc_L4: 0.004615
+        doc_L5: 0.004478
+
+        =======================================================
+        Page 3:
+        Lexical search rrf score:     Tensor search rrf score:
+        doc_B1: 0.004918              doc_B2: 0.011475
+        doc_L1: 0.004839              doc_B1: 0.011290
+        doc_L2: 0.004762              doc_T1: 0.011111
+        doc_L3: 0.004688              doc_T2: 0.010938
+        doc_L4: 0.004615              doc_T3: 0.010769
+        doc_B3: 0.004545              doc_T4: 0.010606
+        doc_L5: 0.004478              doc_B4: 0.010448
+        doc_B5: 0.004412              doc_T5: 0.010294
+        doc_B2: 0.004348              doc_B3: 0.010145
+        doc_B4: 0.004286              doc_B5: 0.01
+                                      doc_L1: 0.009859
+                                      doc_L5: 0.009722
+                                      doc_L3: 0.009589
+                                      doc_L4: 0.009459
+                                      doc_L2: 0.009333
+
+        After fusion: (global score modifiers applied to all docs)
+        doc_B5: 15.014412  (MISSED)
+        doc_B4: 14.014734  (MISSED)
+        doc_B3: 13.014690  (MISSED)
+        doc_B2: 12.015823
+        doc_B1: 11.016208
+        doc_L5: 10.014200  (MISSED)
+        doc_L4: 9.014074   (MISSED)
+        doc_L3: 8.014277   (MISSED)
+        doc_L2: 7.014095   (MISSED)
+        doc_L1: 6.014698   (MISSED)
+        doc_T3: 3.010769   (DUP)
+        doc_T2: 2.010938   (DUP)
+        doc_T1: 1.011111   (DUP)
+        doc_T4: 0.010606   <- global reranking will not reach 14th element (rerankDepthGlobal = 10 + 3)  (DUP)
+        doc_T5: 0.010294   (DUP)
+        """
+        # Test with page size 5 for clean 3-page pagination
+        page_size = 5
+        all_paginated_hits = []
+
+        # Collect all pages
+        for page_num in range(3):  # 3 pages for 15 docs with page size 5
+            offset = page_num * page_size
+
+            page_res = tensor_search.search(
+                search_method="HYBRID",
+                hybrid_parameters=self.hp_rrf,
+                config=self.config,
+                index_name=self.index_unstructured.name,
+                result_count=page_size,
+                offset=offset,
+                text=None,
+                score_modifiers=ScoreModifierLists(
+                    add_to_score=[
+                        ScoreModifierOperator(field_name="score_boost", weight=1)
+                    ]
+                ),
+                rerank_depth=3,  # rerank only 3 items
+            )
+
+            all_paginated_hits.extend(page_res["hits"])
+
+        # Page 1
+        self.assertEqual(['doc_B2', 'doc_B1', 'doc_T1', 'doc_T2', 'doc_T3'],
+                         [h['_id'] for h in all_paginated_hits[:5]])
+        # Page 2
+        self.assertEqual(['doc_T3', 'doc_T2', 'doc_T1', 'doc_T4', 'doc_T5'],
+                         [h['_id'] for h in all_paginated_hits[5:-5]])
+        # Page 3
+        self.assertEqual(['doc_T3', 'doc_T2', 'doc_T1', 'doc_T4', 'doc_T5'],
+                         [h['_id'] for h in all_paginated_hits[-5:]])
+        

--- a/tests/integ_tests/vespa/test_vespa_client.py
+++ b/tests/integ_tests/vespa/test_vespa_client.py
@@ -1,9 +1,10 @@
 import asyncio
 import functools
+import json
 import os
-import sys
+import time
 import unittest
-from unittest.mock import patch, Mock, AsyncMock, ANY
+from unittest.mock import Mock, patch
 
 import httpcore
 import httpx
@@ -13,13 +14,13 @@ import vespa.application as pyvespa
 from marqo.tensor_search.api import generate_config
 from marqo.tensor_search.enums import EnvVars
 from marqo.vespa import concurrency
-from marqo.vespa.exceptions import VespaError, VespaStatusError, VespaTimeoutError, VespaNotConvergedError
-from marqo.vespa.models import VespaDocument, QueryResult
-from marqo.vespa.models.get_document_response import GetBatchResponse, GetBatchDocumentResponse, Document
+from marqo.vespa.exceptions import (VespaError, VespaNotConvergedError,
+                                    VespaStatusError, VespaTimeoutError)
+from marqo.vespa.models import QueryResult, VespaDocument
 from marqo.vespa.models.application_metrics import ApplicationMetrics
 from marqo.vespa.models.query_result import Error
 from marqo.vespa.vespa_client import VespaClient
-from tests.integ_tests.marqo_test import AsyncMarqoTestCase, MarqoTestCase
+from tests.integ_tests.marqo_test import AsyncMarqoTestCase
 
 
 class TestVespaClient(AsyncMarqoTestCase):
@@ -838,3 +839,30 @@ class TestVespaClient(AsyncMarqoTestCase):
                 )
 
         assert mock_delete.call_count == 1
+
+    def test_httpx_client_should_not_timeout_before_vespa_timeout(self):
+        """Test that httpx client will not time out before Vespa timeout"""
+        def delayed_vespa_504(*args, **kwargs):
+            time.sleep(7)  # emulate Vespa taking ~7s
+            payload = {
+                "root": {
+                    "relevance": 0.0,
+                    "errors": [{
+                        "code": 8,
+                        "summary": "Error in search reply.",
+                        "message": "Search request soft doomed during query setup and initialization."
+                    }]
+                }
+            }
+            req = httpx.Request("POST", "http://dummy/search/")
+            return httpx.Response(status_code=504, content=json.dumps(payload).encode(), request=req)
+
+        query_client = VespaClient("http://localhost:8080","http://localhost:8080",
+                                   "http://localhost:8080","content_default")
+
+        with patch.object(httpx.Client, "post", side_effect=delayed_vespa_504):
+            with self.assertRaisesStrict(VespaTimeoutError):
+                query_client.query(
+                    yql="select * from sources * where title contains 'Title 1';",
+                    timeout=7000 # 7 seconds Vespa timeout, 8 seconds httpx timeout
+                )

--- a/tests/unit_tests/marqo/core/typeahead/test_typeahead.py
+++ b/tests/unit_tests/marqo/core/typeahead/test_typeahead.py
@@ -782,5 +782,102 @@ class TestTypeaheadGetQueries(unittest.TestCase):
         self.assertEqual(result.queries[0].query, "found query")
 
 
+class TestTypeaheadEscaping(unittest.TestCase):
+    """Test cases for the special character escaping functionality."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_vespa_client = Mock(spec=VespaClient)
+        self.mock_index_management = Mock(spec=IndexManagement)
+        self.typeahead = Typeahead(
+            vespa_client=self.mock_vespa_client,
+            index_management=self.mock_index_management
+        )
+
+    def test_escape_token_no_special_chars(self):
+        """Test escaping tokens with no special characters."""
+        # Simple strings should not be modified
+        test_cases = [
+            "hello",
+            "world",
+            "123",
+            "test_query",
+            "simple-text",
+            "with spaces",
+            "",
+        ]
+
+        for token in test_cases:
+            with self.subTest(token=token):
+                result = self.typeahead._escape_token(token)
+                self.assertEqual(result, token)
+
+    def test_escape_token_quotes(self):
+        """Test escaping tokens with double quotes."""
+        test_cases = [
+            ('"', '\\"'),
+            ('hello"world', 'hello\\"world'),
+            ('"start', '\\"start'),
+            ('end"', 'end\\"'),
+            ('""', '\\"\\"'),
+            ('say "hello"', 'say \\"hello\\"'),
+        ]
+
+        for input_token, expected in test_cases:
+            with self.subTest(input_token=input_token):
+                result = self.typeahead._escape_token(input_token)
+                self.assertEqual(result, expected)
+
+    def test_escape_token_backslashes(self):
+        """Test escaping tokens with backslashes."""
+        test_cases = [
+            ('\\', '\\\\'),
+            ('hello\\world', 'hello\\\\world'),
+            ('\\start', '\\\\start'),
+            ('end\\', 'end\\\\'),
+            ('\\\\', '\\\\\\\\'),
+            ('path\\to\\file', 'path\\\\to\\\\file'),
+        ]
+
+        for input_token, expected in test_cases:
+            with self.subTest(input_token=input_token):
+                result = self.typeahead._escape_token(input_token)
+                self.assertEqual(result, expected)
+
+    def test_escape_token_mixed_special_chars(self):
+        """Test escaping tokens with both quotes and backslashes."""
+        test_cases = [
+            ('"\\', '\\"\\\\'),
+            ('"hello\\world"', '\\"hello\\\\world\\"'),
+            ('C:\\Program Files\\"test"', 'C:\\\\Program Files\\\\\\"test\\"'),
+            ('a"b\\c"d', 'a\\"b\\\\c\\"d'),
+        ]
+
+        for input_token, expected in test_cases:
+            with self.subTest(input_token=input_token):
+                result = self.typeahead._escape_token(input_token)
+                self.assertEqual(result, expected)
+
+    def test_escape_token_preserves_other_chars(self):
+        """Test that escaping preserves other special characters."""
+        # Characters that are NOT in CHARACTERS_TO_BE_ESCAPED_IN_VESPA should be preserved
+        test_cases = [
+            "hello!world",
+            "test@example.com",
+            "price$100",
+            "50%off",
+            "a+b=c",
+            "question?",
+            "array[0]",
+            "function()",
+            "hash#tag",
+        ]
+
+        for token in test_cases:
+            with self.subTest(token=token):
+                result = self.typeahead._escape_token(token)
+                self.assertEqual(result, token)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit_tests/marqo/test_logging.py
+++ b/tests/unit_tests/marqo/test_logging.py
@@ -99,13 +99,22 @@ class TestLoggingConfig(unittest.TestCase):
                 self.assertEqual(LOGGING_CONFIG['loggers']['httpx']['level'], expected_level)
 
     def test_access_log_level_changes_with_root_log_level(self):
-        """Test that access log level is always INFO"""
+        """Test that access log level changes with the root log level"""
         for level in ['debug', 'info', 'warning', 'error']:
             with patch.dict(os.environ, {'MARQO_LOG_LEVEL': level, 'MARQO_LOG_FORMAT': 'plain'}):
                 importlib.reload(marqo_logging)
                 from marqo.logging import LOGGING_CONFIG
 
                 self.assertEqual(level.upper(), LOGGING_CONFIG['loggers']['uvicorn.access']['level'])
+
+    def test_metric_log_level_is_fixed(self):
+        """Test that metrics log level is always INFO"""
+        for level in ['debug', 'info', 'warning', 'error']:
+            with patch.dict(os.environ, {'MARQO_LOG_LEVEL': level, 'MARQO_LOG_FORMAT': 'plain'}):
+                importlib.reload(marqo_logging)
+                from marqo.logging import LOGGING_CONFIG
+
+                self.assertEqual("INFO", LOGGING_CONFIG['loggers']['metrics']['level'])
 
     def test_plain_format_output(self):
         """Test the exact plain text format output"""

--- a/tests/unit_tests/vespa/test_vespa_client.py
+++ b/tests/unit_tests/vespa/test_vespa_client.py
@@ -1,5 +1,6 @@
 import unittest
-from unittest.mock import Mock, patch, AsyncMock
+from unittest.mock import Mock, patch
+import httpx
 from marqo.vespa.vespa_client import VespaClient
 
 
@@ -25,8 +26,6 @@ class TestVespaClient(unittest.TestCase):
             
             # Verify that close was called
             mock_close.assert_called_once()
-
-
 
     def test_get_content_url_single_path(self):
         """Test get_content_url with single path component"""
@@ -125,6 +124,39 @@ class TestVespaClient(unittest.TestCase):
         # Should return empty response without making any requests
         self.assertEqual(len(result.responses), 0)
         self.assertFalse(result.errors)
+
+    def test_query_httpx_timeout_configuration_small_vespa_timeout(self):
+        """Test that httpx read timeout is set to max(5.0, (vespa_timeout + 1000) / 1000) for Vespa timeouts"""
+        def mock_post(*args, **kwargs):
+            # Return a mock response
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.text = '{"root": {"id": "test", "relevance": 1.0, "children": []}}'
+            return mock_response
+
+        test_cases = [
+            (1000, 5.0, "1000ms", "Vespa timeout 1000ms -> httpx timeout 5.0s"),
+            (1, 5.0, "1ms", "Vespa timeout 1ms -> httpx timeout 5.0s"),
+            (6000, 7.0, "6000ms", "Vespa timeout 6000ms -> httpx timeout 7.0s"),
+            (None, 5.0, "1000ms", "Vespa timeout None -> Default to 1000 -> httpx timeout 5.0s"),
+            (0, 5.0, "1000ms", "Vespa timeout 0ms -> Default to 1000 -> httpx timeout 5.0s"),
+        ]
+
+        for provided_vespa_timeout_ms, httpx_read_timeout_second, expected_vespa_timeout_ms, msg in test_cases:
+            with self.subTest(msg=msg):
+                with patch.object(httpx.Client, 'post', side_effect=mock_post) as mock_query:
+                    self.vespa_client.query(
+                        yql="select * from sources * where test;",
+                        timeout=provided_vespa_timeout_ms
+                    )
+
+                    timeout_obj = mock_query.call_args.kwargs["timeout"]
+                    vespa_time_out = mock_query.call_args.kwargs["json"]["timeout"]
+                    self.assertEqual(expected_vespa_timeout_ms, vespa_time_out)
+                    self.assertEqual(httpx_read_timeout_second, timeout_obj.read)
+                    self.assertEqual(5.0, timeout_obj.connect)
+                    self.assertEqual(5.0, timeout_obj.write)
+                    self.assertEqual(5.0, timeout_obj.pool)
 
 
 if __name__ == '__main__':

--- a/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
+++ b/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
@@ -224,6 +224,7 @@ public class HybridSearcher extends Searcher {
         // --- Update the query hits, offset and targetHits, if sort or relevance cut-off is used
         boolean isRelevanceCutoffMethodEnabled = relevanceCutoffMethod != null;
         boolean isSortByEnabled = sortByFields != null;
+        boolean isDisjunctionSearch = retrievalMethod.equals("disjunction");
 
         query =
                 updateQueryHitsOffsetsAndTargetHits(
@@ -231,10 +232,11 @@ public class HybridSearcher extends Searcher {
                         relevantCandidates,
                         sortByMinSortCandidates,
                         isRelevanceCutoffMethodEnabled,
-                        isSortByEnabled);
+                        isSortByEnabled,
+                        isDisjunctionSearch);
 
         HitGroup hitsForPostProcessing;
-        if (retrievalMethod.equals("disjunction")) {
+        if (isDisjunctionSearch) {
             Result resultLexical, resultTensor;
             Query queryLexical =
                     createSubQuery(
@@ -320,6 +322,9 @@ public class HybridSearcher extends Searcher {
             sortCandidates = hitsForPostProcessing.size();
         } else {
             // If sortBy is not set, we use the default post-processing
+            // when we do disjunction search or use relevance cutoff, the offset is set to 0, so we
+            // need to trim previous pages
+            boolean needToTrimPreviousPages = isDisjunctionSearch || isRelevanceCutoffMethodEnabled;
             processedHits =
                     postProcessResults(
                             hitsForPostProcessing,
@@ -327,6 +332,7 @@ public class HybridSearcher extends Searcher {
                             rerankDepthGlobal,
                             limit,
                             offset,
+                            needToTrimPreviousPages,
                             verbose);
         }
 
@@ -415,11 +421,13 @@ public class HybridSearcher extends Searcher {
 
     /**
      * Updates the query hits, offsets, and targetHits based on the provided parameters.
-     * @param query the query to update.
-     * @param relevantCandidates the number of relevant candidates found in the probe search.
-     * @param sortByMinSortCandidates the minimum number of candidates required for sorting, from Marqo
+     *
+     * @param query                    the query to update.
+     * @param relevantCandidates       the number of relevant candidates found in the probe search.
+     * @param sortByMinSortCandidates  the minimum number of candidates required for sorting, from Marqo
      * @param isRelevanceCutoffEnabled whether relevance cutoff is enabled.
-     * @param isSortByEnabled whether sorting is enabled.
+     * @param isSortByEnabled          whether sorting is enabled.
+     * @param isDisjunctionSearch      whether the retrieval method is disjunction
      * @return The updated query with new hits, offsets, and targetHits.
      */
     public Query updateQueryHitsOffsetsAndTargetHits(
@@ -427,10 +435,16 @@ public class HybridSearcher extends Searcher {
             Integer relevantCandidates,
             Integer sortByMinSortCandidates,
             boolean isRelevanceCutoffEnabled,
-            boolean isSortByEnabled) {
+            boolean isSortByEnabled,
+            boolean isDisjunctionSearch) {
 
         // Validate input parameters
         if (!isRelevanceCutoffEnabled && !isSortByEnabled) {
+            if (isDisjunctionSearch) {
+                query.setHits(query.getOffset() + query.getHits());
+                query.setOffset(0);
+            }
+
             return query;
         }
 
@@ -942,8 +956,10 @@ public class HybridSearcher extends Searcher {
             Integer rerankDepthGlobal,
             int limit,
             int offset,
+            boolean needToTrimPreviousPages,
             boolean verbose) {
-        // Split original hits into 2 lists: result to rerank and excess hits
+
+        // Step 1: Split original hits into 2 lists: result to rerank and excess hits
         // Excess hits will not be reranked, and will be added back after reranking the other
         // results
         HitGroup resultToRerank = new HitGroup();
@@ -953,15 +969,23 @@ public class HybridSearcher extends Searcher {
         // If rerank count global is not set, rerank all hits
         if (rerankDepthGlobal == null) {
             rerankDepthGlobal = hitsForPostProcessing.size();
+        } else if (needToTrimPreviousPages) {
+            // When previous pages are also in search result, we need to increase the original
+            // rerankDepthGlobal to make sure global score modifiers are applied to current page
+            rerankDepthGlobal = rerankDepthGlobal + offset;
         }
+        // Calculate total hits needed: when needToTrimPreviousPages is true, we need offset + limit
+        // hits
+        int totalHitsNeeded = needToTrimPreviousPages ? offset + limit : limit;
+
         for (Hit hit : hitsForPostProcessing) {
             if (idx < rerankDepthGlobal) {
                 resultToRerank.add(hit);
-            } else if (idx < limit) {
-                // Total hits to return caps out at limit
+            } else if (idx < totalHitsNeeded) {
+                // Total hits to process should be offset + limit when trimming previous pages
                 excessHits.add(hit);
             } else {
-                // Ignore all hits after limit
+                // Ignore all hits after totalHitsNeeded
                 break;
             }
             idx++;
@@ -974,7 +998,7 @@ public class HybridSearcher extends Searcher {
             logHitGroup(excessHits, verbose);
         }
 
-        // Apply global score modifiers and rerank
+        // Step 2: Apply global score modifiers and rerank
         // Skip whole process if global modifier weight tensors don't exist in query
         Tensor queryMultWeightsGlobal =
                 extractTensorRankFeature(query, addQueryWrapper(QUERY_INPUT_MULT_WEIGHTS_GLOBAL));
@@ -992,12 +1016,14 @@ public class HybridSearcher extends Searcher {
         logIfVerbose("Rescored result list (UNSORTED): ", verbose);
         logHitGroup(resultToRerank, verbose);
 
+        // Step 3: Sort  TODO should only sort after applying global score modifiers
         resultToRerank.sort();
 
         logIfVerbose("Reranked result list (SORTED): ", verbose);
         logHitGroup(resultToRerank, verbose);
 
-        if (limit > rerankDepthGlobal) {
+        // Step 4: Add excess hits if needed
+        if (totalHitsNeeded > rerankDepthGlobal) {
             // Add excess hits to the end of reranked results then sort
             logIfVerbose(
                     String.format(
@@ -1007,12 +1033,18 @@ public class HybridSearcher extends Searcher {
             resultToRerank.addAll(excessHits.asList());
         }
 
-        // Paginate and/or trim
-        // Result list should always have limit length (if possible)
-        logIfVerbose(
-                String.format("Trimming result list. " + "limit: %d, offset: %d", limit, offset),
-                verbose);
-        resultToRerank.trim(0, limit);
+        // Step 5: Final trim to limit (pagination was already applied if needed)
+        if (needToTrimPreviousPages) {
+            logIfVerbose(
+                    String.format(
+                            "Final trimming result list from offset %s and limit: %d",
+                            offset, limit),
+                    verbose);
+            resultToRerank.trim(offset, limit);
+        } else {
+            logIfVerbose(String.format("Final trimming result list to limit: %d", limit), verbose);
+            resultToRerank.trim(0, limit);
+        }
 
         logIfVerbose("Final result list (EXCESS HITS ADDED/REMOVED): ", verbose);
         logHitGroup(resultToRerank, verbose);

--- a/vespa/src/test/java/ai/marqo/search/HybridSearcherPostProcessResultsTest.java
+++ b/vespa/src/test/java/ai/marqo/search/HybridSearcherPostProcessResultsTest.java
@@ -1,0 +1,268 @@
+package ai.marqo.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.yahoo.search.Query;
+import com.yahoo.search.result.Hit;
+import com.yahoo.search.result.HitGroup;
+import com.yahoo.tensor.Tensor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for HybridSearcher.postProcessResults method.
+ * Tests the new pagination logic controlled by needToTrimPreviousPages parameter.
+ */
+@DisplayName("HybridSearcher PostProcessResults Tests")
+class HybridSearcherPostProcessResultsTest {
+
+    private HybridSearcher hybridSearcher;
+
+    @BeforeEach
+    void setUp() {
+        hybridSearcher = new HybridSearcher();
+    }
+
+    /**
+     * Helper method to create a HitGroup with specified number of hits.
+     * Each hit has a relevance score of 1.0/(index+1) to ensure predictable sorting.
+     */
+    private HitGroup createTestHitGroup(int size) {
+        HitGroup hitGroup = new HitGroup();
+        for (int i = 0; i < size; i++) {
+            Hit hit = new Hit("hit_" + i, 1.0 / (i + 1));
+            hitGroup.add(hit);
+        }
+        return hitGroup;
+    }
+
+    /**
+     * Helper method to create a query with no global modifiers.
+     */
+    private Query createTestQuery() {
+        Query query = new Query();
+        // Ensure no global modifiers are present
+        // TODO add test coverage for global score modifier later
+        query.getRanking()
+                .getFeatures()
+                .put("query(marqo__mult_weights_global)", Tensor.from("tensor(p{}):{}"));
+        query.getRanking()
+                .getFeatures()
+                .put("query(marqo__add_weights_global)", Tensor.from("tensor(p{}):{}"));
+        return query;
+    }
+
+    @Test
+    @DisplayName("Test 1: needToTrimPreviousPages=true adjusts rerankDepthGlobal by adding offset")
+    void testPostProcessResults_NeedToTrimTrue_AdjustsRerankDepth() {
+        // Arrange
+        HitGroup inputHits = createTestHitGroup(20); // 20 hits
+        Query query = createTestQuery();
+
+        int limit = 10;
+        int offset = 5;
+        Integer rerankDepthGlobal = 10; // Should become 15 (10 + 5)
+        boolean needToTrimPreviousPages = true;
+        boolean verbose = false;
+
+        // Act
+        HitGroup result =
+                hybridSearcher.postProcessResults(
+                        inputHits,
+                        query,
+                        rerankDepthGlobal,
+                        limit,
+                        offset,
+                        needToTrimPreviousPages,
+                        verbose);
+
+        // Assert
+        // When needToTrimPreviousPages=true, rerankDepthGlobal becomes 15 (10+5)
+        // So hits 0-14 should be reranked (sorted by relevance)
+        // Final result should have 10 hits starting from offset 5
+        assertThat(result.size()).isEqualTo(10);
+
+        // Verify we get hits from positions 5-14 (after reranking adjustment)
+        // Since all hits have descending relevance scores, the first hit should be hit_0
+        assertThat(result.get(0).getId().toString()).isEqualTo("hit_5");
+    }
+
+    @Test
+    @DisplayName("Test 2: needToTrimPreviousPages=false keeps original rerankDepthGlobal")
+    void testPostProcessResults_NeedToTrimFalse_KeepsOriginalRerankDepth() {
+        // Arrange
+        HitGroup inputHits = createTestHitGroup(20); // 20 hits
+        Query query = createTestQuery();
+
+        int limit = 10;
+        int offset = 5;
+        Integer rerankDepthGlobal = 10; // Should stay 10
+        boolean needToTrimPreviousPages = false;
+        boolean verbose = false;
+
+        // Act
+        HitGroup result =
+                hybridSearcher.postProcessResults(
+                        inputHits,
+                        query,
+                        rerankDepthGlobal,
+                        limit,
+                        offset,
+                        needToTrimPreviousPages,
+                        verbose);
+
+        // Assert
+        // When needToTrimPreviousPages=false, rerankDepthGlobal stays 10
+        // So only hits 0-9 are reranked
+        // Final result should have 10 hits starting from position 0 (ignoring offset)
+        assertThat(result.size()).isEqualTo(10);
+
+        // Should get the first 10 hits after reranking (starts from 0, ignores offset)
+        assertThat(result.get(0).getId().toString()).isEqualTo("hit_0");
+    }
+
+    @Test
+    @DisplayName(
+            "Test 3: needToTrimPreviousPages=true with null rerankDepthGlobal reranks all hits")
+    void testPostProcessResults_NeedToTrimTrue_WithNullRerankDepth() {
+        // Arrange
+        HitGroup inputHits = createTestHitGroup(15); // 15 hits
+        Query query = createTestQuery();
+
+        int limit = 10;
+        int offset = 5;
+        Integer rerankDepthGlobal = null; // Should rerank all hits regardless of offset
+        boolean needToTrimPreviousPages = true;
+        boolean verbose = false;
+
+        // Act
+        HitGroup result =
+                hybridSearcher.postProcessResults(
+                        inputHits,
+                        query,
+                        rerankDepthGlobal,
+                        limit,
+                        offset,
+                        needToTrimPreviousPages,
+                        verbose);
+
+        // Assert
+        // When rerankDepthGlobal is null, all hits are reranked regardless of
+        // needToTrimPreviousPages
+        // Final result should have 10 hits starting from offset 5
+        assertThat(result.size()).isEqualTo(10);
+
+        // Verify we get hits from positions 5-14 after reranking
+        assertThat(result.get(0).getId().toString()).isEqualTo("hit_5");
+    }
+
+    @Test
+    @DisplayName("Test 4: needToTrimPreviousPages=true uses trim(offset, limit)")
+    void testPostProcessResults_NeedToTrimTrue_TrimsWithOffset() {
+        // Arrange
+        HitGroup inputHits = createTestHitGroup(20); // 20 hits
+        Query query = createTestQuery();
+
+        int limit = 5;
+        int offset = 3;
+        Integer rerankDepthGlobal = 20; // Rerank all
+        boolean needToTrimPreviousPages = true;
+        boolean verbose = false;
+
+        // Act
+        HitGroup result =
+                hybridSearcher.postProcessResults(
+                        inputHits,
+                        query,
+                        rerankDepthGlobal,
+                        limit,
+                        offset,
+                        needToTrimPreviousPages,
+                        verbose);
+
+        // Assert
+        // Should return 5 hits starting from offset 3 (positions 3,4,5,6,7)
+        assertThat(result.size()).isEqualTo(5);
+
+        // After reranking, hits are sorted by relevance (hit_0 has highest score)
+        // So result should contain hits starting from position 3
+        assertThat(result.get(0).getId().toString()).isEqualTo("hit_3");
+        assertThat(result.get(1).getId().toString()).isEqualTo("hit_4");
+        assertThat(result.get(4).getId().toString()).isEqualTo("hit_7");
+    }
+
+    @Test
+    @DisplayName("Test 5: needToTrimPreviousPages=false uses trim(0, limit)")
+    void testPostProcessResults_NeedToTrimFalse_TrimsFromZero() {
+        // Arrange
+        HitGroup inputHits = createTestHitGroup(20); // 20 hits
+        Query query = createTestQuery();
+
+        int limit = 5;
+        int offset = 3; // Should be ignored
+        Integer rerankDepthGlobal = 20; // Rerank all
+        boolean needToTrimPreviousPages = false;
+        boolean verbose = false;
+
+        // Act
+        HitGroup result =
+                hybridSearcher.postProcessResults(
+                        inputHits,
+                        query,
+                        rerankDepthGlobal,
+                        limit,
+                        offset,
+                        needToTrimPreviousPages,
+                        verbose);
+
+        // Assert
+        // Should return 5 hits starting from position 0 (ignoring offset)
+        assertThat(result.size()).isEqualTo(5);
+
+        // After reranking, should get the top 5 hits (positions 0,1,2,3,4)
+        assertThat(result.get(0).getId().toString()).isEqualTo("hit_0");
+        assertThat(result.get(1).getId().toString()).isEqualTo("hit_1");
+        assertThat(result.get(4).getId().toString()).isEqualTo("hit_4");
+    }
+
+    @Test
+    @DisplayName("Test 6: Sufficient hits processed for pagination with offset")
+    void testPostProcessResults_PaginationBugFix_ProcessesSufficientHits() {
+        // This test verifies the fix for the pagination bug where insufficient hits
+        // were processed when needToTrimPreviousPages=true with large offset
+
+        // Arrange
+        HitGroup inputHits = createTestHitGroup(20); // 20 hits
+        Query query = createTestQuery();
+
+        int limit = 5;
+        int offset = 10; // Large offset
+        Integer rerankDepthGlobal = 8; // Small rerank depth (less than offset + limit)
+        boolean needToTrimPreviousPages = true;
+        boolean verbose = false;
+
+        // Act
+        HitGroup result =
+                hybridSearcher.postProcessResults(
+                        inputHits,
+                        query,
+                        rerankDepthGlobal,
+                        limit,
+                        offset,
+                        needToTrimPreviousPages,
+                        verbose);
+
+        // Assert
+        // Should return exactly 5 hits even with large offset
+        // Before the bug fix, this would return fewer than 5 hits because
+        // the loop was incorrectly capped at 'limit' instead of 'offset + limit'
+        assertThat(result.size()).isEqualTo(5);
+
+        // Verify we get hits from the correct range (offset 10, limit 5)
+        // After reranking with adjusted depth (8 + 10 = 18), hits should be sorted by relevance
+        assertThat(result.get(0).getId().toString()).isEqualTo("hit_10");
+        assertThat(result.get(1).getId().toString()).isEqualTo("hit_11");
+        assertThat(result.get(4).getId().toString()).isEqualTo("hit_14");
+    }
+}

--- a/vespa/src/test/java/ai/marqo/search/SortByTest.java
+++ b/vespa/src/test/java/ai/marqo/search/SortByTest.java
@@ -326,7 +326,8 @@ class SortByTest {
         verify(spy, times(1))
                 .postProcessBySort(any(HitGroup.class), anyString(), any(), anyInt(), anyInt());
         verify(spy, never())
-                .postProcessResults(any(), any(), any(), anyInt(), anyInt(), anyBoolean());
+                .postProcessResults(
+                        any(), any(), any(), anyInt(), anyInt(), anyBoolean(), anyBoolean());
     }
 
     /*
@@ -345,7 +346,8 @@ class SortByTest {
         doReturn(null).when(spy).extractTensorRankFeature(any(), contains("add_weights_global"));
         doReturn(new HitGroup())
                 .when(spy)
-                .postProcessResults(any(), any(), any(), anyInt(), anyInt(), anyBoolean());
+                .postProcessResults(
+                        any(), any(), any(), anyInt(), anyInt(), anyBoolean(), anyBoolean());
 
         Query q = new Query("?q");
         q.properties().set("hits", 1);
@@ -356,7 +358,8 @@ class SortByTest {
 
         spy.search(q, makeEmptyExec());
 
-        verify(spy, times(1)).postProcessResults(any(), eq(q), any(), eq(1), eq(0), eq(false));
+        verify(spy, times(1))
+                .postProcessResults(any(), eq(q), any(), eq(1), eq(0), eq(false), eq(false));
         verify(spy, never()).postProcessBySort(any(), anyString(), any(), anyInt(), anyInt());
     }
 
@@ -746,17 +749,31 @@ class SortByTest {
     class UpdateQueryHitsOffsetsAndTargetHitsTest {
 
         @Test
-        void shouldReturnOriginalQueryWhenNeitherFeatureEnabled() {
+        void shouldReturnOriginalQueryWhenNeitherFeatureEnabledAndNotDisjunctionSearch() {
             HybridSearcher searcher = new HybridSearcher();
             Query originalQuery = new Query("?q=test&hits=10&offset=5");
 
             Query result =
                     searcher.updateQueryHitsOffsetsAndTargetHits(
-                            originalQuery, 100, 200, false, false);
+                            originalQuery, 100, 200, false, false, false);
 
             assertThat(result).isSameAs(originalQuery);
             assertThat(result.getHits()).isEqualTo(10);
             assertThat(result.getOffset()).isEqualTo(5);
+        }
+
+        @Test
+        void shouldUpdateHitsForDisjunctionSearch() {
+            HybridSearcher searcher = new HybridSearcher();
+            Query originalQuery = new Query("?q=test&hits=10&offset=5");
+
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            originalQuery, 100, 200, false, false, true);
+
+            assertThat(result).isSameAs(originalQuery);
+            assertThat(result.getHits()).isEqualTo(15);
+            assertThat(result.getOffset()).isEqualTo(0);
         }
 
         @Test
@@ -767,7 +784,7 @@ class SortByTest {
             assertThatThrownBy(
                             () ->
                                     searcher.updateQueryHitsOffsetsAndTargetHits(
-                                            query, null, null, true, false))
+                                            query, null, null, true, false, true))
                     .isInstanceOf(RuntimeException.class)
                     .hasMessageContaining(
                             "Either relevantCandidates or sortByMinSortCandidates must be"
@@ -780,7 +797,8 @@ class SortByTest {
             Query query = new Query("?q=test&hits=10&offset=5");
 
             Query result =
-                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 20, null, true, false);
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, 20, null, true, false, true);
 
             // Should use Math.min(relevantCandidates, limit+offset) = Math.min(20, 15) = 15
             assertThat(result.getHits()).isEqualTo(15);
@@ -793,7 +811,7 @@ class SortByTest {
             Query query = new Query("?q=test&hits=10&offset=5");
 
             Query result =
-                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 8, null, true, false);
+                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 8, null, true, false, true);
 
             // Should use Math.min(relevantCandidates, limit+offset) = Math.min(8, 15) = 8
             assertThat(result.getHits()).isEqualTo(8);
@@ -806,7 +824,8 @@ class SortByTest {
             Query query = new Query("?q=test&hits=10&offset=5");
 
             Query result =
-                    searcher.updateQueryHitsOffsetsAndTargetHits(query, null, 20, false, true);
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, null, 20, false, true, true);
 
             // Should use Math.max(sortByMinSortCandidates, limit+offset) = Math.max(20, 15) = 20
             assertThat(result.getHits()).isEqualTo(20);
@@ -819,7 +838,8 @@ class SortByTest {
             Query query = new Query("?q=test&hits=10&offset=5");
 
             Query result =
-                    searcher.updateQueryHitsOffsetsAndTargetHits(query, null, 30, false, true);
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, null, 30, false, true, false);
 
             // Should use Math.max(sortByMinSortCandidates, limit+offset) = Math.max(30, 15) = 15
             assertThat(result.getHits()).isEqualTo(30);
@@ -832,7 +852,8 @@ class SortByTest {
             Query query = new Query("?q=test&hits=10&offset=5");
 
             Query result =
-                    searcher.updateQueryHitsOffsetsAndTargetHits(query, null, 8, false, true);
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, null, 8, false, true, false);
 
             // Should use Math.max(sortByMinSortCandidates, limit+offset) = Math.max(8, 15) = 15
             assertThat(result.getHits()).isEqualTo(15);
@@ -844,7 +865,8 @@ class SortByTest {
             HybridSearcher searcher = new HybridSearcher();
             Query query = new Query("?q=test&hits=10&offset=5");
 
-            Query result = searcher.updateQueryHitsOffsetsAndTargetHits(query, 30, 25, true, true);
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 30, 25, true, true, false);
 
             // Should use Math.max(relevantCandidates, sortByMinSortCandidates) = Math.max(30, 25)
             // = 30
@@ -857,7 +879,8 @@ class SortByTest {
             HybridSearcher searcher = new HybridSearcher();
             Query query = new Query("?q=test&hits=10&offset=5");
 
-            Query result = searcher.updateQueryHitsOffsetsAndTargetHits(query, 25, 30, true, true);
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 25, 30, true, true, false);
 
             // Should use Math.max(relevantCandidates, sortByMinSortCandidates) = Math.max(25, 30)
             // = 30
@@ -876,7 +899,8 @@ class SortByTest {
                                     + " hnsw.exploreAdditionalHits: 1950}");
 
             Query result =
-                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 20, null, true, false);
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, 20, null, true, false, false);
 
             // Should use Math.min(newHits, currentTensorTargetHits) = Math.min(15, 50) = 15
             String updatedYql = result.properties().getString("marqo__yql.tensor");
@@ -897,7 +921,8 @@ class SortByTest {
                                     + " hnsw.exploreAdditionalHits: 1950}");
 
             Query result =
-                    searcher.updateQueryHitsOffsetsAndTargetHits(query, null, 60, false, true);
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, null, 60, false, true, false);
 
             // Should use Math.max(newHits, currentTensorTargetHits) = Math.max(60, 50) = 60
             String updatedYql = result.properties().getString("marqo__yql.tensor");
@@ -917,7 +942,8 @@ class SortByTest {
                             "select * from sources * where {targetHits: 40,"
                                     + " hnsw.exploreAdditionalHits: 1960}");
 
-            Query result = searcher.updateQueryHitsOffsetsAndTargetHits(query, 30, 35, true, true);
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 30, 35, true, true, false);
 
             // newHits = Math.max(30, 35) = 35
             // newTensorTargetHits = Math.max(35, 40) = 40
@@ -940,7 +966,7 @@ class SortByTest {
             assertThatThrownBy(
                             () ->
                                     searcher.updateQueryHitsOffsetsAndTargetHits(
-                                            query, 20, null, true, false))
+                                            query, 20, null, true, false, false))
                     .isInstanceOf(RuntimeException.class)
                     .hasMessageContaining(
                             "The targetHits in the tensor query should not be smaller than"
@@ -955,7 +981,8 @@ class SortByTest {
             query.properties().set("marqo__yql.tensor", "");
 
             Query result =
-                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 20, null, true, false);
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, 20, null, true, false, false);
 
             assertThat(result.getHits()).isEqualTo(15);
             assertThat(result.getOffset()).isEqualTo(0);
@@ -974,7 +1001,8 @@ class SortByTest {
                                     + " hnsw.exploreAdditionalHits: 1900, param2: true}");
 
             Query result =
-                    searcher.updateQueryHitsOffsetsAndTargetHits(query, null, 150, false, true);
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, null, 150, false, true, false);
 
             String updatedYql = result.properties().getString("marqo__yql.tensor");
             assertThat(updatedYql)
@@ -996,7 +1024,8 @@ class SortByTest {
                             "select * from sources * where {targetHits: 60,"
                                     + " hnsw.exploreAdditionalHits: 1940}");
 
-            Query result = searcher.updateQueryHitsOffsetsAndTargetHits(query, 40, 45, true, true);
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 40, 45, true, true, false);
 
             // newHits = Math.max(40, 45) = 45
             // newTensorTargetHits = Math.max(45, 60) = 60 (keeps existing higher value)
@@ -1018,7 +1047,8 @@ class SortByTest {
                             "select * from sources * where {targetHits: 30,"
                                     + " hnsw.exploreAdditionalHits: 1970}");
 
-            Query result = searcher.updateQueryHitsOffsetsAndTargetHits(query, 40, 45, true, true);
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 40, 45, true, true, false);
 
             // newHits = Math.max(40, 45) = 45
             // newTensorTargetHits = Math.max(45, 30) = 45 (uses new higher value)
@@ -1035,7 +1065,8 @@ class SortByTest {
             HybridSearcher searcher = new HybridSearcher();
             Query query = new Query("?q=test&hits=5&offset=2");
 
-            Query result = searcher.updateQueryHitsOffsetsAndTargetHits(query, 40, 40, true, true);
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 40, 40, true, true, false);
 
             // Should use Math.max(40, 40) = 40
             assertThat(result.getHits()).isEqualTo(40);
@@ -1052,7 +1083,8 @@ class SortByTest {
                             "select * from sources * where {queryVector: [1,2,3], targetHits: 50,"
                                     + " hnsw.exploreAdditionalHits: 1950, threshold: 0.8}");
 
-            Query result = searcher.updateQueryHitsOffsetsAndTargetHits(query, 35, 40, true, true);
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 35, 40, true, true, false);
 
             // newHits = Math.max(35, 40) = 40
             // newTensorTargetHits = Math.max(40, 50) = 50
@@ -1069,7 +1101,8 @@ class SortByTest {
             HybridSearcher searcher = new HybridSearcher();
             Query query = new Query("?q=test&hits=1&offset=0");
 
-            Query result = searcher.updateQueryHitsOffsetsAndTargetHits(query, 1, 1, true, true);
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 1, 1, true, true, false);
 
             // Should use Math.max(1, 1) = 1
             assertThat(result.getHits()).isEqualTo(1);
@@ -1087,7 +1120,8 @@ class SortByTest {
                                     + " hnsw.exploreAdditionalHits: 1000}");
 
             Query result =
-                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 500, 750, true, true);
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, 500, 750, true, true, false);
 
             // newHits = Math.max(500, 750) = 750
             // newTensorTargetHits = Math.max(750, 1000) = 1000
@@ -1114,7 +1148,8 @@ class SortByTest {
 
             // Call with relevantCandidates = 0, which should result in hits = 0 but targetHits = 1
             Query result =
-                    searcher.updateQueryHitsOffsetsAndTargetHits(query, 0, null, true, false);
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, 0, null, true, false, false);
 
             // Verify hits is set to 0 (original relevantCandidates value)
             assertThat(result.getHits()).isEqualTo(0);
@@ -1142,12 +1177,9 @@ class SortByTest {
             // - Uses Math.max instead of Math.min for tensorTargetHits
             Query result =
                     searcher.updateQueryHitsOffsetsAndTargetHits(
-                            query,
-                            8,
-                            12,
-                            true,
-                            true // relevantCandidates < limit+offset, but with sortBy enabled
-                            );
+                            query, 8, 12, true,
+                            true, // relevantCandidates < limit+offset, but with sortBy enabled
+                            true);
 
             // Should use Math.max(8, 12) = 12 (not Math.min like pure relevance cutoff)
             assertThat(result.getHits()).isEqualTo(12);


### PR DESCRIPTION
## Change Summary
Merge changes on relaeses/2.24 branch to mainline

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves hybrid search pagination and Vespa timeouts, escapes special chars in typeahead queries, adds a fixed-INFO metrics logger, and bumps version.
> 
> - **Hybrid Search (Vespa custom searcher)**:
>   - Adjust pagination for disjunction and relevance-cutoff: reset offsets, expand rerank depth, and trim previous pages correctly.
>   - Update `updateQueryHitsOffsetsAndTargetHits(...)` and `postProcessResults(...)`; add comprehensive unit tests.
> - **Vespa Client**:
>   - Set query `timeout` in ms and configure httpx timeouts to exceed Vespa timeout (min 5s) to avoid early read timeouts.
>   - Extend tests for timeout behavior and concurrency defaults.
> - **Typeahead**:
>   - Escape special characters in tokens for YQL (quotes, backslashes) to prevent 500s; integrate into retrieval/ranking terms.
>   - Add unit/integration tests for special-character inputs and query retrieval.
> - **Logging**:
>   - Add `metrics` logger at INFO level; keep access level tied to root; update tests.
> - **Indexes**:
>   - Use numeric timeout (ms) in vector-count queries for structured/unstructured indexes.
> - **Tests & Misc**:
>   - Add RRF pagination scenarios and relevance-cutoff pagination/sorting tests; minor test adjustments in index bootstrap.
> - **Version**: bump to `2.24.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb980b48908d670e4903cc0d98c33e6f3343a322. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->