### PR TITLE
Introduce a document summary for collapsing and a way to safely roll it out

### DIFF
--- a/src/marqo/core/constants.py
+++ b/src/marqo/core/constants.py
@@ -31,6 +31,7 @@ MARQO_PARTIAL_UPDATE_MINIMUM_VERSION = semver.VersionInfo.parse('2.16.0')
 MARQO_COLLAPSE_FIELDS_MINIMUM_VERSION = semver.VersionInfo.parse('2.23.0')
 MARQO_TYPEAHEAD_SCHEMA_MINIMUM_VERSION = semver.VersionInfo.parse('2.23.0')
 MARQO_UPDATE_SCHEMA_MINIMUM_VERSION = semver.VersionInfo.parse('2.23.0')
+MARQO_COLLAPSE_MINIMAL_SUMMARY_MINIMUM_VERSION = semver.VersionInfo.parse('2.24.6')
 
 # For score modifiers
 QUERY_INPUT_SCORE_MODIFIERS_MULT_WEIGHTS_2_9 = 'marqo__mult_weights'

--- a/src/marqo/core/index_management/index_management.py
+++ b/src/marqo/core/index_management/index_management.py
@@ -313,6 +313,15 @@ class IndexManagement:
                     f"Please recreate the index with a newer version of Marqo to use this feature."
                 )
 
+            # Validate that index's marqo_version is not greater than current version
+            current_version_parsed = semver.VersionInfo.parse(version.get_version())
+            if existing_index.parsed_marqo_version() > current_version_parsed:
+                raise InternalError(
+                    f"Cannot update schema for index '{index_name}' created with Marqo version "
+                    f"{existing_index.marqo_version} using current Marqo version {version.get_version()}. "
+                    f"The index was created with a newer version of Marqo than is currently running."
+                )
+
             # Early return if schema is already at current version
             if existing_index.schema_version == version.get_version():
                 logger.info(f'Index {index_name} schema is already at version {version.get_version()}')

--- a/src/marqo/core/index_management/index_management.py
+++ b/src/marqo/core/index_management/index_management.py
@@ -323,7 +323,7 @@ class IndexManagement:
                 )
 
             # Early return if schema is already at current version
-            if existing_index.schema_version == version.get_version():
+            if existing_index.schema_template_version == version.get_version():
                 logger.info(f'Index {index_name} schema is already at version {version.get_version()}')
                 return {
                     "updated": False,

--- a/src/marqo/core/index_management/index_management.py
+++ b/src/marqo/core/index_management/index_management.py
@@ -313,6 +313,15 @@ class IndexManagement:
                     f"Please recreate the index with a newer version of Marqo to use this feature."
                 )
 
+            # Early return if schema is already at current version
+            if existing_index.schema_version == version.get_version():
+                logger.info(f'Index {index_name} schema is already at version {version.get_version()}')
+                return {
+                    "updated": False,
+                    "schemaChanged": False,
+                    "reason": f"Schema is already at current Marqo version {version.get_version()}"
+                }
+
             # Generate new schema from current settings using latest template
             new_schema = SemiStructuredVespaSchema.generate_vespa_schema(existing_index)
 
@@ -343,7 +352,6 @@ class IndexManagement:
                 "newSchema": new_schema,
                 "schemaDiff": schema_diff,
                 "configChangeActions": {},
-                "reason": ""
             }
 
             # Scenario 1: Schemas are identical - no changes needed

--- a/src/marqo/core/index_management/vespa_application_package.py
+++ b/src/marqo/core/index_management/vespa_application_package.py
@@ -774,7 +774,7 @@ class VespaApplicationPackage:
         self._store.save_file(schema, 'schemas', f'{index.schema_name}.sd')
         self._index_setting_store.save_index_setting(index.copy(update={
             'version': version,
-            'schema_version': marqo_version.get_version()
+            'schema_template_version': marqo_version.get_version()
         }))
         self._persist_index_settings()
 

--- a/src/marqo/core/index_management/vespa_application_package.py
+++ b/src/marqo/core/index_management/vespa_application_package.py
@@ -20,6 +20,7 @@ from marqo.core.exceptions import InternalError, OperationConflictError, IndexNo
 from marqo.core.models import MarqoIndex
 from marqo.core.typeahead.typeahead_vespa_schema import TypeaheadVespaSchema
 import marqo.logging
+from marqo import version as marqo_version
 from marqo.vespa.exceptions import VespaError
 from marqo.vespa.vespa_client import VespaClient
 
@@ -772,7 +773,10 @@ class VespaApplicationPackage:
 
         version = index.version + 1 if index.version is not None else 1
         self._store.save_file(schema, 'schemas', f'{index.schema_name}.sd')
-        self._index_setting_store.save_index_setting(index.copy(update={'version': version}))
+        self._index_setting_store.save_index_setting(index.copy(update={
+            'version': version,
+            'schema_version': marqo_version.get_version()
+        }))
         self._persist_index_settings()
 
         if prepare_only:

--- a/src/marqo/core/index_management/vespa_application_package.py
+++ b/src/marqo/core/index_management/vespa_application_package.py
@@ -21,7 +21,6 @@ from marqo.core.models import MarqoIndex
 from marqo.core.typeahead.typeahead_vespa_schema import TypeaheadVespaSchema
 import marqo.logging
 from marqo import version as marqo_version
-from marqo.vespa.exceptions import VespaError
 from marqo.vespa.vespa_client import VespaClient
 
 

--- a/src/marqo/core/models/marqo_index.py
+++ b/src/marqo/core/models/marqo_index.py
@@ -540,7 +540,7 @@ class SemiStructuredMarqoIndex(UnstructuredMarqoIndex):
     string_array_fields: Optional[List[
         StringArrayField]]  # This is required so that when saving a document containing string array fields, we can make changes to the schema on the fly. Ref: https://github.com/marqo-ai/marqo/blob/cfea70adea7039d1586c94e36adae8e66cabe306/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2#L83
     collapse_fields: Optional[List[CollapseField]] = None
-    schema_version: Optional[str] = None
+    schema_template_version: Optional[str] = None
 
     def __init__(self, **data):
         super().__init__(**data)
@@ -561,14 +561,14 @@ class SemiStructuredMarqoIndex(UnstructuredMarqoIndex):
             return False
         return field_name in [field.name for field in self.collapse_fields]
 
-    def parsed_schema_version(self) -> semver.VersionInfo:
+    def parsed_schema_template_version(self) -> semver.VersionInfo:
         """
-        Get the schema version as a semver object.
-        Falls back to marqo_version if schema_version is not set (backward compatibility).
+        Get the schema template version as a semver object.
+        Falls back to marqo_version if schema_template_version is not set (backward compatibility).
         """
-        if self.schema_version is not None:
-            return semver.VersionInfo.parse(self.schema_version)
-        # Backward compatibility: old indexes don't have schema_version
+        if self.schema_template_version is not None:
+            return semver.VersionInfo.parse(self.schema_template_version)
+        # Backward compatibility: old indexes don't have schema_template_version
         return self.parsed_marqo_version()
 
     @property
@@ -662,10 +662,10 @@ class SemiStructuredMarqoIndex(UnstructuredMarqoIndex):
 
         return self._cache_or_get('tensor_subfield_map', generate)
 
-    # TODO: Update index_supports_* properties to use parsed_schema_version()
+    # TODO: Update index_supports_* properties to use parsed_schema_template_version()
     # instead of parsed_marqo_version() for more accurate feature detection
     # after schema updates. This will allow features to be detected based on
-    # the deployed schema version rather than index creation version.
+    # the deployed schema template version rather than index creation version.
 
     @property
     def index_supports_partial_updates(self) -> bool:
@@ -712,7 +712,7 @@ class SemiStructuredMarqoIndex(UnstructuredMarqoIndex):
         """
         return self._cache_or_get(
             'index_supports_collapse_minimal_summary',
-            lambda: self.parsed_schema_version() >= constants.MARQO_COLLAPSE_MINIMAL_SUMMARY_MINIMUM_VERSION)
+            lambda: self.parsed_schema_template_version() >= constants.MARQO_COLLAPSE_MINIMAL_SUMMARY_MINIMUM_VERSION)
 
 
 _PROTECTED_FIELD_NAMES = ['_id', '_tensor_facets', '_highlights', '_score', '_found']

--- a/src/marqo/core/models/marqo_index.py
+++ b/src/marqo/core/models/marqo_index.py
@@ -299,7 +299,6 @@ class MarqoIndex(ImmutableBaseModel, ABC):
     vector_numeric_type: VectorNumericType
     hnsw_config: HnswConfig
     marqo_version: str
-    schema_version: Optional[str] = None
     created_at: int = pydantic.Field(gt=0)
     updated_at: int = pydantic.Field(gt=0)
     # TODO After upgraded to pydantic v2, _cache can be removed. We can use @cached_property instead
@@ -321,16 +320,6 @@ class MarqoIndex(ImmutableBaseModel, ABC):
 
     def parsed_marqo_version(self) -> semver.VersionInfo:
         return semver.VersionInfo.parse(self.marqo_version)
-
-    def parsed_schema_version(self) -> semver.VersionInfo:
-        """
-        Get the schema version as a semver object.
-        Falls back to marqo_version if schema_version is not set (backward compatibility).
-        """
-        if self.schema_version is not None:
-            return semver.VersionInfo.parse(self.schema_version)
-        # Backward compatibility: old indexes don't have schema_version
-        return self.parsed_marqo_version()
 
     @classmethod
     @abstractmethod
@@ -551,6 +540,7 @@ class SemiStructuredMarqoIndex(UnstructuredMarqoIndex):
     string_array_fields: Optional[List[
         StringArrayField]]  # This is required so that when saving a document containing string array fields, we can make changes to the schema on the fly. Ref: https://github.com/marqo-ai/marqo/blob/cfea70adea7039d1586c94e36adae8e66cabe306/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2#L83
     collapse_fields: Optional[List[CollapseField]] = None
+    schema_version: Optional[str] = None
 
     def __init__(self, **data):
         super().__init__(**data)
@@ -570,6 +560,16 @@ class SemiStructuredMarqoIndex(UnstructuredMarqoIndex):
         if not self.collapse_fields:
             return False
         return field_name in [field.name for field in self.collapse_fields]
+
+    def parsed_schema_version(self) -> semver.VersionInfo:
+        """
+        Get the schema version as a semver object.
+        Falls back to marqo_version if schema_version is not set (backward compatibility).
+        """
+        if self.schema_version is not None:
+            return semver.VersionInfo.parse(self.schema_version)
+        # Backward compatibility: old indexes don't have schema_version
+        return self.parsed_marqo_version()
 
     @property
     def field_map(self) -> Dict[str, Field]:

--- a/src/marqo/core/models/marqo_index.py
+++ b/src/marqo/core/models/marqo_index.py
@@ -299,6 +299,7 @@ class MarqoIndex(ImmutableBaseModel, ABC):
     vector_numeric_type: VectorNumericType
     hnsw_config: HnswConfig
     marqo_version: str
+    schema_version: Optional[str] = None
     created_at: int = pydantic.Field(gt=0)
     updated_at: int = pydantic.Field(gt=0)
     # TODO After upgraded to pydantic v2, _cache can be removed. We can use @cached_property instead
@@ -320,6 +321,16 @@ class MarqoIndex(ImmutableBaseModel, ABC):
 
     def parsed_marqo_version(self) -> semver.VersionInfo:
         return semver.VersionInfo.parse(self.marqo_version)
+
+    def parsed_schema_version(self) -> semver.VersionInfo:
+        """
+        Get the schema version as a semver object.
+        Falls back to marqo_version if schema_version is not set (backward compatibility).
+        """
+        if self.schema_version is not None:
+            return semver.VersionInfo.parse(self.schema_version)
+        # Backward compatibility: old indexes don't have schema_version
+        return self.parsed_marqo_version()
 
     @classmethod
     @abstractmethod
@@ -651,6 +662,11 @@ class SemiStructuredMarqoIndex(UnstructuredMarqoIndex):
 
         return self._cache_or_get('tensor_subfield_map', generate)
 
+    # TODO: Update index_supports_* properties to use parsed_schema_version()
+    # instead of parsed_marqo_version() for more accurate feature detection
+    # after schema updates. This will allow features to be detected based on
+    # the deployed schema version rather than index creation version.
+
     @property
     def index_supports_partial_updates(self) -> bool:
         """
@@ -686,6 +702,17 @@ class SemiStructuredMarqoIndex(UnstructuredMarqoIndex):
         return self._cache_or_get(
             'index_supports_sort_by',
             lambda: self.parsed_marqo_version() >= constants.MARQO_SORT_BY_MINIMUM_VERSION)
+
+    @property
+    def index_supports_collapse_minimal_summary(self) -> bool:
+        """
+        Check if the index schema supports collapse-minimal-summary.
+        This summary class was added in version 2.24.6 to optimize
+        collapse query performance by returning minimal fields.
+        """
+        return self._cache_or_get(
+            'index_supports_collapse_minimal_summary',
+            lambda: self.parsed_schema_version() >= constants.MARQO_COLLAPSE_MINIMAL_SUMMARY_MINIMUM_VERSION)
 
 
 _PROTECTED_FIELD_NAMES = ['_id', '_tensor_facets', '_highlights', '_score', '_found']

--- a/src/marqo/core/models/marqo_index_request.py
+++ b/src/marqo/core/models/marqo_index_request.py
@@ -42,7 +42,7 @@ class UnstructuredMarqoIndexRequest(MarqoIndexRequest):
     treat_urls_and_pointers_as_media: bool
     filter_string_max_length: int
     collapse_fields: Optional[List[marqo_index.CollapseField]] = None
-    schema_version: Optional[str] = None  # For testing: allows simulating older schema versions
+    schema_template_version: Optional[str] = None  # For testing: allows simulating older schema template versions
 
     @root_validator
     def validate_collapse_fields(cls, values):

--- a/src/marqo/core/models/marqo_index_request.py
+++ b/src/marqo/core/models/marqo_index_request.py
@@ -42,6 +42,7 @@ class UnstructuredMarqoIndexRequest(MarqoIndexRequest):
     treat_urls_and_pointers_as_media: bool
     filter_string_max_length: int
     collapse_fields: Optional[List[marqo_index.CollapseField]] = None
+    schema_version: Optional[str] = None  # For testing: allows simulating older schema versions
 
     @root_validator
     def validate_collapse_fields(cls, values):

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -125,6 +125,7 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
         return {
             'collapsefield': collapse_field_name,
             'collapsesize': 1,  # currently fixed to 1, will support multiple if needed in the future
+            'collapse.summary': 'collapse-minimal-summary',  # use minimal summary for collapsed hits to reduce data transfer
 
             # use a different rank profile to ensure diversity in the result returned to Vespa container
             'marqo__ranking.lexical.lexical': common.RANK_PROFILE_BM25 + '_diversity',

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -122,10 +122,9 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
         return query
 
     def _generate_collapse_query_params(self, collapse_field_name: str):
-        return {
+        params = {
             'collapsefield': collapse_field_name,
             'collapsesize': 1,  # currently fixed to 1, will support multiple if needed in the future
-            'collapse.summary': 'collapse-minimal-summary',  # use minimal summary for collapsed hits to reduce data transfer
 
             # use a different rank profile to ensure diversity in the result returned to Vespa container
             'marqo__ranking.lexical.lexical': common.RANK_PROFILE_BM25 + '_diversity',
@@ -133,6 +132,12 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
             'marqo__ranking.lexical.tensor': common.RANK_PROFILE_HYBRID_BM25_THEN_EMBEDDING_SIMILARITY + '_diversity',
             'marqo__ranking.tensor.lexical': common.RANK_PROFILE_HYBRID_EMBEDDING_SIMILARITY_THEN_BM25 + '_diversity',
         }
+
+        # Only use minimal summary if the schema supports it (version check)
+        if self.get_marqo_index().index_supports_collapse_minimal_summary:
+            params['collapse.summary'] = 'collapse-minimal-summary'
+
+        return params
 
     def _add_relevance_cutoff_and_sort_by_params(self, marqo_query, query):
         if marqo_query.relevance_cutoff:

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema.py
@@ -55,7 +55,7 @@ class SemiStructuredVespaSchema(VespaSchema):
             vector_numeric_type=self._index_request.vector_numeric_type,
             hnsw_config=self._index_request.hnsw_config,
             marqo_version=self._index_request.marqo_version,
-            schema_version=self._index_request.schema_version or self._index_request.marqo_version,
+            schema_template_version=self._index_request.schema_template_version or self._index_request.marqo_version,
             created_at=self._index_request.created_at,
             updated_at=self._index_request.updated_at,
             lexical_fields=[],

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema.py
@@ -55,7 +55,7 @@ class SemiStructuredVespaSchema(VespaSchema):
             vector_numeric_type=self._index_request.vector_numeric_type,
             hnsw_config=self._index_request.hnsw_config,
             marqo_version=self._index_request.marqo_version,
-            schema_version=self._index_request.marqo_version,  # Initially same as marqo_version
+            schema_version=self._index_request.schema_version or self._index_request.marqo_version,
             created_at=self._index_request.created_at,
             updated_at=self._index_request.updated_at,
             lexical_fields=[],

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema.py
@@ -55,6 +55,7 @@ class SemiStructuredVespaSchema(VespaSchema):
             vector_numeric_type=self._index_request.vector_numeric_type,
             hnsw_config=self._index_request.hnsw_config,
             marqo_version=self._index_request.marqo_version,
+            schema_version=self._index_request.marqo_version,  # Initially same as marqo_version
             created_at=self._index_request.created_at,
             updated_at=self._index_request.updated_at,
             lexical_fields=[],

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2
@@ -403,4 +403,10 @@ schema {{ index.schema_name }} {
         summary {{ field.embeddings_field_name }} type tensor<float>(p{}, x[{{ dimension }}]) {}
         {%- endfor %}
     }
+
+    {% if collapse_field -%}
+    document-summary collapse-minimal-summary {
+        summary {{ collapse_field.name }} type string {}
+    }
+    {%- endif %}
 }

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.24.5"
+__version__ = "2.24.6"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/tests/integ_tests/core/index_management/test_index_management_schema_update.py
+++ b/tests/integ_tests/core/index_management/test_index_management_schema_update.py
@@ -47,11 +47,11 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         # pre-create all indexes for tests
         index_requests = [
-            cls.unstructured_marqo_index_request(name='test_schema_update_index', marqo_version=cls.original_marqo_version, schema_version=cls.original_schema_template_version),
-            cls.unstructured_marqo_index_request(name='test_config_change_restart', marqo_version=cls.original_marqo_version, schema_version=cls.original_schema_template_version),
-            cls.unstructured_marqo_index_request(name='test_config_change_reindex', marqo_version=cls.original_marqo_version, schema_version=cls.original_schema_template_version),
-            cls.unstructured_marqo_index_request(name='test_config_change_refeed', marqo_version=cls.original_marqo_version, schema_version=cls.original_schema_template_version),
-            cls.unstructured_marqo_index_request(name='test_schema_version_current'),
+            cls.unstructured_marqo_index_request(name='test_schema_update_index', marqo_version=cls.original_marqo_version, schema_template_version=cls.original_schema_template_version),
+            cls.unstructured_marqo_index_request(name='test_config_change_restart', marqo_version=cls.original_marqo_version, schema_template_version=cls.original_schema_template_version),
+            cls.unstructured_marqo_index_request(name='test_config_change_reindex', marqo_version=cls.original_marqo_version, schema_template_version=cls.original_schema_template_version),
+            cls.unstructured_marqo_index_request(name='test_config_change_refeed', marqo_version=cls.original_marqo_version, schema_template_version=cls.original_schema_template_version),
+            cls.unstructured_marqo_index_request(name='test_schema_template_version_current'),
             cls.unstructured_marqo_index_request(name='old_version_index', marqo_version='2.22.0'),
             cls.unstructured_marqo_index_request(name='legacy_unstructured_index', marqo_version='2.12.0'),
             cls.structured_marqo_index_request(
@@ -102,9 +102,9 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.assertEqual(original_schema, result['oldSchema'])
         self.assertEqual(original_schema, result['newSchema'])
 
-        # Verify version and schema_version not updated (remains None when no changes)
+        # Verify version and schema_template_version not updated (remains None when no changes)
         updated_index = self.index_management.get_index(test_index_name)
-        self.assertEqual(self.original_schema_template_version, updated_index.schema_version)
+        self.assertEqual(self.original_schema_template_version, updated_index.schema_template_version)
         self.assertEqual(original_version, updated_index.version)
 
     @patch('marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema.SemiStructuredVespaSchema.generate_vespa_schema')
@@ -136,9 +136,9 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         # Verify schema was actually deployed to Vespa
         self.assertEqual(modified_schema, self._get_schema_from_vespa(saved_index.schema_name))
 
-        # Verify schema_version updated to current version; and index version becomes +1
+        # Verify schema_template_version updated to current version; and index version becomes +1
         updated_index = self.index_management.get_index(test_index_name)
-        self.assertEqual(version.get_version(), updated_index.schema_version)
+        self.assertEqual(version.get_version(), updated_index.schema_template_version)
         self.assertEqual(original_version + 1, updated_index.version)
 
     @patch('marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema.SemiStructuredVespaSchema.generate_vespa_schema')
@@ -169,9 +169,9 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         # Verify schema was NOT deployed to Vespa (original schema still present)
         self.assertEqual(original_schema, self._get_schema_from_vespa(saved_index.schema_name))
 
-        # Verify schema_version not updated in dry run
+        # Verify schema_template_version not updated in dry run
         updated_index = self.index_management.get_index(test_index_name)
-        self.assertEqual(self.original_schema_template_version, updated_index.schema_version)
+        self.assertEqual(self.original_schema_template_version, updated_index.schema_template_version)
 
     # ============================================================================
     # Error Case Tests
@@ -198,7 +198,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         self.assertIn('only semi-structured indexes support schema updates', str(ctx.exception))
 
-    def test_update_schema_version_too_old(self):
+    def test_update_schema_template_version_too_old(self):
         """Should raise UnsupportedFeatureError for indexes created with Marqo < 2.23.0."""
         with self.assertRaisesStrict(UnsupportedFeatureError) as ctx:
             self.index_management.apply_latest_schema_template('old_version_index')
@@ -207,10 +207,10 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
                       str(ctx.exception))
         self.assertIn('created with Marqo 2.22.0', str(ctx.exception))
 
-    def test_shortcut_when_schema_version_current(self):
-        """When schema_version matches current version, shortcut is triggered."""
+    def test_shortcut_when_schema_template_version_current(self):
+        """When schema_template_version matches current version, shortcut is triggered."""
         current_version = version.get_version()
-        index_name = 'test_schema_version_current'
+        index_name = 'test_schema_template_version_current'
 
         result = self.index_management.apply_latest_schema_template(index_name)
 
@@ -219,9 +219,9 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.assertFalse(result['schemaChanged'])
         self.assertIn(f'already at current Marqo version {current_version}', result['reason'])
 
-        # Verify schema_version unchanged
+        # Verify schema_template_version unchanged
         index = self.index_management.get_index(index_name)
-        self.assertEqual(current_version, index.schema_version)
+        self.assertEqual(current_version, index.schema_template_version)
 
     # ============================================================================
     # configChangeActions Tests
@@ -276,9 +276,9 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         # Verify schema was NOT deployed
         self.assertEqual(original_schema, self._get_schema_from_vespa(saved_index.schema_name))
 
-        # Verify schema_version not updated when blocked
+        # Verify schema_template_version not updated when blocked
         blocked_index = self.index_management.get_index(test_index_name)
-        self.assertEqual(self.original_schema_template_version, blocked_index.schema_version)
+        self.assertEqual(self.original_schema_template_version, blocked_index.schema_template_version)
 
         # Verify it updates the schema when forced set to true
         result_forced = self.index_management.apply_latest_schema_template(
@@ -290,9 +290,9 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.assertIn('Update forced despite required actions', result_forced['reason'])
         self.assertEqual(modified_schema, self._get_schema_from_vespa(saved_index.schema_name))
 
-        # Verify schema_version updated when forced
+        # Verify schema_template_version updated when forced
         forced_index = self.index_management.get_index(test_index_name)
-        self.assertEqual(version.get_version(), forced_index.schema_version)
+        self.assertEqual(version.get_version(), forced_index.schema_template_version)
 
     @patch('marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema.SemiStructuredVespaSchema.generate_vespa_schema')
     def test_update_schema_with_refeed_actions(self, mock_generate_schema):
@@ -336,9 +336,9 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         self.assertEqual(original_schema, self._get_schema_from_vespa(saved_index.schema_name))
 
-        # Verify schema_version not updated when blocked
+        # Verify schema_template_version not updated when blocked
         blocked_index = self.index_management.get_index(test_index_name)
-        self.assertEqual(self.original_schema_template_version, blocked_index.schema_version)
+        self.assertEqual(self.original_schema_template_version, blocked_index.schema_template_version)
 
         # Force update
         result_forced = self.index_management.apply_latest_schema_template(
@@ -353,9 +353,9 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         self.assertEqual(modified_schema, self._get_schema_from_vespa(saved_index.schema_name))
 
-        # Verify schema_version updated when forced
+        # Verify schema_template_version updated when forced
         forced_index = self.index_management.get_index(test_index_name)
-        self.assertEqual(version.get_version(), forced_index.schema_version)
+        self.assertEqual(version.get_version(), forced_index.schema_template_version)
 
     @patch('marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema.SemiStructuredVespaSchema.generate_vespa_schema')
     def test_update_schema_with_reindex_actions(self, mock_generate_schema):
@@ -405,9 +405,9 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         self.assertEqual(original_schema, self._get_schema_from_vespa(saved_index.schema_name))
 
-        # Verify schema_version not updated when blocked
+        # Verify schema_template_version not updated when blocked
         blocked_index = self.index_management.get_index(test_index_name)
-        self.assertEqual(self.original_schema_template_version, blocked_index.schema_version)
+        self.assertEqual(self.original_schema_template_version, blocked_index.schema_template_version)
 
         # Force update
         result_forced = self.index_management.apply_latest_schema_template(
@@ -422,6 +422,6 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.assertIn('reindex', result_forced['configChangeActions'])
         self.assertEqual(modified_schema, self._get_schema_from_vespa(saved_index.schema_name))
 
-        # Verify schema_version updated when forced
+        # Verify schema_template_version updated when forced
         forced_index = self.index_management.get_index(test_index_name)
-        self.assertEqual(version.get_version(), forced_index.schema_version)
+        self.assertEqual(version.get_version(), forced_index.schema_template_version)

--- a/tests/integ_tests/core/index_management/test_index_management_schema_update.py
+++ b/tests/integ_tests/core/index_management/test_index_management_schema_update.py
@@ -3,6 +3,7 @@ import textwrap
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
+from marqo import version
 from marqo.core.exceptions import IndexNotFoundError, InternalError, UnsupportedFeatureError
 from marqo.core.models.add_docs_params import AddDocsParams
 from marqo.core.models.marqo_index import FieldType
@@ -41,12 +42,16 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         # Bootstrap Vespa
         cls.index_management.bootstrap_vespa()
 
+        cls.original_marqo_version = '2.23.0'
+        cls.original_schema_template_version = '2.24.0'
+
         # pre-create all indexes for tests
         index_requests = [
-            cls.unstructured_marqo_index_request(name='test_schema_update_index'),
-            cls.unstructured_marqo_index_request(name='test_config_change_restart'),
-            cls.unstructured_marqo_index_request(name='test_config_change_reindex'),
-            cls.unstructured_marqo_index_request(name='test_config_change_refeed'),
+            cls.unstructured_marqo_index_request(name='test_schema_update_index', marqo_version=cls.original_marqo_version, schema_version=cls.original_schema_template_version),
+            cls.unstructured_marqo_index_request(name='test_config_change_restart', marqo_version=cls.original_marqo_version, schema_version=cls.original_schema_template_version),
+            cls.unstructured_marqo_index_request(name='test_config_change_reindex', marqo_version=cls.original_marqo_version, schema_version=cls.original_schema_template_version),
+            cls.unstructured_marqo_index_request(name='test_config_change_refeed', marqo_version=cls.original_marqo_version, schema_version=cls.original_schema_template_version),
+            cls.unstructured_marqo_index_request(name='test_schema_version_current'),
             cls.unstructured_marqo_index_request(name='old_version_index', marqo_version='2.22.0'),
             cls.unstructured_marqo_index_request(name='legacy_unstructured_index', marqo_version='2.12.0'),
             cls.structured_marqo_index_request(
@@ -57,12 +62,13 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         ]
         cls.create_indexes(index_requests)
 
-        # feed in a doc to add a 'title' lexical field to 'test_config_change_restart'
-        cls.add_documents(cls.config, AddDocsParams(
-            index_name='test_config_change_restart',
-            docs=[{'_id': '1', 'title': 'hello'}],
-            tensor_fields=[]
-        ))
+        # feed in a doc to add a 'title' lexical field to 'test_config_change_restart', keep the schema version unchanged
+        with patch('marqo.version.get_version', return_value=cls.original_schema_template_version):
+            cls.add_documents(cls.config, AddDocsParams(
+                index_name='test_config_change_restart',
+                docs=[{'_id': '1', 'title': 'hello'}],
+                tensor_fields=[]
+            ))
 
     def _get_validation_overrides(self) -> str:
         app = self.vespa_client.download_application()
@@ -96,7 +102,10 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.assertEqual(original_schema, result['oldSchema'])
         self.assertEqual(original_schema, result['newSchema'])
 
-        self.assertEqual(original_version, self.index_management.get_index(test_index_name).version)
+        # Verify version and schema_version not updated (remains None when no changes)
+        updated_index = self.index_management.get_index(test_index_name)
+        self.assertEqual(self.original_schema_template_version, updated_index.schema_version)
+        self.assertEqual(original_version, updated_index.version)
 
     @patch('marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema.SemiStructuredVespaSchema.generate_vespa_schema')
     def test_update_schema_successful(self, mock_generate_schema):
@@ -126,8 +135,11 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         # Verify schema was actually deployed to Vespa
         self.assertEqual(modified_schema, self._get_schema_from_vespa(saved_index.schema_name))
-        # Verify the index version is also updated
-        self.assertEqual(original_version + 1, self.index_management.get_index(test_index_name).version)
+
+        # Verify schema_version updated to current version; and index version becomes +1
+        updated_index = self.index_management.get_index(test_index_name)
+        self.assertEqual(version.get_version(), updated_index.schema_version)
+        self.assertEqual(original_version + 1, updated_index.version)
 
     @patch('marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema.SemiStructuredVespaSchema.generate_vespa_schema')
     def test_update_schema_dry_run_prevents_deployment(self, mock_generate_schema):
@@ -156,6 +168,10 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         # Verify schema was NOT deployed to Vespa (original schema still present)
         self.assertEqual(original_schema, self._get_schema_from_vespa(saved_index.schema_name))
+
+        # Verify schema_version not updated in dry run
+        updated_index = self.index_management.get_index(test_index_name)
+        self.assertEqual(self.original_schema_template_version, updated_index.schema_version)
 
     # ============================================================================
     # Error Case Tests
@@ -190,6 +206,22 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.assertIn('Schema update is only supported for indexes created with Marqo 2.23.0 or later',
                       str(ctx.exception))
         self.assertIn('created with Marqo 2.22.0', str(ctx.exception))
+
+    def test_shortcut_when_schema_version_current(self):
+        """When schema_version matches current version, shortcut is triggered."""
+        current_version = version.get_version()
+        index_name = 'test_schema_version_current'
+
+        result = self.index_management.apply_latest_schema_template(index_name)
+
+        # Verify shortcut response
+        self.assertFalse(result['updated'])
+        self.assertFalse(result['schemaChanged'])
+        self.assertIn(f'already at current Marqo version {current_version}', result['reason'])
+
+        # Verify schema_version unchanged
+        index = self.index_management.get_index(index_name)
+        self.assertEqual(current_version, index.schema_version)
 
     # ============================================================================
     # configChangeActions Tests
@@ -244,6 +276,10 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         # Verify schema was NOT deployed
         self.assertEqual(original_schema, self._get_schema_from_vespa(saved_index.schema_name))
 
+        # Verify schema_version not updated when blocked
+        blocked_index = self.index_management.get_index(test_index_name)
+        self.assertEqual(self.original_schema_template_version, blocked_index.schema_version)
+
         # Verify it updates the schema when forced set to true
         result_forced = self.index_management.apply_latest_schema_template(
             test_index_name,
@@ -253,6 +289,10 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.assertTrue(result_forced['schemaChanged'])
         self.assertIn('Update forced despite required actions', result_forced['reason'])
         self.assertEqual(modified_schema, self._get_schema_from_vespa(saved_index.schema_name))
+
+        # Verify schema_version updated when forced
+        forced_index = self.index_management.get_index(test_index_name)
+        self.assertEqual(version.get_version(), forced_index.schema_version)
 
     @patch('marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema.SemiStructuredVespaSchema.generate_vespa_schema')
     def test_update_schema_with_refeed_actions(self, mock_generate_schema):
@@ -296,6 +336,10 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         self.assertEqual(original_schema, self._get_schema_from_vespa(saved_index.schema_name))
 
+        # Verify schema_version not updated when blocked
+        blocked_index = self.index_management.get_index(test_index_name)
+        self.assertEqual(self.original_schema_template_version, blocked_index.schema_version)
+
         # Force update
         result_forced = self.index_management.apply_latest_schema_template(
             test_index_name,
@@ -308,6 +352,10 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.assertIn('Update forced despite required actions', result_forced['reason'])
 
         self.assertEqual(modified_schema, self._get_schema_from_vespa(saved_index.schema_name))
+
+        # Verify schema_version updated when forced
+        forced_index = self.index_management.get_index(test_index_name)
+        self.assertEqual(version.get_version(), forced_index.schema_version)
 
     @patch('marqo.core.semi_structured_vespa_index.semi_structured_vespa_schema.SemiStructuredVespaSchema.generate_vespa_schema')
     def test_update_schema_with_reindex_actions(self, mock_generate_schema):
@@ -357,6 +405,10 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         self.assertEqual(original_schema, self._get_schema_from_vespa(saved_index.schema_name))
 
+        # Verify schema_version not updated when blocked
+        blocked_index = self.index_management.get_index(test_index_name)
+        self.assertEqual(self.original_schema_template_version, blocked_index.schema_version)
+
         # Force update
         result_forced = self.index_management.apply_latest_schema_template(
             test_index_name,
@@ -369,3 +421,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.assertIn('Update forced despite required actions', result_forced['reason'])
         self.assertIn('reindex', result_forced['configChangeActions'])
         self.assertEqual(modified_schema, self._get_schema_from_vespa(saved_index.schema_name))
+
+        # Verify schema_version updated when forced
+        forced_index = self.index_management.get_index(test_index_name)
+        self.assertEqual(version.get_version(), forced_index.schema_version)

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_fields_with_collapse_fields.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_fields_with_collapse_fields.sd
@@ -337,4 +337,8 @@ schema marqo__test_00semi_00structured_00schema {
         summary marqo__chunks_tensor_field2 type array<string> {}
         summary marqo__embeddings_tensor_field2 type tensor<float>(p{}, x[32]) {}
     }
+
+    document-summary collapse-minimal-summary {
+        summary parent_id type string {}
+    }
 }

--- a/tests/integ_tests/marqo_test.py
+++ b/tests/integ_tests/marqo_test.py
@@ -365,6 +365,7 @@ class MarqoTestCase(unittest.TestCase):
             filter_string_max_length: int = 50,
             collapse_fields: Optional[List[CollapseField]] = None,
             marqo_version=version.get_version(),
+            schema_version=version.get_version(),
             created_at=time.time(),
             updated_at=time.time(),
     ) -> UnstructuredMarqoIndexRequest:
@@ -391,6 +392,7 @@ class MarqoTestCase(unittest.TestCase):
             vector_numeric_type=vector_numeric_type,
             hnsw_config=hnsw_config,
             marqo_version=marqo_version,
+            schema_version=schema_version,
             created_at=created_at,
             updated_at=updated_at,
         )

--- a/tests/integ_tests/marqo_test.py
+++ b/tests/integ_tests/marqo_test.py
@@ -365,7 +365,7 @@ class MarqoTestCase(unittest.TestCase):
             filter_string_max_length: int = 50,
             collapse_fields: Optional[List[CollapseField]] = None,
             marqo_version=version.get_version(),
-            schema_version=version.get_version(),
+            schema_template_version=version.get_version(),
             created_at=time.time(),
             updated_at=time.time(),
     ) -> UnstructuredMarqoIndexRequest:
@@ -392,7 +392,7 @@ class MarqoTestCase(unittest.TestCase):
             vector_numeric_type=vector_numeric_type,
             hnsw_config=hnsw_config,
             marqo_version=marqo_version,
-            schema_version=schema_version,
+            schema_template_version=schema_template_version,
             created_at=created_at,
             updated_at=updated_at,
         )

--- a/tests/integ_tests/tensor_search/test_api.py
+++ b/tests/integ_tests/tensor_search/test_api.py
@@ -136,7 +136,7 @@ class ValidationApiTests(MarqoTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        test_index_request = cls.unstructured_marqo_index_request(schema_version=None)
+        test_index_request = cls.unstructured_marqo_index_request(schema_template_version=None)
         cls.indexes = cls.create_indexes([test_index_request])
 
         cls.test_index = cls.indexes[0]
@@ -252,7 +252,7 @@ class ValidationApiTests(MarqoTestCase):
             index_name = self.test_index.name
             response = self.client.post(f"/indexes/{index_name}/apply-latest-schema-template")
             self.assertEqual(response.status_code, 200)
-            # Since the test index is created with schema_version defaulting to current version,
+            # Since the test index is created with schema_template_version defaulting to current version,
             # the shortcut is triggered
             current_version = version.get_version()
             self.assertEqual(f"Schema is already at current Marqo version {current_version}", response.json()["reason"])

--- a/tests/integ_tests/tensor_search/test_api.py
+++ b/tests/integ_tests/tensor_search/test_api.py
@@ -6,7 +6,6 @@ from unittest import mock
 from unittest.mock import patch
 
 import pydantic
-import pytest
 from fastapi.exceptions import RequestValidationError
 from fastapi.testclient import TestClient
 from pydantic.v1.error_wrappers import ErrorWrapper
@@ -15,6 +14,7 @@ from pydantic_core import InitErrorDetails, PydanticCustomError
 import marqo.tensor_search.api as api
 from tests.integ_tests.marqo_test import MarqoTestCase
 from marqo import exceptions as base_exceptions
+from marqo import version
 from marqo.api.exceptions import InvalidArgError
 from marqo.core import exceptions as core_exceptions
 from marqo.core.models.add_docs_params import AddDocsParams
@@ -136,7 +136,7 @@ class ValidationApiTests(MarqoTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        test_index_request = cls.unstructured_marqo_index_request()
+        test_index_request = cls.unstructured_marqo_index_request(schema_version=None)
         cls.indexes = cls.create_indexes([test_index_request])
 
         cls.test_index = cls.indexes[0]
@@ -252,7 +252,10 @@ class ValidationApiTests(MarqoTestCase):
             index_name = self.test_index.name
             response = self.client.post(f"/indexes/{index_name}/apply-latest-schema-template")
             self.assertEqual(response.status_code, 200)
-            self.assertEqual("Schema is already up to date", response.json()["reason"])
+            # Since the test index is created with schema_version defaulting to current version,
+            # the shortcut is triggered
+            current_version = version.get_version()
+            self.assertEqual(f"Schema is already at current Marqo version {current_version}", response.json()["reason"])
 
 
 class TestApiCustomEnvVars(MarqoTestCase):

--- a/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
+++ b/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
@@ -241,6 +241,22 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.assertIn("2.23.0", str(context.exception))
         self.assertIn("2.22.0", str(context.exception))
 
+    def test_apply_latest_schema_template_index_from_future_version(self):
+        """Test error when index was created with Marqo version > current version."""
+        # Setup index with future version
+        test_index = self._create_test_index(marqo_version="2.99.0")
+
+        # Mock get_index
+        self.index_mgmt.get_index = Mock(return_value=test_index)
+
+        # Execute and verify exception
+        with self.assertRaises(InternalError) as context:
+            self.index_mgmt.apply_latest_schema_template("test_index")
+
+        # Verify error message contains version information
+        error_msg = str(context.exception)
+        self.assertIn("The index was created with a newer version of Marqo than is currently running.", error_msg)
+
     def test_apply_latest_schema_template_dry_run(self):
         """Test dry_run mode in different scenarios."""
         # Test cases: (scenario_name, schemas_match, has_actions)

--- a/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
+++ b/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
@@ -33,25 +33,48 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.mock_lock.__exit__ = Mock(return_value=None)
         self.index_mgmt._vespa_deployment_lock = Mock(return_value=self.mock_lock)
 
+    def _create_test_index(self, schema_version=None, marqo_version=None):
+        """Helper to create a test index with common defaults."""
+        kwargs = {
+            'schema_version': schema_version,
+            'name': 'test_index',
+            'schema_name': 'test_schema'
+        }
+        if marqo_version:
+            kwargs['marqo_version'] = marqo_version
+        return self.semi_structured_marqo_index(**kwargs)
+
+    def _setup_vespa_app_mock(self, current_schema, prepare_response=None):
+        """Helper to set up vespa application mock."""
+        mock_vespa_app = Mock(spec=VespaApplicationPackage)
+        mock_vespa_app.get_schema = Mock(return_value=current_schema)
+        mock_vespa_app._store = Mock(spec=ApplicationPackageDeploymentSessionStore)
+
+        if prepare_response is not None:
+            mock_vespa_app.update_index_setting_and_schema = Mock(return_value=prepare_response)
+
+        self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
+        return mock_vespa_app
+
+    def _create_prepare_response(self, actions=None):
+        """Helper to create a prepare response with given actions."""
+        response = {
+            'activate': 'http://activate_url',
+            'configChangeActions': actions or {}
+        }
+        return response
+
     def test_apply_latest_schema_template_no_changes(self):
         """Test update when schema is already up-to-date."""
         # Setup
-        test_index = self.semi_structured_marqo_index(
-            schema_version=None,
-            name="test_index",
-            schema_name="test_schema"
-        )
-
+        test_index = self._create_test_index()
         current_schema = "schema test_schema { document test_schema {} }"
 
         # Mock get_index to return test index
         self.index_mgmt.get_index = Mock(return_value=test_index)
 
         # Mock vespa application
-        mock_vespa_app = Mock(spec=VespaApplicationPackage)
-        mock_vespa_app.get_schema = Mock(return_value=current_schema)
-        mock_vespa_app._store = Mock(spec=ApplicationPackageDeploymentSessionStore)
-        self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
+        mock_vespa_app = self._setup_vespa_app_mock(current_schema)
 
         # Mock schema generation to return same schema
         with patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema') as mock_schema_class:
@@ -70,12 +93,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
     def test_apply_latest_schema_template_with_changes_no_actions(self):
         """Test update when schema changed but no Vespa actions required."""
         # Setup
-        test_index = self.semi_structured_marqo_index(
-            schema_version=None,
-            name="test_index",
-            schema_name="test_schema"
-        )
-
+        test_index = self._create_test_index()
         current_schema = "schema test_schema { document test_schema { field old_field type string {} } }"
         new_schema = "schema test_schema { document test_schema { field new_field type string {} } }"
 
@@ -83,18 +101,8 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.index_mgmt.get_index = Mock(return_value=test_index)
 
         # Mock vespa application
-        mock_vespa_app = Mock(spec=VespaApplicationPackage)
-        mock_vespa_app.get_schema = Mock(return_value=current_schema)
-        mock_vespa_app._store = Mock(spec=ApplicationPackageDeploymentSessionStore)
-
-        # Mock prepare response with no actions
-        prepare_response = {
-            'activate': 'http://activate_url',
-            'configChangeActions': {}
-        }
-        mock_vespa_app.update_index_setting_and_schema = Mock(return_value=prepare_response)
-
-        self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
+        prepare_response = self._create_prepare_response()
+        mock_vespa_app = self._setup_vespa_app_mock(current_schema, prepare_response)
 
         # Mock schema generation
         with patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema') as mock_schema_class:
@@ -117,110 +125,47 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         # Verify activate was called
         mock_vespa_app.activate_prepared_deployment.assert_called_once_with(prepare_response)
 
-    def test_apply_latest_schema_template_with_actions_not_forced(self):
-        """Test update blocks when actions required and force=False."""
-        # Setup
-        test_index = self.semi_structured_marqo_index(
-            schema_version=None,
-            name="test_index",
-            schema_name="test_schema"
-        )
-
+    def test_apply_latest_schema_template_force_parameter(self):
+        """Test force parameter behavior with actions required."""
+        test_index = self._create_test_index()
         current_schema = "schema test_schema { }"
         new_schema = "schema test_schema { field new_field type string {} }"
 
-        # Mock get_index
-        self.index_mgmt.get_index = Mock(return_value=test_index)
+        # Test cases: (force, should_update, expected_reason)
+        test_cases = [
+            (False, False, "Vespa requires manual actions"),
+            (True, True, "Update forced despite required actions")
+        ]
 
-        # Mock vespa application
-        mock_vespa_app = Mock(spec=VespaApplicationPackage)
-        mock_vespa_app.get_schema = Mock(return_value=current_schema)
-        mock_vespa_app._store = Mock(spec=ApplicationPackageDeploymentSessionStore)
+        for force, should_update, expected_reason_fragment in test_cases:
+            with self.subTest(force=force):
+                # Mock get_index
+                self.index_mgmt.get_index = Mock(return_value=test_index)
 
-        # Mock prepare response with restart action
-        prepare_response = {
-            'activate': 'http://activate_url',
-            'configChangeActions': {
-                'restart': [
-                    {
-                        'name': 'restart',
-                        'services': ['searchnode'],
-                        'messages': ['Field new_field added']
-                    }
-                ]
-            }
-        }
-        mock_vespa_app.update_index_setting_and_schema = Mock(return_value=prepare_response)
+                # Mock vespa application with restart action
+                prepare_response = self._create_prepare_response({
+                    'restart': [{'name': 'restart', 'services': ['searchnode']}]
+                })
+                mock_vespa_app = self._setup_vespa_app_mock(current_schema, prepare_response)
 
-        self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
+                # Mock schema generation
+                with patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema') as mock_schema_class:
+                    mock_schema_class.generate_vespa_schema.return_value = new_schema
 
-        # Mock schema generation
-        with patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema') as mock_schema_class:
-            mock_schema_class.generate_vespa_schema.return_value = new_schema
+                    # Execute
+                    result = self.index_mgmt.apply_latest_schema_template("test_index", force=force)
 
-            # Execute
-            result = self.index_mgmt.apply_latest_schema_template("test_index", force=False)
+                # Verify
+                self.assertEqual(result['updated'], should_update)
+                self.assertTrue(result['schemaChanged'])
+                self.assertIn(expected_reason_fragment, result['reason'])
+                self.assertIn('restart', result['configChangeActions'])
 
-        # Verify
-        self.assertFalse(result['updated'])
-        self.assertTrue(result['schemaChanged'])
-        self.assertIn("Vespa requires manual actions", result['reason'])
-        self.assertIn('restart', result['configChangeActions'])
-
-        # Verify activate was NOT called
-        mock_vespa_app.activate_prepared_deployment.assert_not_called()
-
-    def test_apply_latest_schema_template_with_actions_forced(self):
-        """Test update proceeds when actions required but force=True."""
-        # Setup
-        test_index = self.semi_structured_marqo_index(
-            schema_version=None,
-            name="test_index",
-            schema_name="test_schema"
-        )
-
-        current_schema = "schema test_schema { }"
-        new_schema = "schema test_schema { field new_field type string {} }"
-
-        # Mock get_index
-        self.index_mgmt.get_index = Mock(return_value=test_index)
-
-        # Mock vespa application
-        mock_vespa_app = Mock(spec=VespaApplicationPackage)
-        mock_vespa_app.get_schema = Mock(return_value=current_schema)
-        mock_vespa_app._store = Mock(spec=ApplicationPackageDeploymentSessionStore)
-
-        # Mock prepare response with restart action
-        prepare_response = {
-            'activate': 'http://activate_url',
-            'configChangeActions': {
-                'restart': [
-                    {
-                        'name': 'restart',
-                        'services': ['searchnode']
-                    }
-                ]
-            }
-        }
-        mock_vespa_app.update_index_setting_and_schema = Mock(return_value=prepare_response)
-
-        self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
-
-        # Mock schema generation
-        with patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema') as mock_schema_class:
-            mock_schema_class.generate_vespa_schema.return_value = new_schema
-
-            # Execute
-            result = self.index_mgmt.apply_latest_schema_template("test_index", force=True)
-
-        # Verify
-        self.assertTrue(result['updated'])
-        self.assertTrue(result['schemaChanged'])
-        self.assertEqual(result['reason'], "Update forced despite required actions")
-        self.assertIn('restart', result['configChangeActions'])
-
-        # Verify activate WAS called
-        mock_vespa_app.activate_prepared_deployment.assert_called_once_with(prepare_response)
+                # Verify activate was called only when force=True
+                if should_update:
+                    mock_vespa_app.activate_prepared_deployment.assert_called_once_with(prepare_response)
+                else:
+                    mock_vespa_app.activate_prepared_deployment.assert_not_called()
 
     def test_apply_latest_schema_template_index_not_found(self):
         """Test error when index doesn't exist."""
@@ -235,7 +180,6 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         """Test error when index is not SemiStructuredMarqoIndex."""
         # Setup structured index
         test_index = self.structured_marqo_index(
-            schema_version=None,
             name="test_index",
             schema_name="test_schema"
         )
@@ -249,104 +193,42 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
         self.assertIn("only semi-structured indexes support schema updates", str(context.exception))
 
-    def test_configChangeActions_detection_refeed(self):
-        """Test detection of refeed actions."""
-        # Setup
-        test_index = self.semi_structured_marqo_index(
-            schema_version=None,
-            name="test_index",
-            schema_name="test_schema"
-        )
-
+    def test_configChangeActions_detection(self):
+        """Test detection of different configChangeActions."""
+        test_index = self._create_test_index()
         current_schema = "schema test_schema { }"
         new_schema = "schema test_schema { field new_field type string {} }"
 
-        self.index_mgmt.get_index = Mock(return_value=test_index)
+        # Test cases: (action_type, action_data)
+        test_cases = [
+            ('refeed', {'refeed': [{'name': 'refeed', 'documentType': 'test_schema', 'clusterName': 'content'}]}),
+            ('reindex', {'reindex': [{'name': 'reindex', 'documentType': 'test_schema'}]}),
+            ('restart', {'restart': [{'name': 'restart', 'services': ['searchnode']}]})
+        ]
 
-        mock_vespa_app = Mock(spec=VespaApplicationPackage)
-        mock_vespa_app.get_schema = Mock(return_value=current_schema)
-        mock_vespa_app._store = Mock(spec=ApplicationPackageDeploymentSessionStore)
+        for action_type, action_data in test_cases:
+            with self.subTest(action=action_type):
+                self.index_mgmt.get_index = Mock(return_value=test_index)
 
-        # Mock prepare response with refeed action
-        prepare_response = {
-            'activate': 'http://activate_url',
-            'configChangeActions': {
-                'refeed': [
-                    {
-                        'name': 'refeed',
-                        'documentType': 'test_schema',
-                        'clusterName': 'content'
-                    }
-                ]
-            }
-        }
-        mock_vespa_app.update_index_setting_and_schema = Mock(return_value=prepare_response)
-        self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
+                # Mock vespa application with the specific action
+                prepare_response = self._create_prepare_response(action_data)
+                mock_vespa_app = self._setup_vespa_app_mock(current_schema, prepare_response)
 
-        with patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema') as mock_schema_class:
-            mock_schema_class.generate_vespa_schema.return_value = new_schema
+                with patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema') as mock_schema_class:
+                    mock_schema_class.generate_vespa_schema.return_value = new_schema
 
-            # Execute with force=False
-            result = self.index_mgmt.apply_latest_schema_template("test_index", force=False)
+                    # Execute with force=False
+                    result = self.index_mgmt.apply_latest_schema_template("test_index", force=False)
 
-        # Verify - should block on refeed action
-        self.assertFalse(result['updated'])
-        self.assertIn('refeed', result['configChangeActions'])
-        mock_vespa_app.activate_prepared_deployment.assert_not_called()
-
-    def test_configChangeActions_detection_reindex(self):
-        """Test detection of reindex actions."""
-        # Setup
-        test_index = self.semi_structured_marqo_index(
-            schema_version=None,
-            name="test_index",
-            schema_name="test_schema"
-        )
-
-        current_schema = "schema test_schema { }"
-        new_schema = "schema test_schema { field new_field type string {} }"
-
-        self.index_mgmt.get_index = Mock(return_value=test_index)
-
-        mock_vespa_app = Mock(spec=VespaApplicationPackage)
-        mock_vespa_app.get_schema = Mock(return_value=current_schema)
-        mock_vespa_app._store = Mock(spec=ApplicationPackageDeploymentSessionStore)
-
-        # Mock prepare response with reindex action
-        prepare_response = {
-            'activate': 'http://activate_url',
-            'configChangeActions': {
-                'reindex': [
-                    {
-                        'name': 'reindex',
-                        'documentType': 'test_schema'
-                    }
-                ]
-            }
-        }
-        mock_vespa_app.update_index_setting_and_schema = Mock(return_value=prepare_response)
-        self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
-
-        with patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema') as mock_schema_class:
-            mock_schema_class.generate_vespa_schema.return_value = new_schema
-
-            # Execute with force=False
-            result = self.index_mgmt.apply_latest_schema_template("test_index", force=False)
-
-        # Verify - should block on reindex action
-        self.assertFalse(result['updated'])
-        self.assertIn('reindex', result['configChangeActions'])
-        mock_vespa_app.activate_prepared_deployment.assert_not_called()
+                # Verify - should block on the action
+                self.assertFalse(result['updated'])
+                self.assertIn(action_type, result['configChangeActions'])
+                mock_vespa_app.activate_prepared_deployment.assert_not_called()
 
     def test_apply_latest_schema_template_version_too_old(self):
         """Test error when index was created with Marqo < 2.23.0."""
         # Setup index with old version
-        test_index = self.semi_structured_marqo_index(
-            schema_version=None,
-            name="test_index",
-            schema_name="test_schema",
-            marqo_version="2.22.0"  # Below 2.23.0
-        )
+        test_index = self._create_test_index(marqo_version="2.22.0")
 
         # Mock get_index
         self.index_mgmt.get_index = Mock(return_value=test_index)
@@ -359,176 +241,57 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.assertIn("2.23.0", str(context.exception))
         self.assertIn("2.22.0", str(context.exception))
 
-    def test_apply_latest_schema_template_dry_run_no_changes(self):
-        """Test dry_run when schema is already up to date."""
-        # Setup
-        test_index = self.semi_structured_marqo_index(
-            schema_version=None,
-            name="test_index",
-            schema_name="test_schema"
-        )
+    def test_apply_latest_schema_template_dry_run(self):
+        """Test dry_run mode in different scenarios."""
+        # Test cases: (scenario_name, schemas_match, has_actions)
+        test_cases = [
+            ("no_changes", True, False),
+            ("with_changes", False, False),
+            ("with_actions", False, True),
+            ("ignores_force", False, True)  # Test dry_run takes precedence over force
+        ]
 
-        current_schema = "schema test_schema { document test_schema {} }"
+        for scenario, schemas_match, has_actions in test_cases:
+            with self.subTest(scenario=scenario):
+                test_index = self._create_test_index()
+                current_schema = "schema test_schema { document test_schema {} }"
+                new_schema = current_schema if schemas_match else "schema test_schema { field new_field type string {} }"
 
-        # Mock get_index
-        self.index_mgmt.get_index = Mock(return_value=test_index)
+                # Mock get_index
+                self.index_mgmt.get_index = Mock(return_value=test_index)
 
-        # Mock vespa application
-        mock_vespa_app = Mock(spec=VespaApplicationPackage)
-        mock_vespa_app.get_schema = Mock(return_value=current_schema)
-        self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
+                # Mock vespa application
+                actions = {'restart': [{'name': 'restart', 'services': ['searchnode']}]} if has_actions else {}
+                prepare_response = self._create_prepare_response(actions)
+                mock_vespa_app = self._setup_vespa_app_mock(current_schema, prepare_response)
 
-        # Mock schema generation to return same schema
-        with patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema') as mock_schema_class:
-            mock_schema_class.generate_vespa_schema.return_value = current_schema
+                # Mock schema generation
+                with patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema') as mock_schema_class:
+                    mock_schema_class.generate_vespa_schema.return_value = new_schema
 
-            # Execute with dry_run=True
-            result = self.index_mgmt.apply_latest_schema_template("test_index", dry_run=True)
+                    # Execute with dry_run=True (and force=True for "ignores_force" scenario)
+                    force = (scenario == "ignores_force")
+                    result = self.index_mgmt.apply_latest_schema_template("test_index", dry_run=True, force=force)
 
-        # Verify
-        self.assertFalse(result['updated'])
-        self.assertFalse(result['schemaChanged'])
-        self.assertEqual(result['reason'], "Schema is already up to date")
-        self.assertIn('oldSchema', result)
-        self.assertIn('newSchema', result)
-        self.assertIn('schemaDiff', result)
-        self.assertEqual(result['schemaDiff'], 'No changes')
+                # Verify - should never update in dry run
+                self.assertFalse(result['updated'])
 
-    def test_apply_latest_schema_template_dry_run_with_changes(self):
-        """Test dry_run with schema changes - should not deploy."""
-        # Setup
-        test_index = self.semi_structured_marqo_index(
-            schema_version=None,
-            name="test_index",
-            schema_name="test_schema"
-        )
+                if schemas_match:
+                    self.assertFalse(result['schemaChanged'])
+                    self.assertEqual(result['reason'], "Schema is already up to date")
+                    self.assertEqual(result['schemaDiff'], 'No changes')
+                else:
+                    self.assertTrue(result['schemaChanged'])
+                    self.assertEqual(result['reason'], "Dry run - no changes deployed")
+                    self.assertNotEqual(result['schemaDiff'], 'No changes')
 
-        current_schema = "schema test_schema { document test_schema { field old_field type string {} } }"
-        new_schema = "schema test_schema { document test_schema { field new_field type string {} } }"
+                # Verify result contains schema information
+                self.assertIn('oldSchema', result)
+                self.assertIn('newSchema', result)
+                self.assertIn('schemaDiff', result)
 
-        # Mock get_index
-        self.index_mgmt.get_index = Mock(return_value=test_index)
-
-        # Mock vespa application
-        mock_vespa_app = Mock(spec=VespaApplicationPackage)
-        mock_vespa_app.get_schema = Mock(return_value=current_schema)
-
-        # Mock prepare response with no actions
-        prepare_response = {
-            'activate': 'http://activate_url',
-            'configChangeActions': {}
-        }
-        mock_vespa_app.update_index_setting_and_schema = Mock(return_value=prepare_response)
-
-        self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
-
-        # Mock schema generation
-        with patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema') as mock_schema_class:
-            mock_schema_class.generate_vespa_schema.return_value = new_schema
-
-            # Execute with dry_run=True
-            result = self.index_mgmt.apply_latest_schema_template("test_index", dry_run=True)
-
-        # Verify
-        self.assertFalse(result['updated'])  # Should not be updated in dry run
-        self.assertTrue(result['schemaChanged'])
-        self.assertEqual(result['reason'], "Dry run - no changes deployed")
-        self.assertIn('oldSchema', result)
-        self.assertIn('newSchema', result)
-        self.assertIn('schemaDiff', result)
-        self.assertNotEqual(result['schemaDiff'], 'No changes')
-
-        # Verify prepare was called but activate was NOT
-        mock_vespa_app.update_index_setting_and_schema.assert_called_once()
-        mock_vespa_app.activate_prepared_deployment.assert_not_called()
-
-    def test_apply_latest_schema_template_dry_run_with_actions(self):
-        """Test dry_run with actions required - should still not deploy."""
-        # Setup
-        test_index = self.semi_structured_marqo_index(
-            schema_version=None,
-            name="test_index",
-            schema_name="test_schema"
-        )
-
-        current_schema = "schema test_schema {}"
-        new_schema = "schema test_schema { field new_field type string {} }"
-
-        # Mock get_index
-        self.index_mgmt.get_index = Mock(return_value=test_index)
-
-        # Mock vespa application
-        mock_vespa_app = Mock(spec=VespaApplicationPackage)
-        mock_vespa_app.get_schema = Mock(return_value=current_schema)
-
-        # Mock prepare response with restart action
-        prepare_response = {
-            'activate': 'http://activate_url',
-            'configChangeActions': {
-                'restart': [{'name': 'restart', 'services': ['searchnode']}]
-            }
-        }
-        mock_vespa_app.update_index_setting_and_schema = Mock(return_value=prepare_response)
-
-        self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
-
-        # Mock schema generation
-        with patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema') as mock_schema_class:
-            mock_schema_class.generate_vespa_schema.return_value = new_schema
-
-            # Execute with dry_run=True
-            result = self.index_mgmt.apply_latest_schema_template("test_index", dry_run=True)
-
-        # Verify
-        self.assertFalse(result['updated'])
-        self.assertTrue(result['schemaChanged'])
-        self.assertEqual(result['reason'], "Dry run - no changes deployed")
-        self.assertIn('restart', result['configChangeActions'])
-
-        # Verify activate was NOT called
-        mock_vespa_app.activate_prepared_deployment.assert_not_called()
-
-    def test_apply_latest_schema_template_dry_run_ignores_force(self):
-        """Test that dry_run takes precedence over force parameter."""
-        # Setup
-        test_index = self.semi_structured_marqo_index(
-            schema_version=None,
-            name="test_index",
-            schema_name="test_schema"
-        )
-
-        current_schema = "schema test_schema {}"
-        new_schema = "schema test_schema { field new_field type string {} }"
-
-        # Mock get_index
-        self.index_mgmt.get_index = Mock(return_value=test_index)
-
-        # Mock vespa application
-        mock_vespa_app = Mock(spec=VespaApplicationPackage)
-        mock_vespa_app.get_schema = Mock(return_value=current_schema)
-
-        # Mock prepare response with actions
-        prepare_response = {
-            'activate': 'http://activate_url',
-            'configChangeActions': {
-                'restart': [{'name': 'restart'}]
-            }
-        }
-        mock_vespa_app.update_index_setting_and_schema = Mock(return_value=prepare_response)
-
-        self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
-
-        # Mock schema generation
-        with patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema') as mock_schema_class:
-            mock_schema_class.generate_vespa_schema.return_value = new_schema
-
-            # Execute with both dry_run=True and force=True
-            result = self.index_mgmt.apply_latest_schema_template("test_index", force=True, dry_run=True)
-
-        # Verify - dry_run should take precedence, no deployment
-        self.assertFalse(result['updated'])
-        self.assertEqual(result['reason'], "Dry run - no changes deployed")
-        mock_vespa_app.activate_prepared_deployment.assert_not_called()
+                # Verify activate was NEVER called in dry run
+                mock_vespa_app.activate_prepared_deployment.assert_not_called()
 
     def test_apply_latest_schema_template_with_old_vespa_store_raises_error(self):
         """Test that prepare_only with VespaApplicationFileStore raises InternalError.
@@ -538,11 +301,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         deployment session API).
         """
         # Setup
-        test_index = self.semi_structured_marqo_index(
-            schema_version=None,
-            name="test_index",
-            schema_name="test_schema"
-        )
+        test_index = self._create_test_index()
         current_schema = "schema test_schema { document test_schema {} }"
         new_schema = "# Modified\nschema test_schema { document test_schema {} }"
 
@@ -627,61 +386,47 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.assertIn("Deployment activation requires ApplicationPackageDeploymentSessionStore", str(ctx.exception))
 
     @patch('marqo.version.get_version')
-    def test_apply_latest_schema_template_shortcut_when_schema_already_current(self, mock_get_version):
-        """Test that apply_latest_schema_template returns early when schema_version matches current version."""
-        mock_get_version.return_value = "2.24.6"
-
-        # Create an index with schema_version already at current version
-        existing_index = self.semi_structured_marqo_index(
-            name="test_index",
-            schema_version="2.24.6"
-        )
-
-        self.index_mgmt.get_index = Mock(return_value=existing_index)
-
-        result = self.index_mgmt.apply_latest_schema_template("test_index", force=False)
-
-        # Verify early shortcut response
-        self.assertFalse(result["updated"])
-        self.assertFalse(result["schemaChanged"])
-        self.assertIn("already at current Marqo version 2.24.6", result["reason"])
-        # Early shortcut doesn't include schemaDiff or other fields
-
-    @patch('marqo.version.get_version')
     @patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema.generate_vespa_schema')
-    def test_apply_latest_schema_template_proceeds_when_schema_not_current(self, mock_generate_schema, mock_get_version):
-        """Test that apply_latest_schema_template proceeds normally when schema_version is outdated or None."""
+    def test_apply_latest_schema_template_schema_version_handling(self, mock_generate_schema, mock_get_version):
+        """Test schema_version-based shortcut and normal processing paths."""
         mock_get_version.return_value = "2.24.6"
 
+        # Test cases: (scenario, schema_version, should_shortcut)
         test_cases = [
-            ("outdated schema_version", "2.24.5"),
-            ("schema_version is None (old index)", None)
+            ("current", "2.24.6", True),
+            ("outdated", "2.24.5", False),
+            ("none", None, False)
         ]
 
-        for case_name, schema_version in test_cases:
-            with self.subTest(case=case_name, schema_version=schema_version):
+        for scenario, schema_version, should_shortcut in test_cases:
+            with self.subTest(scenario=scenario, schema_version=schema_version):
                 # Create an index with the test schema_version
-                existing_index = self.semi_structured_marqo_index(
-                    name="test_index",
-                    schema_version=schema_version
-                )
-
-                # Setup mocks
-                mock_generate_schema.return_value = "new_schema_content"
-                mock_generate_schema.reset_mock()
-
-                mock_vespa_app = Mock()
-                mock_vespa_app.get_schema.return_value = "old_schema_content"
-
+                existing_index = self._create_test_index(schema_version=schema_version)
                 self.index_mgmt.get_index = Mock(return_value=existing_index)
-                self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
 
-                self.index_mgmt.apply_latest_schema_template("test_index", force=False)
+                if should_shortcut:
+                    # Test shortcut path
+                    result = self.index_mgmt.apply_latest_schema_template("test_index", force=False)
 
-                # Verify schema generation was called (not short-circuited)
-                mock_generate_schema.assert_called_once()
-                # Verify get_schema was called to get current schema
-                mock_vespa_app.get_schema.assert_called_once()
+                    # Verify early shortcut response
+                    self.assertFalse(result["updated"])
+                    self.assertFalse(result["schemaChanged"])
+                    self.assertIn("already at current Marqo version 2.24.6", result["reason"])
+                else:
+                    # Test normal path
+                    mock_generate_schema.return_value = "new_schema_content"
+                    mock_generate_schema.reset_mock()
+
+                    mock_vespa_app = Mock()
+                    mock_vespa_app.get_schema.return_value = "old_schema_content"
+                    self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
+
+                    self.index_mgmt.apply_latest_schema_template("test_index", force=False)
+
+                    # Verify schema generation was called (not short-circuited)
+                    mock_generate_schema.assert_called_once()
+                    # Verify get_schema was called to get current schema
+                    mock_vespa_app.get_schema.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
+++ b/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
@@ -614,6 +614,63 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         # Verify error message
         self.assertIn("Deployment activation requires ApplicationPackageDeploymentSessionStore", str(ctx.exception))
 
+    @patch('marqo.version.get_version')
+    def test_apply_latest_schema_template_shortcut_when_schema_already_current(self, mock_get_version):
+        """Test that apply_latest_schema_template returns early when schema_version matches current version."""
+        mock_get_version.return_value = "2.24.6"
+
+        # Create an index with schema_version already at current version
+        existing_index = self.semi_structured_marqo_index(
+            name="test_index",
+            schema_version="2.24.6"
+        )
+
+        self.index_mgmt.get_index = Mock(return_value=existing_index)
+
+        result = self.index_mgmt.apply_latest_schema_template("test_index", force=False)
+
+        # Verify early shortcut response
+        self.assertFalse(result["updated"])
+        self.assertFalse(result["schemaChanged"])
+        self.assertIn("already at current Marqo version 2.24.6", result["reason"])
+        # Early shortcut doesn't include schemaDiff or other fields
+
+    @patch('marqo.version.get_version')
+    @patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema.generate_vespa_schema')
+    def test_apply_latest_schema_template_proceeds_when_schema_not_current(self, mock_generate_schema, mock_get_version):
+        """Test that apply_latest_schema_template proceeds normally when schema_version is outdated or None."""
+        mock_get_version.return_value = "2.24.6"
+
+        test_cases = [
+            ("outdated schema_version", "2.24.5"),
+            ("schema_version is None (old index)", None)
+        ]
+
+        for case_name, schema_version in test_cases:
+            with self.subTest(case=case_name, schema_version=schema_version):
+                # Create an index with the test schema_version
+                existing_index = self.semi_structured_marqo_index(
+                    name="test_index",
+                    schema_version=schema_version
+                )
+
+                # Setup mocks
+                mock_generate_schema.return_value = "new_schema_content"
+                mock_generate_schema.reset_mock()
+
+                mock_vespa_app = Mock()
+                mock_vespa_app.get_schema.return_value = "old_schema_content"
+
+                self.index_mgmt.get_index = Mock(return_value=existing_index)
+                self.index_mgmt._get_vespa_application = Mock(return_value=mock_vespa_app)
+
+                self.index_mgmt.apply_latest_schema_template("test_index", force=False)
+
+                # Verify schema generation was called (not short-circuited)
+                mock_generate_schema.assert_called_once()
+                # Verify get_schema was called to get current schema
+                mock_vespa_app.get_schema.assert_called_once()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
+++ b/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
@@ -33,10 +33,10 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         self.mock_lock.__exit__ = Mock(return_value=None)
         self.index_mgmt._vespa_deployment_lock = Mock(return_value=self.mock_lock)
 
-    def _create_test_index(self, schema_version=None, marqo_version=None):
+    def _create_test_index(self, schema_template_version=None, marqo_version=None):
         """Helper to create a test index with common defaults."""
         kwargs = {
-            'schema_version': schema_version,
+            'schema_template_version': schema_template_version,
             'name': 'test_index',
             'schema_name': 'test_schema'
         }
@@ -403,21 +403,21 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
 
     @patch('marqo.version.get_version')
     @patch('marqo.core.index_management.index_management.SemiStructuredVespaSchema.generate_vespa_schema')
-    def test_apply_latest_schema_template_schema_version_handling(self, mock_generate_schema, mock_get_version):
-        """Test schema_version-based shortcut and normal processing paths."""
+    def test_apply_latest_schema_template_schema_template_version_handling(self, mock_generate_schema, mock_get_version):
+        """Test schema_template_version-based shortcut and normal processing paths."""
         mock_get_version.return_value = "2.24.6"
 
-        # Test cases: (scenario, schema_version, should_shortcut)
+        # Test cases: (scenario, schema_template_version, should_shortcut)
         test_cases = [
             ("current", "2.24.6", True),
             ("outdated", "2.24.5", False),
             ("none", None, False)
         ]
 
-        for scenario, schema_version, should_shortcut in test_cases:
-            with self.subTest(scenario=scenario, schema_version=schema_version):
-                # Create an index with the test schema_version
-                existing_index = self._create_test_index(schema_version=schema_version)
+        for scenario, schema_template_version, should_shortcut in test_cases:
+            with self.subTest(scenario=scenario, schema_template_version=schema_template_version):
+                # Create an index with the test schema_template_version
+                existing_index = self._create_test_index(schema_template_version=schema_template_version)
                 self.index_mgmt.get_index = Mock(return_value=existing_index)
 
                 if should_shortcut:

--- a/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
+++ b/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
@@ -9,7 +9,6 @@ from marqo.core.index_management.vespa_application_package import (
     ApplicationPackageDeploymentSessionStore,
     VespaApplicationFileStore
 )
-from marqo.core.models.marqo_index import SemiStructuredMarqoIndex, StructuredMarqoIndex
 from tests.unit_tests.marqo_test import MarqoTestCase
 
 
@@ -38,6 +37,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         """Test update when schema is already up-to-date."""
         # Setup
         test_index = self.semi_structured_marqo_index(
+            schema_version=None,
             name="test_index",
             schema_name="test_schema"
         )
@@ -71,6 +71,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         """Test update when schema changed but no Vespa actions required."""
         # Setup
         test_index = self.semi_structured_marqo_index(
+            schema_version=None,
             name="test_index",
             schema_name="test_schema"
         )
@@ -120,6 +121,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         """Test update blocks when actions required and force=False."""
         # Setup
         test_index = self.semi_structured_marqo_index(
+            schema_version=None,
             name="test_index",
             schema_name="test_schema"
         )
@@ -172,6 +174,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         """Test update proceeds when actions required but force=True."""
         # Setup
         test_index = self.semi_structured_marqo_index(
+            schema_version=None,
             name="test_index",
             schema_name="test_schema"
         )
@@ -232,6 +235,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         """Test error when index is not SemiStructuredMarqoIndex."""
         # Setup structured index
         test_index = self.structured_marqo_index(
+            schema_version=None,
             name="test_index",
             schema_name="test_schema"
         )
@@ -249,6 +253,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         """Test detection of refeed actions."""
         # Setup
         test_index = self.semi_structured_marqo_index(
+            schema_version=None,
             name="test_index",
             schema_name="test_schema"
         )
@@ -293,6 +298,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         """Test detection of reindex actions."""
         # Setup
         test_index = self.semi_structured_marqo_index(
+            schema_version=None,
             name="test_index",
             schema_name="test_schema"
         )
@@ -336,6 +342,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         """Test error when index was created with Marqo < 2.23.0."""
         # Setup index with old version
         test_index = self.semi_structured_marqo_index(
+            schema_version=None,
             name="test_index",
             schema_name="test_schema",
             marqo_version="2.22.0"  # Below 2.23.0
@@ -356,6 +363,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         """Test dry_run when schema is already up to date."""
         # Setup
         test_index = self.semi_structured_marqo_index(
+            schema_version=None,
             name="test_index",
             schema_name="test_schema"
         )
@@ -390,6 +398,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         """Test dry_run with schema changes - should not deploy."""
         # Setup
         test_index = self.semi_structured_marqo_index(
+            schema_version=None,
             name="test_index",
             schema_name="test_schema"
         )
@@ -437,6 +446,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         """Test dry_run with actions required - should still not deploy."""
         # Setup
         test_index = self.semi_structured_marqo_index(
+            schema_version=None,
             name="test_index",
             schema_name="test_schema"
         )
@@ -482,6 +492,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         """Test that dry_run takes precedence over force parameter."""
         # Setup
         test_index = self.semi_structured_marqo_index(
+            schema_version=None,
             name="test_index",
             schema_name="test_schema"
         )
@@ -528,6 +539,7 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         """
         # Setup
         test_index = self.semi_structured_marqo_index(
+            schema_version=None,
             name="test_index",
             schema_name="test_schema"
         )

--- a/tests/unit_tests/marqo/core/models/test_marqo_index.py
+++ b/tests/unit_tests/marqo/core/models/test_marqo_index.py
@@ -682,3 +682,39 @@ class TestForwardCompatibility(unittest.TestCase):
         )
         # Assert all existing fields are populated correctly
         self.assertEqual(image_preprocessing.patch_method, PatchMethod.Simple)
+
+
+class TestMarqoIndexSchemaVersion(MarqoTestCase):
+    """Unit tests for MarqoIndex schema_version functionality."""
+
+    def test_parsed_schema_version(self):
+        """Test parsed_schema_version() returns schema_version when set, or falls back to marqo_version."""
+        test_cases = [
+            ("with schema_version set", {"schema_version": "2.24.6"}, "2.24.6"),
+            ("fallback to marqo_version", {"marqo_version": "2.24.5", "schema_version": None}, "2.24.5")
+        ]
+
+        for case_name, index_kwargs, expected_version in test_cases:
+            with self.subTest(case=case_name):
+                index = self.semi_structured_marqo_index(
+                    name="test_index",
+                    **index_kwargs
+                )
+                parsed_version = index.parsed_schema_version()
+                self.assertEqual(str(parsed_version), expected_version)
+
+    def test_index_supports_collapse_minimal_summary(self):
+        """Test index_supports_collapse_minimal_summary with different schema_version and marqo_version values."""
+        test_cases = [
+            ("schema_version >= 2.24.6", {"schema_version": "2.24.6"}, True),
+            ("schema_version < 2.24.6", {"schema_version": "2.24.5"}, False),
+            ("schema_version None, marqo_version < 2.24.6", {"marqo_version": "2.24.5", "schema_version": None}, False)
+        ]
+
+        for case_name, index_kwargs, expected_result in test_cases:
+            with self.subTest(case=case_name):
+                index = self.semi_structured_marqo_index(
+                    name="test_index",
+                    **index_kwargs
+                )
+                self.assertEqual(index.index_supports_collapse_minimal_summary, expected_result)

--- a/tests/unit_tests/marqo/core/models/test_marqo_index.py
+++ b/tests/unit_tests/marqo/core/models/test_marqo_index.py
@@ -685,13 +685,13 @@ class TestForwardCompatibility(unittest.TestCase):
 
 
 class TestMarqoIndexSchemaVersion(MarqoTestCase):
-    """Unit tests for MarqoIndex schema_version functionality."""
+    """Unit tests for MarqoIndex schema_template_version functionality."""
 
-    def test_parsed_schema_version(self):
-        """Test parsed_schema_version() returns schema_version when set, or falls back to marqo_version."""
+    def test_parsed_schema_template_version(self):
+        """Test parsed_schema_template_version() returns schema_template_version when set, or falls back to marqo_version."""
         test_cases = [
-            ("with schema_version set", {"schema_version": "2.24.6"}, "2.24.6"),
-            ("fallback to marqo_version", {"marqo_version": "2.24.5", "schema_version": None}, "2.24.5")
+            ("with schema_template_version set", {"schema_template_version": "2.24.6"}, "2.24.6"),
+            ("fallback to marqo_version", {"marqo_version": "2.24.5", "schema_template_version": None}, "2.24.5")
         ]
 
         for case_name, index_kwargs, expected_version in test_cases:
@@ -700,15 +700,15 @@ class TestMarqoIndexSchemaVersion(MarqoTestCase):
                     name="test_index",
                     **index_kwargs
                 )
-                parsed_version = index.parsed_schema_version()
+                parsed_version = index.parsed_schema_template_version()
                 self.assertEqual(str(parsed_version), expected_version)
 
     def test_index_supports_collapse_minimal_summary(self):
-        """Test index_supports_collapse_minimal_summary with different schema_version and marqo_version values."""
+        """Test index_supports_collapse_minimal_summary with different schema_template_version and marqo_version values."""
         test_cases = [
-            ("schema_version >= 2.24.6", {"schema_version": "2.24.6"}, True),
-            ("schema_version < 2.24.6", {"schema_version": "2.24.5"}, False),
-            ("schema_version None, marqo_version < 2.24.6", {"marqo_version": "2.24.5", "schema_version": None}, False)
+            ("schema_template_version >= 2.24.6", {"schema_template_version": "2.24.6"}, True),
+            ("schema_template_version < 2.24.6", {"schema_template_version": "2.24.5"}, False),
+            ("schema_template_version None, marqo_version < 2.24.6", {"marqo_version": "2.24.5", "schema_template_version": None}, False)
         ]
 
         for case_name, index_kwargs, expected_result in test_cases:

--- a/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_semi_structured_vespa_index_to_vespa_query.py
+++ b/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_semi_structured_vespa_index_to_vespa_query.py
@@ -805,6 +805,7 @@ class TestSemiStructuredVespaIndexToVespaQueryCollapseFields(MarqoTestCase):
         # assert collapsefield are populated
         self.assertEqual('parent_id', vespa_query['collapsefield'])
         self.assertEqual(1, vespa_query['collapsesize'])
+        self.assertEqual('collapse-minimal-summary', vespa_query['collapse.summary'])
 
         # assert rank profiles with '_diversity' suffix is used
         self.assertEqual(common.RANK_PROFILE_BM25 + '_diversity',
@@ -852,6 +853,7 @@ class TestSemiStructuredVespaIndexToVespaQueryCollapseFields(MarqoTestCase):
 
         self.assertNotIn('collapsefield', vespa_query)
         self.assertNotIn('collapsesize', vespa_query)
+        self.assertNotIn('collapse.summary', vespa_query)
 
         self.assertEqual(common.RANK_PROFILE_BM25,
                          vespa_query['marqo__ranking.lexical.lexical'])

--- a/tests/unit_tests/marqo_test.py
+++ b/tests/unit_tests/marqo_test.py
@@ -218,6 +218,7 @@ class MarqoTestCase(TestCase):
             filter_string_max_length: int = 50,
             collapse_fields: Optional[List[CollapseField]] = None,
             marqo_version=version.get_version(),
+            schema_version=version.get_version(),
             created_at=time.time(),
             updated_at=time.time(),
     ) -> UnstructuredMarqoIndexRequest:
@@ -244,6 +245,7 @@ class MarqoTestCase(TestCase):
             vector_numeric_type=vector_numeric_type,
             hnsw_config=hnsw_config,
             marqo_version=marqo_version,
+            schema_version=schema_version,
             created_at=created_at,
             updated_at=updated_at,
         )

--- a/tests/unit_tests/marqo_test.py
+++ b/tests/unit_tests/marqo_test.py
@@ -63,6 +63,7 @@ class MarqoTestCase(TestCase):
                 m=16
             ),
             marqo_version=get_version(),
+            schema_version=get_version(),
             created_at=int(time.time()),
             updated_at=int(time.time()),
             version=None
@@ -85,6 +86,7 @@ class MarqoTestCase(TestCase):
             fields=fields,
             tensor_fields=tensor_fields,
             marqo_version=marqo_version,
+            schema_version=schema_version,
             created_at=created_at,
             updated_at=updated_at,
             version=version
@@ -121,6 +123,7 @@ class MarqoTestCase(TestCase):
                 m=16
             ),
             marqo_version=get_version(),
+            schema_version=get_version(),  # Default to current version like marqo_version
             created_at=int(time.time()),
             updated_at=int(time.time()),
             treat_urls_and_pointers_as_images=True,
@@ -149,6 +152,7 @@ class MarqoTestCase(TestCase):
             vector_numeric_type=vector_numeric_type,
             hnsw_config=hnsw_config,
             marqo_version=marqo_version,
+            schema_version=schema_version,
             created_at=created_at,
             updated_at=updated_at,
             treat_urls_and_pointers_as_images=treat_urls_and_pointers_as_images,

--- a/tests/unit_tests/marqo_test.py
+++ b/tests/unit_tests/marqo_test.py
@@ -63,7 +63,7 @@ class MarqoTestCase(TestCase):
                 m=16
             ),
             marqo_version=get_version(),
-            schema_version=get_version(),
+            schema_template_version=get_version(),
             created_at=int(time.time()),
             updated_at=int(time.time()),
             version=None
@@ -86,7 +86,7 @@ class MarqoTestCase(TestCase):
             fields=fields,
             tensor_fields=tensor_fields,
             marqo_version=marqo_version,
-            schema_version=schema_version,
+            schema_template_version=schema_template_version,
             created_at=created_at,
             updated_at=updated_at,
             version=version
@@ -123,7 +123,7 @@ class MarqoTestCase(TestCase):
                 m=16
             ),
             marqo_version=get_version(),
-            schema_version=get_version(),  # Default to current version like marqo_version
+            schema_template_version=get_version(),  # Default to current version like marqo_version
             created_at=int(time.time()),
             updated_at=int(time.time()),
             treat_urls_and_pointers_as_images=True,
@@ -152,7 +152,7 @@ class MarqoTestCase(TestCase):
             vector_numeric_type=vector_numeric_type,
             hnsw_config=hnsw_config,
             marqo_version=marqo_version,
-            schema_version=schema_version,
+            schema_template_version=schema_template_version,
             created_at=created_at,
             updated_at=updated_at,
             treat_urls_and_pointers_as_images=treat_urls_and_pointers_as_images,
@@ -218,7 +218,7 @@ class MarqoTestCase(TestCase):
             filter_string_max_length: int = 50,
             collapse_fields: Optional[List[CollapseField]] = None,
             marqo_version=version.get_version(),
-            schema_version=version.get_version(),
+            schema_template_version=version.get_version(),
             created_at=time.time(),
             updated_at=time.time(),
     ) -> UnstructuredMarqoIndexRequest:
@@ -245,7 +245,7 @@ class MarqoTestCase(TestCase):
             vector_numeric_type=vector_numeric_type,
             hnsw_config=hnsw_config,
             marqo_version=marqo_version,
-            schema_version=schema_version,
+            schema_template_version=schema_template_version,
             created_at=created_at,
             updated_at=updated_at,
         )


### PR DESCRIPTION
## Change Summary
Collapsing search uses the default document summary right now, which means it retrieves (fills) much more fields than it needs to do collapsing. This causes large performance overheads when the retrieval is deep. For example:
- collection with sortBy reaches 5000 depth by default
- search with sort by can also go as deep as relevantCandidate or sortCandidate
- collection without sortBy faces the same issue when page number is large

This change tries to solve this problem by introducing a minimal document summary that only contains the fields used for collapsing, in our case, there's only one collapse_field, defined in the index setting.

In order by smoothly release this change out on existing indexes without impacting prod traffic, we leverage two other changes
- manual update schema support, which is already covered in a merged PR: https://github.com/marqo-ai/marqo/pull/1331
- introduce a concept of `schema_template_version` to track the schema status. Based on this info, we will conditionally choose the right document summary use for collapsing query. This change is included in this PR.

I'll add a compatibility test in a following PR.

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [x] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `collapse-minimal-summary` (used when schema >= 2.24.6) and track `schema_template_version`; schema update adds version guards and shortcut, and queries pass `collapse.summary` when supported.
> 
> - **Semi-Structured Query/Schema**:
>   - Add `collapse-minimal-summary` document summary in `semi_structured_vespa_schema_template_2_16.sd.jinja2` and test schema; gate via `MARQO_COLLAPSE_MINIMAL_SUMMARY_MINIMUM_VERSION=2.24.6`.
>   - Add `SemiStructuredMarqoIndex.index_supports_collapse_minimal_summary` (uses new `parsed_schema_template_version()`).
>   - In `SemiStructuredVespaIndex`, include `collapse.summary: collapse-minimal-summary` in collapse queries when supported.
> - **Schema Template Version Tracking**:
>   - Add `schema_template_version` to `SemiStructuredMarqoIndex` and `UnstructuredMarqoIndexRequest`; set on index creation and on schema updates.
>   - `SemiStructuredVespaSchema` populates `schema_template_version`; `VespaApplicationPackage.update_index_setting_and_schema()` updates it to current Marqo version.
> - **Schema Update Flow (`apply_latest_schema_template`)**:
>   - Early exit if `schema_template_version` already matches current version.
>   - Error when index `marqo_version` > current runtime; keep minimum supported version check.
>   - Always compute diff; prepare/activate logic unchanged; response structure streamlined.
> - **Constants/Version**:
>   - Add `MARQO_COLLAPSE_MINIMAL_SUMMARY_MINIMUM_VERSION`.
>   - Bump Marqo version to `2.24.6`.
> - **Tests**:
>   - Extensive unit/integration tests added/updated for collapse summary usage, schema version tracking, update guards, dry-run/force paths, and API shortcut behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffd7f7ad4b3aa956ca84b3c5557fc96651a1b800. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->