### PR TITLE
[merge-mainline]Update ranking.rerankCount in relevance cut-off

### DIFF
--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.24.4"
+__version__ = "2.24.5"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/tests/integ_tests/tensor_search/integ_tests/test_search_relevance_cutoff_feature.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_search_relevance_cutoff_feature.py
@@ -915,8 +915,8 @@ class TestSearchRelevanceCutoffFeature(MarqoTestCase):
         regular_result_ids = [hit["_id"] for hit in regular_result["hits"]]
         self.assertEqual(
             set(relevance_cutoff_result_ids),
-            set(regular_result_ids[:3]), # ["h1", "h3", "h2"]
-            "Relevance cutoff should return the top 3 most relevant documents."
+            {"h9", "h10", "h6"},
+            "Relevance cutoff should return the most relevant documents."
         )
 
     def test_relevance_cutoff_feature_works_for_lexical_lexical_search(self):

--- a/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
+++ b/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
@@ -54,6 +54,7 @@ public class HybridSearcher extends Searcher {
     private static String QUERY_INPUT_ADD_WEIGHTS_GLOBAL = "marqo__add_weights_global";
     private static String MARQO_SEARCH_METHOD_LEXICAL = "lexical";
     private static String MARQO_SEARCH_METHOD_TENSOR = "tensor";
+    private static String QUERY_RERANK_COUNT = "ranking.rerankCount";
     private List<String> STANDARD_SEARCH_TYPES = new ArrayList<>();
 
     // Thread-safe ObjectReader for parsing SortField JSON
@@ -491,6 +492,7 @@ public class HybridSearcher extends Searcher {
         // Update query hits and offset
         query.setHits(newHits);
         query.setOffset(0);
+        query.properties().set(QUERY_RERANK_COUNT, newHits);
 
         // Update tensor YQL targetHits if it exists
         if (currentTensorTargetHits != null
@@ -1065,6 +1067,7 @@ public class HybridSearcher extends Searcher {
 
         probeLexicalQuery.setHits(probeDepth);
         probeLexicalQuery.setOffset(0);
+        probeLexicalQuery.properties().set(QUERY_RERANK_COUNT, probeDepth);
 
         logIfVerbose(
                 String.format(

--- a/vespa/src/test/java/ai/marqo/search/RelevanceCutoffTest.java
+++ b/vespa/src/test/java/ai/marqo/search/RelevanceCutoffTest.java
@@ -4,16 +4,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.yahoo.search.Query;
-import com.yahoo.search.Searcher;
 import com.yahoo.search.result.Hit;
 import com.yahoo.search.result.HitGroup;
+import com.yahoo.tensor.Tensor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class RelevanceCutoffTest {
     private HybridSearcher hybridSearcher;
-    private Searcher downstreamSearcher;
 
     @BeforeEach
     void setUp() {
@@ -638,6 +637,62 @@ class RelevanceCutoffTest {
     }
 
     @Nested
+    class UpdateRankingRerankCountTest {
+
+        @Test
+        void shouldReturnModifiedRankingRerankCount() {
+            Query query = new Query("search/?query=test&hits=10&offset=5");
+            query.properties().set("ranking.rerankCount", 15);
+
+            hybridSearcher.updateQueryHitsOffsetsAndTargetHits(query, 100, 200, true, true);
+
+            assertThat(query.properties().get("ranking.rerankCount")).isEqualTo(200);
+        }
+
+        @Test
+        void shouldReturnUnmodifiedQueryWhenBothFlagsAreFalse() {
+            Query query = new Query("search/?query=test&hits=10&offset=5");
+            query.properties().set("ranking.rerankCount", 15);
+
+            hybridSearcher.updateQueryHitsOffsetsAndTargetHits(query, 100, 200, false, false);
+
+            assertThat(query.properties().get("ranking.rerankCount")).isEqualTo(15);
+        }
+
+        @Test
+        void shouldUpdateRankingRerankCountIfOnlySortIsUsed() {
+            Query query = new Query("search/?query=test&hits=10&offset=5");
+            query.properties().set("ranking.rerankCount", 15);
+
+            hybridSearcher.updateQueryHitsOffsetsAndTargetHits(query, null, 202, false, true);
+
+            assertThat(query.properties().get("ranking.rerankCount")).isEqualTo(202);
+        }
+
+        @Test
+        void shouldUnmodifiedRankingRerankIfRelevanceCutoffIsTooSmall() {
+            Query query = new Query("search/?query=test&hits=10&offset=5");
+            query.properties().set("ranking.rerankCount", 15);
+
+            hybridSearcher.updateQueryHitsOffsetsAndTargetHits(query, 150, null, true, false);
+
+            assertThat(query.properties().get("ranking.rerankCount")).isEqualTo(15);
+            assertThat(query.getHits()).isEqualTo(15);
+            assertThat(query.getOffset()).isEqualTo(0);
+        }
+
+        @Test
+        void shouldUpdateRankingRerankIfRelevanceCutoffIsSmall() {
+            Query query = new Query("search/?query=test&hits=100&offset=0");
+            query.properties().set("ranking.rerankCount", 100);
+
+            hybridSearcher.updateQueryHitsOffsetsAndTargetHits(query, 100, null, true, false);
+
+            assertThat(query.properties().get("ranking.rerankCount")).isEqualTo(100);
+        }
+    }
+
+    @Nested
     class CountGreaterOrEqualTest {
 
         @Test
@@ -734,6 +789,36 @@ class RelevanceCutoffTest {
 
             int result = HybridSearcher.countGreaterOrEqual(scores, 750.0);
             assertThat(result).isEqualTo(251); // 1000, 999, ..., 750 are >= 750
+        }
+    }
+
+    @Nested
+    class CreateProbeLexicalQueryTest {
+        @Test
+        void shouldSetRankingRerankCountToProbeDepth() {
+            Query originalQuery = new Query("search/?query=test&hits=60&offset=0");
+            Integer probeDepth = 2000;
+
+            // Set up minimal required properties for createProbeLexialQuery
+            originalQuery
+                    .properties()
+                    .set("marqo__yql.lexical", "select * from sources * where userQuery()");
+            originalQuery
+                    .properties()
+                    .set("marqo__ranking.lexical.lexical", "lexical_rank_profile");
+
+            // Set up the required tensor for fields to rank (empty tensor is fine for this test)
+            originalQuery
+                    .getRanking()
+                    .getFeatures()
+                    .put("query(marqo__fields_to_rank_lexical)", Tensor.from("tensor(p{}):{}"));
+
+            Query probeQuery =
+                    hybridSearcher.createProbeLexialQuery(originalQuery, probeDepth, false);
+
+            assertThat(probeQuery.properties().getInteger("ranking.rerankCount")).isEqualTo(2000);
+            assertThat(probeQuery.getHits()).isEqualTo(2000);
+            assertThat(probeQuery.getOffset()).isEqualTo(0);
         }
     }
 }


### PR DESCRIPTION
## Change Summary

Merge in [PR-1332](https://github.com/marqo-ai/marqo/pull/1332/files)(bab36046f47572963d36f961378ab7c330a37b84) from releases/2.24 branch to mainline

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 52b0b3c9ed39f830ac55b033ea3f0fb4072f4914. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->