### PR TITLE
Fix the build and push workflow for AMI ECR

### DIFF
--- a/.github/workflows/build_push_img.yml
+++ b/.github/workflows/build_push_img.yml
@@ -124,7 +124,7 @@ jobs:
         uses: docker/login-action@v2
         if: env.PUSH_TO == 'AMI-ECR'
         with:
-          registry: public.ecr.aws/marqoai
+          registry: 975050213659.dkr.ecr.us-east-1.amazonaws.com
           username: ${{ secrets.AMI_ECR_PUSHER_AWS_ACCESS_KEY_ID }}
           password: ${{ secrets.AMI_ECR_PUSHER_AWS_SECRET_ACCESS_KEY }}
 

--- a/.github/workflows/build_push_img.yml
+++ b/.github/workflows/build_push_img.yml
@@ -18,7 +18,7 @@ on:
         type: string
         default: OS-ECR
       image_namespace:
-        description: 'The namespace of the repo, by default "marqoai-dev". We will push 3 images: {prefix}/api, {prefix}/inference-orchestrator, {prefix}/model-management'
+        description: 'The namespace of the repo, by default "marqoai-dev". We will push 3 images: {ECR}/{name_space}/api, {ECR}/{name_space}/inference-orchestrator, {ECR}/{name_space}/model-management'
         required: true
         type: string
         default: 'marqoai-dev'


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->
Fix the build and push workflow for AMI ECR. The wrong registry was provided.

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects the AMI ECR registry and clarifies image namespace paths in the Docker build/push workflow.
> 
> - **GitHub Actions (`.github/workflows/build_push_img.yml`)**:
>   - **Registry Fix**: Update AMI-ECR login `registry` to `975050213659.dkr.ecr.us-east-1.amazonaws.com` and align registry selection in `prepare` step.
>   - **Input Description**: Clarify `image_namespace` description to show full image paths as `{ECR}/{name_space}/api|inference-orchestrator|model-management`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6f926e7dc0a70f44a279780e0f503ba0fef3198. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->