### PR TITLE
Vitus/configurable-marqo-host

### DIFF
--- a/run_marqo.sh
+++ b/run_marqo.sh
@@ -152,11 +152,15 @@ fi
 export MARQO_LOG_LEVEL=${MARQO_LOG_LEVEL:-info}
 MARQO_LOG_LEVEL=`echo "$MARQO_LOG_LEVEL" | tr '[:upper:]' '[:lower:]'`
 
+
+# set the default host to 0.0.0.0
+export MARQO_HOST=${MARQO_HOST:-"0.0.0.0"}
+
 case "$MARQO_MODE" in
   COMBINED)
     # Start the combined Marqo API and Inference in the background
     cd /app/src/marqo/tensor_search || { echo "Failed to navigate to tensor_search directory"; exit 1; }
-    uvicorn api:app --host 0.0.0.0 --port 8882 --timeout-keep-alive 75 --log-level "$MARQO_LOG_LEVEL" &
+    uvicorn api:app --host $MARQO_HOST --port 8882 --timeout-keep-alive 75 --log-level "$MARQO_LOG_LEVEL" &
     ;;
   API)
     # set default number of workers to 1
@@ -166,12 +170,12 @@ case "$MARQO_MODE" in
 
     # Start the Marqo API in the background
     cd /app/src/marqo/tensor_search || { echo "Failed to navigate to tensor_search directory"; exit 1; }
-    uvicorn api:app --host 0.0.0.0 --port 8882 --workers $MARQO_API_WORKERS --timeout-keep-alive 75 --log-level "$MARQO_LOG_LEVEL" &
+    uvicorn api:app --host $MARQO_HOST --port 8882 --workers $MARQO_API_WORKERS --timeout-keep-alive 75 --log-level "$MARQO_LOG_LEVEL" &
     ;;
   INFERENCE)
     # Start the native Inference server app in the background
     cd /app/src/marqo/inference/native_inference/remote/server || { echo "Failed to navigate to inference server directory"; exit 1; }
-    uvicorn inference_api:app --host 0.0.0.0 --port 8881 --timeout-keep-alive 75 --log-level "$MARQO_LOG_LEVEL" &
+    uvicorn inference_api:app --host $MARQO_HOST --port 8881 --timeout-keep-alive 75 --log-level "$MARQO_LOG_LEVEL" &
     ;;
   *)
     echo "Invalid MARQO_MODE: $MARQO_MODE. Supported modes are 'COMBINED', 'API' and 'INFERENCE'"

--- a/run_marqo.sh
+++ b/run_marqo.sh
@@ -160,7 +160,7 @@ case "$MARQO_MODE" in
   COMBINED)
     # Start the combined Marqo API and Inference in the background
     cd /app/src/marqo/tensor_search || { echo "Failed to navigate to tensor_search directory"; exit 1; }
-    uvicorn api:app --host $MARQO_HOST --port 8882 --timeout-keep-alive 75 --log-level "$MARQO_LOG_LEVEL" &
+    uvicorn api:app --host "$MARQO_HOST" --port 8882 --timeout-keep-alive 75 --log-level "$MARQO_LOG_LEVEL" &
     ;;
   API)
     # set default number of workers to 1
@@ -170,12 +170,12 @@ case "$MARQO_MODE" in
 
     # Start the Marqo API in the background
     cd /app/src/marqo/tensor_search || { echo "Failed to navigate to tensor_search directory"; exit 1; }
-    uvicorn api:app --host $MARQO_HOST --port 8882 --workers $MARQO_API_WORKERS --timeout-keep-alive 75 --log-level "$MARQO_LOG_LEVEL" &
+    uvicorn api:app --host "$MARQO_HOST" --port 8882 --workers $MARQO_API_WORKERS --timeout-keep-alive 75 --log-level "$MARQO_LOG_LEVEL" &
     ;;
   INFERENCE)
     # Start the native Inference server app in the background
     cd /app/src/marqo/inference/native_inference/remote/server || { echo "Failed to navigate to inference server directory"; exit 1; }
-    uvicorn inference_api:app --host $MARQO_HOST --port 8881 --timeout-keep-alive 75 --log-level "$MARQO_LOG_LEVEL" &
+    uvicorn inference_api:app --host "$MARQO_HOST" --port 8881 --timeout-keep-alive 75 --log-level "$MARQO_LOG_LEVEL" &
     ;;
   *)
     echo "Invalid MARQO_MODE: $MARQO_MODE. Supported modes are 'COMBINED', 'API' and 'INFERENCE'"


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds MARQO_HOST env var (default 0.0.0.0) and uses it for all Uvicorn startups across modes.
> 
> - **Scripts**:
>   - **`run_marqo.sh`**:
>     - Introduces `MARQO_HOST` env var (default `"0.0.0.0"`).
>     - Replaces hardcoded `--host 0.0.0.0` with `--host "$MARQO_HOST"` for Uvicorn in `COMBINED`, `API`, and `INFERENCE` modes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d09a8b153c2c9d7d4cc4e34d9e7b41cb9eaefa69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->