### PR TITLE
update schema

### DIFF
--- a/.github/workflows/integration_tests_CI.yml
+++ b/.github/workflows/integration_tests_CI.yml
@@ -70,7 +70,7 @@ jobs:
             echo "Now using multi-node Vespa setup. Shards are $NUMBER_OF_SHARDS_INT and replicas are $NUMBER_OF_REPLICAS_INT."
             echo "VESPA_MULTINODE_SETUP=true" >> $GITHUB_OUTPUT
             # If multinode vespa, ignore unrelated tests to save time and prevent errors
-            echo "MULTINODE_TEST_ARGS=--multinode --ignore=tests/integ_tests/core/index_management/test_index_management.py --ignore=tests/integ_tests/core/inference --ignore=tests/integ_tests/processing --ignore=tests/integ_tests/s2_inference" >> $GITHUB_OUTPUT
+            echo "MULTINODE_TEST_ARGS=--multinode --ignore=tests/integ_tests/core/index_management/test_index_management.py --ignore=tests/integ_tests/core/index_management/test_index_management_schema_update.py --ignore=tests/integ_tests/core/inference --ignore=tests/integ_tests/processing --ignore=tests/integ_tests/s2_inference" >> $GITHUB_OUTPUT
           fi
 
   Test-Marqo:

--- a/src/marqo/core/constants.py
+++ b/src/marqo/core/constants.py
@@ -30,6 +30,7 @@ MARQO_STEMMING_MINIMUM_VERSION = semver.VersionInfo.parse('2.16.0')
 MARQO_PARTIAL_UPDATE_MINIMUM_VERSION = semver.VersionInfo.parse('2.16.0')
 MARQO_COLLAPSE_FIELDS_MINIMUM_VERSION = semver.VersionInfo.parse('2.23.0')
 MARQO_TYPEAHEAD_SCHEMA_MINIMUM_VERSION = semver.VersionInfo.parse('2.23.0')
+MARQO_UPDATE_SCHEMA_MINIMUM_VERSION = semver.VersionInfo.parse('2.23.0')
 
 # For score modifiers
 QUERY_INPUT_SCORE_MODIFIERS_MULT_WEIGHTS_2_9 = 'marqo__mult_weights'

--- a/src/marqo/core/index_management/index_management.py
+++ b/src/marqo/core/index_management/index_management.py
@@ -11,7 +11,7 @@ from marqo.core import constants
 from marqo.core.distributed_lock.zookeeper_distributed_lock import get_deployment_lock
 from marqo.core.exceptions import IndexNotFoundError, ApplicationNotInitializedError
 from marqo.core.exceptions import OperationConflictError
-from marqo.core.exceptions import ZookeeperLockNotAcquiredError, InternalError
+from marqo.core.exceptions import ZookeeperLockNotAcquiredError, InternalError, UnsupportedFeatureError
 from marqo.core.index_management.vespa_application_package import VespaApplicationPackage, VespaApplicationFileStore, \
     ApplicationPackageDeploymentSessionStore
 from marqo.core.models import MarqoIndex
@@ -283,6 +283,7 @@ class IndexManagement:
         Raises:
             IndexNotFoundError: If index doesn't exist
             InternalError: If index type doesn't support schema updates
+            UnsupportedFeatureError: If index was created with Marqo < 2.23.0
             OperationConflictError: If deployment lock cannot be acquired
         """
         with self._vespa_deployment_lock():
@@ -294,6 +295,15 @@ class IndexManagement:
                 raise InternalError(
                     f'Index {index_name} is type {existing_index.type}, '
                     f'only semi-structured indexes support schema updates'
+                )
+
+            # Check minimum version requirement
+            if existing_index.parsed_marqo_version() < constants.MARQO_UPDATE_SCHEMA_MINIMUM_VERSION:
+                raise UnsupportedFeatureError(
+                    f"Schema update is only supported for indexes created with Marqo "
+                    f"{str(constants.MARQO_UPDATE_SCHEMA_MINIMUM_VERSION)} or later. "
+                    f"This index was created with Marqo {existing_index.marqo_version}. "
+                    f"Please recreate the index with a newer version of Marqo to use this feature."
                 )
 
             # Generate new schema from current settings using latest template

--- a/src/marqo/core/index_management/index_management.py
+++ b/src/marqo/core/index_management/index_management.py
@@ -255,7 +255,7 @@ class IndexManagement:
             logger.debug(f'Updating index {marqo_index.name} with schema:\n{schema}')
             self._get_vespa_application().update_index_setting_and_schema(marqo_index, schema)
 
-    def update_index_main_schema(self, index_name: str, force: bool = False, dry_run: bool = False) -> Dict[str, any]:
+    def apply_latest_schema_template(self, index_name: str, force: bool = False, dry_run: bool = False) -> Dict[str, any]:
         """
         Update an index's main schema to the latest template version.
 

--- a/src/marqo/core/index_management/index_management.py
+++ b/src/marqo/core/index_management/index_management.py
@@ -285,7 +285,6 @@ class IndexManagement:
                 "schema_diff": str,           # Unified diff between old and new
                 "reason": str,                # Explanation of the result
                 "config_change_actions": {}   # Vespa configChangeActions if any
-                "warning": str                # Optional, only if forced with actions
             }
 
         Raises:
@@ -389,7 +388,6 @@ class IndexManagement:
             result["updated"] = True
             if has_actions:
                 result["reason"] = "Update forced despite required actions"
-                result["warning"] = f"Vespa requires these actions: {config_change_actions}"
             else:
                 result["reason"] = "Schema updated successfully"
 

--- a/src/marqo/core/index_management/index_management.py
+++ b/src/marqo/core/index_management/index_management.py
@@ -357,25 +357,22 @@ class IndexManagement:
                 }
 
             # Either no actions required, or force=True - proceed with activation
-            if isinstance(vespa_app._store, ApplicationPackageDeploymentSessionStore):
-                vespa_app._store.activate_deployment(prepare_response)
-                logger.info(f'Successfully updated schema for index {index_name}')
+            vespa_app.activate_prepared_deployment(prepare_response)
+            logger.info(f'Successfully updated schema for index {index_name}')
 
-                result = {
-                    "updated": True,
-                    "schema_changed": True,
-                    "config_change_actions": config_change_actions
-                }
+            result = {
+                "updated": True,
+                "schema_changed": True,
+                "config_change_actions": config_change_actions
+            }
 
-                if has_actions:
-                    result["reason"] = "Update forced despite required actions"
-                    result["warning"] = f"Vespa requires these actions: {config_change_actions}"
-                else:
-                    result["reason"] = "Schema updated successfully"
-
-                return result
+            if has_actions:
+                result["reason"] = "Update forced despite required actions"
+                result["warning"] = f"Vespa requires these actions: {config_change_actions}"
             else:
-                raise InternalError("Schema update requires ApplicationPackageDeploymentSessionStore")
+                result["reason"] = "Schema updated successfully"
+
+            return result
 
     def _get_existing_indexes(self) -> List[MarqoIndex]:
         """

--- a/src/marqo/core/index_management/index_management.py
+++ b/src/marqo/core/index_management/index_management.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from typing import List, Tuple
+from typing import List, Tuple, Dict
 from typing import Optional
 
 import semver
@@ -253,6 +253,119 @@ class IndexManagement:
             schema = SemiStructuredVespaSchema.generate_vespa_schema(marqo_index)
             logger.debug(f'Updating index {marqo_index.name} with schema:\n{schema}')
             self._get_vespa_application().update_index_setting_and_schema(marqo_index, schema)
+
+    def update_index_main_schema(self, index_name: str, force: bool = False) -> Dict[str, any]:
+        """
+        Update an index's main schema to the latest template version.
+
+        This method:
+        1. Retrieves the existing index
+        2. Generates a new schema from the latest template
+        3. Compares it with the current deployed schema
+        4. If different, prepares the deployment
+        5. Checks Vespa's configChangeActions
+        6. If actions required and force=False, returns actions without deploying
+        7. If force=True or no actions, activates the deployment
+
+        Args:
+            index_name: Name of the index to update
+            force: If True, proceed with update even if configChangeActions are required
+
+        Returns:
+            Dict with update status:
+            {
+                "updated": bool,              # Whether schema was actually deployed
+                "schema_changed": bool,       # Whether generated schema differs from current
+                "reason": str,                # Explanation of the result
+                "config_change_actions": {}   # Vespa configChangeActions if any
+            }
+
+        Raises:
+            IndexNotFoundError: If index doesn't exist
+            InternalError: If index type doesn't support schema updates
+            OperationConflictError: If deployment lock cannot be acquired
+        """
+        with self._vespa_deployment_lock():
+            # Get existing index
+            existing_index = self.get_index(index_name)
+
+            # Only SemiStructuredMarqoIndex supports schema regeneration
+            if not isinstance(existing_index, SemiStructuredMarqoIndex):
+                raise InternalError(
+                    f'Index {index_name} is type {existing_index.type}, '
+                    f'only semi-structured indexes support schema updates'
+                )
+
+            # Generate new schema from current settings using latest template
+            new_schema = SemiStructuredVespaSchema.generate_vespa_schema(existing_index)
+
+            # Get current deployed schema
+            vespa_app = self._get_vespa_application()
+            current_schema = vespa_app.get_schema(existing_index.schema_name)
+
+            # Compare schemas (normalize whitespace for comparison)
+            def normalize_schema(schema: Optional[str]) -> str:
+                if schema is None:
+                    return ""
+                # Remove extra whitespace and blank lines for comparison
+                lines = [line.strip() for line in schema.split('\n') if line.strip()]
+                return '\n'.join(lines)
+
+            if normalize_schema(new_schema) == normalize_schema(current_schema):
+                logger.info(f'Schema for index {index_name} is already up to date')
+                return {
+                    "updated": False,
+                    "schema_changed": False,
+                    "reason": "Schema is already up to date",
+                    "config_change_actions": {}
+                }
+
+            # Schema is different - prepare deployment
+            logger.info(f'Schema for index {index_name} has changes, preparing deployment')
+            prepare_response = vespa_app.update_index_setting_and_schema(
+                existing_index,
+                new_schema,
+                prepare_only=True
+            )
+
+            # Extract configChangeActions from prepare response
+            config_change_actions = prepare_response.get('configChangeActions', {})
+
+            # Check if there are any required actions
+            has_actions = bool(config_change_actions.get('restart') or
+                               config_change_actions.get('refeed') or
+                               config_change_actions.get('reindex'))
+
+            if has_actions and not force:
+                # Actions required but not forced - return without deploying
+                logger.warning(f'Schema update for index {index_name} requires Vespa actions: {config_change_actions}')
+                return {
+                    "updated": False,
+                    "schema_changed": True,
+                    "reason": "Vespa requires manual actions before proceeding. Use force=true to proceed anyway.",
+                    "config_change_actions": config_change_actions
+                }
+
+            # Either no actions required, or force=True - proceed with activation
+            if isinstance(vespa_app._store, ApplicationPackageDeploymentSessionStore):
+                vespa_app._store.activate_deployment(prepare_response)
+                logger.info(f'Successfully updated schema for index {index_name}')
+
+                result = {
+                    "updated": True,
+                    "schema_changed": True,
+                    "config_change_actions": config_change_actions
+                }
+
+                if has_actions:
+                    result["reason"] = "Update forced despite required actions"
+                    result["warning"] = f"Vespa requires these actions: {config_change_actions}"
+                else:
+                    result["reason"] = "Schema updated successfully"
+
+                return result
+            else:
+                raise InternalError("Schema update requires ApplicationPackageDeploymentSessionStore")
 
     def _get_existing_indexes(self) -> List[MarqoIndex]:
         """

--- a/src/marqo/core/index_management/index_management.py
+++ b/src/marqo/core/index_management/index_management.py
@@ -278,13 +278,13 @@ class IndexManagement:
         Returns:
             Dict with update status:
             {
-                "updated": bool,              # Whether schema was actually deployed
-                "schema_changed": bool,       # Whether generated schema differs from current
-                "old_schema": str,            # Current deployed schema
-                "new_schema": str,            # Proposed/generated schema
-                "schema_diff": str,           # Unified diff between old and new
-                "reason": str,                # Explanation of the result
-                "config_change_actions": {}   # Vespa configChangeActions if any
+                "updated": bool,                # Whether schema was actually deployed
+                "schemaChanged": bool,          # Whether generated schema differs from current
+                "oldSchema": str,               # Current deployed schema
+                "newSchema": str,               # Proposed/generated schema
+                "schemaDiff": str,              # Unified diff between old and new
+                "reason": str,                  # Explanation of the result
+                "configChangeActions": {}       # Vespa configChangeActions if any
             }
 
         Raises:
@@ -338,11 +338,11 @@ class IndexManagement:
             # Initialize response template with common fields
             result = {
                 "updated": False,
-                "schema_changed": not schemas_identical,
-                "old_schema": current_schema or '',
-                "new_schema": new_schema,
-                "schema_diff": schema_diff,
-                "config_change_actions": {},
+                "schemaChanged": not schemas_identical,
+                "oldSchema": current_schema or '',
+                "newSchema": new_schema,
+                "schemaDiff": schema_diff,
+                "configChangeActions": {},
                 "reason": ""
             }
 
@@ -362,7 +362,7 @@ class IndexManagement:
 
             # Extract configChangeActions from prepare response
             config_change_actions = prepare_response.get('configChangeActions', {})
-            result["config_change_actions"] = config_change_actions
+            result["configChangeActions"] = config_change_actions
 
             # Check if there are any required actions
             has_actions = bool(config_change_actions.get('restart') or

--- a/src/marqo/core/index_management/index_management.py
+++ b/src/marqo/core/index_management/index_management.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 from typing import List, Tuple, Dict
 from typing import Optional
+import difflib
 
 import semver
 
@@ -254,7 +255,7 @@ class IndexManagement:
             logger.debug(f'Updating index {marqo_index.name} with schema:\n{schema}')
             self._get_vespa_application().update_index_setting_and_schema(marqo_index, schema)
 
-    def update_index_main_schema(self, index_name: str, force: bool = False) -> Dict[str, any]:
+    def update_index_main_schema(self, index_name: str, force: bool = False, dry_run: bool = False) -> Dict[str, any]:
         """
         Update an index's main schema to the latest template version.
 
@@ -264,20 +265,27 @@ class IndexManagement:
         3. Compares it with the current deployed schema
         4. If different, prepares the deployment
         5. Checks Vespa's configChangeActions
-        6. If actions required and force=False, returns actions without deploying
-        7. If force=True or no actions, activates the deployment
+        6. Behavior based on parameters:
+           - dry_run=True: Show diff and actions, never deploy
+           - dry_run=False, force=False: Deploy only if no configChangeActions
+           - dry_run=False, force=True: Always deploy
 
         Args:
             index_name: Name of the index to update
             force: If True, proceed with update even if configChangeActions are required
+            dry_run: If True, show schema diff and configChangeActions without deploying
 
         Returns:
             Dict with update status:
             {
                 "updated": bool,              # Whether schema was actually deployed
                 "schema_changed": bool,       # Whether generated schema differs from current
+                "old_schema": str,            # Current deployed schema
+                "new_schema": str,            # Proposed/generated schema
+                "schema_diff": str,           # Unified diff between old and new
                 "reason": str,                # Explanation of the result
                 "config_change_actions": {}   # Vespa configChangeActions if any
+                "warning": str                # Optional, only if forced with actions
             }
 
         Raises:
@@ -313,24 +321,39 @@ class IndexManagement:
             vespa_app = self._get_vespa_application()
             current_schema = vespa_app.get_schema(existing_index.schema_name)
 
-            # Compare schemas (normalize whitespace for comparison)
-            def normalize_schema(schema: Optional[str]) -> str:
-                if schema is None:
-                    return ""
-                # Remove extra whitespace and blank lines for comparison
-                lines = [line.strip() for line in schema.split('\n') if line.strip()]
-                return '\n'.join(lines)
+            # Generate schema diff (always, for all scenarios)
+            current_schema_lines = (current_schema or '').splitlines(keepends=True)
+            new_schema_lines = new_schema.splitlines(keepends=True)
+            diff_lines = list(difflib.unified_diff(
+                current_schema_lines,
+                new_schema_lines,
+                fromfile='old_schema',
+                tofile='new_schema',
+                lineterm=''
+            ))
+            schema_diff = ''.join(diff_lines) if diff_lines else 'No changes'
 
-            if normalize_schema(new_schema) == normalize_schema(current_schema):
+            # Check if schemas are identical (based on diff)
+            schemas_identical = len(diff_lines) == 0
+
+            # Initialize response template with common fields
+            result = {
+                "updated": False,
+                "schema_changed": not schemas_identical,
+                "old_schema": current_schema or '',
+                "new_schema": new_schema,
+                "schema_diff": schema_diff,
+                "config_change_actions": {},
+                "reason": ""
+            }
+
+            # Scenario 1: Schemas are identical - no changes needed
+            if schemas_identical:
                 logger.info(f'Schema for index {index_name} is already up to date')
-                return {
-                    "updated": False,
-                    "schema_changed": False,
-                    "reason": "Schema is already up to date",
-                    "config_change_actions": {}
-                }
+                result["reason"] = "Schema is already up to date"
+                return result
 
-            # Schema is different - prepare deployment
+            # Schema is different - prepare deployment to get configChangeActions
             logger.info(f'Schema for index {index_name} has changes, preparing deployment')
             prepare_response = vespa_app.update_index_setting_and_schema(
                 existing_index,
@@ -340,32 +363,30 @@ class IndexManagement:
 
             # Extract configChangeActions from prepare response
             config_change_actions = prepare_response.get('configChangeActions', {})
+            result["config_change_actions"] = config_change_actions
 
             # Check if there are any required actions
             has_actions = bool(config_change_actions.get('restart') or
                                config_change_actions.get('refeed') or
                                config_change_actions.get('reindex'))
 
-            if has_actions and not force:
-                # Actions required but not forced - return without deploying
-                logger.warning(f'Schema update for index {index_name} requires Vespa actions: {config_change_actions}')
-                return {
-                    "updated": False,
-                    "schema_changed": True,
-                    "reason": "Vespa requires manual actions before proceeding. Use force=true to proceed anyway.",
-                    "config_change_actions": config_change_actions
-                }
+            # Scenario 2: dry_run=True - never deploy, just return info
+            if dry_run:
+                logger.info(f'Dry run for index {index_name} - showing schema diff without deploying')
+                result["reason"] = "Dry run - no changes deployed"
+                return result
 
-            # Either no actions required, or force=True - proceed with activation
+            # Scenario 3: dry_run=False, force=False - block if actions required
+            if has_actions and not force:
+                logger.warning(f'Schema update for index {index_name} requires Vespa actions: {config_change_actions}')
+                result["reason"] = "Vespa requires manual actions before proceeding. Use force=true to proceed anyway."
+                return result
+
+            # Scenario 4: dry_run=False, force=True OR no actions - proceed with deployment
             vespa_app.activate_prepared_deployment(prepare_response)
             logger.info(f'Successfully updated schema for index {index_name}')
 
-            result = {
-                "updated": True,
-                "schema_changed": True,
-                "config_change_actions": config_change_actions
-            }
-
+            result["updated"] = True
             if has_actions:
                 result["reason"] = "Update forced despite required actions"
                 result["warning"] = f"Vespa requires these actions: {config_change_actions}"

--- a/src/marqo/core/index_management/vespa_application_package.py
+++ b/src/marqo/core/index_management/vespa_application_package.py
@@ -559,12 +559,31 @@ class ApplicationPackageDeploymentSessionStore(VespaApplicationStore):
                 backup.backup_file(self.read_binary_file(*paths), *paths)
             self._vespa_client.delete_content(self._content_base_url, *paths)
 
-    def deploy_application(self) -> None:
+    def prepare_deployment(self) -> Dict:
+        """
+        Prepare deployment without activating.
+
+        Returns:
+            Prepare response from Vespa including configChangeActions
+        """
         prepare_response = self._vespa_client.prepare(self._prepare_url, timeout=self._deploy_timeout)
-        # TODO handle prepare configChangeActions
-        # https://docs.vespa.ai/en/reference/deploy-rest-api-v2.html#prepare-session
+        return prepare_response
+
+    def activate_deployment(self, prepare_response: Dict) -> None:
+        """
+        Activate a prepared deployment.
+
+        Args:
+            prepare_response: Response from prepare_deployment()
+        """
         self._vespa_client.activate(prepare_response['activate'], timeout=self._deploy_timeout)
         self._vespa_client.wait_for_application_convergence(timeout=self._wait_for_convergence_timeout)
+
+    def deploy_application(self) -> None:
+        prepare_response = self.prepare_deployment()
+        # TODO handle prepare configChangeActions
+        # https://docs.vespa.ai/en/reference/deploy-rest-api-v2.html#prepare-session
+        self.activate_deployment(prepare_response)
 
 
 class VespaApplicationPackage:
@@ -734,7 +753,20 @@ class VespaApplicationPackage:
         self._store.save_file(self._service_xml.to_xml(), self._SERVICES_XML_FILE)
         self._deploy()
 
-    def update_index_setting_and_schema(self, index: MarqoIndex, schema: str) -> None:
+    def update_index_setting_and_schema(self, index: MarqoIndex, schema: str,
+                                         prepare_only: bool = False) -> Optional[Dict]:
+        """
+        Update index settings and schema in Vespa.
+
+        Args:
+            index: Index with updated settings
+            schema: New schema content
+            prepare_only: If True, only prepare deployment and return configChangeActions without activating
+
+        Returns:
+            If prepare_only=True, returns dict with prepare response including configChangeActions.
+            If prepare_only=False, returns None (deploys immediately).
+        """
         if not self.has_index(index.name):
             raise IndexNotFoundError(f"Index {index.name} not found")
 
@@ -742,10 +774,32 @@ class VespaApplicationPackage:
         self._store.save_file(schema, 'schemas', f'{index.schema_name}.sd')
         self._index_setting_store.save_index_setting(index.copy(update={'version': version}))
         self._persist_index_settings()
-        self._deploy()
+
+        if prepare_only:
+            # Only prepare, don't activate - return prepare response
+            if isinstance(self._store, ApplicationPackageDeploymentSessionStore):
+                prepare_response = self._store.prepare_deployment()
+                return prepare_response
+            else:
+                raise InternalError("prepare_only mode requires ApplicationPackageDeploymentSessionStore")
+        else:
+            self._deploy()
+            return None
 
     def has_schema(self, name: str) -> bool:
         return self._store.file_exists('schemas', f'{name}.sd')
+
+    def get_schema(self, name: str) -> Optional[str]:
+        """
+        Get the current deployed schema content.
+
+        Args:
+            name: Schema name (without .sd extension)
+
+        Returns:
+            Schema content as string, or None if schema doesn't exist
+        """
+        return self._store.read_text_file('schemas', f'{name}.sd')
 
     def has_index(self, name: str) -> bool:
         return self._index_setting_store.get_index(name) is not None

--- a/src/marqo/core/index_management/vespa_application_package.py
+++ b/src/marqo/core/index_management/vespa_application_package.py
@@ -786,6 +786,26 @@ class VespaApplicationPackage:
             self._deploy()
             return None
 
+    def activate_prepared_deployment(self, prepare_response: Dict) -> None:
+        """
+        Activate a prepared deployment session.
+
+        This method should be called after update_index_setting_and_schema() with prepare_only=True
+        to complete the two-phase deployment process.
+
+        Args:
+            prepare_response: The response dict returned from a prepare_only update operation.
+                             Must contain an 'activate' URL from Vespa.
+
+        Raises:
+            InternalError: If the underlying store doesn't support two-phase deployment
+                          (requires ApplicationPackageDeploymentSessionStore, which needs Vespa >= 8.382.22)
+        """
+        if isinstance(self._store, ApplicationPackageDeploymentSessionStore):
+            self._store.activate_deployment(prepare_response)
+        else:
+            raise InternalError("Deployment activation requires ApplicationPackageDeploymentSessionStore")
+
     def has_schema(self, name: str) -> bool:
         return self._store.file_exists('schemas', f'{name}.sd')
 

--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -376,7 +376,7 @@ def delete_index(index_name: str, marqo_config: config.Config = Depends(get_conf
 
 
 @app.post("/indexes/{index_name}/update-main-schema")
-def update_index_main_schema(index_name: str, force: bool = False, marqo_config: config.Config = Depends(get_config)):
+def update_index_main_schema(index_name: str, force: bool = False, dry_run: bool = False, marqo_config: config.Config = Depends(get_config)):
     """
     Update an index's main schema to the latest template version.
 
@@ -389,17 +389,23 @@ def update_index_main_schema(index_name: str, force: bool = False, marqo_config:
     2. Compares with currently deployed schema
     3. If different, prepares the deployment in Vespa
     4. Checks for required Vespa actions (restart, refeed, reindex)
-    5. If actions required and force=false, returns actions without deploying
-    6. If force=true or no actions, deploys the update
+    5. Behavior based on parameters:
+       - dry_run=true: Show diff and actions, never deploy
+       - dry_run=false, force=false: Deploy only if no configChangeActions
+       - dry_run=false, force=true: Always deploy
 
     Args:
         index_name: Name of the index to update
         force: If true, proceed even if Vespa requires actions (restart/refeed/reindex)
+        dry_run: If true, show schema diff and required actions without deploying
 
     Returns:
         JSON response with:
         - updated: Whether schema was deployed
         - schema_changed: Whether schema differs from current
+        - old_schema: Current deployed schema
+        - new_schema: Proposed/generated schema
+        - schema_diff: Unified diff output
         - reason: Explanation of result
         - config_change_actions: Vespa actions required (if any)
         - warning: Warning message if forced despite required actions
@@ -409,7 +415,7 @@ def update_index_main_schema(index_name: str, force: bool = False, marqo_config:
         400: Index type doesn't support schema updates
         500: Internal error during update
     """
-    result = marqo_config.index_management.update_index_main_schema(index_name, force=force)
+    result = marqo_config.index_management.update_index_main_schema(index_name, force=force, dry_run=dry_run)
     return JSONResponse(content=result, status_code=200)
 
 

--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -375,6 +375,52 @@ def delete_index(index_name: str, marqo_config: config.Config = Depends(get_conf
     return JSONResponse(content={"acknowledged": True}, status_code=200)
 
 
+@app.post("/indexes/{index_name}/update-main-schema")
+def update_index_main_schema(index_name: str, force: bool = False, marqo_config: config.Config = Depends(get_config)):
+    """
+    Update an index's main schema to the latest template version.
+
+    This endpoint regenerates the index's Vespa schema from its current settings using
+    the latest schema template. It's useful for applying schema updates (like new features)
+    to existing indexes without recreating them.
+
+    The update process:
+    1. Generates new schema from latest template
+    2. Compares with currently deployed schema
+    3. If different, prepares the deployment in Vespa
+    4. Checks for required Vespa actions (restart, refeed, reindex)
+    5. If actions required and force=false, returns actions without deploying
+    6. If force=true or no actions, deploys the update
+
+    Args:
+        index_name: Name of the index to update
+        force: If true, proceed even if Vespa requires actions (restart/refeed/reindex)
+
+    Returns:
+        JSON response with:
+        - updated: Whether schema was deployed
+        - schema_changed: Whether schema differs from current
+        - reason: Explanation of result
+        - config_change_actions: Vespa actions required (if any)
+        - warning: Warning message if forced despite required actions
+
+    Raises:
+        404: Index not found
+        400: Index type doesn't support schema updates
+        500: Internal error during update
+    """
+    try:
+        result = marqo_config.index_management.update_index_main_schema(index_name, force=force)
+        return JSONResponse(content=result, status_code=200)
+    except core_exceptions.IndexNotFoundError as e:
+        return JSONResponse(content={"error": str(e)}, status_code=404)
+    except core_exceptions.InternalError as e:
+        return JSONResponse(content={"error": str(e)}, status_code=400)
+    except Exception as e:
+        logger.error(f"Error updating schema for index {index_name}: {e}", exc_info=True)
+        return JSONResponse(content={"error": f"Internal error: {str(e)}"}, status_code=500)
+
+
 @app.get("/indexes/{index_name}/health")
 def check_index_health(index_name: str, marqo_config: config.Config = Depends(get_config)):
     """

--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -375,8 +375,9 @@ def delete_index(index_name: str, marqo_config: config.Config = Depends(get_conf
     return JSONResponse(content={"acknowledged": True}, status_code=200)
 
 
-@app.post("/indexes/{index_name}/update-main-schema")
-def update_index_main_schema(index_name: str, force: bool = False, dry_run: bool = False, marqo_config: config.Config = Depends(get_config)):
+@app.post("/indexes/{index_name}/apply-latest-schema-template")
+@utils.enable_ops_api()
+def apply_latest_schema_template(index_name: str, force: bool = False, dry_run: bool = False, marqo_config: config.Config = Depends(get_config)):
     """
     Update an index's main schema to the latest template version.
 
@@ -414,7 +415,7 @@ def update_index_main_schema(index_name: str, force: bool = False, dry_run: bool
         400: Index type doesn't support schema updates
         500: Internal error during update
     """
-    result = marqo_config.index_management.update_index_main_schema(index_name, force=force, dry_run=dry_run)
+    result = marqo_config.index_management.apply_latest_schema_template(index_name, force=force, dry_run=dry_run)
     return JSONResponse(content=result, status_code=200)
 
 

--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -403,12 +403,12 @@ def apply_latest_schema_template(index_name: str, force: bool = False, dry_run: 
     Returns:
         JSON response with:
         - updated: Whether schema was deployed
-        - schema_changed: Whether schema differs from current
-        - old_schema: Current deployed schema
-        - new_schema: Proposed/generated schema
-        - schema_diff: Unified diff output
+        - schemaChanged: Whether schema differs from current
+        - oldSchema: Current deployed schema
+        - newSchema: Proposed/generated schema
+        - schemaDiff: Unified diff output
         - reason: Explanation of result
-        - config_change_actions: Vespa actions required (if any)
+        - configChangeActions: Vespa actions required (if any)
 
     Raises:
         404: Index not found

--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -409,16 +409,8 @@ def update_index_main_schema(index_name: str, force: bool = False, marqo_config:
         400: Index type doesn't support schema updates
         500: Internal error during update
     """
-    try:
-        result = marqo_config.index_management.update_index_main_schema(index_name, force=force)
-        return JSONResponse(content=result, status_code=200)
-    except core_exceptions.IndexNotFoundError as e:
-        return JSONResponse(content={"error": str(e)}, status_code=404)
-    except core_exceptions.InternalError as e:
-        return JSONResponse(content={"error": str(e)}, status_code=400)
-    except Exception as e:
-        logger.error(f"Error updating schema for index {index_name}: {e}", exc_info=True)
-        return JSONResponse(content={"error": f"Internal error: {str(e)}"}, status_code=500)
+    result = marqo_config.index_management.update_index_main_schema(index_name, force=force)
+    return JSONResponse(content=result, status_code=200)
 
 
 @app.get("/indexes/{index_name}/health")

--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -408,7 +408,6 @@ def update_index_main_schema(index_name: str, force: bool = False, dry_run: bool
         - schema_diff: Unified diff output
         - reason: Explanation of result
         - config_change_actions: Vespa actions required (if any)
-        - warning: Warning message if forced despite required actions
 
     Raises:
         404: Index not found

--- a/tests/integ_tests/core/index_management/test_index_management_schema_update.py
+++ b/tests/integ_tests/core/index_management/test_index_management_schema_update.py
@@ -1,0 +1,375 @@
+import os
+from unittest.mock import patch
+
+from marqo.core.exceptions import IndexNotFoundError, InternalError, UnsupportedFeatureError
+from marqo.core.models.marqo_index import Model
+from tests.integ_tests.marqo_test import MarqoTestCase
+
+
+class TestIndexManagementSchemaUpdate(MarqoTestCase):
+    """Integration tests for the update_index_main_schema feature."""
+
+    def setUp(self):
+        super().setUp()
+        # Bootstrap Vespa
+        self.index_management.bootstrap_vespa()
+
+        # Create a semi-structured index (Marqo >= 2.13.0) for testing
+        self.test_index_name = "test_schema_update_index"
+
+        # Delete the index if it already exists from previous test
+        try:
+            self.index_management.delete_index_by_name(self.test_index_name)
+        except IndexNotFoundError:
+            pass
+
+        self.request = self.unstructured_marqo_index_request(
+            name=self.test_index_name,
+            model=Model(name='hf/e5-small')
+        )
+        created_index = self.index_management.create_index(self.request)
+
+        # Track index for cleanup in tearDownClass
+        if created_index not in self.indexes:
+            self.indexes.append(created_index)
+
+        # Get the created index
+        self.test_index = self.index_management.get_index(self.test_index_name)
+
+        # Get the original schema for reference by downloading the app
+        app = self.vespa_client.download_application()
+        schema_path = os.path.join(app, 'schemas', f'{self.test_index.schema_name}.sd')
+        with open(schema_path, 'r') as f:
+            self.original_schema = f.read()
+
+    # ============================================================================
+    # Basic Flow Tests
+    # ============================================================================
+
+    def test_update_schema_no_changes(self):
+        """When schema hasn't changed, should return schema_changed=False and not deploy."""
+        result = self.index_management.update_index_main_schema(self.test_index_name)
+
+        self.assertFalse(result['updated'])
+        self.assertFalse(result['schema_changed'])
+        self.assertEqual('Schema is already up to date', result['reason'])
+        self.assertEqual('No changes', result['schema_diff'])
+        self.assertEqual(self.original_schema, result['old_schema'])
+        self.assertEqual(self.original_schema, result['new_schema'])
+
+    @patch('marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema.SemiStructuredVespaSchema.generate_vespa_schema')
+    def test_update_schema_successful(self, mock_generate_schema):
+        """When schema changes with no actions required, should deploy successfully."""
+        # Generate a modified schema (add a comment to create a harmless change)
+        modified_schema = self.original_schema.replace(
+            'schema marqo__',
+            '# Updated schema\nschema marqo__'
+        )
+        mock_generate_schema.return_value = modified_schema
+
+        result = self.index_management.update_index_main_schema(self.test_index_name)
+
+        # Verify the result
+        self.assertTrue(result['updated'])
+        self.assertTrue(result['schema_changed'])
+        self.assertIn('Schema updated successfully', result['reason'])
+        self.assertEqual(self.original_schema, result['old_schema'])
+        self.assertEqual(modified_schema, result['new_schema'])
+        self.assertIn('# Updated schema', result['schema_diff'])
+
+        # Verify schema was actually deployed to Vespa
+        app = self.vespa_client.download_application()
+        schema_path = os.path.join(app, 'schemas', f'{self.test_index.schema_name}.sd')
+        with open(schema_path, 'r') as f:
+            deployed_schema = f.read()
+        self.assertEqual(modified_schema, deployed_schema)
+
+    @patch('marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema.SemiStructuredVespaSchema.generate_vespa_schema')
+    def test_update_schema_dry_run_prevents_deployment(self, mock_generate_schema):
+        """When dry_run=True, should show changes but never deploy."""
+        modified_schema = self.original_schema.replace(
+            'schema marqo__',
+            '# Dry run test\nschema marqo__'
+        )
+        mock_generate_schema.return_value = modified_schema
+
+        result = self.index_management.update_index_main_schema(
+            self.test_index_name,
+            dry_run=True
+        )
+
+        # Verify no deployment occurred
+        self.assertFalse(result['updated'])
+        self.assertTrue(result['schema_changed'])
+        self.assertEqual('Dry run - no changes deployed', result['reason'])
+        self.assertEqual(modified_schema, result['new_schema'])
+        self.assertIn('# Dry run test', result['schema_diff'])
+
+        # Verify schema was NOT deployed to Vespa (original schema still present)
+        app = self.vespa_client.download_application()
+        schema_path = os.path.join(app, 'schemas', f'{self.test_index.schema_name}.sd')
+        with open(schema_path, 'r') as f:
+            deployed_schema = f.read()
+        self.assertEqual(self.original_schema, deployed_schema)
+        self.assertNotIn('# Dry run test', deployed_schema)
+
+    # ============================================================================
+    # configChangeActions Tests
+    # ============================================================================
+
+    @patch('marqo.vespa.vespa_client.VespaClient.prepare')
+    @patch('marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema.SemiStructuredVespaSchema.generate_vespa_schema')
+    def test_update_schema_with_restart_actions_blocked(self, mock_generate_schema, mock_prepare):
+        """When restart actions are required and force=False, should block deployment."""
+        modified_schema = self.original_schema.replace(
+            'schema marqo__',
+            '# Change requiring restart\nschema marqo__'
+        )
+        mock_generate_schema.return_value = modified_schema
+
+        # Mock Vespa prepare response with restart actions
+        mock_prepare.return_value = {
+            'activate': 'http://activate_url',
+            'configChangeActions': {
+                'restart': [{
+                    'clusterName': 'marqo_content',
+                    'clusterType': 'search',
+                    'serviceType': 'searchnode',
+                    'messages': ['Change requires service restart'],
+                    'services': [{'serviceName': 'searchnode', 'serviceType': 'searchnode'}]
+                }]
+            }
+        }
+
+        result = self.index_management.update_index_main_schema(
+            self.test_index_name,
+            force=False
+        )
+
+        # Verify deployment was blocked
+        self.assertFalse(result['updated'])
+        self.assertTrue(result['schema_changed'])
+        self.assertIn('Vespa requires manual actions before proceeding', result['reason'])
+        self.assertIn('restart', result['config_change_actions'])
+        self.assertEqual(1, len(result['config_change_actions']['restart']))
+
+        # Verify schema was NOT deployed
+        app = self.vespa_client.download_application()
+        schema_path = os.path.join(app, 'schemas', f'{self.test_index.schema_name}.sd')
+        with open(schema_path, 'r') as f:
+            deployed_schema = f.read()
+        self.assertEqual(self.original_schema, deployed_schema)
+
+    @patch('marqo.vespa.vespa_client.VespaClient.activate')
+    @patch('marqo.vespa.vespa_client.VespaClient.prepare')
+    @patch('marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema.SemiStructuredVespaSchema.generate_vespa_schema')
+    def test_update_schema_with_restart_actions_forced(self, mock_generate_schema, mock_prepare, mock_activate):
+        """When restart actions are required and force=True, should deploy anyway."""
+        modified_schema = self.original_schema.replace(
+            'schema marqo__',
+            '# Forced change with restart\nschema marqo__'
+        )
+        mock_generate_schema.return_value = modified_schema
+
+        # Mock Vespa prepare response with restart actions
+        mock_prepare.return_value = {
+            'activate': 'http://activate_url',
+            'configChangeActions': {
+                'restart': [{
+                    'clusterName': 'marqo_content',
+                    'clusterType': 'search',
+                    'serviceType': 'searchnode',
+                    'messages': ['Change requires service restart'],
+                    'services': [{'serviceName': 'searchnode', 'serviceType': 'searchnode'}]
+                }]
+            }
+        }
+
+        result = self.index_management.update_index_main_schema(
+            self.test_index_name,
+            force=True
+        )
+
+        # Verify deployment proceeded despite actions
+        self.assertTrue(result['updated'])
+        self.assertTrue(result['schema_changed'])
+        self.assertIn('Update forced despite required actions', result['reason'])
+        self.assertIn('warning', result)
+        self.assertIn('restart', result['config_change_actions'])
+
+        # Verify activate was called
+        mock_activate.assert_called_once()
+
+    @patch('marqo.vespa.vespa_client.VespaClient.prepare')
+    @patch('marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema.SemiStructuredVespaSchema.generate_vespa_schema')
+    def test_update_schema_with_refeed_actions_blocked(self, mock_generate_schema, mock_prepare):
+        """When refeed actions are required and force=False, should block deployment."""
+        modified_schema = self.original_schema.replace(
+            'schema marqo__',
+            '# Change requiring refeed\nschema marqo__'
+        )
+        mock_generate_schema.return_value = modified_schema
+
+        # Mock Vespa prepare response with refeed actions
+        mock_prepare.return_value = {
+            'activate': 'http://activate_url',
+            'configChangeActions': {
+                'refeed': [{
+                    'name': 'refeed',
+                    'documentType': self.test_index.schema_name,
+                    'clusterName': 'marqo_content',
+                    'messages': ['Field type change requires re-feeding']
+                }]
+            }
+        }
+
+        result = self.index_management.update_index_main_schema(
+            self.test_index_name,
+            force=False
+        )
+
+        # Verify deployment was blocked
+        self.assertFalse(result['updated'])
+        self.assertTrue(result['schema_changed'])
+        self.assertIn('Vespa requires manual actions before proceeding', result['reason'])
+        self.assertIn('refeed', result['config_change_actions'])
+
+    @patch('marqo.vespa.vespa_client.VespaClient.activate')
+    @patch('marqo.vespa.vespa_client.VespaClient.prepare')
+    @patch('marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema.SemiStructuredVespaSchema.generate_vespa_schema')
+    def test_update_schema_with_refeed_actions_forced(self, mock_generate_schema, mock_prepare, mock_activate):
+        """When refeed actions are required and force=True, should deploy anyway."""
+        modified_schema = self.original_schema.replace(
+            'schema marqo__',
+            '# Forced refeed change\nschema marqo__'
+        )
+        mock_generate_schema.return_value = modified_schema
+
+        # Mock Vespa prepare response with refeed actions
+        mock_prepare.return_value = {
+            'activate': 'http://activate_url',
+            'configChangeActions': {
+                'refeed': [{
+                    'name': 'refeed',
+                    'documentType': self.test_index.schema_name,
+                    'clusterName': 'marqo_content',
+                    'messages': ['Field type change requires re-feeding']
+                }]
+            }
+        }
+
+        result = self.index_management.update_index_main_schema(
+            self.test_index_name,
+            force=True
+        )
+
+        # Verify deployment proceeded despite actions
+        self.assertTrue(result['updated'])
+        self.assertTrue(result['schema_changed'])
+        self.assertIn('Update forced despite required actions', result['reason'])
+        self.assertIn('refeed', result['config_change_actions'])
+
+        # Verify activate was called
+        mock_activate.assert_called_once()
+
+    @patch('marqo.vespa.vespa_client.VespaClient.prepare')
+    @patch('marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema.SemiStructuredVespaSchema.generate_vespa_schema')
+    def test_update_schema_with_reindex_actions_blocked(self, mock_generate_schema, mock_prepare):
+        """When reindex actions are required and force=False, should block deployment."""
+        modified_schema = self.original_schema.replace(
+            'schema marqo__',
+            '# Change requiring reindex\nschema marqo__'
+        )
+        mock_generate_schema.return_value = modified_schema
+
+        # Mock Vespa prepare response with reindex actions
+        mock_prepare.return_value = {
+            'activate': 'http://activate_url',
+            'configChangeActions': {
+                'reindex': [{
+                    'name': 'reindex',
+                    'documentType': self.test_index.schema_name,
+                    'messages': ['Indexing script change requires reindexing']
+                }]
+            }
+        }
+
+        result = self.index_management.update_index_main_schema(
+            self.test_index_name,
+            force=False
+        )
+
+        # Verify deployment was blocked
+        self.assertFalse(result['updated'])
+        self.assertTrue(result['schema_changed'])
+        self.assertIn('Vespa requires manual actions before proceeding', result['reason'])
+        self.assertIn('reindex', result['config_change_actions'])
+
+    # ============================================================================
+    # Error Case Tests
+    # ============================================================================
+
+    def test_update_schema_index_not_found(self):
+        """Should raise IndexNotFoundError for non-existent index."""
+        with self.assertRaisesStrict(IndexNotFoundError) as ctx:
+            self.index_management.update_index_main_schema('nonexistent_index')
+
+        self.assertIn('nonexistent_index', str(ctx.exception))
+
+    def test_update_schema_wrong_index_type_structured(self):
+        """Should raise InternalError for structured indexes (not supported)."""
+        from marqo.core.models.marqo_index_request import FieldRequest
+        from marqo.core.models.marqo_index import FieldType
+
+        # Create a structured index
+        structured_request = self.structured_marqo_index_request(
+            name='structured_index',
+            fields=[FieldRequest(name='title', type=FieldType.Text)],
+            tensor_fields=['title']
+        )
+        self.index_management.create_index(structured_request)
+
+        try:
+            with self.assertRaisesStrict(InternalError) as ctx:
+                self.index_management.update_index_main_schema('structured_index')
+
+            self.assertIn('only semi-structured indexes support schema updates', str(ctx.exception))
+        finally:
+            self.index_management.delete_index_by_name('structured_index')
+
+    def test_update_schema_wrong_index_type_legacy_unstructured(self):
+        """Should raise InternalError for legacy unstructured indexes (Marqo < 2.13.0)."""
+        # Create a legacy unstructured index (marqo_version < 2.13.0)
+        legacy_request = self.unstructured_marqo_index_request(
+            name='legacy_index',
+            marqo_version='2.12.0',
+            model=Model(name='hf/e5-small')
+        )
+        self.index_management.create_index(legacy_request)
+
+        try:
+            with self.assertRaisesStrict(InternalError) as ctx:
+                self.index_management.update_index_main_schema('legacy_index')
+
+            self.assertIn('only semi-structured indexes support schema updates', str(ctx.exception))
+        finally:
+            self.index_management.delete_index_by_name('legacy_index')
+
+    def test_update_schema_version_too_old(self):
+        """Should raise UnsupportedFeatureError for indexes created with Marqo < 2.23.0."""
+        # Create an index with Marqo 2.22.0 (before schema update feature)
+        old_version_request = self.unstructured_marqo_index_request(
+            name='old_version_index',
+            marqo_version='2.22.0',
+            model=Model(name='hf/e5-small')
+        )
+        self.index_management.create_index(old_version_request)
+
+        try:
+            with self.assertRaisesStrict(UnsupportedFeatureError) as ctx:
+                self.index_management.update_index_main_schema('old_version_index')
+
+            self.assertIn('Schema update is only supported for indexes created with Marqo 2.23.0 or later', str(ctx.exception))
+            self.assertIn('created with Marqo 2.22.0', str(ctx.exception))
+        finally:
+            self.index_management.delete_index_by_name('old_version_index')

--- a/tests/integ_tests/core/index_management/test_index_management_schema_update.py
+++ b/tests/integ_tests/core/index_management/test_index_management_schema_update.py
@@ -1,46 +1,80 @@
 import os
+import textwrap
+from datetime import datetime, timedelta
 from unittest.mock import patch
 
 from marqo.core.exceptions import IndexNotFoundError, InternalError, UnsupportedFeatureError
-from marqo.core.models.marqo_index import Model
+from marqo.core.models.add_docs_params import AddDocsParams
+from marqo.core.models.marqo_index import FieldType
+from marqo.core.models.marqo_index_request import FieldRequest
 from tests.integ_tests.marqo_test import MarqoTestCase
 
 
 class TestIndexManagementSchemaUpdate(MarqoTestCase):
     """Integration tests for the update_index_main_schema feature."""
 
-    def setUp(self):
-        super().setUp()
+    @classmethod
+    def _add_validation_overrides(self, app_root_path: str):
+        tomorrow = (datetime.utcnow() + timedelta(days=1)).strftime('%Y-%m-%d')
+        content = textwrap.dedent(
+            f'''
+            <validation-overrides>
+                 <allow until='{tomorrow}'>indexing-change</allow>
+                 <allow until='{tomorrow}'>field-type-change</allow>
+                 <allow until='{tomorrow}'>schema-removal</allow>
+            </validation-overrides>
+            '''
+        ).strip()
+        with open(os.path.join(app_root_path, 'validation-overrides.xml'), 'w') as f:
+            f.write(content)
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+
+        # Deploy initial app package with validation overrides
+        app_root_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'initial_vespa_app')
+        cls._add_validation_overrides(app_root_path)
+        cls.vespa_client.deploy_application(app_root_path)
+        cls.vespa_client.wait_for_application_convergence()
+
         # Bootstrap Vespa
-        self.index_management.bootstrap_vespa()
+        cls.index_management.bootstrap_vespa()
 
-        # Create a semi-structured index (Marqo >= 2.13.0) for testing
-        self.test_index_name = "test_schema_update_index"
+        # pre-create all indexes for tests
+        index_requests = [
+            cls.unstructured_marqo_index_request(name='test_schema_update_index'),
+            cls.unstructured_marqo_index_request(name='test_config_change_restart'),
+            cls.unstructured_marqo_index_request(name='test_config_change_reindex'),
+            cls.unstructured_marqo_index_request(name='test_config_change_refeed'),
+            cls.unstructured_marqo_index_request(name='old_version_index', marqo_version='2.22.0'),
+            cls.unstructured_marqo_index_request(name='legacy_unstructured_index', marqo_version='2.12.0'),
+            cls.structured_marqo_index_request(
+                name='structured_index',
+                fields=[FieldRequest(name='title', type=FieldType.Text)],
+                tensor_fields=['title']
+            )
+        ]
+        cls.create_indexes(index_requests)
 
-        # Delete the index if it already exists from previous test
-        try:
-            self.index_management.delete_index_by_name(self.test_index_name)
-        except IndexNotFoundError:
-            pass
+        # feed in a doc to add a 'title' lexical field to 'test_config_change_restart'
+        cls.add_documents(cls.config, AddDocsParams(
+            index_name='test_config_change_restart',
+            docs=[{'_id': '1', 'title': 'hello'}],
+            tensor_fields=[]
+        ))
 
-        self.request = self.unstructured_marqo_index_request(
-            name=self.test_index_name,
-            model=Model(name='hf/e5-small')
-        )
-        created_index = self.index_management.create_index(self.request)
+    def _get_validation_overrides(self) -> str:
+        app = self.vespa_client.download_application()
+        with open(os.path.join(app, 'validation-overrides.xml'), 'r') as f:
+            return f.read()
 
-        # Track index for cleanup in tearDownClass
-        if created_index not in self.indexes:
-            self.indexes.append(created_index)
-
-        # Get the created index
-        self.test_index = self.index_management.get_index(self.test_index_name)
-
+    def _get_schema_from_vespa(self, schema_name: str) -> str:
         # Get the original schema for reference by downloading the app
         app = self.vespa_client.download_application()
-        schema_path = os.path.join(app, 'schemas', f'{self.test_index.schema_name}.sd')
+        schema_path = os.path.join(app, 'schemas', f'{schema_name}.sd')
         with open(schema_path, 'r') as f:
-            self.original_schema = f.read()
+            return f.read()
 
     # ============================================================================
     # Basic Flow Tests
@@ -48,53 +82,68 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
     def test_update_schema_no_changes(self):
         """When schema hasn't changed, should return schema_changed=False and not deploy."""
-        result = self.index_management.update_index_main_schema(self.test_index_name)
+        test_index_name = 'test_schema_update_index'
+        result = self.index_management.update_index_main_schema(test_index_name)
+
+        saved_index = self.index_management.get_index(test_index_name)
+        original_schema = self._get_schema_from_vespa(saved_index.schema_name)
+        original_version = saved_index.version
 
         self.assertFalse(result['updated'])
         self.assertFalse(result['schema_changed'])
         self.assertEqual('Schema is already up to date', result['reason'])
         self.assertEqual('No changes', result['schema_diff'])
-        self.assertEqual(self.original_schema, result['old_schema'])
-        self.assertEqual(self.original_schema, result['new_schema'])
+        self.assertEqual(original_schema, result['old_schema'])
+        self.assertEqual(original_schema, result['new_schema'])
+
+        self.assertEqual(original_version, self.index_management.get_index(test_index_name).version)
 
     @patch('marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema.SemiStructuredVespaSchema.generate_vespa_schema')
     def test_update_schema_successful(self, mock_generate_schema):
         """When schema changes with no actions required, should deploy successfully."""
+
+        test_index_name = 'test_schema_update_index'
+        saved_index = self.index_management.get_index(test_index_name)
+        original_schema = self._get_schema_from_vespa(saved_index.schema_name)
+        original_version = saved_index.version
+
         # Generate a modified schema (add a comment to create a harmless change)
-        modified_schema = self.original_schema.replace(
+        modified_schema = original_schema.replace(
             'schema marqo__',
             '# Updated schema\nschema marqo__'
         )
         mock_generate_schema.return_value = modified_schema
 
-        result = self.index_management.update_index_main_schema(self.test_index_name)
+        result = self.index_management.update_index_main_schema(test_index_name)
 
         # Verify the result
         self.assertTrue(result['updated'])
         self.assertTrue(result['schema_changed'])
         self.assertIn('Schema updated successfully', result['reason'])
-        self.assertEqual(self.original_schema, result['old_schema'])
+        self.assertEqual(original_schema, result['old_schema'])
         self.assertEqual(modified_schema, result['new_schema'])
         self.assertIn('# Updated schema', result['schema_diff'])
 
         # Verify schema was actually deployed to Vespa
-        app = self.vespa_client.download_application()
-        schema_path = os.path.join(app, 'schemas', f'{self.test_index.schema_name}.sd')
-        with open(schema_path, 'r') as f:
-            deployed_schema = f.read()
-        self.assertEqual(modified_schema, deployed_schema)
+        self.assertEqual(modified_schema, self._get_schema_from_vespa(saved_index.schema_name))
+        # Verify the index version is also updated
+        self.assertEqual(original_version + 1, self.index_management.get_index(test_index_name).version)
 
     @patch('marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema.SemiStructuredVespaSchema.generate_vespa_schema')
     def test_update_schema_dry_run_prevents_deployment(self, mock_generate_schema):
         """When dry_run=True, should show changes but never deploy."""
-        modified_schema = self.original_schema.replace(
+        test_index_name = 'test_schema_update_index'
+        saved_index = self.index_management.get_index(test_index_name)
+        original_schema = self._get_schema_from_vespa(saved_index.schema_name)
+
+        modified_schema = original_schema.replace(
             'schema marqo__',
             '# Dry run test\nschema marqo__'
         )
         mock_generate_schema.return_value = modified_schema
 
         result = self.index_management.update_index_main_schema(
-            self.test_index_name,
+            test_index_name,
             dry_run=True
         )
 
@@ -106,204 +155,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.assertIn('# Dry run test', result['schema_diff'])
 
         # Verify schema was NOT deployed to Vespa (original schema still present)
-        app = self.vespa_client.download_application()
-        schema_path = os.path.join(app, 'schemas', f'{self.test_index.schema_name}.sd')
-        with open(schema_path, 'r') as f:
-            deployed_schema = f.read()
-        self.assertEqual(self.original_schema, deployed_schema)
-        self.assertNotIn('# Dry run test', deployed_schema)
-
-    # ============================================================================
-    # configChangeActions Tests
-    # ============================================================================
-
-    @patch('marqo.vespa.vespa_client.VespaClient.prepare')
-    @patch('marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema.SemiStructuredVespaSchema.generate_vespa_schema')
-    def test_update_schema_with_restart_actions_blocked(self, mock_generate_schema, mock_prepare):
-        """When restart actions are required and force=False, should block deployment."""
-        modified_schema = self.original_schema.replace(
-            'schema marqo__',
-            '# Change requiring restart\nschema marqo__'
-        )
-        mock_generate_schema.return_value = modified_schema
-
-        # Mock Vespa prepare response with restart actions
-        mock_prepare.return_value = {
-            'activate': 'http://activate_url',
-            'configChangeActions': {
-                'restart': [{
-                    'clusterName': 'marqo_content',
-                    'clusterType': 'search',
-                    'serviceType': 'searchnode',
-                    'messages': ['Change requires service restart'],
-                    'services': [{'serviceName': 'searchnode', 'serviceType': 'searchnode'}]
-                }]
-            }
-        }
-
-        result = self.index_management.update_index_main_schema(
-            self.test_index_name,
-            force=False
-        )
-
-        # Verify deployment was blocked
-        self.assertFalse(result['updated'])
-        self.assertTrue(result['schema_changed'])
-        self.assertIn('Vespa requires manual actions before proceeding', result['reason'])
-        self.assertIn('restart', result['config_change_actions'])
-        self.assertEqual(1, len(result['config_change_actions']['restart']))
-
-        # Verify schema was NOT deployed
-        app = self.vespa_client.download_application()
-        schema_path = os.path.join(app, 'schemas', f'{self.test_index.schema_name}.sd')
-        with open(schema_path, 'r') as f:
-            deployed_schema = f.read()
-        self.assertEqual(self.original_schema, deployed_schema)
-
-    @patch('marqo.vespa.vespa_client.VespaClient.activate')
-    @patch('marqo.vespa.vespa_client.VespaClient.prepare')
-    @patch('marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema.SemiStructuredVespaSchema.generate_vespa_schema')
-    def test_update_schema_with_restart_actions_forced(self, mock_generate_schema, mock_prepare, mock_activate):
-        """When restart actions are required and force=True, should deploy anyway."""
-        modified_schema = self.original_schema.replace(
-            'schema marqo__',
-            '# Forced change with restart\nschema marqo__'
-        )
-        mock_generate_schema.return_value = modified_schema
-
-        # Mock Vespa prepare response with restart actions
-        mock_prepare.return_value = {
-            'activate': 'http://activate_url',
-            'configChangeActions': {
-                'restart': [{
-                    'clusterName': 'marqo_content',
-                    'clusterType': 'search',
-                    'serviceType': 'searchnode',
-                    'messages': ['Change requires service restart'],
-                    'services': [{'serviceName': 'searchnode', 'serviceType': 'searchnode'}]
-                }]
-            }
-        }
-
-        result = self.index_management.update_index_main_schema(
-            self.test_index_name,
-            force=True
-        )
-
-        # Verify deployment proceeded despite actions
-        self.assertTrue(result['updated'])
-        self.assertTrue(result['schema_changed'])
-        self.assertIn('Update forced despite required actions', result['reason'])
-        self.assertIn('warning', result)
-        self.assertIn('restart', result['config_change_actions'])
-
-        # Verify activate was called
-        mock_activate.assert_called_once()
-
-    @patch('marqo.vespa.vespa_client.VespaClient.prepare')
-    @patch('marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema.SemiStructuredVespaSchema.generate_vespa_schema')
-    def test_update_schema_with_refeed_actions_blocked(self, mock_generate_schema, mock_prepare):
-        """When refeed actions are required and force=False, should block deployment."""
-        modified_schema = self.original_schema.replace(
-            'schema marqo__',
-            '# Change requiring refeed\nschema marqo__'
-        )
-        mock_generate_schema.return_value = modified_schema
-
-        # Mock Vespa prepare response with refeed actions
-        mock_prepare.return_value = {
-            'activate': 'http://activate_url',
-            'configChangeActions': {
-                'refeed': [{
-                    'name': 'refeed',
-                    'documentType': self.test_index.schema_name,
-                    'clusterName': 'marqo_content',
-                    'messages': ['Field type change requires re-feeding']
-                }]
-            }
-        }
-
-        result = self.index_management.update_index_main_schema(
-            self.test_index_name,
-            force=False
-        )
-
-        # Verify deployment was blocked
-        self.assertFalse(result['updated'])
-        self.assertTrue(result['schema_changed'])
-        self.assertIn('Vespa requires manual actions before proceeding', result['reason'])
-        self.assertIn('refeed', result['config_change_actions'])
-
-    @patch('marqo.vespa.vespa_client.VespaClient.activate')
-    @patch('marqo.vespa.vespa_client.VespaClient.prepare')
-    @patch('marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema.SemiStructuredVespaSchema.generate_vespa_schema')
-    def test_update_schema_with_refeed_actions_forced(self, mock_generate_schema, mock_prepare, mock_activate):
-        """When refeed actions are required and force=True, should deploy anyway."""
-        modified_schema = self.original_schema.replace(
-            'schema marqo__',
-            '# Forced refeed change\nschema marqo__'
-        )
-        mock_generate_schema.return_value = modified_schema
-
-        # Mock Vespa prepare response with refeed actions
-        mock_prepare.return_value = {
-            'activate': 'http://activate_url',
-            'configChangeActions': {
-                'refeed': [{
-                    'name': 'refeed',
-                    'documentType': self.test_index.schema_name,
-                    'clusterName': 'marqo_content',
-                    'messages': ['Field type change requires re-feeding']
-                }]
-            }
-        }
-
-        result = self.index_management.update_index_main_schema(
-            self.test_index_name,
-            force=True
-        )
-
-        # Verify deployment proceeded despite actions
-        self.assertTrue(result['updated'])
-        self.assertTrue(result['schema_changed'])
-        self.assertIn('Update forced despite required actions', result['reason'])
-        self.assertIn('refeed', result['config_change_actions'])
-
-        # Verify activate was called
-        mock_activate.assert_called_once()
-
-    @patch('marqo.vespa.vespa_client.VespaClient.prepare')
-    @patch('marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema.SemiStructuredVespaSchema.generate_vespa_schema')
-    def test_update_schema_with_reindex_actions_blocked(self, mock_generate_schema, mock_prepare):
-        """When reindex actions are required and force=False, should block deployment."""
-        modified_schema = self.original_schema.replace(
-            'schema marqo__',
-            '# Change requiring reindex\nschema marqo__'
-        )
-        mock_generate_schema.return_value = modified_schema
-
-        # Mock Vespa prepare response with reindex actions
-        mock_prepare.return_value = {
-            'activate': 'http://activate_url',
-            'configChangeActions': {
-                'reindex': [{
-                    'name': 'reindex',
-                    'documentType': self.test_index.schema_name,
-                    'messages': ['Indexing script change requires reindexing']
-                }]
-            }
-        }
-
-        result = self.index_management.update_index_main_schema(
-            self.test_index_name,
-            force=False
-        )
-
-        # Verify deployment was blocked
-        self.assertFalse(result['updated'])
-        self.assertTrue(result['schema_changed'])
-        self.assertIn('Vespa requires manual actions before proceeding', result['reason'])
-        self.assertIn('reindex', result['config_change_actions'])
+        self.assertEqual(original_schema, self._get_schema_from_vespa(saved_index.schema_name))
 
     # ============================================================================
     # Error Case Tests
@@ -318,58 +170,202 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
     def test_update_schema_wrong_index_type_structured(self):
         """Should raise InternalError for structured indexes (not supported)."""
-        from marqo.core.models.marqo_index_request import FieldRequest
-        from marqo.core.models.marqo_index import FieldType
+        with self.assertRaisesStrict(InternalError) as ctx:
+            self.index_management.update_index_main_schema('structured_index')
 
-        # Create a structured index
-        structured_request = self.structured_marqo_index_request(
-            name='structured_index',
-            fields=[FieldRequest(name='title', type=FieldType.Text)],
-            tensor_fields=['title']
-        )
-        self.index_management.create_index(structured_request)
-
-        try:
-            with self.assertRaisesStrict(InternalError) as ctx:
-                self.index_management.update_index_main_schema('structured_index')
-
-            self.assertIn('only semi-structured indexes support schema updates', str(ctx.exception))
-        finally:
-            self.index_management.delete_index_by_name('structured_index')
+        self.assertIn('only semi-structured indexes support schema updates', str(ctx.exception))
 
     def test_update_schema_wrong_index_type_legacy_unstructured(self):
         """Should raise InternalError for legacy unstructured indexes (Marqo < 2.13.0)."""
-        # Create a legacy unstructured index (marqo_version < 2.13.0)
-        legacy_request = self.unstructured_marqo_index_request(
-            name='legacy_index',
-            marqo_version='2.12.0',
-            model=Model(name='hf/e5-small')
-        )
-        self.index_management.create_index(legacy_request)
+        with self.assertRaisesStrict(InternalError) as ctx:
+            self.index_management.update_index_main_schema('legacy_unstructured_index')
 
-        try:
-            with self.assertRaisesStrict(InternalError) as ctx:
-                self.index_management.update_index_main_schema('legacy_index')
-
-            self.assertIn('only semi-structured indexes support schema updates', str(ctx.exception))
-        finally:
-            self.index_management.delete_index_by_name('legacy_index')
+        self.assertIn('only semi-structured indexes support schema updates', str(ctx.exception))
 
     def test_update_schema_version_too_old(self):
         """Should raise UnsupportedFeatureError for indexes created with Marqo < 2.23.0."""
-        # Create an index with Marqo 2.22.0 (before schema update feature)
-        old_version_request = self.unstructured_marqo_index_request(
-            name='old_version_index',
-            marqo_version='2.22.0',
-            model=Model(name='hf/e5-small')
+        with self.assertRaisesStrict(UnsupportedFeatureError) as ctx:
+            self.index_management.update_index_main_schema('old_version_index')
+
+        self.assertIn('Schema update is only supported for indexes created with Marqo 2.23.0 or later',
+                      str(ctx.exception))
+        self.assertIn('created with Marqo 2.22.0', str(ctx.exception))
+
+    # ============================================================================
+    # configChangeActions Tests
+    # ============================================================================
+
+    @patch('marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema.SemiStructuredVespaSchema.generate_vespa_schema')
+    def test_update_schema_with_restart_actions(self, mock_generate_schema):
+        """When restart actions are required and force=False, should block deployment.
+        In this case, we will replace
+        ```
+        field marqo__lexical_title type string {
+            indexing: index | summary
+            index: enable-bm25
+        }
+        ```
+        with
+        ```
+        field marqo__lexical_title type string {
+            indexing: index | summary | attribute
+            index: enable-bm25
+        }
+        ```
+        Adding the attribute aspect will require a restart.
+        See https://docs.vespa.ai/en/reference/schema-reference.html#changes-that-require-restart-but-not-re-feed for details
+        """
+
+        test_index_name = 'test_config_change_restart'
+        saved_index = self.index_management.get_index(test_index_name)
+        original_schema = self._get_schema_from_vespa(saved_index.schema_name)
+
+        modified_schema = original_schema.replace(
+            'indexing: index | summary',
+            'indexing: index | summary | attribute',
+            1
         )
-        self.index_management.create_index(old_version_request)
+        mock_generate_schema.return_value = modified_schema
 
-        try:
-            with self.assertRaisesStrict(UnsupportedFeatureError) as ctx:
-                self.index_management.update_index_main_schema('old_version_index')
+        # Verify it reject updates if not forced
+        result = self.index_management.update_index_main_schema(
+            test_index_name,
+            force=False
+        )
 
-            self.assertIn('Schema update is only supported for indexes created with Marqo 2.23.0 or later', str(ctx.exception))
-            self.assertIn('created with Marqo 2.22.0', str(ctx.exception))
-        finally:
-            self.index_management.delete_index_by_name('old_version_index')
+        # Verify deployment was blocked
+        self.assertFalse(result['updated'])
+        self.assertTrue(result['schema_changed'])
+        self.assertIn('Vespa requires manual actions before proceeding', result['reason'])
+        self.assertIn('restart', result['config_change_actions'])
+        self.assertEqual(1, len(result['config_change_actions']['restart']))
+        self.assertIn("Field 'marqo__lexical_title' changed: add attribute aspect", result['config_change_actions']['restart'][0]['messages'][0])
+
+        # Verify schema was NOT deployed
+        self.assertEqual(original_schema, self._get_schema_from_vespa(saved_index.schema_name))
+
+        # Verify it updates the schema when forced set to true
+        result_forced = self.index_management.update_index_main_schema(
+            test_index_name,
+            force=True
+        )
+        self.assertTrue(result_forced['updated'])
+        self.assertTrue(result_forced['schema_changed'])
+        self.assertIn('Update forced despite required actions', result_forced['reason'])
+        self.assertEqual(modified_schema, self._get_schema_from_vespa(saved_index.schema_name))
+
+    @patch('marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema.SemiStructuredVespaSchema.generate_vespa_schema')
+    def test_update_schema_with_refeed_actions(self, mock_generate_schema):
+        """When re-feed actions are required and force=False, should block deployment.
+        In this case, we will replace
+        ```
+        field marqo__id type string
+        summary marqo__id type string
+        ```
+        with
+        ```
+        field marqo__id type int
+        summary marqo__id type int
+        ```
+        Changing field type will require a re-feed.
+        See https://docs.vespa.ai/en/reference/schema-reference.html#changes-that-require-re-feed for details
+        """
+
+        test_index_name = 'test_config_change_refeed'
+        saved_index = self.index_management.get_index(test_index_name)
+        original_schema = self._get_schema_from_vespa(saved_index.schema_name)
+
+        modified_schema = original_schema.replace(
+            'marqo__id type string',
+            'marqo__id type int',
+        )
+        mock_generate_schema.return_value = modified_schema
+
+        result = self.index_management.update_index_main_schema(
+            test_index_name,
+            force=False
+        )
+
+        # Verify deployment was blocked
+        self.assertFalse(result['updated'])
+        self.assertTrue(result['schema_changed'])
+        self.assertIn('Vespa requires manual actions before proceeding', result['reason'])
+        self.assertIn('refeed', result['config_change_actions'])
+        self.assertIn("Field 'marqo__id' changed: data type: 'string' -> 'int'",
+                      result['config_change_actions']['refeed'][0]['messages'][0])
+
+        self.assertEqual(original_schema, self._get_schema_from_vespa(saved_index.schema_name))
+
+        # Force update
+        result_forced = self.index_management.update_index_main_schema(
+            test_index_name,
+            force=True
+        )
+
+        # Verify deployment proceeded despite actions
+        self.assertTrue(result_forced['updated'])
+        self.assertTrue(result_forced['schema_changed'])
+        self.assertIn('Update forced despite required actions', result_forced['reason'])
+
+        self.assertEqual(modified_schema, self._get_schema_from_vespa(saved_index.schema_name))
+
+    @patch('marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema.SemiStructuredVespaSchema.generate_vespa_schema')
+    def test_update_schema_with_reindex_actions(self, mock_generate_schema):
+        """When reindex actions are required and force=False, should block deployment.
+        In this case, we will replace
+        ```
+        field marqo__id type string {
+            indexing: attribute | summary
+            attribute: fast-search
+            rank: filter
+        }
+        ```
+        with
+        ```
+        field marqo__id type string {
+            indexing: attribute | summary | index
+            attribute: fast-search
+            rank: filter
+        }
+        ```
+        Adding the index aspect to a string field will require a reindex.
+        See https://docs.vespa.ai/en/reference/schema-reference.html#changes-that-require-reindexing for details
+        """
+        test_index_name = 'test_config_change_reindex'
+        saved_index = self.index_management.get_index(test_index_name)
+        original_schema = self._get_schema_from_vespa(saved_index.schema_name)
+
+        modified_schema = original_schema.replace(
+            'indexing: attribute | summary',
+            'indexing: attribute | summary | index',
+            1
+        )
+        mock_generate_schema.return_value = modified_schema
+
+        result = self.index_management.update_index_main_schema(
+            test_index_name,
+            force=False
+        )
+
+        # Verify deployment was blocked
+        self.assertFalse(result['updated'])
+        self.assertTrue(result['schema_changed'])
+        self.assertIn('Vespa requires manual actions before proceeding', result['reason'])
+        self.assertIn('reindex', result['config_change_actions'])
+        self.assertIn("Field 'marqo__id' changed: add index aspect",
+                      result['config_change_actions']['reindex'][0]['messages'][0])
+
+        self.assertEqual(original_schema, self._get_schema_from_vespa(saved_index.schema_name))
+
+        # Force update
+        result_forced = self.index_management.update_index_main_schema(
+            test_index_name,
+            force=True
+        )
+
+        # Verify deployment is done
+        self.assertTrue(result_forced['updated'])
+        self.assertTrue(result_forced['schema_changed'])
+        self.assertIn('Update forced despite required actions', result_forced['reason'])
+        self.assertIn('reindex', result_forced['config_change_actions'])
+        self.assertEqual(modified_schema, self._get_schema_from_vespa(saved_index.schema_name))

--- a/tests/integ_tests/core/index_management/test_index_management_schema_update.py
+++ b/tests/integ_tests/core/index_management/test_index_management_schema_update.py
@@ -81,7 +81,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
     # ============================================================================
 
     def test_update_schema_no_changes(self):
-        """When schema hasn't changed, should return schema_changed=False and not deploy."""
+        """When schema hasn't changed, should return schemaChanged=False and not deploy."""
         test_index_name = 'test_schema_update_index'
         result = self.index_management.apply_latest_schema_template(test_index_name)
 
@@ -90,11 +90,11 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         original_version = saved_index.version
 
         self.assertFalse(result['updated'])
-        self.assertFalse(result['schema_changed'])
+        self.assertFalse(result['schemaChanged'])
         self.assertEqual('Schema is already up to date', result['reason'])
-        self.assertEqual('No changes', result['schema_diff'])
-        self.assertEqual(original_schema, result['old_schema'])
-        self.assertEqual(original_schema, result['new_schema'])
+        self.assertEqual('No changes', result['schemaDiff'])
+        self.assertEqual(original_schema, result['oldSchema'])
+        self.assertEqual(original_schema, result['newSchema'])
 
         self.assertEqual(original_version, self.index_management.get_index(test_index_name).version)
 
@@ -118,11 +118,11 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         # Verify the result
         self.assertTrue(result['updated'])
-        self.assertTrue(result['schema_changed'])
+        self.assertTrue(result['schemaChanged'])
         self.assertIn('Schema updated successfully', result['reason'])
-        self.assertEqual(original_schema, result['old_schema'])
-        self.assertEqual(modified_schema, result['new_schema'])
-        self.assertIn('# Updated schema', result['schema_diff'])
+        self.assertEqual(original_schema, result['oldSchema'])
+        self.assertEqual(modified_schema, result['newSchema'])
+        self.assertIn('# Updated schema', result['schemaDiff'])
 
         # Verify schema was actually deployed to Vespa
         self.assertEqual(modified_schema, self._get_schema_from_vespa(saved_index.schema_name))
@@ -149,10 +149,10 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         # Verify no deployment occurred
         self.assertFalse(result['updated'])
-        self.assertTrue(result['schema_changed'])
+        self.assertTrue(result['schemaChanged'])
         self.assertEqual('Dry run - no changes deployed', result['reason'])
-        self.assertEqual(modified_schema, result['new_schema'])
-        self.assertIn('# Dry run test', result['schema_diff'])
+        self.assertEqual(modified_schema, result['newSchema'])
+        self.assertIn('# Dry run test', result['schemaDiff'])
 
         # Verify schema was NOT deployed to Vespa (original schema still present)
         self.assertEqual(original_schema, self._get_schema_from_vespa(saved_index.schema_name))
@@ -235,11 +235,11 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         # Verify deployment was blocked
         self.assertFalse(result['updated'])
-        self.assertTrue(result['schema_changed'])
+        self.assertTrue(result['schemaChanged'])
         self.assertIn('Vespa requires manual actions before proceeding', result['reason'])
-        self.assertIn('restart', result['config_change_actions'])
-        self.assertEqual(1, len(result['config_change_actions']['restart']))
-        self.assertIn("Field 'marqo__lexical_title' changed: add attribute aspect", result['config_change_actions']['restart'][0]['messages'][0])
+        self.assertIn('restart', result['configChangeActions'])
+        self.assertEqual(1, len(result['configChangeActions']['restart']))
+        self.assertIn("Field 'marqo__lexical_title' changed: add attribute aspect", result['configChangeActions']['restart'][0]['messages'][0])
 
         # Verify schema was NOT deployed
         self.assertEqual(original_schema, self._get_schema_from_vespa(saved_index.schema_name))
@@ -250,7 +250,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
             force=True
         )
         self.assertTrue(result_forced['updated'])
-        self.assertTrue(result_forced['schema_changed'])
+        self.assertTrue(result_forced['schemaChanged'])
         self.assertIn('Update forced despite required actions', result_forced['reason'])
         self.assertEqual(modified_schema, self._get_schema_from_vespa(saved_index.schema_name))
 
@@ -288,11 +288,11 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         # Verify deployment was blocked
         self.assertFalse(result['updated'])
-        self.assertTrue(result['schema_changed'])
+        self.assertTrue(result['schemaChanged'])
         self.assertIn('Vespa requires manual actions before proceeding', result['reason'])
-        self.assertIn('refeed', result['config_change_actions'])
+        self.assertIn('refeed', result['configChangeActions'])
         self.assertIn("Field 'marqo__id' changed: data type: 'string' -> 'int'",
-                      result['config_change_actions']['refeed'][0]['messages'][0])
+                      result['configChangeActions']['refeed'][0]['messages'][0])
 
         self.assertEqual(original_schema, self._get_schema_from_vespa(saved_index.schema_name))
 
@@ -304,7 +304,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         # Verify deployment proceeded despite actions
         self.assertTrue(result_forced['updated'])
-        self.assertTrue(result_forced['schema_changed'])
+        self.assertTrue(result_forced['schemaChanged'])
         self.assertIn('Update forced despite required actions', result_forced['reason'])
 
         self.assertEqual(modified_schema, self._get_schema_from_vespa(saved_index.schema_name))
@@ -349,11 +349,11 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         # Verify deployment was blocked
         self.assertFalse(result['updated'])
-        self.assertTrue(result['schema_changed'])
+        self.assertTrue(result['schemaChanged'])
         self.assertIn('Vespa requires manual actions before proceeding', result['reason'])
-        self.assertIn('reindex', result['config_change_actions'])
+        self.assertIn('reindex', result['configChangeActions'])
         self.assertIn("Field 'marqo__id' changed: add index aspect",
-                      result['config_change_actions']['reindex'][0]['messages'][0])
+                      result['configChangeActions']['reindex'][0]['messages'][0])
 
         self.assertEqual(original_schema, self._get_schema_from_vespa(saved_index.schema_name))
 
@@ -365,7 +365,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         # Verify deployment is done
         self.assertTrue(result_forced['updated'])
-        self.assertTrue(result_forced['schema_changed'])
+        self.assertTrue(result_forced['schemaChanged'])
         self.assertIn('Update forced despite required actions', result_forced['reason'])
-        self.assertIn('reindex', result_forced['config_change_actions'])
+        self.assertIn('reindex', result_forced['configChangeActions'])
         self.assertEqual(modified_schema, self._get_schema_from_vespa(saved_index.schema_name))

--- a/tests/integ_tests/core/index_management/test_index_management_schema_update.py
+++ b/tests/integ_tests/core/index_management/test_index_management_schema_update.py
@@ -11,7 +11,7 @@ from tests.integ_tests.marqo_test import MarqoTestCase
 
 
 class TestIndexManagementSchemaUpdate(MarqoTestCase):
-    """Integration tests for the update_index_main_schema feature."""
+    """Integration tests for the apply_latest_schema_template feature."""
 
     @classmethod
     def _add_validation_overrides(self, app_root_path: str):
@@ -83,7 +83,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
     def test_update_schema_no_changes(self):
         """When schema hasn't changed, should return schema_changed=False and not deploy."""
         test_index_name = 'test_schema_update_index'
-        result = self.index_management.update_index_main_schema(test_index_name)
+        result = self.index_management.apply_latest_schema_template(test_index_name)
 
         saved_index = self.index_management.get_index(test_index_name)
         original_schema = self._get_schema_from_vespa(saved_index.schema_name)
@@ -114,7 +114,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         )
         mock_generate_schema.return_value = modified_schema
 
-        result = self.index_management.update_index_main_schema(test_index_name)
+        result = self.index_management.apply_latest_schema_template(test_index_name)
 
         # Verify the result
         self.assertTrue(result['updated'])
@@ -142,7 +142,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         )
         mock_generate_schema.return_value = modified_schema
 
-        result = self.index_management.update_index_main_schema(
+        result = self.index_management.apply_latest_schema_template(
             test_index_name,
             dry_run=True
         )
@@ -164,28 +164,28 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
     def test_update_schema_index_not_found(self):
         """Should raise IndexNotFoundError for non-existent index."""
         with self.assertRaisesStrict(IndexNotFoundError) as ctx:
-            self.index_management.update_index_main_schema('nonexistent_index')
+            self.index_management.apply_latest_schema_template('nonexistent_index')
 
         self.assertIn('nonexistent_index', str(ctx.exception))
 
     def test_update_schema_wrong_index_type_structured(self):
         """Should raise InternalError for structured indexes (not supported)."""
         with self.assertRaisesStrict(InternalError) as ctx:
-            self.index_management.update_index_main_schema('structured_index')
+            self.index_management.apply_latest_schema_template('structured_index')
 
         self.assertIn('only semi-structured indexes support schema updates', str(ctx.exception))
 
     def test_update_schema_wrong_index_type_legacy_unstructured(self):
         """Should raise InternalError for legacy unstructured indexes (Marqo < 2.13.0)."""
         with self.assertRaisesStrict(InternalError) as ctx:
-            self.index_management.update_index_main_schema('legacy_unstructured_index')
+            self.index_management.apply_latest_schema_template('legacy_unstructured_index')
 
         self.assertIn('only semi-structured indexes support schema updates', str(ctx.exception))
 
     def test_update_schema_version_too_old(self):
         """Should raise UnsupportedFeatureError for indexes created with Marqo < 2.23.0."""
         with self.assertRaisesStrict(UnsupportedFeatureError) as ctx:
-            self.index_management.update_index_main_schema('old_version_index')
+            self.index_management.apply_latest_schema_template('old_version_index')
 
         self.assertIn('Schema update is only supported for indexes created with Marqo 2.23.0 or later',
                       str(ctx.exception))
@@ -228,7 +228,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         mock_generate_schema.return_value = modified_schema
 
         # Verify it reject updates if not forced
-        result = self.index_management.update_index_main_schema(
+        result = self.index_management.apply_latest_schema_template(
             test_index_name,
             force=False
         )
@@ -245,7 +245,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.assertEqual(original_schema, self._get_schema_from_vespa(saved_index.schema_name))
 
         # Verify it updates the schema when forced set to true
-        result_forced = self.index_management.update_index_main_schema(
+        result_forced = self.index_management.apply_latest_schema_template(
             test_index_name,
             force=True
         )
@@ -281,7 +281,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         )
         mock_generate_schema.return_value = modified_schema
 
-        result = self.index_management.update_index_main_schema(
+        result = self.index_management.apply_latest_schema_template(
             test_index_name,
             force=False
         )
@@ -297,7 +297,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.assertEqual(original_schema, self._get_schema_from_vespa(saved_index.schema_name))
 
         # Force update
-        result_forced = self.index_management.update_index_main_schema(
+        result_forced = self.index_management.apply_latest_schema_template(
             test_index_name,
             force=True
         )
@@ -342,7 +342,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         )
         mock_generate_schema.return_value = modified_schema
 
-        result = self.index_management.update_index_main_schema(
+        result = self.index_management.apply_latest_schema_template(
             test_index_name,
             force=False
         )
@@ -358,7 +358,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.assertEqual(original_schema, self._get_schema_from_vespa(saved_index.schema_name))
 
         # Force update
-        result_forced = self.index_management.update_index_main_schema(
+        result_forced = self.index_management.apply_latest_schema_template(
             test_index_name,
             force=True
         )

--- a/tests/integ_tests/tensor_search/test_api.py
+++ b/tests/integ_tests/tensor_search/test_api.py
@@ -133,6 +133,14 @@ class ApiTests(MarqoTestCase):
 
 
 class ValidationApiTests(MarqoTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        test_index_request = cls.unstructured_marqo_index_request()
+        cls.indexes = cls.create_indexes([test_index_request])
+
+        cls.test_index = cls.indexes[0]
+
     def setUp(self):
         self.client = TestClient(api.app)
 
@@ -216,6 +224,35 @@ class ValidationApiTests(MarqoTestCase):
             self.assertIn("message", response.json())
             self.assertEqual(response.json()["code"], "invalid_argument")
             self.assertEqual(response.json()["type"], "invalid_request")
+
+    def test_apply_latest_schema_template_defaultDisabled(self):
+        """
+        Test that the apply_latest_schema_template endpoint returns 403 by default.
+        """
+        index_name = self.test_index.name
+        response = self.client.post(f"/indexes/{index_name}/apply-latest-schema-template")
+        self.assertEqual(response.status_code, 403)
+        self.assertIn("This API endpoint is disabled", response.json()["detail"])
+
+    def test_apply_latest_schema_template_disabled(self):
+        """
+        Test that the apply_latest_schema_template endpoint returns 403 when ops API is disabled explicitly.
+        """
+        with patch.dict('os.environ', {EnvVars.MARQO_ENABLE_OPS_API: 'FALSE'}):
+            index_name = self.test_index.name
+            response = self.client.post(f"/indexes/{index_name}/apply-latest-schema-template")
+            self.assertEqual(response.status_code, 403)
+            self.assertIn("This API endpoint is disabled", response.json()["detail"])
+
+    def test_apply_latest_schema_template_enabled(self):
+        """
+        Test that the apply_latest_schema_template endpoint is accessible when ops API is enabled.
+        """
+        with patch.dict('os.environ', {EnvVars.MARQO_ENABLE_OPS_API: 'TRUE'}):
+            index_name = self.test_index.name
+            response = self.client.post(f"/indexes/{index_name}/apply-latest-schema-template")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual("Schema is already up to date", response.json()["reason"])
 
 
 class TestApiCustomEnvVars(MarqoTestCase):

--- a/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
+++ b/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
@@ -1,0 +1,378 @@
+"""Unit tests for IndexManagement.update_index_main_schema() method."""
+import unittest
+from unittest.mock import Mock, MagicMock, patch
+
+from marqo.core.exceptions import IndexNotFoundError, InternalError
+from marqo.core.index_management.index_management import IndexManagement
+from marqo.core.index_management.vespa_application_package import (
+    VespaApplicationPackage,
+    ApplicationPackageDeploymentSessionStore
+)
+from marqo.core.models.marqo_index import SemiStructuredMarqoIndex, StructuredMarqoIndex
+from tests.unit_tests.marqo_test import MarqoTestCase
+
+
+class TestIndexManagementSchemaUpdate(MarqoTestCase):
+    """Test cases for IndexManagement.update_index_main_schema() method."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_vespa_client = Mock()
+        self.mock_zookeeper_client = Mock()
+
+        # Create IndexManagement instance with mocks
+        self.index_mgmt = IndexManagement(
+            vespa_client=self.mock_vespa_client,
+            zookeeper_client=self.mock_zookeeper_client,
+            enable_index_operations=True
+        )
+
+        # Mock the vespa deployment lock to be a no-op context manager
+        self.mock_lock = MagicMock()
+        self.mock_lock.__enter__ = Mock(return_value=None)
+        self.mock_lock.__exit__ = Mock(return_value=None)
+        self.index_mgmt._vespa_deployment_lock = Mock(return_value=self.mock_lock)
+
+    def test_update_index_main_schema_no_changes(self):
+        """Test update when schema is already up-to-date."""
+        # Setup
+        test_index = self.semi_structured_marqo_index(
+            name="test_index",
+            schema_name="test_schema"
+        )
+
+        current_schema = "schema test_schema { document test_schema {} }"
+
+        # Mock get_index to return test index
+        self.index_mgmt.get_index = Mock(return_value=test_index)
+
+        # Mock vespa application
+        mock_vespa_app = Mock(spec=VespaApplicationPackage)
+        mock_vespa_app.get_schema = Mock(return_value=current_schema)
+        mock_vespa_app._store = Mock(spec=ApplicationPackageDeploymentSessionStore)
+        self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
+
+        # Mock schema generation to return same schema
+        with patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema') as mock_schema_class:
+            mock_schema_class.generate_vespa_schema.return_value = current_schema
+
+            # Execute
+            result = self.index_mgmt.update_index_main_schema("test_index", force=False)
+
+        # Verify
+        self.assertFalse(result['updated'])
+        self.assertFalse(result['schema_changed'])
+        self.assertEqual(result['reason'], "Schema is already up to date")
+        self.assertEqual(result['config_change_actions'], {})
+        mock_vespa_app.update_index_setting_and_schema.assert_not_called()
+
+    def test_update_index_main_schema_with_changes_no_actions(self):
+        """Test update when schema changed but no Vespa actions required."""
+        # Setup
+        test_index = self.semi_structured_marqo_index(
+            name="test_index",
+            schema_name="test_schema"
+        )
+
+        current_schema = "schema test_schema { document test_schema { field old_field type string {} } }"
+        new_schema = "schema test_schema { document test_schema { field new_field type string {} } }"
+
+        # Mock get_index
+        self.index_mgmt.get_index = Mock(return_value=test_index)
+
+        # Mock vespa application
+        mock_vespa_app = Mock(spec=VespaApplicationPackage)
+        mock_vespa_app.get_schema = Mock(return_value=current_schema)
+        mock_vespa_app._store = Mock(spec=ApplicationPackageDeploymentSessionStore)
+
+        # Mock prepare response with no actions
+        prepare_response = {
+            'activate': 'http://activate_url',
+            'configChangeActions': {}
+        }
+        mock_vespa_app.update_index_setting_and_schema = Mock(return_value=prepare_response)
+
+        self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
+
+        # Mock schema generation
+        with patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema') as mock_schema_class:
+            mock_schema_class.generate_vespa_schema.return_value = new_schema
+
+            # Execute
+            result = self.index_mgmt.update_index_main_schema("test_index", force=False)
+
+        # Verify
+        self.assertTrue(result['updated'])
+        self.assertTrue(result['schema_changed'])
+        self.assertEqual(result['reason'], "Schema updated successfully")
+        self.assertEqual(result['config_change_actions'], {})
+
+        # Verify prepare was called
+        mock_vespa_app.update_index_setting_and_schema.assert_called_once()
+        call_args = mock_vespa_app.update_index_setting_and_schema.call_args
+        self.assertTrue(call_args[1]['prepare_only'])
+
+        # Verify activate was called
+        mock_vespa_app._store.activate_deployment.assert_called_once_with(prepare_response)
+
+    def test_update_index_main_schema_with_actions_not_forced(self):
+        """Test update blocks when actions required and force=False."""
+        # Setup
+        test_index = self.semi_structured_marqo_index(
+            name="test_index",
+            schema_name="test_schema"
+        )
+
+        current_schema = "schema test_schema { }"
+        new_schema = "schema test_schema { field new_field type string {} }"
+
+        # Mock get_index
+        self.index_mgmt.get_index = Mock(return_value=test_index)
+
+        # Mock vespa application
+        mock_vespa_app = Mock(spec=VespaApplicationPackage)
+        mock_vespa_app.get_schema = Mock(return_value=current_schema)
+        mock_vespa_app._store = Mock(spec=ApplicationPackageDeploymentSessionStore)
+
+        # Mock prepare response with restart action
+        prepare_response = {
+            'activate': 'http://activate_url',
+            'configChangeActions': {
+                'restart': [
+                    {
+                        'name': 'restart',
+                        'services': ['searchnode'],
+                        'messages': ['Field new_field added']
+                    }
+                ]
+            }
+        }
+        mock_vespa_app.update_index_setting_and_schema = Mock(return_value=prepare_response)
+
+        self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
+
+        # Mock schema generation
+        with patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema') as mock_schema_class:
+            mock_schema_class.generate_vespa_schema.return_value = new_schema
+
+            # Execute
+            result = self.index_mgmt.update_index_main_schema("test_index", force=False)
+
+        # Verify
+        self.assertFalse(result['updated'])
+        self.assertTrue(result['schema_changed'])
+        self.assertIn("Vespa requires manual actions", result['reason'])
+        self.assertIn('restart', result['config_change_actions'])
+
+        # Verify activate was NOT called
+        mock_vespa_app._store.activate_deployment.assert_not_called()
+
+    def test_update_index_main_schema_with_actions_forced(self):
+        """Test update proceeds when actions required but force=True."""
+        # Setup
+        test_index = self.semi_structured_marqo_index(
+            name="test_index",
+            schema_name="test_schema"
+        )
+
+        current_schema = "schema test_schema { }"
+        new_schema = "schema test_schema { field new_field type string {} }"
+
+        # Mock get_index
+        self.index_mgmt.get_index = Mock(return_value=test_index)
+
+        # Mock vespa application
+        mock_vespa_app = Mock(spec=VespaApplicationPackage)
+        mock_vespa_app.get_schema = Mock(return_value=current_schema)
+        mock_vespa_app._store = Mock(spec=ApplicationPackageDeploymentSessionStore)
+
+        # Mock prepare response with restart action
+        prepare_response = {
+            'activate': 'http://activate_url',
+            'configChangeActions': {
+                'restart': [
+                    {
+                        'name': 'restart',
+                        'services': ['searchnode']
+                    }
+                ]
+            }
+        }
+        mock_vespa_app.update_index_setting_and_schema = Mock(return_value=prepare_response)
+
+        self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
+
+        # Mock schema generation
+        with patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema') as mock_schema_class:
+            mock_schema_class.generate_vespa_schema.return_value = new_schema
+
+            # Execute
+            result = self.index_mgmt.update_index_main_schema("test_index", force=True)
+
+        # Verify
+        self.assertTrue(result['updated'])
+        self.assertTrue(result['schema_changed'])
+        self.assertEqual(result['reason'], "Update forced despite required actions")
+        self.assertIn('warning', result)
+        self.assertIn('restart', result['config_change_actions'])
+
+        # Verify activate WAS called
+        mock_vespa_app._store.activate_deployment.assert_called_once_with(prepare_response)
+
+    def test_update_index_main_schema_index_not_found(self):
+        """Test error when index doesn't exist."""
+        # Mock get_index to raise IndexNotFoundError
+        self.index_mgmt.get_index = Mock(side_effect=IndexNotFoundError("Index not found"))
+
+        # Execute and verify exception
+        with self.assertRaises(IndexNotFoundError):
+            self.index_mgmt.update_index_main_schema("nonexistent_index")
+
+    def test_update_index_main_schema_wrong_index_type(self):
+        """Test error when index is not SemiStructuredMarqoIndex."""
+        # Setup structured index
+        test_index = self.structured_marqo_index(
+            name="test_index",
+            schema_name="test_schema"
+        )
+
+        # Mock get_index
+        self.index_mgmt.get_index = Mock(return_value=test_index)
+
+        # Execute and verify exception
+        with self.assertRaises(InternalError) as context:
+            self.index_mgmt.update_index_main_schema("test_index")
+
+        self.assertIn("only semi-structured indexes support schema updates", str(context.exception))
+
+    def test_schema_normalization_handles_whitespace(self):
+        """Test that schema comparison normalizes whitespace correctly."""
+        # Setup
+        test_index = self.semi_structured_marqo_index(
+            name="test_index",
+            schema_name="test_schema"
+        )
+
+        # Schema with different whitespace but same content
+        current_schema = """schema test_schema {
+    document test_schema {
+        field test_field type string {}
+    }
+}"""
+
+        new_schema = """schema test_schema {
+            document test_schema {
+                    field test_field type string {}
+            }
+}"""
+
+        # Mock get_index
+        self.index_mgmt.get_index = Mock(return_value=test_index)
+
+        # Mock vespa application
+        mock_vespa_app = Mock(spec=VespaApplicationPackage)
+        mock_vespa_app.get_schema = Mock(return_value=current_schema)
+        mock_vespa_app._store = Mock(spec=ApplicationPackageDeploymentSessionStore)
+        self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
+
+        # Mock schema generation
+        with patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema') as mock_schema_class:
+            mock_schema_class.generate_vespa_schema.return_value = new_schema
+
+            # Execute
+            result = self.index_mgmt.update_index_main_schema("test_index")
+
+        # Verify - should detect no changes despite whitespace differences
+        self.assertFalse(result['updated'])
+        self.assertFalse(result['schema_changed'])
+
+    def test_configChangeActions_detection_refeed(self):
+        """Test detection of refeed actions."""
+        # Setup
+        test_index = self.semi_structured_marqo_index(
+            name="test_index",
+            schema_name="test_schema"
+        )
+
+        current_schema = "schema test_schema { }"
+        new_schema = "schema test_schema { field new_field type string {} }"
+
+        self.index_mgmt.get_index = Mock(return_value=test_index)
+
+        mock_vespa_app = Mock(spec=VespaApplicationPackage)
+        mock_vespa_app.get_schema = Mock(return_value=current_schema)
+        mock_vespa_app._store = Mock(spec=ApplicationPackageDeploymentSessionStore)
+
+        # Mock prepare response with refeed action
+        prepare_response = {
+            'activate': 'http://activate_url',
+            'configChangeActions': {
+                'refeed': [
+                    {
+                        'name': 'refeed',
+                        'documentType': 'test_schema',
+                        'clusterName': 'content'
+                    }
+                ]
+            }
+        }
+        mock_vespa_app.update_index_setting_and_schema = Mock(return_value=prepare_response)
+        self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
+
+        with patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema') as mock_schema_class:
+            mock_schema_class.generate_vespa_schema.return_value = new_schema
+
+            # Execute with force=False
+            result = self.index_mgmt.update_index_main_schema("test_index", force=False)
+
+        # Verify - should block on refeed action
+        self.assertFalse(result['updated'])
+        self.assertIn('refeed', result['config_change_actions'])
+        mock_vespa_app._store.activate_deployment.assert_not_called()
+
+    def test_configChangeActions_detection_reindex(self):
+        """Test detection of reindex actions."""
+        # Setup
+        test_index = self.semi_structured_marqo_index(
+            name="test_index",
+            schema_name="test_schema"
+        )
+
+        current_schema = "schema test_schema { }"
+        new_schema = "schema test_schema { field new_field type string {} }"
+
+        self.index_mgmt.get_index = Mock(return_value=test_index)
+
+        mock_vespa_app = Mock(spec=VespaApplicationPackage)
+        mock_vespa_app.get_schema = Mock(return_value=current_schema)
+        mock_vespa_app._store = Mock(spec=ApplicationPackageDeploymentSessionStore)
+
+        # Mock prepare response with reindex action
+        prepare_response = {
+            'activate': 'http://activate_url',
+            'configChangeActions': {
+                'reindex': [
+                    {
+                        'name': 'reindex',
+                        'documentType': 'test_schema'
+                    }
+                ]
+            }
+        }
+        mock_vespa_app.update_index_setting_and_schema = Mock(return_value=prepare_response)
+        self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
+
+        with patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema') as mock_schema_class:
+            mock_schema_class.generate_vespa_schema.return_value = new_schema
+
+            # Execute with force=False
+            result = self.index_mgmt.update_index_main_schema("test_index", force=False)
+
+        # Verify - should block on reindex action
+        self.assertFalse(result['updated'])
+        self.assertIn('reindex', result['config_change_actions'])
+        mock_vespa_app._store.activate_deployment.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
+++ b/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
@@ -6,7 +6,8 @@ from marqo.core.exceptions import IndexNotFoundError, InternalError, Unsupported
 from marqo.core.index_management.index_management import IndexManagement
 from marqo.core.index_management.vespa_application_package import (
     VespaApplicationPackage,
-    ApplicationPackageDeploymentSessionStore
+    ApplicationPackageDeploymentSessionStore,
+    VespaApplicationFileStore
 )
 from marqo.core.models.marqo_index import SemiStructuredMarqoIndex, StructuredMarqoIndex
 from tests.unit_tests.marqo_test import MarqoTestCase
@@ -517,6 +518,101 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.assertFalse(result['updated'])
         self.assertEqual(result['reason'], "Dry run - no changes deployed")
         mock_vespa_app.activate_prepared_deployment.assert_not_called()
+
+    def test_update_index_main_schema_with_old_vespa_store_raises_error(self):
+        """Test that prepare_only with VespaApplicationFileStore raises InternalError.
+
+        This covers the error path in update_index_setting_and_schema() when prepare_only=True
+        is used with VespaApplicationFileStore (old Vespa < 8.382.22 that doesn't support
+        deployment session API).
+        """
+        # Setup
+        test_index = self.semi_structured_marqo_index(
+            name="test_index",
+            schema_name="test_schema"
+        )
+        current_schema = "schema test_schema { document test_schema {} }"
+        new_schema = "# Modified\nschema test_schema { document test_schema {} }"
+
+        # Mock get_index
+        self.index_mgmt.get_index = Mock(return_value=test_index)
+
+        # Create VespaApplicationPackage with VespaApplicationFileStore (old Vespa)
+        mock_vespa_app = Mock(spec=VespaApplicationPackage)
+        mock_vespa_app.get_schema.return_value = current_schema
+
+        # Create actual VespaApplicationFileStore to trigger the isinstance check
+        mock_file_store = Mock(spec=VespaApplicationFileStore)
+        mock_vespa_app._store = mock_file_store
+
+        # When update_index_setting_and_schema is called with prepare_only=True,
+        # it should raise InternalError because VespaApplicationFileStore doesn't support it
+        def raise_internal_error(*args, **kwargs):
+            if kwargs.get('prepare_only'):
+                raise InternalError("prepare_only mode requires ApplicationPackageDeploymentSessionStore")
+            return None
+
+        mock_vespa_app.update_index_setting_and_schema = Mock(side_effect=raise_internal_error)
+
+        self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
+
+        # Mock schema generation
+        with patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema') as mock_schema_class:
+            mock_schema_class.generate_vespa_schema.return_value = new_schema
+
+            # Execute - this should raise InternalError
+            with self.assertRaises(InternalError) as ctx:
+                self.index_mgmt.update_index_main_schema("test_index")
+
+        # Verify error message
+        self.assertIn("prepare_only mode requires ApplicationPackageDeploymentSessionStore", str(ctx.exception))
+
+    def test_activate_prepared_deployment_with_old_vespa_store_raises_error(self):
+        """Test that activate_prepared_deployment with VespaApplicationFileStore raises InternalError.
+
+        This directly tests the activate_prepared_deployment() method's error path when called
+        with VespaApplicationFileStore.
+        """
+        # Create a mock VespaApplicationFileStore with proper XML content
+        mock_file_store = Mock(spec=VespaApplicationFileStore)
+        mock_file_store.file_exists.return_value = True
+
+        # Return valid XML for services.xml and JSON for config files
+        def mock_read_text_file(filename):
+            if filename == 'services.xml':
+                return '''<?xml version="1.0" encoding="utf-8" ?>
+                <services version="1.0">
+                    <container id="default" version="1.0"></container>
+                    <content id="content_default" version="1.0">
+                        <documents>
+                            <document type="test" mode="index"/>
+                        </documents>
+                    </content>
+                </services>'''
+            elif filename == 'marqo_config.json':
+                return '{"version": "1.0.0"}'
+            elif filename in ['marqo_index_settings.json', 'marqo_index_settings_history.json']:
+                return '{}'
+            return None
+
+        mock_file_store.read_text_file.side_effect = mock_read_text_file
+
+        # Create VespaApplicationPackage with the file store
+        vespa_app = VespaApplicationPackage(store=mock_file_store)
+
+        # Prepare response
+        prepare_response = {
+            'activate': 'http://activate_url',
+            'configChangeActions': {}
+        }
+
+        # Execute - should raise InternalError because VespaApplicationFileStore doesn't support
+        # the two-phase deployment (prepare/activate separately)
+        with self.assertRaises(InternalError) as ctx:
+            vespa_app.activate_prepared_deployment(prepare_response)
+
+        # Verify error message
+        self.assertIn("Deployment activation requires ApplicationPackageDeploymentSessionStore", str(ctx.exception))
 
 
 if __name__ == '__main__':

--- a/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
+++ b/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
@@ -113,7 +113,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.assertTrue(call_args[1]['prepare_only'])
 
         # Verify activate was called
-        mock_vespa_app._store.activate_deployment.assert_called_once_with(prepare_response)
+        mock_vespa_app.activate_prepared_deployment.assert_called_once_with(prepare_response)
 
     def test_update_index_main_schema_with_actions_not_forced(self):
         """Test update blocks when actions required and force=False."""
@@ -165,7 +165,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.assertIn('restart', result['config_change_actions'])
 
         # Verify activate was NOT called
-        mock_vespa_app._store.activate_deployment.assert_not_called()
+        mock_vespa_app.activate_prepared_deployment.assert_not_called()
 
     def test_update_index_main_schema_with_actions_forced(self):
         """Test update proceeds when actions required but force=True."""
@@ -217,7 +217,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.assertIn('restart', result['config_change_actions'])
 
         # Verify activate WAS called
-        mock_vespa_app._store.activate_deployment.assert_called_once_with(prepare_response)
+        mock_vespa_app.activate_prepared_deployment.assert_called_once_with(prepare_response)
 
     def test_update_index_main_schema_index_not_found(self):
         """Test error when index doesn't exist."""
@@ -328,7 +328,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         # Verify - should block on refeed action
         self.assertFalse(result['updated'])
         self.assertIn('refeed', result['config_change_actions'])
-        mock_vespa_app._store.activate_deployment.assert_not_called()
+        mock_vespa_app.activate_prepared_deployment.assert_not_called()
 
     def test_configChangeActions_detection_reindex(self):
         """Test detection of reindex actions."""
@@ -371,7 +371,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         # Verify - should block on reindex action
         self.assertFalse(result['updated'])
         self.assertIn('reindex', result['config_change_actions'])
-        mock_vespa_app._store.activate_deployment.assert_not_called()
+        mock_vespa_app.activate_prepared_deployment.assert_not_called()
 
     def test_update_index_main_schema_version_too_old(self):
         """Test error when index was created with Marqo < 2.23.0."""

--- a/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
+++ b/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
@@ -245,47 +245,6 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         self.assertIn("only semi-structured indexes support schema updates", str(context.exception))
 
-    def test_schema_normalization_handles_whitespace(self):
-        """Test that schema comparison normalizes whitespace correctly."""
-        # Setup
-        test_index = self.semi_structured_marqo_index(
-            name="test_index",
-            schema_name="test_schema"
-        )
-
-        # Schema with different whitespace but same content
-        current_schema = """schema test_schema {
-    document test_schema {
-        field test_field type string {}
-    }
-}"""
-
-        new_schema = """schema test_schema {
-            document test_schema {
-                    field test_field type string {}
-            }
-}"""
-
-        # Mock get_index
-        self.index_mgmt.get_index = Mock(return_value=test_index)
-
-        # Mock vespa application
-        mock_vespa_app = Mock(spec=VespaApplicationPackage)
-        mock_vespa_app.get_schema = Mock(return_value=current_schema)
-        mock_vespa_app._store = Mock(spec=ApplicationPackageDeploymentSessionStore)
-        self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
-
-        # Mock schema generation
-        with patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema') as mock_schema_class:
-            mock_schema_class.generate_vespa_schema.return_value = new_schema
-
-            # Execute
-            result = self.index_mgmt.update_index_main_schema("test_index")
-
-        # Verify - should detect no changes despite whitespace differences
-        self.assertFalse(result['updated'])
-        self.assertFalse(result['schema_changed'])
-
     def test_configChangeActions_detection_refeed(self):
         """Test detection of refeed actions."""
         # Setup
@@ -392,6 +351,173 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         # Verify error message contains version information
         self.assertIn("2.23.0", str(context.exception))
         self.assertIn("2.22.0", str(context.exception))
+
+    def test_update_index_main_schema_dry_run_no_changes(self):
+        """Test dry_run when schema is already up to date."""
+        # Setup
+        test_index = self.semi_structured_marqo_index(
+            name="test_index",
+            schema_name="test_schema"
+        )
+
+        current_schema = "schema test_schema { document test_schema {} }"
+
+        # Mock get_index
+        self.index_mgmt.get_index = Mock(return_value=test_index)
+
+        # Mock vespa application
+        mock_vespa_app = Mock(spec=VespaApplicationPackage)
+        mock_vespa_app.get_schema = Mock(return_value=current_schema)
+        self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
+
+        # Mock schema generation to return same schema
+        with patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema') as mock_schema_class:
+            mock_schema_class.generate_vespa_schema.return_value = current_schema
+
+            # Execute with dry_run=True
+            result = self.index_mgmt.update_index_main_schema("test_index", dry_run=True)
+
+        # Verify
+        self.assertFalse(result['updated'])
+        self.assertFalse(result['schema_changed'])
+        self.assertEqual(result['reason'], "Schema is already up to date")
+        self.assertIn('old_schema', result)
+        self.assertIn('new_schema', result)
+        self.assertIn('schema_diff', result)
+        self.assertEqual(result['schema_diff'], 'No changes')
+
+    def test_update_index_main_schema_dry_run_with_changes(self):
+        """Test dry_run with schema changes - should not deploy."""
+        # Setup
+        test_index = self.semi_structured_marqo_index(
+            name="test_index",
+            schema_name="test_schema"
+        )
+
+        current_schema = "schema test_schema { document test_schema { field old_field type string {} } }"
+        new_schema = "schema test_schema { document test_schema { field new_field type string {} } }"
+
+        # Mock get_index
+        self.index_mgmt.get_index = Mock(return_value=test_index)
+
+        # Mock vespa application
+        mock_vespa_app = Mock(spec=VespaApplicationPackage)
+        mock_vespa_app.get_schema = Mock(return_value=current_schema)
+
+        # Mock prepare response with no actions
+        prepare_response = {
+            'activate': 'http://activate_url',
+            'configChangeActions': {}
+        }
+        mock_vespa_app.update_index_setting_and_schema = Mock(return_value=prepare_response)
+
+        self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
+
+        # Mock schema generation
+        with patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema') as mock_schema_class:
+            mock_schema_class.generate_vespa_schema.return_value = new_schema
+
+            # Execute with dry_run=True
+            result = self.index_mgmt.update_index_main_schema("test_index", dry_run=True)
+
+        # Verify
+        self.assertFalse(result['updated'])  # Should not be updated in dry run
+        self.assertTrue(result['schema_changed'])
+        self.assertEqual(result['reason'], "Dry run - no changes deployed")
+        self.assertIn('old_schema', result)
+        self.assertIn('new_schema', result)
+        self.assertIn('schema_diff', result)
+        self.assertNotEqual(result['schema_diff'], 'No changes')
+
+        # Verify prepare was called but activate was NOT
+        mock_vespa_app.update_index_setting_and_schema.assert_called_once()
+        mock_vespa_app.activate_prepared_deployment.assert_not_called()
+
+    def test_update_index_main_schema_dry_run_with_actions(self):
+        """Test dry_run with actions required - should still not deploy."""
+        # Setup
+        test_index = self.semi_structured_marqo_index(
+            name="test_index",
+            schema_name="test_schema"
+        )
+
+        current_schema = "schema test_schema {}"
+        new_schema = "schema test_schema { field new_field type string {} }"
+
+        # Mock get_index
+        self.index_mgmt.get_index = Mock(return_value=test_index)
+
+        # Mock vespa application
+        mock_vespa_app = Mock(spec=VespaApplicationPackage)
+        mock_vespa_app.get_schema = Mock(return_value=current_schema)
+
+        # Mock prepare response with restart action
+        prepare_response = {
+            'activate': 'http://activate_url',
+            'configChangeActions': {
+                'restart': [{'name': 'restart', 'services': ['searchnode']}]
+            }
+        }
+        mock_vespa_app.update_index_setting_and_schema = Mock(return_value=prepare_response)
+
+        self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
+
+        # Mock schema generation
+        with patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema') as mock_schema_class:
+            mock_schema_class.generate_vespa_schema.return_value = new_schema
+
+            # Execute with dry_run=True
+            result = self.index_mgmt.update_index_main_schema("test_index", dry_run=True)
+
+        # Verify
+        self.assertFalse(result['updated'])
+        self.assertTrue(result['schema_changed'])
+        self.assertEqual(result['reason'], "Dry run - no changes deployed")
+        self.assertIn('restart', result['config_change_actions'])
+
+        # Verify activate was NOT called
+        mock_vespa_app.activate_prepared_deployment.assert_not_called()
+
+    def test_update_index_main_schema_dry_run_ignores_force(self):
+        """Test that dry_run takes precedence over force parameter."""
+        # Setup
+        test_index = self.semi_structured_marqo_index(
+            name="test_index",
+            schema_name="test_schema"
+        )
+
+        current_schema = "schema test_schema {}"
+        new_schema = "schema test_schema { field new_field type string {} }"
+
+        # Mock get_index
+        self.index_mgmt.get_index = Mock(return_value=test_index)
+
+        # Mock vespa application
+        mock_vespa_app = Mock(spec=VespaApplicationPackage)
+        mock_vespa_app.get_schema = Mock(return_value=current_schema)
+
+        # Mock prepare response with actions
+        prepare_response = {
+            'activate': 'http://activate_url',
+            'configChangeActions': {
+                'restart': [{'name': 'restart'}]
+            }
+        }
+        mock_vespa_app.update_index_setting_and_schema = Mock(return_value=prepare_response)
+
+        self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
+
+        # Mock schema generation
+        with patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema') as mock_schema_class:
+            mock_schema_class.generate_vespa_schema.return_value = new_schema
+
+            # Execute with both dry_run=True and force=True
+            result = self.index_mgmt.update_index_main_schema("test_index", force=True, dry_run=True)
+
+        # Verify - dry_run should take precedence, no deployment
+        self.assertFalse(result['updated'])
+        self.assertEqual(result['reason'], "Dry run - no changes deployed")
+        mock_vespa_app.activate_prepared_deployment.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
+++ b/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
@@ -2,7 +2,7 @@
 import unittest
 from unittest.mock import Mock, MagicMock, patch
 
-from marqo.core.exceptions import IndexNotFoundError, InternalError
+from marqo.core.exceptions import IndexNotFoundError, InternalError, UnsupportedFeatureError
 from marqo.core.index_management.index_management import IndexManagement
 from marqo.core.index_management.vespa_application_package import (
     VespaApplicationPackage,
@@ -372,6 +372,26 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.assertFalse(result['updated'])
         self.assertIn('reindex', result['config_change_actions'])
         mock_vespa_app._store.activate_deployment.assert_not_called()
+
+    def test_update_index_main_schema_version_too_old(self):
+        """Test error when index was created with Marqo < 2.23.0."""
+        # Setup index with old version
+        test_index = self.semi_structured_marqo_index(
+            name="test_index",
+            schema_name="test_schema",
+            marqo_version="2.22.0"  # Below 2.23.0
+        )
+
+        # Mock get_index
+        self.index_mgmt.get_index = Mock(return_value=test_index)
+
+        # Execute and verify exception
+        with self.assertRaises(UnsupportedFeatureError) as context:
+            self.index_mgmt.update_index_main_schema("test_index")
+
+        # Verify error message contains version information
+        self.assertIn("2.23.0", str(context.exception))
+        self.assertIn("2.22.0", str(context.exception))
 
 
 if __name__ == '__main__':

--- a/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
+++ b/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
@@ -62,9 +62,9 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         # Verify
         self.assertFalse(result['updated'])
-        self.assertFalse(result['schema_changed'])
+        self.assertFalse(result['schemaChanged'])
         self.assertEqual(result['reason'], "Schema is already up to date")
-        self.assertEqual(result['config_change_actions'], {})
+        self.assertEqual(result['configChangeActions'], {})
         mock_vespa_app.update_index_setting_and_schema.assert_not_called()
 
     def test_apply_latest_schema_template_with_changes_no_actions(self):
@@ -104,9 +104,9 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         # Verify
         self.assertTrue(result['updated'])
-        self.assertTrue(result['schema_changed'])
+        self.assertTrue(result['schemaChanged'])
         self.assertEqual(result['reason'], "Schema updated successfully")
-        self.assertEqual(result['config_change_actions'], {})
+        self.assertEqual(result['configChangeActions'], {})
 
         # Verify prepare was called
         mock_vespa_app.update_index_setting_and_schema.assert_called_once()
@@ -161,9 +161,9 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         # Verify
         self.assertFalse(result['updated'])
-        self.assertTrue(result['schema_changed'])
+        self.assertTrue(result['schemaChanged'])
         self.assertIn("Vespa requires manual actions", result['reason'])
-        self.assertIn('restart', result['config_change_actions'])
+        self.assertIn('restart', result['configChangeActions'])
 
         # Verify activate was NOT called
         mock_vespa_app.activate_prepared_deployment.assert_not_called()
@@ -212,9 +212,9 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         # Verify
         self.assertTrue(result['updated'])
-        self.assertTrue(result['schema_changed'])
+        self.assertTrue(result['schemaChanged'])
         self.assertEqual(result['reason'], "Update forced despite required actions")
-        self.assertIn('restart', result['config_change_actions'])
+        self.assertIn('restart', result['configChangeActions'])
 
         # Verify activate WAS called
         mock_vespa_app.activate_prepared_deployment.assert_called_once_with(prepare_response)
@@ -286,7 +286,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         # Verify - should block on refeed action
         self.assertFalse(result['updated'])
-        self.assertIn('refeed', result['config_change_actions'])
+        self.assertIn('refeed', result['configChangeActions'])
         mock_vespa_app.activate_prepared_deployment.assert_not_called()
 
     def test_configChangeActions_detection_reindex(self):
@@ -329,7 +329,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         # Verify - should block on reindex action
         self.assertFalse(result['updated'])
-        self.assertIn('reindex', result['config_change_actions'])
+        self.assertIn('reindex', result['configChangeActions'])
         mock_vespa_app.activate_prepared_deployment.assert_not_called()
 
     def test_apply_latest_schema_template_version_too_old(self):
@@ -379,12 +379,12 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         # Verify
         self.assertFalse(result['updated'])
-        self.assertFalse(result['schema_changed'])
+        self.assertFalse(result['schemaChanged'])
         self.assertEqual(result['reason'], "Schema is already up to date")
-        self.assertIn('old_schema', result)
-        self.assertIn('new_schema', result)
-        self.assertIn('schema_diff', result)
-        self.assertEqual(result['schema_diff'], 'No changes')
+        self.assertIn('oldSchema', result)
+        self.assertIn('newSchema', result)
+        self.assertIn('schemaDiff', result)
+        self.assertEqual(result['schemaDiff'], 'No changes')
 
     def test_apply_latest_schema_template_dry_run_with_changes(self):
         """Test dry_run with schema changes - should not deploy."""
@@ -422,12 +422,12 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         # Verify
         self.assertFalse(result['updated'])  # Should not be updated in dry run
-        self.assertTrue(result['schema_changed'])
+        self.assertTrue(result['schemaChanged'])
         self.assertEqual(result['reason'], "Dry run - no changes deployed")
-        self.assertIn('old_schema', result)
-        self.assertIn('new_schema', result)
-        self.assertIn('schema_diff', result)
-        self.assertNotEqual(result['schema_diff'], 'No changes')
+        self.assertIn('oldSchema', result)
+        self.assertIn('newSchema', result)
+        self.assertIn('schemaDiff', result)
+        self.assertNotEqual(result['schemaDiff'], 'No changes')
 
         # Verify prepare was called but activate was NOT
         mock_vespa_app.update_index_setting_and_schema.assert_called_once()
@@ -471,9 +471,9 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         # Verify
         self.assertFalse(result['updated'])
-        self.assertTrue(result['schema_changed'])
+        self.assertTrue(result['schemaChanged'])
         self.assertEqual(result['reason'], "Dry run - no changes deployed")
-        self.assertIn('restart', result['config_change_actions'])
+        self.assertIn('restart', result['configChangeActions'])
 
         # Verify activate was NOT called
         mock_vespa_app.activate_prepared_deployment.assert_not_called()

--- a/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
+++ b/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
@@ -213,7 +213,6 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.assertTrue(result['updated'])
         self.assertTrue(result['schema_changed'])
         self.assertEqual(result['reason'], "Update forced despite required actions")
-        self.assertIn('warning', result)
         self.assertIn('restart', result['config_change_actions'])
 
         # Verify activate WAS called

--- a/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
+++ b/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
@@ -1,4 +1,4 @@
-"""Unit tests for IndexManagement.update_index_main_schema() method."""
+"""Unit tests for IndexManagement.apply_latest_schema_template() method."""
 import unittest
 from unittest.mock import Mock, MagicMock, patch
 
@@ -14,7 +14,7 @@ from tests.unit_tests.marqo_test import MarqoTestCase
 
 
 class TestIndexManagementSchemaUpdate(MarqoTestCase):
-    """Test cases for IndexManagement.update_index_main_schema() method."""
+    """Test cases for IndexManagement.apply_latest_schema_template() method."""
 
     def setUp(self):
         """Set up test fixtures."""
@@ -34,7 +34,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.mock_lock.__exit__ = Mock(return_value=None)
         self.index_mgmt._vespa_deployment_lock = Mock(return_value=self.mock_lock)
 
-    def test_update_index_main_schema_no_changes(self):
+    def test_apply_latest_schema_template_no_changes(self):
         """Test update when schema is already up-to-date."""
         # Setup
         test_index = self.semi_structured_marqo_index(
@@ -58,7 +58,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
             mock_schema_class.generate_vespa_schema.return_value = current_schema
 
             # Execute
-            result = self.index_mgmt.update_index_main_schema("test_index", force=False)
+            result = self.index_mgmt.apply_latest_schema_template("test_index", force=False)
 
         # Verify
         self.assertFalse(result['updated'])
@@ -67,7 +67,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.assertEqual(result['config_change_actions'], {})
         mock_vespa_app.update_index_setting_and_schema.assert_not_called()
 
-    def test_update_index_main_schema_with_changes_no_actions(self):
+    def test_apply_latest_schema_template_with_changes_no_actions(self):
         """Test update when schema changed but no Vespa actions required."""
         # Setup
         test_index = self.semi_structured_marqo_index(
@@ -100,7 +100,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
             mock_schema_class.generate_vespa_schema.return_value = new_schema
 
             # Execute
-            result = self.index_mgmt.update_index_main_schema("test_index", force=False)
+            result = self.index_mgmt.apply_latest_schema_template("test_index", force=False)
 
         # Verify
         self.assertTrue(result['updated'])
@@ -116,7 +116,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         # Verify activate was called
         mock_vespa_app.activate_prepared_deployment.assert_called_once_with(prepare_response)
 
-    def test_update_index_main_schema_with_actions_not_forced(self):
+    def test_apply_latest_schema_template_with_actions_not_forced(self):
         """Test update blocks when actions required and force=False."""
         # Setup
         test_index = self.semi_structured_marqo_index(
@@ -157,7 +157,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
             mock_schema_class.generate_vespa_schema.return_value = new_schema
 
             # Execute
-            result = self.index_mgmt.update_index_main_schema("test_index", force=False)
+            result = self.index_mgmt.apply_latest_schema_template("test_index", force=False)
 
         # Verify
         self.assertFalse(result['updated'])
@@ -168,7 +168,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         # Verify activate was NOT called
         mock_vespa_app.activate_prepared_deployment.assert_not_called()
 
-    def test_update_index_main_schema_with_actions_forced(self):
+    def test_apply_latest_schema_template_with_actions_forced(self):
         """Test update proceeds when actions required but force=True."""
         # Setup
         test_index = self.semi_structured_marqo_index(
@@ -208,7 +208,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
             mock_schema_class.generate_vespa_schema.return_value = new_schema
 
             # Execute
-            result = self.index_mgmt.update_index_main_schema("test_index", force=True)
+            result = self.index_mgmt.apply_latest_schema_template("test_index", force=True)
 
         # Verify
         self.assertTrue(result['updated'])
@@ -219,16 +219,16 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         # Verify activate WAS called
         mock_vespa_app.activate_prepared_deployment.assert_called_once_with(prepare_response)
 
-    def test_update_index_main_schema_index_not_found(self):
+    def test_apply_latest_schema_template_index_not_found(self):
         """Test error when index doesn't exist."""
         # Mock get_index to raise IndexNotFoundError
         self.index_mgmt.get_index = Mock(side_effect=IndexNotFoundError("Index not found"))
 
         # Execute and verify exception
         with self.assertRaises(IndexNotFoundError):
-            self.index_mgmt.update_index_main_schema("nonexistent_index")
+            self.index_mgmt.apply_latest_schema_template("nonexistent_index")
 
-    def test_update_index_main_schema_wrong_index_type(self):
+    def test_apply_latest_schema_template_wrong_index_type(self):
         """Test error when index is not SemiStructuredMarqoIndex."""
         # Setup structured index
         test_index = self.structured_marqo_index(
@@ -241,7 +241,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         # Execute and verify exception
         with self.assertRaises(InternalError) as context:
-            self.index_mgmt.update_index_main_schema("test_index")
+            self.index_mgmt.apply_latest_schema_template("test_index")
 
         self.assertIn("only semi-structured indexes support schema updates", str(context.exception))
 
@@ -282,7 +282,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
             mock_schema_class.generate_vespa_schema.return_value = new_schema
 
             # Execute with force=False
-            result = self.index_mgmt.update_index_main_schema("test_index", force=False)
+            result = self.index_mgmt.apply_latest_schema_template("test_index", force=False)
 
         # Verify - should block on refeed action
         self.assertFalse(result['updated'])
@@ -325,14 +325,14 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
             mock_schema_class.generate_vespa_schema.return_value = new_schema
 
             # Execute with force=False
-            result = self.index_mgmt.update_index_main_schema("test_index", force=False)
+            result = self.index_mgmt.apply_latest_schema_template("test_index", force=False)
 
         # Verify - should block on reindex action
         self.assertFalse(result['updated'])
         self.assertIn('reindex', result['config_change_actions'])
         mock_vespa_app.activate_prepared_deployment.assert_not_called()
 
-    def test_update_index_main_schema_version_too_old(self):
+    def test_apply_latest_schema_template_version_too_old(self):
         """Test error when index was created with Marqo < 2.23.0."""
         # Setup index with old version
         test_index = self.semi_structured_marqo_index(
@@ -346,13 +346,13 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         # Execute and verify exception
         with self.assertRaises(UnsupportedFeatureError) as context:
-            self.index_mgmt.update_index_main_schema("test_index")
+            self.index_mgmt.apply_latest_schema_template("test_index")
 
         # Verify error message contains version information
         self.assertIn("2.23.0", str(context.exception))
         self.assertIn("2.22.0", str(context.exception))
 
-    def test_update_index_main_schema_dry_run_no_changes(self):
+    def test_apply_latest_schema_template_dry_run_no_changes(self):
         """Test dry_run when schema is already up to date."""
         # Setup
         test_index = self.semi_structured_marqo_index(
@@ -375,7 +375,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
             mock_schema_class.generate_vespa_schema.return_value = current_schema
 
             # Execute with dry_run=True
-            result = self.index_mgmt.update_index_main_schema("test_index", dry_run=True)
+            result = self.index_mgmt.apply_latest_schema_template("test_index", dry_run=True)
 
         # Verify
         self.assertFalse(result['updated'])
@@ -386,7 +386,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.assertIn('schema_diff', result)
         self.assertEqual(result['schema_diff'], 'No changes')
 
-    def test_update_index_main_schema_dry_run_with_changes(self):
+    def test_apply_latest_schema_template_dry_run_with_changes(self):
         """Test dry_run with schema changes - should not deploy."""
         # Setup
         test_index = self.semi_structured_marqo_index(
@@ -418,7 +418,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
             mock_schema_class.generate_vespa_schema.return_value = new_schema
 
             # Execute with dry_run=True
-            result = self.index_mgmt.update_index_main_schema("test_index", dry_run=True)
+            result = self.index_mgmt.apply_latest_schema_template("test_index", dry_run=True)
 
         # Verify
         self.assertFalse(result['updated'])  # Should not be updated in dry run
@@ -433,7 +433,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         mock_vespa_app.update_index_setting_and_schema.assert_called_once()
         mock_vespa_app.activate_prepared_deployment.assert_not_called()
 
-    def test_update_index_main_schema_dry_run_with_actions(self):
+    def test_apply_latest_schema_template_dry_run_with_actions(self):
         """Test dry_run with actions required - should still not deploy."""
         # Setup
         test_index = self.semi_structured_marqo_index(
@@ -467,7 +467,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
             mock_schema_class.generate_vespa_schema.return_value = new_schema
 
             # Execute with dry_run=True
-            result = self.index_mgmt.update_index_main_schema("test_index", dry_run=True)
+            result = self.index_mgmt.apply_latest_schema_template("test_index", dry_run=True)
 
         # Verify
         self.assertFalse(result['updated'])
@@ -478,7 +478,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         # Verify activate was NOT called
         mock_vespa_app.activate_prepared_deployment.assert_not_called()
 
-    def test_update_index_main_schema_dry_run_ignores_force(self):
+    def test_apply_latest_schema_template_dry_run_ignores_force(self):
         """Test that dry_run takes precedence over force parameter."""
         # Setup
         test_index = self.semi_structured_marqo_index(
@@ -512,14 +512,14 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
             mock_schema_class.generate_vespa_schema.return_value = new_schema
 
             # Execute with both dry_run=True and force=True
-            result = self.index_mgmt.update_index_main_schema("test_index", force=True, dry_run=True)
+            result = self.index_mgmt.apply_latest_schema_template("test_index", force=True, dry_run=True)
 
         # Verify - dry_run should take precedence, no deployment
         self.assertFalse(result['updated'])
         self.assertEqual(result['reason'], "Dry run - no changes deployed")
         mock_vespa_app.activate_prepared_deployment.assert_not_called()
 
-    def test_update_index_main_schema_with_old_vespa_store_raises_error(self):
+    def test_apply_latest_schema_template_with_old_vespa_store_raises_error(self):
         """Test that prepare_only with VespaApplicationFileStore raises InternalError.
 
         This covers the error path in update_index_setting_and_schema() when prepare_only=True
@@ -562,7 +562,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
             # Execute - this should raise InternalError
             with self.assertRaises(InternalError) as ctx:
-                self.index_mgmt.update_index_main_schema("test_index")
+                self.index_mgmt.apply_latest_schema_template("test_index")
 
         # Verify error message
         self.assertIn("prepare_only mode requires ApplicationPackageDeploymentSessionStore", str(ctx.exception))

--- a/tests/unit_tests/marqo/core/index_management/test_schema_update.py
+++ b/tests/unit_tests/marqo/core/index_management/test_schema_update.py
@@ -1,0 +1,273 @@
+"""Unit tests for schema update functionality in VespaApplicationPackage and IndexManagement."""
+import json
+import unittest
+from unittest.mock import Mock, MagicMock, patch, call
+
+from marqo.core.exceptions import IndexNotFoundError, InternalError
+from marqo.core.index_management.vespa_application_package import (
+    VespaApplicationPackage,
+    VespaApplicationStore,
+    ApplicationPackageDeploymentSessionStore
+)
+from marqo.core.index_management.index_management import IndexManagement
+from marqo.core.models.marqo_index import SemiStructuredMarqoIndex, StructuredMarqoIndex
+from tests.unit_tests.marqo_test import MarqoTestCase
+
+
+class TestVespaApplicationPackageSchemaUpdate(MarqoTestCase):
+    """Test cases for schema update methods in VespaApplicationPackage."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_store = Mock(spec=VespaApplicationStore)
+
+        # Mock basic file operations
+        self.mock_store.read_text_file.side_effect = self._mock_read_text_file
+        self.mock_store.file_exists.side_effect = self._mock_file_exists
+
+        self.vespa_app = VespaApplicationPackage(self.mock_store)
+
+    def _mock_file_exists(self, *paths):
+        """Mock file_exists."""
+        if paths == ('marqo_config.json',) or paths == ('services.xml',):
+            return True
+        if paths == ('schemas', 'test_schema.sd'):
+            return True
+        return False
+
+    def _mock_read_text_file(self, *paths):
+        """Mock read_text_file."""
+        if paths == ('services.xml',):
+            return '''<?xml version="1.0" encoding="utf-8"?>
+<services xmlns:deploy="vespa" xmlns:preprocess="properties">
+    <container><document-api/></container>
+    <content><documents></documents></content>
+</services>'''
+        elif paths == ('marqo_config.json',):
+            return '{"version": "2.23.0"}'
+        elif paths == ('marqo_index_settings.json',):
+            return '{}'
+        elif paths == ('schemas', 'test_schema.sd'):
+            return '''schema test_schema {
+    document test_schema {
+        field test_field type string {}
+    }
+}'''
+        return None
+
+    def test_get_schema_returns_existing_schema(self):
+        """Test that get_schema returns schema content for existing schema."""
+        result = self.vespa_app.get_schema('test_schema')
+
+        self.assertIsNotNone(result)
+        self.assertIn('schema test_schema', result)
+        self.assertIn('field test_field', result)
+        self.mock_store.read_text_file.assert_called_with('schemas', 'test_schema.sd')
+
+    def test_get_schema_returns_none_when_not_exists(self):
+        """Test that get_schema returns None for non-existent schema."""
+        result = self.vespa_app.get_schema('nonexistent_schema')
+
+        self.assertIsNone(result)
+        self.mock_store.read_text_file.assert_called_with('schemas', 'nonexistent_schema.sd')
+
+
+class TestApplicationPackageDeploymentSessionStore(MarqoTestCase):
+    """Test cases for prepare_deployment and activate_deployment methods."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_vespa_client = Mock()
+        self.mock_vespa_client.create_deployment_session.return_value = (
+            'http://content_url',
+            'http://prepare_url'
+        )
+        self.mock_vespa_client.list_contents.return_value = []
+
+        self.store = ApplicationPackageDeploymentSessionStore(
+            vespa_client=self.mock_vespa_client,
+            deploy_timeout=60,
+            wait_for_convergence_timeout=120
+        )
+
+    def test_prepare_deployment_returns_response(self):
+        """Test that prepare_deployment returns Vespa prepare response."""
+        # Setup mock prepare response
+        expected_response = {
+            'activate': 'http://activate_url',
+            'configChangeActions': {
+                'restart': [],
+                'refeed': [],
+                'reindex': []
+            }
+        }
+        self.mock_vespa_client.prepare.return_value = expected_response
+
+        # Execute
+        result = self.store.prepare_deployment()
+
+        # Verify
+        self.assertEqual(result, expected_response)
+        self.mock_vespa_client.prepare.assert_called_once_with(
+            'http://prepare_url',
+            timeout=60
+        )
+
+    def test_activate_deployment_calls_activate_and_waits(self):
+        """Test that activate_deployment activates and waits for convergence."""
+        prepare_response = {
+            'activate': 'http://activate_url'
+        }
+
+        # Execute
+        self.store.activate_deployment(prepare_response)
+
+        # Verify
+        self.mock_vespa_client.activate.assert_called_once_with(
+            'http://activate_url',
+            timeout=60
+        )
+        self.mock_vespa_client.wait_for_application_convergence.assert_called_once_with(
+            timeout=120
+        )
+
+    def test_deploy_application_prepares_and_activates(self):
+        """Test that deploy_application calls prepare then activate."""
+        prepare_response = {
+            'activate': 'http://activate_url',
+            'configChangeActions': {}
+        }
+        self.mock_vespa_client.prepare.return_value = prepare_response
+
+        # Execute
+        self.store.deploy_application()
+
+        # Verify prepare was called
+        self.mock_vespa_client.prepare.assert_called_once()
+
+        # Verify activate was called with the activate URL
+        self.mock_vespa_client.activate.assert_called_once_with(
+            'http://activate_url',
+            timeout=60
+        )
+
+        # Verify convergence wait was called
+        self.mock_vespa_client.wait_for_application_convergence.assert_called_once()
+
+
+class TestVespaApplicationPackagePrepareOnly(MarqoTestCase):
+    """Test cases for update_index_setting_and_schema with prepare_only mode."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Create mock deployment session store
+        self.mock_vespa_client = Mock()
+        self.mock_vespa_client.create_deployment_session.return_value = (
+            'http://content_url',
+            'http://prepare_url'
+        )
+        self.mock_vespa_client.list_contents.return_value = []
+        self.mock_vespa_client.get_text_content.return_value = '''<?xml version="1.0" encoding="utf-8"?>
+<services><container><document-api/></container></services>'''
+
+        self.mock_store = ApplicationPackageDeploymentSessionStore(
+            vespa_client=self.mock_vespa_client,
+            deploy_timeout=60,
+            wait_for_convergence_timeout=120
+        )
+
+        # Mock store methods
+        self.mock_store.file_exists = Mock(return_value=True)
+        self.mock_store.read_text_file = Mock(side_effect=self._mock_read_text_file)
+        self.mock_store.save_file = Mock()
+
+        self.vespa_app = VespaApplicationPackage(self.mock_store)
+
+        # Mock has_index to return True for test_index
+        self.vespa_app.has_index = Mock(return_value=True)
+
+        # Mock the index setting store methods to avoid version conflicts
+        self.vespa_app._index_setting_store.save_index_setting = Mock()
+        self.vespa_app._persist_index_settings = Mock()
+
+    def _mock_read_text_file(self, *paths):
+        """Mock read_text_file."""
+        if paths == ('services.xml',):
+            return '''<?xml version="1.0" encoding="utf-8"?>
+<services xmlns:deploy="vespa" xmlns:preprocess="properties">
+    <container>
+        <document-api/>
+    </container>
+    <content>
+        <documents></documents>
+    </content>
+</services>'''
+        elif paths == ('marqo_config.json',):
+            return '{"version": "2.23.0"}'
+        elif paths == ('marqo_index_settings.json',):
+            # Return empty dict to avoid index serialization issues during setup
+            return '{}'
+        return '{}'
+
+    def test_update_index_setting_and_schema_prepare_only_returns_response(self):
+        """Test that prepare_only=True returns prepare response without activating."""
+        # Setup
+        test_index = self.semi_structured_marqo_index(
+            name="test_index",
+            schema_name="test_schema",
+            version=1
+        )
+        test_schema = "schema test_schema { document test_schema {} }"
+
+        prepare_response = {
+            'activate': 'http://activate_url',
+            'configChangeActions': {
+                'restart': [{'name': 'restart', 'services': ['searchnode']}]
+            }
+        }
+        self.mock_vespa_client.prepare.return_value = prepare_response
+
+        # Execute
+        result = self.vespa_app.update_index_setting_and_schema(
+            test_index,
+            test_schema,
+            prepare_only=True
+        )
+
+        # Verify
+        self.assertEqual(result, prepare_response)
+        self.mock_vespa_client.prepare.assert_called_once()
+        self.mock_vespa_client.activate.assert_not_called()
+
+    def test_update_index_setting_and_schema_activates_when_not_prepare_only(self):
+        """Test that prepare_only=False activates deployment."""
+        # Setup
+        test_index = self.semi_structured_marqo_index(
+            name="test_index",
+            schema_name="test_schema",
+            version=1
+        )
+        test_schema = "schema test_schema { document test_schema {} }"
+
+        prepare_response = {
+            'activate': 'http://activate_url',
+            'configChangeActions': {}
+        }
+        self.mock_vespa_client.prepare.return_value = prepare_response
+
+        # Execute
+        result = self.vespa_app.update_index_setting_and_schema(
+            test_index,
+            test_schema,
+            prepare_only=False
+        )
+
+        # Verify
+        self.assertIsNone(result)
+        self.mock_vespa_client.prepare.assert_called_once()
+        self.mock_vespa_client.activate.assert_called_once()
+        self.mock_vespa_client.wait_for_application_convergence.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [x] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an ops endpoint and core logic to apply the latest schema template (dry-run/force) using Vespa prepare/activate, with version gating and comprehensive tests.
> 
> - **Backend/Core**:
>   - `IndexManagement.apply_latest_schema_template()` to regenerate and diff schemas, prepare deployments, inspect `configChangeActions`, and optionally activate (supports `dry_run` and `force`; gated to indexes created with `>= 2.23.0`).
>   - Add `MARQO_UPDATE_SCHEMA_MINIMUM_VERSION` in `core/constants.py`.
> - **Vespa Application Package**:
>   - Two-phase deploy support: `prepare_deployment()`, `activate_deployment()`, `activate_prepared_deployment()`; `update_index_setting_and_schema(..., prepare_only=True)`; `get_schema()`.
> - **API**:
>   - New ops endpoint `POST /indexes/{index_name}/apply-latest-schema-template` (guarded by `enable_ops_api`).
> - **Tests**:
>   - New unit and integration tests covering no-op, dry-run, restart/refeed/reindex actions, version gating, and old-store error paths.
> - **CI**:
>   - Multinode test workflow ignores new schema update integ test to speed up runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e4d3d3bdef9fd86406735f833c1321cd864b2f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->