### PR TITLE
Fix rerank count in relevance cut-off

### DIFF
--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.24.4"
+__version__ = "2.24.5"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/tests/integ_tests/tensor_search/integ_tests/test_search_relevance_cutoff_feature.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_search_relevance_cutoff_feature.py
@@ -915,7 +915,7 @@ class TestSearchRelevanceCutoffFeature(MarqoTestCase):
         regular_result_ids = [hit["_id"] for hit in regular_result["hits"]]
         self.assertEqual(
             set(relevance_cutoff_result_ids),
-            set("h9", "h10", "h6"),
+            {"h9", "h10", "h6"},
             "Relevance cutoff should return the most relevant documents."
         )
 

--- a/tests/integ_tests/tensor_search/integ_tests/test_search_relevance_cutoff_feature.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_search_relevance_cutoff_feature.py
@@ -915,8 +915,8 @@ class TestSearchRelevanceCutoffFeature(MarqoTestCase):
         regular_result_ids = [hit["_id"] for hit in regular_result["hits"]]
         self.assertEqual(
             set(relevance_cutoff_result_ids),
-            set(regular_result_ids[:3]), # ["h1", "h3", "h2"]
-            "Relevance cutoff should return the top 3 most relevant documents."
+            set("h9", "h10", "h6"),
+            "Relevance cutoff should return the most relevant documents."
         )
 
     def test_relevance_cutoff_feature_works_for_lexical_lexical_search(self):

--- a/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
+++ b/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
@@ -54,6 +54,7 @@ public class HybridSearcher extends Searcher {
     private static String QUERY_INPUT_ADD_WEIGHTS_GLOBAL = "marqo__add_weights_global";
     private static String MARQO_SEARCH_METHOD_LEXICAL = "lexical";
     private static String MARQO_SEARCH_METHOD_TENSOR = "tensor";
+    private static String QUERY_RERANK_COUNT = "ranking.rerankCount";
     private List<String> STANDARD_SEARCH_TYPES = new ArrayList<>();
 
     // Thread-safe ObjectReader for parsing SortField JSON
@@ -491,6 +492,7 @@ public class HybridSearcher extends Searcher {
         // Update query hits and offset
         query.setHits(newHits);
         query.setOffset(0);
+        query.properties().set(QUERY_RERANK_COUNT, newHits);
 
         // Update tensor YQL targetHits if it exists
         if (currentTensorTargetHits != null
@@ -499,6 +501,7 @@ public class HybridSearcher extends Searcher {
             String tensorYQLUpdated = overwriteTargetHits(tensorYQL, newTensorTargetHits, efSearch);
             query.properties().set("marqo__yql." + MARQO_SEARCH_METHOD_TENSOR, tensorYQLUpdated);
         }
+
         return query;
     }
 
@@ -1065,6 +1068,7 @@ public class HybridSearcher extends Searcher {
 
         probeLexicalQuery.setHits(probeDepth);
         probeLexicalQuery.setOffset(0);
+        probeLexicalQuery.properties().set(QUERY_RERANK_COUNT, probeDepth);
 
         logIfVerbose(
                 String.format(

--- a/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
+++ b/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
@@ -501,7 +501,6 @@ public class HybridSearcher extends Searcher {
             String tensorYQLUpdated = overwriteTargetHits(tensorYQL, newTensorTargetHits, efSearch);
             query.properties().set("marqo__yql." + MARQO_SEARCH_METHOD_TENSOR, tensorYQLUpdated);
         }
-
         return query;
     }
 

--- a/vespa/src/test/java/ai/marqo/search/RelevanceCutoffTest.java
+++ b/vespa/src/test/java/ai/marqo/search/RelevanceCutoffTest.java
@@ -4,16 +4,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.yahoo.search.Query;
-import com.yahoo.search.Searcher;
 import com.yahoo.search.result.Hit;
 import com.yahoo.search.result.HitGroup;
+import com.yahoo.tensor.Tensor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class RelevanceCutoffTest {
     private HybridSearcher hybridSearcher;
-    private Searcher downstreamSearcher;
 
     @BeforeEach
     void setUp() {
@@ -638,84 +637,58 @@ class RelevanceCutoffTest {
     }
 
     @Nested
-    class UpdateQueryHitsOffsetsAndTargetHitsTest {
+    class UpdateRankingRerankCountTest {
+
+        @Test
+        void shouldReturnModifiedRankingRerankCount() {
+            Query query = new Query("search/?query=test&hits=10&offset=5");
+            query.properties().set("ranking.rerankCount", 15);
+
+            hybridSearcher.updateQueryHitsOffsetsAndTargetHits(query, 100, 200, true, true);
+
+            assertThat(query.properties().get("ranking.rerankCount")).isEqualTo(200);
+        }
 
         @Test
         void shouldReturnUnmodifiedQueryWhenBothFlagsAreFalse() {
             Query query = new Query("search/?query=test&hits=10&offset=5");
+            query.properties().set("ranking.rerankCount", 15);
 
             hybridSearcher.updateQueryHitsOffsetsAndTargetHits(query, 100, 200, false, false);
 
-            assertThat(query.properties().get("ranking.rerankCount")).isNull();
+            assertThat(query.properties().get("ranking.rerankCount")).isEqualTo(15);
         }
 
         @Test
-        void shouldThrowExceptionWhenBothCandidatesAreNull() {
+        void shouldUpdateRankingRerankCountIfOnlySortIsUsed() {
             Query query = new Query("search/?query=test&hits=10&offset=5");
+            query.properties().set("ranking.rerankCount", 15);
 
-            assertThrows(
-                    RuntimeException.class,
-                    () ->
-                            hybridSearcher.updateQueryHitsOffsetsAndTargetHits(
-                                    query, null, null, true, false));
+            hybridSearcher.updateQueryHitsOffsetsAndTargetHits(query, null, 202, false, true);
+
+            assertThat(query.properties().get("ranking.rerankCount")).isEqualTo(202);
         }
 
         @Test
-        void shouldSetRerankCountWithRelevanceCutoffAboveLimitPlusOffset() {
+        void shouldUnmodifiedRankingRerankIfRelevanceCutoffIsTooSmall() {
             Query query = new Query("search/?query=test&hits=10&offset=5");
+            query.properties().set("ranking.rerankCount", 15);
 
-            hybridSearcher.updateQueryHitsOffsetsAndTargetHits(query, 50, null, true, false);
+            hybridSearcher.updateQueryHitsOffsetsAndTargetHits(query, 150, null, true, false);
 
-            assertThat(query.properties().getInteger("ranking.rerankCount")).isEqualTo(15);
+            assertThat(query.properties().get("ranking.rerankCount")).isEqualTo(15);
+            assertThat(query.getHits()).isEqualTo(15);
+            assertThat(query.getOffset()).isEqualTo(0);
         }
 
         @Test
-        void shouldSetRerankCountWithRelevanceCutoffBelowLimitPlusOffset() {
-            Query query = new Query("search/?query=test&hits=10&offset=5");
+        void shouldUpdateRankingRerankIfRelevanceCutoffIsSmall() {
+            Query query = new Query("search/?query=test&hits=100&offset=0");
+            query.properties().set("ranking.rerankCount", 100);
 
-            hybridSearcher.updateQueryHitsOffsetsAndTargetHits(query, 8, null, true, false);
+            hybridSearcher.updateQueryHitsOffsetsAndTargetHits(query, 100, null, true, false);
 
-            assertThat(query.properties().getInteger("ranking.rerankCount")).isEqualTo(8);
-        }
-
-        @Test
-        void shouldSetRerankCountWithSortByOnly() {
-            Query query = new Query("search/?query=test&hits=10&offset=5");
-
-            hybridSearcher.updateQueryHitsOffsetsAndTargetHits(query, null, 100, false, true);
-
-            assertThat(query.properties().getInteger("ranking.rerankCount")).isEqualTo(100);
-        }
-
-        @Test
-        void shouldSetRerankCountWithBothEnabledUsingMaxValue() {
-            Query query = new Query("search/?query=test&hits=10&offset=5");
-
-            hybridSearcher.updateQueryHitsOffsetsAndTargetHits(query, 150, 100, true, true);
-
-            assertThat(query.properties().getInteger("ranking.rerankCount")).isEqualTo(150);
-        }
-
-        @Test
-        void shouldSetRerankCountToZeroWhenRelevantCandidatesIsZero() {
-            Query query = new Query("search/?query=test&hits=10&offset=5");
-
-            hybridSearcher.updateQueryHitsOffsetsAndTargetHits(query, 0, null, true, false);
-
-            assertThat(query.properties().getInteger("ranking.rerankCount")).isEqualTo(0);
-        }
-
-        @Test
-        void shouldUpdateTensorYqlTargetHitsWhenSortByEnabled() {
-            Query query = new Query("search/?query=test&hits=10&offset=5");
-            query.properties()
-                    .set("marqo__yql.tensor", "{targetHits:100, hnsw.exploreAdditionalHits:1900}");
-
-            hybridSearcher.updateQueryHitsOffsetsAndTargetHits(query, null, 150, false, true);
-
-            assertThat(query.properties().getInteger("ranking.rerankCount")).isEqualTo(150);
-            assertThat(query.properties().getString("marqo__yql.tensor"))
-                    .isEqualTo("{targetHits:150, hnsw.exploreAdditionalHits:1850}");
+            assertThat(query.properties().get("ranking.rerankCount")).isEqualTo(100);
         }
     }
 
@@ -816,6 +789,36 @@ class RelevanceCutoffTest {
 
             int result = HybridSearcher.countGreaterOrEqual(scores, 750.0);
             assertThat(result).isEqualTo(251); // 1000, 999, ..., 750 are >= 750
+        }
+    }
+
+    @Nested
+    class CreateProbeLexicalQueryTest {
+        @Test
+        void shouldSetRankingRerankCountToProbeDepth() {
+            Query originalQuery = new Query("search/?query=test&hits=60&offset=0");
+            Integer probeDepth = 2000;
+
+            // Set up minimal required properties for createProbeLexialQuery
+            originalQuery
+                    .properties()
+                    .set("marqo__yql.lexical", "select * from sources * where userQuery()");
+            originalQuery
+                    .properties()
+                    .set("marqo__ranking.lexical.lexical", "lexical_rank_profile");
+
+            // Set up the required tensor for fields to rank (empty tensor is fine for this test)
+            originalQuery
+                    .getRanking()
+                    .getFeatures()
+                    .put("query(marqo__fields_to_rank_lexical)", Tensor.from("tensor(p{}):{}"));
+
+            Query probeQuery =
+                    hybridSearcher.createProbeLexialQuery(originalQuery, probeDepth, false);
+
+            assertThat(probeQuery.properties().getInteger("ranking.rerankCount")).isEqualTo(2000);
+            assertThat(probeQuery.getHits()).isEqualTo(2000);
+            assertThat(probeQuery.getOffset()).isEqualTo(0);
         }
     }
 }

--- a/vespa/src/test/java/ai/marqo/search/RelevanceCutoffTest.java
+++ b/vespa/src/test/java/ai/marqo/search/RelevanceCutoffTest.java
@@ -638,6 +638,88 @@ class RelevanceCutoffTest {
     }
 
     @Nested
+    class UpdateQueryHitsOffsetsAndTargetHitsTest {
+
+        @Test
+        void shouldReturnUnmodifiedQueryWhenBothFlagsAreFalse() {
+            Query query = new Query("search/?query=test&hits=10&offset=5");
+
+            hybridSearcher.updateQueryHitsOffsetsAndTargetHits(query, 100, 200, false, false);
+
+            assertThat(query.properties().get("ranking.rerankCount")).isNull();
+        }
+
+        @Test
+        void shouldThrowExceptionWhenBothCandidatesAreNull() {
+            Query query = new Query("search/?query=test&hits=10&offset=5");
+
+            assertThrows(
+                    RuntimeException.class,
+                    () ->
+                            hybridSearcher.updateQueryHitsOffsetsAndTargetHits(
+                                    query, null, null, true, false));
+        }
+
+        @Test
+        void shouldSetRerankCountWithRelevanceCutoffAboveLimitPlusOffset() {
+            Query query = new Query("search/?query=test&hits=10&offset=5");
+
+            hybridSearcher.updateQueryHitsOffsetsAndTargetHits(query, 50, null, true, false);
+
+            assertThat(query.properties().getInteger("ranking.rerankCount")).isEqualTo(15);
+        }
+
+        @Test
+        void shouldSetRerankCountWithRelevanceCutoffBelowLimitPlusOffset() {
+            Query query = new Query("search/?query=test&hits=10&offset=5");
+
+            hybridSearcher.updateQueryHitsOffsetsAndTargetHits(query, 8, null, true, false);
+
+            assertThat(query.properties().getInteger("ranking.rerankCount")).isEqualTo(8);
+        }
+
+        @Test
+        void shouldSetRerankCountWithSortByOnly() {
+            Query query = new Query("search/?query=test&hits=10&offset=5");
+
+            hybridSearcher.updateQueryHitsOffsetsAndTargetHits(query, null, 100, false, true);
+
+            assertThat(query.properties().getInteger("ranking.rerankCount")).isEqualTo(100);
+        }
+
+        @Test
+        void shouldSetRerankCountWithBothEnabledUsingMaxValue() {
+            Query query = new Query("search/?query=test&hits=10&offset=5");
+
+            hybridSearcher.updateQueryHitsOffsetsAndTargetHits(query, 150, 100, true, true);
+
+            assertThat(query.properties().getInteger("ranking.rerankCount")).isEqualTo(150);
+        }
+
+        @Test
+        void shouldSetRerankCountToZeroWhenRelevantCandidatesIsZero() {
+            Query query = new Query("search/?query=test&hits=10&offset=5");
+
+            hybridSearcher.updateQueryHitsOffsetsAndTargetHits(query, 0, null, true, false);
+
+            assertThat(query.properties().getInteger("ranking.rerankCount")).isEqualTo(0);
+        }
+
+        @Test
+        void shouldUpdateTensorYqlTargetHitsWhenSortByEnabled() {
+            Query query = new Query("search/?query=test&hits=10&offset=5");
+            query.properties()
+                    .set("marqo__yql.tensor", "{targetHits:100, hnsw.exploreAdditionalHits:1900}");
+
+            hybridSearcher.updateQueryHitsOffsetsAndTargetHits(query, null, 150, false, true);
+
+            assertThat(query.properties().getInteger("ranking.rerankCount")).isEqualTo(150);
+            assertThat(query.properties().getString("marqo__yql.tensor"))
+                    .isEqualTo("{targetHits:150, hnsw.exploreAdditionalHits:1850}");
+        }
+    }
+
+    @Nested
     class CountGreaterOrEqualTest {
 
         @Test


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->
We update the query's `ranking.rerankCount` during the relevance cut-off process for the following reasons:
1. The `ranking.rerankCount` is set by the original limit and offset(limit + offset). However,  the relevance cut-off feature will do a larger retrieval. In this sense, the original `ranking.rerankCount` is too small for the probe lexical search and the created sub-queries.
2. This was not an issue before because `ranking.rerankCount` controls the candidates in the second-phase reranking. However, the `diversity` feature introduces the second-phase reranking, and we identify this bug. 

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `ranking.rerankCount` is updated to match expanded retrieval in relevance cutoff and sort flows, add tests, and bump version.
> 
> - **Backend (Vespa `HybridSearcher`)**:
>   - Add `QUERY_RERANK_COUNT` and set `ranking.rerankCount` when updating hits/offsets in `updateQueryHitsOffsetsAndTargetHits()` and for probe queries in `createProbeLexialQuery()`.
> - **Tests**:
>   - Java: add tests for rerank count updates and probe query behavior; minor import cleanup.
>   - Python integ: adjust expected IDs for a relevance-cutoff case; keep sort assertion intact.
> - **Version**:
>   - Bump `src/marqo/version.py` to `2.24.5`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 240a162524ec6ceb022e747c43cc0952a6b4fee2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->