### PR TITLE
Ensure totalHits does not exceed MARQO_MAX_RETRIEVABLE_DOCS

### DIFF
--- a/components/marqo/src/marqo/core/search/hybrid_search.py
+++ b/components/marqo/src/marqo/core/search/hybrid_search.py
@@ -29,6 +29,8 @@ from marqo.tensor_search.tensor_search import run_vectorise_pipeline, gather_doc
 from marqo.vespa.exceptions import VespaStatusError
 from marqo.tensor_search.models.sort_by_model import SortByModel
 from marqo.tensor_search.models.relevance_cutoff_model import RelevanceCutoffModel
+from marqo.tensor_search.utils import read_env_vars_and_defaults_ints
+from marqo.tensor_search.enums import EnvVars
 
 
 class HybridSearch:
@@ -342,6 +344,8 @@ class HybridSearch:
             if track_total_hits is not None and "totalHits" not in gathered_results:
                 gathered_results["totalHits"] = 0
 
+        gathered_results = self._max_value_check_for_total_hits(gathered_results)
+
         total_postprocess_time = RequestMetricsStore.for_request().stop("search.hybrid.postprocess")
         logger.debug(
             f"search (hybrid) post-processing: took {(total_postprocess_time):.3f}ms to sort and format "
@@ -368,4 +372,14 @@ class HybridSearch:
             gathered_results["_relevantCandidates"] = responses.root.fields.marqo_fields.relevant_candidates
             gathered_results["_probeCandidates"] = responses.root.fields.marqo_fields.probe_candidates
 
+        return gathered_results
+
+    def _max_value_check_for_total_hits(self, gathered_results: Dict) -> Dict:
+        """
+        Ensure the total hits does not exceed maximum retrievable value.
+        """
+        if "totalHits" in gathered_results and isinstance(gathered_results["totalHits"], int):
+            gathered_results["totalHits"] = (
+                min(gathered_results["totalHits"], read_env_vars_and_defaults_ints(EnvVars.MARQO_MAX_RETRIEVABLE_DOCS))
+            )
         return gathered_results

--- a/components/marqo/tests/integ_tests/marqo_test.py
+++ b/components/marqo/tests/integ_tests/marqo_test.py
@@ -1,3 +1,5 @@
+import os
+
 import contextlib
 import socket
 import threading
@@ -106,10 +108,11 @@ class MarqoTestCase(unittest.TestCase):
         cls.zookeeper_client = zookeeper_client
         cls.index_management = IndexManagement(cls.vespa_client, cls.zookeeper_client, enable_index_operations=True,
                                                deployment_lock_timeout_seconds=2)
+        remote_inference_url=os.environ.get("MARQO_REMOTE_INFERENCE_URL", "http://localhost:8884")
         cls.monitoring = Monitoring(cls.vespa_client, cls.index_management)
         cls.config = config.Config(vespa_client=vespa_client,
-                                   inference=InferenceClient(base_url="http://localhost:8884"),
-                                   model_manager=ModelManagerClient(base_url="http://localhost:8884"),
+                                   inference=InferenceClient(base_url=remote_inference_url),
+                                   model_manager=ModelManagerClient(base_url=remote_inference_url),
                                    zookeeper_client=cls.zookeeper_client)
 
         cls.pyvespa_client = pyvespa.Vespa(url="http://localhost", port=8080)

--- a/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_hybrid_search.py
+++ b/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_hybrid_search.py
@@ -2968,3 +2968,37 @@ class TestHybridSearch(MarqoTestCase):
                 )
 
                 self.assertEqual(res["hits"], [])
+
+
+    def test_track_total_hits_is_capped_by_MARQO_MAX_RETRIEVABLE_DOCS(self):
+        for index in [self.semi_structured_default_image_index, self.semi_structured_text_index_2_14]:
+            with self.subTest(index_name=index.name):
+                with mock.patch.dict(os.environ, {"MARQO_MAX_RETRIEVABLE_DOCS": "50"}):
+                    # Add 100 documents
+                    docs = [{
+                        "_id": f"doc_{i}",
+                        "text_field_1": f"sample text {i}"
+                    } for i in range(100)]
+
+                    tensor_fields = ["text_field_1"] if isinstance(index, UnstructuredMarqoIndex) else None
+
+                    self.add_documents(
+                        config=self.config, add_docs_params=AddDocsParams(
+                            index_name=index.name, docs=docs, tensor_fields=tensor_fields
+                        )
+                    )
+
+                    res = tensor_search.search(
+                        config=self.config, index_name=index.name, text="sample text",
+                        search_method="HYBRID",
+                        hybrid_parameters=HybridParameters(
+                            retrievalMethod=RetrievalMethod.Lexical,
+                            rankingMethod=RankingMethod.Tensor
+                        ),
+                        track_total_hits=True,
+                        result_count=10
+                    )
+                    self.assertEqual(
+                        50, res["totalHits"],
+                        "total_hits should be capped at MARQO_MAX_RETRIEVABLE_DOCS"
+                    )

--- a/components/marqo/tests/unit_tests/marqo/core/search/test_hybrid_search.py
+++ b/components/marqo/tests/unit_tests/marqo/core/search/test_hybrid_search.py
@@ -1,3 +1,4 @@
+import os
 from unittest import TestCase
 from unittest.mock import Mock, patch
 from pydantic.v1 import ValidationError
@@ -17,6 +18,8 @@ from marqo.core.semi_structured_vespa_index.semi_structured_vespa_index import S
 from marqo.tensor_search.models.api_models import ScoreModifierLists, CustomVectorQuery
 from marqo.tensor_search.models.search import SearchContext, SearchContextDocuments, SearchContextTensor
 from marqo.config import Config
+from marqo.tensor_search.utils import read_env_vars_and_defaults_ints
+from marqo.tensor_search.enums import EnvVars
 
 
 class TestHybridSearch(TestCase):
@@ -333,4 +336,77 @@ class TestHybridSearch(TestCase):
         self.assertEqual(context.tensor[0].vector, [0.1, 0.2, 0.3])  # Original tensor
         self.assertEqual(context.tensor[0].weight, 0.5)
         self.assertEqual(context.tensor[1].vector, [0.5, 0.6, 0.7])  # Appended tensor
-        self.assertEqual(context.tensor[1].weight, 1) 
+        self.assertEqual(context.tensor[1].weight, 1)
+
+    @patch('marqo.core.search.hybrid_search.vespa_index_factory')
+    @patch('marqo.core.search.hybrid_search.run_vectorise_pipeline')
+    @patch('marqo.core.search.hybrid_search.utils.parse_lexical_query')
+    @patch('marqo.core.search.hybrid_search.gather_documents_from_response')
+    @patch('marqo.core.search.hybrid_search.RequestMetricsStore')
+    def test_search_custom_vector_query_with_capped_total_hits(
+            self, mock_metrics, mock_gather_docs, mock_parse_lexical,
+            mock_vectorise, mock_vespa_factory
+    ):
+        """Test CustomVectorQuery handling when context.tensor already exists (append scenario)."""
+
+        # Setup mocks
+        config = Mock(spec=Config)
+        config.vespa_client = Mock()
+        mock_response = Mock()
+        mock_response.root.coverage.coverage = 100
+        mock_response.root.coverage.degraded = None
+        config.vespa_client.query.return_value = mock_response
+
+        # Mock marqo_index
+        marqo_index = Mock(spec=SemiStructuredMarqoIndex)
+        marqo_index.name = "test_index"
+        marqo_index.parsed_marqo_version.return_value = semver.VersionInfo.parse("2.21.0")
+        marqo_index.model = Mock()
+        marqo_index.model.get_text_query_prefix.return_value = ""
+
+        # Mock vespa_index
+        mock_vespa_index = Mock(spec=SemiStructuredVespaIndex)
+        mock_vespa_query = {"query": "test"}
+        mock_vespa_index.to_vespa_query.return_value = mock_vespa_query
+        mock_vespa_factory.return_value = mock_vespa_index
+
+        # Mock vectorisation pipeline
+        mock_vectorise.return_value = {0: [0.1, 0.2, 0.3]}
+
+        # Mock lexical query parsing
+        mock_parse_lexical.return_value = (["required"], ["optional"])
+
+        # Mock metrics store
+        mock_metrics_instance = Mock()
+        mock_metrics.for_request.return_value = mock_metrics_instance
+        mock_metrics_instance.start.return_value = None
+        mock_metrics_instance.stop.return_value = 100.0
+        mock_context_manager = Mock()
+        mock_context_manager.__enter__ = Mock(return_value=None)
+        mock_context_manager.__exit__ = Mock(return_value=None)
+        mock_metrics_instance.time.return_value = mock_context_manager
+
+        # Mock gather_documents_from_response
+        mock_gather_docs.return_value = {
+            "hits": [{"_id": "1", "doc": {"field": "value"}}]
+        }
+        mock_vespa_index.gather_facets_from_response.return_value = {"totalHits": 20_000}
+
+        # Execute the search
+        hybrid_search = HybridSearch()
+        result = hybrid_search.search(
+            config=config,
+            marqo_index=marqo_index,
+            query="test",
+            track_total_hits=True,
+            hybrid_parameters=HybridParameters()
+        )
+
+        # Verify the search executed successfully
+        self.assertIsNotNone(result)
+        capped_total_hits = read_env_vars_and_defaults_ints(EnvVars.MARQO_MAX_RETRIEVABLE_DOCS)
+        self.assertEqual(
+            capped_total_hits, result["totalHits"],
+            f"The total hits should be capped to the env var value {capped_total_hits}, "
+            f"but got {result['totalHits']}"
+        )


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->
This pull request introduces logic to cap the `totalHits` value returned by hybrid search results to the environment variable MARQO_MAX_RETRIEVABLE_DOCS, and prevents excessive result counts. It also adds new tests to verify this behavior and updates environment variable usage in integration tests.

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Caps hybrid search totalHits to MARQO_MAX_RETRIEVABLE_DOCS and adds tests; also makes inference URLs configurable in integration tests.
> 
> - **Hybrid Search (backend)**
>   - Cap `totalHits` via `_max_value_check_for_total_hits()` using `EnvVars.MARQO_MAX_RETRIEVABLE_DOCS` and `read_env_vars_and_defaults_ints`.
>   - Apply cap after aggregating results/facets in `HybridSearch.search()`.
> - **Tests**
>   - Add unit test to verify `totalHits` is capped when tracking total hits.
>   - Add integration test that inserts many docs and asserts `totalHits` respects `MARQO_MAX_RETRIEVABLE_DOCS`.
>   - Make inference/model manager base URLs configurable via `MARQO_REMOTE_INFERENCE_URL` in integration test setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7c70962dbce4ede0e221020354aac34bece8104. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->