### PR TITLE
typecast status_code as int before emitting to statsd

### DIFF
--- a/src/marqo/core/monitoring/statsd_middleware.py
+++ b/src/marqo/core/monitoring/statsd_middleware.py
@@ -40,7 +40,7 @@ class StatsDMiddleware(BaseHTTPMiddleware):
         tags = {
             "path": path_tag,
             "method": request.method,
-            "status_code": str(response.status_code),
+            "status_code": str(int(response.status_code)),
         }
 
         # latency

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.24.3"
+__version__ = "2.24.4"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/tests/unit_tests/marqo/core/monitoring/test_statsd_middleware.py
+++ b/tests/unit_tests/marqo/core/monitoring/test_statsd_middleware.py
@@ -215,6 +215,7 @@ class TestStatsDMiddleware(unittest.TestCase):
                 @app.get("/test")
                 async def test_endpoint():
                     # Create a response with IntEnum status_code
+                    response = JSONResponse({"message": "test"})
                     response.status_code = return_enum
                     return response
 

--- a/tests/unit_tests/marqo/core/monitoring/test_statsd_middleware.py
+++ b/tests/unit_tests/marqo/core/monitoring/test_statsd_middleware.py
@@ -221,16 +221,14 @@ class TestStatsDMiddleware(unittest.TestCase):
 
                 with TestClient(app) as client:
                     client.get("/test")
-                    with TestClient(app) as client:
-                        client.get("/test")
 
-                        timings = _extract(stub, "timing", "request.duration_ms")
-                        self.assertTrue(any(f"status_code:{expected_str}" in m for m in timings),
-                                       f"Expected 'status_code:{expected_str}' in metrics, got: {timings}")
-                        # Ensure it doesn't contain enum representation
-                        for timing in timings:
-                            if "status_code:" in timing:
-                                status_part = [part for part in timing.split("|#")[1].split(",") if "status_code:" in part][0]
-                                status_value = status_part.split(":")[1]
-                                self.assertEqual(status_value, expected_str,
-                                               f"Status code should be '{expected_str}', got '{status_value}'")
+                    timings = _extract(stub, "timing", "request.duration_ms")
+                    self.assertTrue(any(f"status_code:{expected_str}" in m for m in timings),
+                                   f"Expected 'status_code:{expected_str}' in metrics, got: {timings}")
+                    # Ensure it doesn't contain enum representation
+                    for timing in timings:
+                        if "status_code:" in timing:
+                            status_part = [part for part in timing.split("|#")[1].split(",") if "status_code:" in part][0]
+                            status_value = status_part.split(":")[1]
+                            self.assertEqual(status_value, expected_str,
+                                           f"Status code should be '{expected_str}', got '{status_value}'")

--- a/tests/unit_tests/marqo/core/monitoring/test_statsd_middleware.py
+++ b/tests/unit_tests/marqo/core/monitoring/test_statsd_middleware.py
@@ -203,7 +203,7 @@ class TestStatsDMiddleware(unittest.TestCase):
         # Create a new stub and middleware for this test
         test_cass = [
             (HTTPStatus.OK, "200"),
-            (HTTPStatus.NOT_FOUND, "404"),
+            (HTTPStatus.BAD_REQUEST, "400"),
             (HTTPStatus.INTERNAL_SERVER_ERROR, "500")
         ]
         for return_enum, expected_str in test_cass:
@@ -222,7 +222,7 @@ class TestStatsDMiddleware(unittest.TestCase):
                 with TestClient(app) as client:
                     client.get("/test")
                     with TestClient(app) as client:
-                        client.get("/test", params={"return_enum": return_enum.value})
+                        client.get("/test")
 
                         timings = _extract(stub, "timing", "request.duration_ms")
                         self.assertTrue(any(f"status_code:{expected_str}" in m for m in timings),

--- a/tests/unit_tests/marqo/core/monitoring/test_statsd_middleware.py
+++ b/tests/unit_tests/marqo/core/monitoring/test_statsd_middleware.py
@@ -215,7 +215,6 @@ class TestStatsDMiddleware(unittest.TestCase):
                 @app.get("/test")
                 async def test_endpoint():
                     # Create a response with IntEnum status_code
-                    response = JSONResponse({"ok": True})
                     response.status_code = return_enum
                     return response
 

--- a/tests/unit_tests/marqo/core/monitoring/test_statsd_middleware.py
+++ b/tests/unit_tests/marqo/core/monitoring/test_statsd_middleware.py
@@ -194,3 +194,16 @@ class TestStatsDMiddleware(unittest.TestCase):
             sanitize("/indexes/foo/documents/get-batch"),
             "/indexes/foo/documents/get-batch",
         )
+
+    def test_status_code_tag_is_string_integer(self):
+        """Ensure status_code tag is always a stringified integer, not float."""
+        resp = self.client.post("/indexes/foo/search")
+        self.assertEqual(resp.status_code, 200)
+
+        # Extract all timing metrics
+        timings = _extract(self.stub, "timing", "request.duration_ms")
+
+        # Verify status_code tag is present and is a string integer (not "200.0")
+        self.assertTrue(any("status_code:200" in m for m in timings))
+        # Ensure it's not accidentally stringified as a float
+        self.assertFalse(any("status_code:200.0" in m for m in timings))

--- a/tests/unit_tests/marqo/core/monitoring/test_statsd_middleware.py
+++ b/tests/unit_tests/marqo/core/monitoring/test_statsd_middleware.py
@@ -1,9 +1,10 @@
-from typing import Dict, List, Optional, Tuple
-import unittest
+from http import HTTPStatus
 
+import unittest
 from fastapi import FastAPI, HTTPException
 from starlette.responses import JSONResponse
 from starlette.testclient import TestClient
+from typing import Dict, List, Optional, Tuple
 
 from marqo.core.monitoring import statsd_middleware as sm
 
@@ -196,14 +197,36 @@ class TestStatsDMiddleware(unittest.TestCase):
         )
 
     def test_status_code_tag_is_string_integer(self):
-        """Ensure status_code tag is always a stringified integer, not float."""
-        resp = self.client.post("/indexes/foo/search")
-        self.assertEqual(resp.status_code, 200)
+        """Ensure status_code tag is always a plain integer string, not an Enum representation."""
+        # Create a mock response with an IntEnum-like status_code
+        # This simulates cases where status_code could be an IntEnum subclass
+        # Create a new stub and middleware for this test
+        stub = _StubStatsD()
+        app = FastAPI()
+        app.add_middleware(sm.StatsDMiddleware, statsd_client=stub)
+    
+        @app.get("/test")
+        async def test_endpoint():
+            # Create a response with IntEnum status_code
+            response = JSONResponse({"ok": True})
+            response.status_code = HTTPStatus.OK  # This is an IntEnum, not a plain int
+            return response
 
-        # Extract all timing metrics
-        timings = _extract(self.stub, "timing", "request.duration_ms")
+        with TestClient(app) as client:
+            client.get("/test")
 
-        # Verify status_code tag is present and is a string integer (not "200.0")
-        self.assertTrue(any("status_code:200" in m for m in timings))
-        # Ensure it's not accidentally stringified as a float
-        self.assertFalse(any("status_code:200.0" in m for m in timings))
+        # Extract timing metrics
+        timings = _extract(stub, "timing", "request.duration_ms")
+
+        # Verify status_code tag is "200" (plain integer string), not "HTTPStatus.OK" or similar
+        self.assertTrue(any("status_code:200" in m for m in timings),
+                       f"Expected 'status_code:200' in metrics, got: {timings}")
+        # Ensure it doesn't contain enum representation
+        for timing in timings:
+            if "status_code:" in timing:
+                # Extract the status_code value
+                status_part = [part for part in timing.split("|#")[1].split(",") if "status_code:" in part][0]
+                status_value = status_part.split(":")[1]
+                # Should be exactly "200", not contain any enum representation
+                self.assertEqual(status_value, "200",
+                               f"Status code should be '200', got '{status_value}'")

--- a/tests/unit_tests/marqo/core/monitoring/test_statsd_middleware.py
+++ b/tests/unit_tests/marqo/core/monitoring/test_statsd_middleware.py
@@ -201,32 +201,36 @@ class TestStatsDMiddleware(unittest.TestCase):
         # Create a mock response with an IntEnum-like status_code
         # This simulates cases where status_code could be an IntEnum subclass
         # Create a new stub and middleware for this test
-        stub = _StubStatsD()
-        app = FastAPI()
-        app.add_middleware(sm.StatsDMiddleware, statsd_client=stub)
-    
-        @app.get("/test")
-        async def test_endpoint():
-            # Create a response with IntEnum status_code
-            response = JSONResponse({"ok": True})
-            response.status_code = HTTPStatus.OK  # This is an IntEnum, not a plain int
-            return response
+        test_cass = [
+            (HTTPStatus.OK, "200"),
+            (HTTPStatus.NOT_FOUND, "404"),
+            (HTTPStatus.INTERNAL_SERVER_ERROR, "500")
+        ]
+        for return_enum, expected_str in test_cass:
+            with self.subTest(msg=f"status_code tag for {return_enum}"):
+                stub = _StubStatsD()
+                app = FastAPI()
+                app.add_middleware(sm.StatsDMiddleware, statsd_client=stub)
 
-        with TestClient(app) as client:
-            client.get("/test")
+                @app.get("/test")
+                async def test_endpoint():
+                    # Create a response with IntEnum status_code
+                    response = JSONResponse({"ok": True})
+                    response.status_code = return_enum
+                    return response
 
-        # Extract timing metrics
-        timings = _extract(stub, "timing", "request.duration_ms")
+                with TestClient(app) as client:
+                    client.get("/test")
+                    with TestClient(app) as client:
+                        client.get("/test", params={"return_enum": return_enum.value})
 
-        # Verify status_code tag is "200" (plain integer string), not "HTTPStatus.OK" or similar
-        self.assertTrue(any("status_code:200" in m for m in timings),
-                       f"Expected 'status_code:200' in metrics, got: {timings}")
-        # Ensure it doesn't contain enum representation
-        for timing in timings:
-            if "status_code:" in timing:
-                # Extract the status_code value
-                status_part = [part for part in timing.split("|#")[1].split(",") if "status_code:" in part][0]
-                status_value = status_part.split(":")[1]
-                # Should be exactly "200", not contain any enum representation
-                self.assertEqual(status_value, "200",
-                               f"Status code should be '200', got '{status_value}'")
+                        timings = _extract(stub, "timing", "request.duration_ms")
+                        self.assertTrue(any(f"status_code:{expected_str}" in m for m in timings),
+                                       f"Expected 'status_code:{expected_str}' in metrics, got: {timings}")
+                        # Ensure it doesn't contain enum representation
+                        for timing in timings:
+                            if "status_code:" in timing:
+                                status_part = [part for part in timing.split("|#")[1].split(",") if "status_code:" in part][0]
+                                status_value = status_part.split(":")[1]
+                                self.assertEqual(status_value, expected_str,
+                                               f"Status code should be '{expected_str}', got '{status_value}'")


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->
Type cast status code to int before emitting to statsd as statsd was emmitting `HTTPStatus.*` enum instead of integer status code otherwise.

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Cast response status_code to int before tagging metrics; add unit test to verify plain integer string; bump version to 2.24.4.
> 
> - **Monitoring**:
>   - Ensure `status_code` tag is a plain integer string by casting with `str(int(response.status_code))` in `src/marqo/core/monitoring/statsd_middleware.py`.
> - **Tests**:
>   - Add `test_status_code_tag_is_string_integer` verifying enum `HTTPStatus` values produce integer `status_code` tags in `tests/unit_tests/marqo/core/monitoring/test_statsd_middleware.py`.
> - **Version**:
>   - Bump `__version__` to `2.24.4` in `src/marqo/version.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e2232f08e9e1c5de27021b3d1f9048bee34703b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->