### PR TITLE
Add approval rules when pushing images to prod ECRs

### DIFF
--- a/.github/workflows/build_push_img.yml
+++ b/.github/workflows/build_push_img.yml
@@ -90,6 +90,8 @@ jobs:
       api_image_identifier: ${{ steps.set-image-identifier-in-output.outputs.api_image_identifier }}
       inference_orchestrator_image_identifier: ${{ steps.set-image-identifier-in-output.outputs.inference_orchestrator_image_identifier }}
       model_management_image_identifier: ${{ steps.set-image-identifier-in-output.outputs.model_management_image_identifier}}
+    environment:
+      name: ${{ (inputs.image_namespace || github.event.inputs.image_namespace) == 'marqoai' && 'production' || 'non-prod' }}
 
     steps:
       - name: Set input variables
@@ -139,7 +141,6 @@ jobs:
             echo "Error: Unknown PUSH_TO value '${{ env.PUSH_TO }}'. Must be 'OS-ECR' or 'AMI-ECR'." >&2
             exit 1
           fi
-
 
       - name: Build and push api image
         id: build-and-push-api


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->
A reviewer is required when pushing images to the ECR registry with the namespace `marqoai`.

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Conditionally assigns the Docker build job to `production` when `image_namespace` is `marqoai`, otherwise to `non-prod`.
> 
> - **CI/CD (GitHub Actions)**:
>   - Set `jobs.Docker-Build.environment.name` dynamically: `production` when `image_namespace` is `marqoai`, else `non-prod`.
>   - Affects image pushes for `api`, `inference-orchestrator`, and `model-management` by associating runs with the appropriate environment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 816e2c0f9541363607805c17fc6df5bddc74483a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->