### PR TITLE
Fix a performance issue when `collapsingFields` is used with `attributesToRetrieve`

### DIFF
--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -136,6 +136,9 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
         # Only use minimal summary if the schema supports it (version check)
         if self.get_marqo_index().index_supports_collapse_minimal_summary:
             params['collapse.summary'] = 'collapse-minimal-summary'
+            # When used with attributesToRetrieve, the searcher will try to pre-fill the specified fields from the
+            # default summary, which defies the purpose of using a minimal summary for collapsing. Disabling
+            # `FieldFiller` will force the searcher to use `collapse-minimal-summary` for collapsing queries.
             params['FieldFiller.disable'] = True
 
         return params

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -136,6 +136,7 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
         # Only use minimal summary if the schema supports it (version check)
         if self.get_marqo_index().index_supports_collapse_minimal_summary:
             params['collapse.summary'] = 'collapse-minimal-summary'
+            params['FieldFiller.disable'] = True
 
         return params
 

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.24.6"
+__version__ = "2.24.7"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
+++ b/tests/unit_tests/marqo/core/index_management/test_index_management_schema_update.py
@@ -417,7 +417,12 @@ class TestIndexManagementSchemaUpdate(MarqoTestCase):
         for scenario, schema_template_version, should_shortcut in test_cases:
             with self.subTest(scenario=scenario, schema_template_version=schema_template_version):
                 # Create an index with the test schema_template_version
-                existing_index = self._create_test_index(schema_template_version=schema_template_version)
+                # Must explicitly pass marqo_version to match the mocked version,
+                # since default arguments are evaluated at import time, not call time
+                existing_index = self._create_test_index(
+                    schema_template_version=schema_template_version,
+                    marqo_version="2.24.6"
+                )
                 self.index_mgmt.get_index = Mock(return_value=existing_index)
 
                 if should_shortcut:

--- a/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_semi_structured_vespa_index_to_vespa_query.py
+++ b/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_semi_structured_vespa_index_to_vespa_query.py
@@ -806,6 +806,7 @@ class TestSemiStructuredVespaIndexToVespaQueryCollapseFields(MarqoTestCase):
         self.assertEqual('parent_id', vespa_query['collapsefield'])
         self.assertEqual(1, vespa_query['collapsesize'])
         self.assertEqual('collapse-minimal-summary', vespa_query['collapse.summary'])
+        self.assertTrue(vespa_query['FieldFiller.disable'])
 
         # assert rank profiles with '_diversity' suffix is used
         self.assertEqual(common.RANK_PROFILE_BM25 + '_diversity',
@@ -880,6 +881,34 @@ class TestSemiStructuredVespaIndexToVespaQueryCollapseFields(MarqoTestCase):
                          'max(marqo__float_fields{"price"}), count()))) '
                          'all(group(marqo__short_string_fields{"color"}) max(100) order(-count()) '
                          'each(output(count()))) )', vespa_query['marqo__yql.facets'])
+
+    def test_hybrid_query_with_collapse_fields_old_schema_version(self):
+        """Test that collapse minimal summary params are NOT set for older schema versions."""
+        marqo_index = self.semi_structured_marqo_index(
+            "test_index_old",
+            collapse_fields=[CollapseField(name='parent_id')],
+            schema_template_version='2.24.5'  # Edge case: just below minimum 2.24.6
+        )
+        vespa_index = SemiStructuredVespaIndex(marqo_index)
+
+        marqo_query = MarqoHybridQuery(
+            index_name="test_index_old",
+            limit=10,
+            offset=0,
+            or_phrases=[],
+            and_phrases=[],
+            hybrid_parameters=HybridParameters(),
+            collapse_field_name='parent_id',
+        )
+        vespa_query = vespa_index.to_vespa_query(marqo_query)
+
+        # Collapse field should still be set
+        self.assertEqual('parent_id', vespa_query['collapsefield'])
+        self.assertEqual(1, vespa_query['collapsesize'])
+
+        # But minimal summary params should NOT be set for old schema versions
+        self.assertNotIn('collapse.summary', vespa_query)
+        self.assertNotIn('FieldFiller.disable', vespa_query)
 
 
 class TestSemiStructuredVespaIndexToVespaQueryFacets(MarqoTestCase):


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [x] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables Vespa `FieldFiller` when using `collapse-minimal-summary` to prevent attribute prefill during collapsed queries; updates tests and bumps version to 2.24.7.
> 
> - **Semi-structured Vespa query building**:
>   - In `SemiStructuredVespaIndex._generate_collapse_query_params()`, when `index_supports_collapse_minimal_summary` is true, add `params['FieldFiller.disable'] = True` alongside `collapse.summary = 'collapse-minimal-summary'` to prevent default summary prefill during collapsing.
> - **Tests**:
>   - `test_semi_structured_vespa_index_to_vespa_query.py`: Assert `FieldFiller.disable` is set for collapse queries; add test ensuring minimal-summary params are omitted for older schema versions; expand collapse + attributesToRetrieve coverage.
>   - `test_index_management_schema_update.py`: Pass explicit `marqo_version` in schema-version shortcut tests to align with mocked version.
> - **Version**:
>   - Bump `__version__` to `2.24.7`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60a9bc03a18544c7e7765fff6cb5d5c1c85fe2d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->