### PR TITLE
recency boosting improvements

### DIFF
--- a/src/marqo/core/constants.py
+++ b/src/marqo/core/constants.py
@@ -34,6 +34,7 @@ MARQO_TYPEAHEAD_SCHEMA_MINIMUM_VERSION = semver.VersionInfo.parse('2.23.0')
 MARQO_UPDATE_SCHEMA_MINIMUM_VERSION = semver.VersionInfo.parse('2.23.0')
 MARQO_COLLAPSE_MINIMAL_SUMMARY_MINIMUM_VERSION = semver.VersionInfo.parse('2.24.6')
 MARQO_RECENCY_SCORING_MINIMUM_VERSION = semver.VersionInfo.parse('2.24.8')
+MARQO_RECENCY_ADDITIVE_MINIMUM_VERSION = semver.VersionInfo.parse('2.24.9')
 
 # For score modifiers
 QUERY_INPUT_SCORE_MODIFIERS_MULT_WEIGHTS_2_9 = 'marqo__mult_weights'
@@ -54,3 +55,4 @@ QUERY_INPUT_RECENCY_OFFSET_SECONDS = 'marqo__recency_offset_seconds'
 QUERY_INPUT_RECENCY_DECAY_TO = 'marqo__recency_decay_to'
 QUERY_INPUT_RECENCY_TIMESTAMP_KEY = 'marqo__recency_timestamp_key'
 QUERY_INPUT_RECENCY_DECAY_FUNCTION_TYPE = 'marqo__recency_decay_function_type'
+QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT = 'marqo__recency_add_to_score_weight'

--- a/src/marqo/core/constants.py
+++ b/src/marqo/core/constants.py
@@ -56,3 +56,11 @@ QUERY_INPUT_RECENCY_DECAY_TO = 'marqo__recency_decay_to'
 QUERY_INPUT_RECENCY_TIMESTAMP_KEY = 'marqo__recency_timestamp_key'
 QUERY_INPUT_RECENCY_DECAY_FUNCTION_TYPE = 'marqo__recency_decay_function_type'
 QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT = 'marqo__recency_add_to_score_weight'
+
+# For grow (future timestamp) scoring
+QUERY_INPUT_RECENCY_GROW_ENABLED = 'marqo__recency_grow_enabled'
+QUERY_INPUT_RECENCY_GROW_FROM = 'marqo__recency_grow_from'
+QUERY_INPUT_RECENCY_GROW_FUNCTION_TYPE = 'marqo__recency_grow_function_type'
+QUERY_INPUT_RECENCY_GROW_SCALE_SECONDS = 'marqo__recency_grow_scale_seconds'
+QUERY_INPUT_RECENCY_GROW_OFFSET_SECONDS = 'marqo__recency_grow_offset_seconds'
+MARQO_RECENCY_GROW_MINIMUM_VERSION = semver.VersionInfo.parse('2.24.9')

--- a/src/marqo/core/models/marqo_index.py
+++ b/src/marqo/core/models/marqo_index.py
@@ -725,6 +725,16 @@ class SemiStructuredMarqoIndex(UnstructuredMarqoIndex):
             'index_supports_recency_scoring',
             lambda: self.parsed_schema_template_version() >= constants.MARQO_RECENCY_SCORING_MINIMUM_VERSION)
 
+    @property
+    def index_supports_recency_additive(self) -> bool:
+        """
+        Check if the index schema supports additive recency scoring.
+        Additive recency scoring was added in version 2.24.9.
+        """
+        return self._cache_or_get(
+            'index_supports_recency_additive',
+            lambda: self.parsed_schema_template_version() >= constants.MARQO_RECENCY_ADDITIVE_MINIMUM_VERSION)
+
 
 _PROTECTED_FIELD_NAMES = ['_id', '_tensor_facets', '_highlights', '_score', '_found']
 _VESPA_NAME_PATTERN = r'[a-zA-Z_][a-zA-Z0-9_]*'

--- a/src/marqo/core/models/marqo_index.py
+++ b/src/marqo/core/models/marqo_index.py
@@ -735,6 +735,16 @@ class SemiStructuredMarqoIndex(UnstructuredMarqoIndex):
             'index_supports_recency_additive',
             lambda: self.parsed_schema_template_version() >= constants.MARQO_RECENCY_ADDITIVE_MINIMUM_VERSION)
 
+    @property
+    def index_supports_recency_grow(self) -> bool:
+        """
+        Check if the index schema supports recency grow parameters for future timestamps.
+        Recency grow parameters were added in version 2.24.9.
+        """
+        return self._cache_or_get(
+            'index_supports_recency_grow',
+            lambda: self.parsed_schema_template_version() >= constants.MARQO_RECENCY_GROW_MINIMUM_VERSION)
+
 
 _PROTECTED_FIELD_NAMES = ['_id', '_tensor_facets', '_highlights', '_score', '_found']
 _VESPA_NAME_PATTERN = r'[a-zA-Z_][a-zA-Z0-9_]*'

--- a/src/marqo/core/search/hybrid_search.py
+++ b/src/marqo/core/search/hybrid_search.py
@@ -191,6 +191,14 @@ class HybridSearch:
                     f"{str(constants.MARQO_RECENCY_SCORING_MINIMUM_VERSION)} or later. "
                     f"This index was created with schema version {marqo_index.schema_template_version or marqo_index.marqo_version}."
                 )
+            # Check if addToScoreWeight requires newer schema version
+            if recency_parameters.add_to_score_weight is not None:
+                if not marqo_index.index_supports_recency_additive:
+                    raise core_exceptions.UnsupportedFeatureError(
+                        f"Additive recency scoring (addToScoreWeight) is only supported for unstructured indexes "
+                        f"created with Marqo {str(constants.MARQO_RECENCY_ADDITIVE_MINIMUM_VERSION)} or later. "
+                        f"This index was created with schema version {marqo_index.schema_template_version or marqo_index.marqo_version}."
+                    )
 
         # Determine the text query prefix
         text_query_prefix = marqo_index.model.get_text_query_prefix(text_query_prefix)

--- a/src/marqo/core/search/hybrid_search.py
+++ b/src/marqo/core/search/hybrid_search.py
@@ -199,6 +199,14 @@ class HybridSearch:
                         f"created with Marqo {str(constants.MARQO_RECENCY_ADDITIVE_MINIMUM_VERSION)} or later. "
                         f"This index was created with schema version {marqo_index.schema_template_version or marqo_index.marqo_version}."
                     )
+            # Check if growFrom requires newer schema version
+            if recency_parameters.grow_from is not None:
+                if not marqo_index.index_supports_recency_grow:
+                    raise core_exceptions.UnsupportedFeatureError(
+                        f"Recency grow parameters (growFrom) are only supported for unstructured indexes "
+                        f"created with Marqo {str(constants.MARQO_RECENCY_GROW_MINIMUM_VERSION)} or later. "
+                        f"This index was created with schema version {marqo_index.schema_template_version or marqo_index.marqo_version}."
+                    )
 
         # Determine the text query prefix
         text_query_prefix = marqo_index.model.get_text_query_prefix(text_query_prefix)

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -137,7 +137,7 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
         scale_seconds = parse_duration_to_seconds(recency_params.scale)
         offset_seconds = parse_duration_to_seconds(recency_params.offset)
 
-        return {
+        result = {
             constants.QUERY_INPUT_RECENCY_SHOULD_CALCULATE_SCORE: 1,
             constants.QUERY_INPUT_RECENCY_SHOULD_APPLY_SCORE: 0 if recency_params.apply_in_ranking_phase == ApplyInRankingPhase.ONLY_GLOBAL else 1,
             constants.QUERY_INPUT_RECENCY_SCALE_SECONDS: scale_seconds,
@@ -147,6 +147,31 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
             constants.QUERY_INPUT_RECENCY_DECAY_FUNCTION_TYPE: DecayFunction(recency_params.decay_function).vespa_value,
             constants.QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT: recency_params.add_to_score_weight if recency_params.add_to_score_weight is not None else 0.0
         }
+
+        # Add grow parameters if grow_from is specified
+        if recency_params.grow_from is not None:
+            result[constants.QUERY_INPUT_RECENCY_GROW_ENABLED] = 1
+            result[constants.QUERY_INPUT_RECENCY_GROW_FROM] = recency_params.grow_from
+
+            # Use grow_function if specified, otherwise default to decay_function
+            grow_func = recency_params.grow_function if recency_params.grow_function else recency_params.decay_function
+            result[constants.QUERY_INPUT_RECENCY_GROW_FUNCTION_TYPE] = DecayFunction(grow_func).vespa_value
+
+            # Use grow_scale if specified, otherwise default to scale
+            grow_scale = recency_params.grow_scale if recency_params.grow_scale else recency_params.scale
+            result[constants.QUERY_INPUT_RECENCY_GROW_SCALE_SECONDS] = parse_duration_to_seconds(grow_scale)
+
+            # Use grow_offset if specified, otherwise default to 0
+            grow_offset = recency_params.grow_offset if recency_params.grow_offset else '0d'
+            result[constants.QUERY_INPUT_RECENCY_GROW_OFFSET_SECONDS] = parse_duration_to_seconds(grow_offset)
+        else:
+            result[constants.QUERY_INPUT_RECENCY_GROW_ENABLED] = 0
+            result[constants.QUERY_INPUT_RECENCY_GROW_FROM] = 1.0
+            result[constants.QUERY_INPUT_RECENCY_GROW_FUNCTION_TYPE] = 0
+            result[constants.QUERY_INPUT_RECENCY_GROW_SCALE_SECONDS] = scale_seconds
+            result[constants.QUERY_INPUT_RECENCY_GROW_OFFSET_SECONDS] = 0
+
+        return result
 
     def _generate_collapse_query_params(self, collapse_field_name: str):
         params = {

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -134,42 +134,26 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
 
     def _get_recency_query_input(self, recency_params: RecencyParameters) -> dict:
         # Parse duration strings to seconds for Vespa
-        scale_seconds = parse_duration_to_seconds(recency_params.scale)
-        offset_seconds = parse_duration_to_seconds(recency_params.offset)
-
         result = {
             constants.QUERY_INPUT_RECENCY_SHOULD_CALCULATE_SCORE: 1,
             constants.QUERY_INPUT_RECENCY_SHOULD_APPLY_SCORE: 0 if recency_params.apply_in_ranking_phase == ApplyInRankingPhase.ONLY_GLOBAL else 1,
-            constants.QUERY_INPUT_RECENCY_SCALE_SECONDS: scale_seconds,
-            constants.QUERY_INPUT_RECENCY_OFFSET_SECONDS: offset_seconds,
+            constants.QUERY_INPUT_RECENCY_SCALE_SECONDS: parse_duration_to_seconds(recency_params.scale),
+            constants.QUERY_INPUT_RECENCY_OFFSET_SECONDS: parse_duration_to_seconds(recency_params.offset),
             constants.QUERY_INPUT_RECENCY_DECAY_TO: recency_params.decay_to,
             constants.QUERY_INPUT_RECENCY_TIMESTAMP_KEY: {recency_params.recency_field: 1.0},
             constants.QUERY_INPUT_RECENCY_DECAY_FUNCTION_TYPE: DecayFunction(recency_params.decay_function).vespa_value,
             constants.QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT: recency_params.add_to_score_weight if recency_params.add_to_score_weight is not None else 0.0
         }
 
-        # Add grow parameters if grow_from is specified
+        # grow params, the recency_params validation ensures all or nothing for these params
         if recency_params.grow_from is not None:
             result[constants.QUERY_INPUT_RECENCY_GROW_ENABLED] = 1
             result[constants.QUERY_INPUT_RECENCY_GROW_FROM] = recency_params.grow_from
-
-            # Use grow_function if specified, otherwise default to decay_function
-            grow_func = recency_params.grow_function if recency_params.grow_function else recency_params.decay_function
-            result[constants.QUERY_INPUT_RECENCY_GROW_FUNCTION_TYPE] = DecayFunction(grow_func).vespa_value
-
-            # Use grow_scale if specified, otherwise default to scale
-            grow_scale = recency_params.grow_scale if recency_params.grow_scale else recency_params.scale
-            result[constants.QUERY_INPUT_RECENCY_GROW_SCALE_SECONDS] = parse_duration_to_seconds(grow_scale)
-
-            # Use grow_offset if specified, otherwise default to 0
-            grow_offset = recency_params.grow_offset if recency_params.grow_offset else '0d'
-            result[constants.QUERY_INPUT_RECENCY_GROW_OFFSET_SECONDS] = parse_duration_to_seconds(grow_offset)
+            result[constants.QUERY_INPUT_RECENCY_GROW_FUNCTION_TYPE] = DecayFunction(recency_params.grow_function).vespa_value
+            result[constants.QUERY_INPUT_RECENCY_GROW_SCALE_SECONDS] = parse_duration_to_seconds(recency_params.grow_scale)
+            result[constants.QUERY_INPUT_RECENCY_GROW_OFFSET_SECONDS] = parse_duration_to_seconds(recency_params.grow_offset)
         else:
             result[constants.QUERY_INPUT_RECENCY_GROW_ENABLED] = 0
-            result[constants.QUERY_INPUT_RECENCY_GROW_FROM] = 1.0
-            result[constants.QUERY_INPUT_RECENCY_GROW_FUNCTION_TYPE] = 0
-            result[constants.QUERY_INPUT_RECENCY_GROW_SCALE_SECONDS] = scale_seconds
-            result[constants.QUERY_INPUT_RECENCY_GROW_OFFSET_SECONDS] = 0
 
         return result
 

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -144,7 +144,8 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
             constants.QUERY_INPUT_RECENCY_OFFSET_SECONDS: offset_seconds,
             constants.QUERY_INPUT_RECENCY_DECAY_TO: recency_params.decay_to,
             constants.QUERY_INPUT_RECENCY_TIMESTAMP_KEY: {recency_params.recency_field: 1.0},
-            constants.QUERY_INPUT_RECENCY_DECAY_FUNCTION_TYPE: DecayFunction(recency_params.decay_function).vespa_value
+            constants.QUERY_INPUT_RECENCY_DECAY_FUNCTION_TYPE: DecayFunction(recency_params.decay_function).vespa_value,
+            constants.QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT: recency_params.add_to_score_weight if recency_params.add_to_score_weight is not None else 0.0
         }
 
     def _generate_collapse_query_params(self, collapse_field_name: str):

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -134,15 +134,19 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
 
     def _get_recency_query_input(self, recency_params: RecencyParameters) -> dict:
         # Parse duration strings to seconds for Vespa
+        scale_seconds = parse_duration_to_seconds(recency_params.scale)
+        offset_seconds = parse_duration_to_seconds(recency_params.offset)
+
         result = {
             constants.QUERY_INPUT_RECENCY_SHOULD_CALCULATE_SCORE: 1,
             constants.QUERY_INPUT_RECENCY_SHOULD_APPLY_SCORE: 0 if recency_params.apply_in_ranking_phase == ApplyInRankingPhase.ONLY_GLOBAL else 1,
-            constants.QUERY_INPUT_RECENCY_SCALE_SECONDS: parse_duration_to_seconds(recency_params.scale),
-            constants.QUERY_INPUT_RECENCY_OFFSET_SECONDS: parse_duration_to_seconds(recency_params.offset),
+            constants.QUERY_INPUT_RECENCY_SCALE_SECONDS: scale_seconds,
+            constants.QUERY_INPUT_RECENCY_OFFSET_SECONDS: offset_seconds,
             constants.QUERY_INPUT_RECENCY_DECAY_TO: recency_params.decay_to,
             constants.QUERY_INPUT_RECENCY_TIMESTAMP_KEY: {recency_params.recency_field: 1.0},
             constants.QUERY_INPUT_RECENCY_DECAY_FUNCTION_TYPE: DecayFunction(recency_params.decay_function).vespa_value,
-            constants.QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT: recency_params.add_to_score_weight
+            # Default to 0.0 for multiplicative mode (None means multiplicative)
+            constants.QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT: recency_params.add_to_score_weight if recency_params.add_to_score_weight is not None else 0.0
         }
 
         # grow params, the recency_params validation ensures all or nothing for these params
@@ -153,7 +157,12 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
             result[constants.QUERY_INPUT_RECENCY_GROW_SCALE_SECONDS] = parse_duration_to_seconds(recency_params.grow_scale)
             result[constants.QUERY_INPUT_RECENCY_GROW_OFFSET_SECONDS] = parse_duration_to_seconds(recency_params.grow_offset)
         else:
+            # Grow disabled - set defaults for all grow parameters
             result[constants.QUERY_INPUT_RECENCY_GROW_ENABLED] = 0
+            result[constants.QUERY_INPUT_RECENCY_GROW_FROM] = 1.0
+            result[constants.QUERY_INPUT_RECENCY_GROW_FUNCTION_TYPE] = 0  # exponential
+            result[constants.QUERY_INPUT_RECENCY_GROW_SCALE_SECONDS] = scale_seconds  # use same as decay scale
+            result[constants.QUERY_INPUT_RECENCY_GROW_OFFSET_SECONDS] = 0
 
         return result
 

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -142,7 +142,7 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
             constants.QUERY_INPUT_RECENCY_DECAY_TO: recency_params.decay_to,
             constants.QUERY_INPUT_RECENCY_TIMESTAMP_KEY: {recency_params.recency_field: 1.0},
             constants.QUERY_INPUT_RECENCY_DECAY_FUNCTION_TYPE: DecayFunction(recency_params.decay_function).vespa_value,
-            constants.QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT: recency_params.add_to_score_weight if recency_params.add_to_score_weight is not None else 0.0
+            constants.QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT: recency_params.add_to_score_weight
         }
 
         # grow params, the recency_params validation ensures all or nothing for these params

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2
@@ -162,6 +162,13 @@ schema {{ index.schema_name }} {
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
             query(marqo__recency_add_to_score_weight) double: 0.0
+
+            # Grow parameters for future timestamp scoring
+            query(marqo__recency_grow_enabled): 0
+            query(marqo__recency_grow_from) double: 1.0
+            query(marqo__recency_grow_function_type): 0
+            query(marqo__recency_grow_scale_seconds) double: 604800.0
+            query(marqo__recency_grow_offset_seconds) double: 0.0
         }
 
         # Recency scoring functions
@@ -181,6 +188,17 @@ schema {{ index.schema_name }} {
         # Documents within offset period get 0 effective age (perfect score)
         function effective_age() {
             expression: max(0, age_in_seconds() - query(marqo__recency_offset_seconds))
+        }
+
+        # Future offset: how far timestamp is beyond now() (for grow functions)
+        function future_offset_in_seconds() {
+            expression: max(0, get_timestamp() - now())
+        }
+
+        # Future age after subtracting growOffset (for growth function calculation)
+        # Returns 0 if within the plateau zone (timestamp between now() and now() + growOffset)
+        function future_age_in_seconds() {
+            expression: max(0, future_offset_in_seconds() - query(marqo__recency_grow_offset_seconds))
         }
 
         # Exponential decay (Elasticsearch-compatible)
@@ -256,8 +274,74 @@ schema {{ index.schema_name }} {
             }
         }
 
+        # Grow functions for future timestamps (mirror of decay functions)
+        # These apply when timestamp > now(), with score increasing toward 1.0 as timestamp approaches now()
+
+        # Exponential grow
+        # At future_age = 0 (within plateau or at now()): score = 1.0
+        # At future_age = scale: score = grow_from
+        function recency_grow_score_exponential(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * exp(log(1.0 - grow_from) * age / scale)))
+            }
+        }
+
+        # Linear grow
+        # At future_age = 0: score = 1.0
+        # At future_age = scale: score = grow_from
+        function recency_grow_score_linear(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * age / scale))
+            }
+        }
+
+        # Gaussian grow
+        # At future_age = 0: score = 1.0
+        # At future_age = scale: score = grow_from
+        function recency_grow_score_gaussian(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * (1.0 - exp(pow(age, 2) * log(grow_from) / pow(scale, 2)))))
+            }
+        }
+
+        # Binary grow (step function)
+        # Score is 1.0 until future_age >= scale, then drops to grow_from
+        function recency_grow_score_binary(age, scale, grow_from) {
+            expression: if(age < scale, 1.0, grow_from)
+        }
+
+        function recency_grow_score_router() {
+            expression {
+                if (query(marqo__recency_grow_function_type) == 0,
+                    recency_grow_score_exponential(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                    if (query(marqo__recency_grow_function_type) == 1,
+                        recency_grow_score_linear(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                        if (query(marqo__recency_grow_function_type) == 2,
+                            recency_grow_score_gaussian(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                            recency_grow_score_binary(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)))))
+            }
+        }
+
+        # Grow score: applies to future timestamps when grow is enabled
+        function grow_score() {
+            expression: if(query(marqo__recency_grow_enabled) != 0, recency_grow_score_router(), 1.0)
+        }
+
+        # Combined recency score: routes between decay (past) and grow (future)
         function recency_score() {
-            expression: if(query(marqo__recency_should_calculate_score) != 0, recency_score_router(), 1.0)
+            expression {
+                if (query(marqo__recency_should_calculate_score) != 0,
+                    if (get_timestamp() <= now(),
+                        recency_score_router(),
+                        grow_score()),
+                    1.0)
+            }
         }
 
         function mult_modifier(mult_weights) {
@@ -437,6 +521,13 @@ schema {{ index.schema_name }} {
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
             query(marqo__recency_add_to_score_weight) double: 0.0
+
+            # Grow parameters for future timestamp scoring
+            query(marqo__recency_grow_enabled): 0
+            query(marqo__recency_grow_from) double: 1.0
+            query(marqo__recency_grow_function_type): 0
+            query(marqo__recency_grow_scale_seconds) double: 604800.0
+            query(marqo__recency_grow_offset_seconds) double: 0.0
         }
     }
 

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2
@@ -154,30 +154,27 @@ schema {{ index.schema_name }} {
             query(marqo__sort_field_weights_1) tensor<double>(p{})
             query(marqo__sort_field_weights_2) tensor<double>(p{})
 
+            # Recency parameters
             query(marqo__recency_should_calculate_score): 0
             query(marqo__recency_should_apply_score): 0
-            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_timestamp_key) tensor<double>(p{})
+            query(marqo__recency_add_to_score_weight) double: 0.0
+            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
-            query(marqo__recency_add_to_score_weight) double: 0.0
-
-            # Grow parameters for future timestamp scoring
             query(marqo__recency_grow_enabled): 0
-            query(marqo__recency_grow_from) double: 1.0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0
             query(marqo__recency_grow_offset_seconds) double: 0.0
+            query(marqo__recency_grow_from) double: 0.5
         }
 
-        # ============ RECENCY SCORING FUNCTIONS (OPTIMIZED) ============
-        # Simplified timestamp retrieval (validation ensures key exists when recency is enabled)
+        # ============ RECENCY SCORING FUNCTIONS ============
         function get_timestamp() {
             expression: reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum)
         }
 
-        # Unified age calculation (negative for future timestamps)
         function age_in_seconds() {
             expression: now() - get_timestamp()
         }
@@ -221,12 +218,12 @@ schema {{ index.schema_name }} {
         # Single entry point with early exits for performance
         # Logic flow:
         # 1. If recency disabled → 1.0
-        # 2. If no timestamp (get_timestamp=0) → decay_to (treat as very old)
-        # 3. If age >= scale + offset → decay_to (very old, beyond decay range)
-        # 4. If age >= offset → compute decay score
-        # 5. If grow disabled → 1.0 (future timestamp, no penalty)
-        # 6. If age >= -growOffset → 1.0 (future, within plateau)
-        # 7. If age >= -growOffset - growScale → compute grow score
+        # 2. Elif no timestamp (get_timestamp=0) → decay_to (treat as very old)
+        # 3. Elif age >= scale + offset → decay_to (very old, beyond decay range)
+        # 4. Elif age >= offset → compute decay score
+        # 5. Elif grow disabled → 1.0 (future timestamp, no penalty when grow is disabled)
+        # 6. Elif age >= -growOffset → 1.0 (future, within plateau)
+        # 7. Elif age >= -growOffset - growScale → compute grow score
         # 8. Else → grow_from (far future)
         function recency_score() {
             expression {
@@ -262,13 +259,21 @@ schema {{ index.schema_name }} {
         function add_modifier(add_weights) {
             expression: reduce(add_weights * attribute(marqo__score_modifiers), sum)
         }
+        function apply_score_modifiers(score, mult_weights, add_weights) {
+            expression: mult_modifier(mult_weights) * score + add_modifier(add_weights)
+        }
+        function apply_recency_score(original_score) {
+            expression {
+                if (query(marqo__recency_add_to_score_weight) > 0,
+                    original_score + recency_score() * query(marqo__recency_add_to_score_weight),
+                    original_score * recency_score())
+            }
+        }
         function modify(score, mult_weights, add_weights) {
             expression {
-                if (query(marqo__recency_should_apply_score) != 0,
-                    if (query(marqo__recency_add_to_score_weight) > 0,
-                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) + recency_score() * query(marqo__recency_add_to_score_weight),
-                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_score()),
-                    mult_modifier(mult_weights) * score + add_modifier(add_weights))
+                if (query(marqo__recency_should_apply_score) == 0,
+                    apply_score_modifiers(score, mult_weights, add_weights),
+                    apply_recency_score(apply_score_modifiers(score, mult_weights, add_weights)))
             }
         }
         function global_mult_modifier() {
@@ -425,21 +430,20 @@ schema {{ index.schema_name }} {
             query(marqo__sort_field_weights_1) tensor<double>(p{})
             query(marqo__sort_field_weights_2) tensor<double>(p{})
 
+            # Recency parameters
             query(marqo__recency_should_calculate_score): 0
             query(marqo__recency_should_apply_score): 0
-            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_timestamp_key) tensor<double>(p{})
+            query(marqo__recency_add_to_score_weight) double: 0.0
+            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
-            query(marqo__recency_add_to_score_weight) double: 0.0
-
-            # Grow parameters for future timestamp scoring
             query(marqo__recency_grow_enabled): 0
-            query(marqo__recency_grow_from) double: 1.0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0
             query(marqo__recency_grow_offset_seconds) double: 0.0
+            query(marqo__recency_grow_from) double: 0.5
         }
     }
 

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2
@@ -171,176 +171,88 @@ schema {{ index.schema_name }} {
             query(marqo__recency_grow_offset_seconds) double: 0.0
         }
 
-        # Recency scoring functions
+        # ============ RECENCY SCORING FUNCTIONS (OPTIMIZED) ============
+        # Simplified timestamp retrieval (validation ensures key exists when recency is enabled)
         function get_timestamp() {
-            expression {
-                if (count(query(marqo__recency_timestamp_key)) > 0,
-                    reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum),
-                    0)
-            }
+            expression: reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum)
         }
 
+        # Unified age calculation (negative for future timestamps)
         function age_in_seconds() {
-            expression: max(0, now() - get_timestamp())
+            expression: now() - get_timestamp()
         }
 
-        # Effective age after applying offset (grace period)
-        # Documents within offset period get 0 effective age (perfect score)
-        function effective_age() {
-            expression: max(0, age_in_seconds() - query(marqo__recency_offset_seconds))
+        # ============ UNIFIED SCORING FUNCTIONS ============
+        # These work for both decay (past) and grow (future) by taking (age, scale, floor_val):
+        # - At age=0: returns 1.0
+        # - At age=scale: returns floor_val
+        # - Beyond scale: clamps to floor_val
+
+        function score_exponential(age, scale, floor_val) {
+            expression: max(floor_val, exp(log(floor_val) * age / scale))
         }
 
-        # Future offset: how far timestamp is beyond now() (for grow functions)
-        function future_offset_in_seconds() {
-            expression: max(0, get_timestamp() - now())
+        function score_linear(age, scale, floor_val) {
+            expression: max(floor_val, (scale - age * (1.0 - floor_val)) / scale)
         }
 
-        # Future age after subtracting growOffset (for growth function calculation)
-        # Returns 0 if within the plateau zone (timestamp between now() and now() + growOffset)
-        function future_age_in_seconds() {
-            expression: max(0, future_offset_in_seconds() - query(marqo__recency_grow_offset_seconds))
+        function score_gaussian(age, scale, floor_val) {
+            expression: max(floor_val, exp(pow(age, 2) * log(floor_val) / pow(scale, 2)))
         }
 
-        # Exponential decay (Elasticsearch-compatible)
-        # Formula: λ = ln(decay_to) / scale
-        #          score = max(decay_to, exp(λ × age))
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        function recency_score_exponential(age, scale, decay_to) {
+        function score_binary(age, scale, floor_val) {
+            expression: if(age < scale, 1.0, floor_val)
+        }
+
+        # Router: selects function based on type (0=exp, 1=linear, 2=gaussian, 3=binary)
+        function compute_score(age, scale, floor_val, func_type) {
             expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, exp(log(decay_to) * age / scale)))
+                if (func_type == 0,
+                    score_exponential(age, scale, floor_val),
+                    if (func_type == 1,
+                        score_linear(age, scale, floor_val),
+                        if (func_type == 2,
+                            score_gaussian(age, scale, floor_val),
+                            score_binary(age, scale, floor_val))))
             }
         }
 
-        # Linear decay (Elasticsearch-compatible)
-        # Formula: score = max(decay_to, (scale - age × (1 - decay_to)) / scale)
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        function recency_score_linear(age, scale, decay_to) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, (scale - age * (1.0 - decay_to)) / scale))
-            }
-        }
-
-        # Gaussian decay (Elasticsearch-compatible)
-        # Formula: σ² = -scale² / (2 × ln(decay_to))
-        #          score = max(decay_to, exp(-age² / (2σ²)))
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        # Formula: score = exp(age² × ln(decay_to) / scale²)
-        function recency_score_gaussian(age, scale, decay_to) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, exp(pow(age, 2) * log(decay_to) / pow(scale, 2))))
-            }
-        }
-
-        # Binary decay (step function)
-        # Score is 1.0 until age >= scale, then drops to decay_to
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: threshold in seconds
-        #   decay_to: score after threshold
-        function recency_score_binary(age, scale, decay_to) {
-            expression: if(age < scale, 1.0, decay_to)
-        }
-
-        function recency_score_router() {
-            expression {
-                if (query(marqo__recency_decay_function_type) == 0,
-                    recency_score_exponential(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                    if (query(marqo__recency_decay_function_type) == 1,
-                        recency_score_linear(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                        if (query(marqo__recency_decay_function_type) == 2,
-                            recency_score_gaussian(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                            recency_score_binary(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)))))
-            }
-        }
-
-        # Grow functions for future timestamps (mirror of decay functions)
-        # These apply when timestamp > now(), with score increasing toward 1.0 as timestamp approaches now()
-
-        # Exponential grow
-        # At future_age = 0 (within plateau or at now()): score = 1.0
-        # At future_age = scale: score = grow_from
-        function recency_grow_score_exponential(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * exp(log(1.0 - grow_from) * age / scale)))
-            }
-        }
-
-        # Linear grow
-        # At future_age = 0: score = 1.0
-        # At future_age = scale: score = grow_from
-        function recency_grow_score_linear(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * age / scale))
-            }
-        }
-
-        # Gaussian grow
-        # At future_age = 0: score = 1.0
-        # At future_age = scale: score = grow_from
-        function recency_grow_score_gaussian(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * (1.0 - exp(pow(age, 2) * log(grow_from) / pow(scale, 2)))))
-            }
-        }
-
-        # Binary grow (step function)
-        # Score is 1.0 until future_age >= scale, then drops to grow_from
-        function recency_grow_score_binary(age, scale, grow_from) {
-            expression: if(age < scale, 1.0, grow_from)
-        }
-
-        function recency_grow_score_router() {
-            expression {
-                if (query(marqo__recency_grow_function_type) == 0,
-                    recency_grow_score_exponential(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                    if (query(marqo__recency_grow_function_type) == 1,
-                        recency_grow_score_linear(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                        if (query(marqo__recency_grow_function_type) == 2,
-                            recency_grow_score_gaussian(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                            recency_grow_score_binary(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)))))
-            }
-        }
-
-        # Grow score: applies to future timestamps when grow is enabled
-        function grow_score() {
-            expression: if(query(marqo__recency_grow_enabled) != 0, recency_grow_score_router(), 1.0)
-        }
-
-        # Combined recency score: routes between decay (past) and grow (future)
+        # ============ UNIFIED RECENCY SCORE ============
+        # Single entry point with early exits for performance
+        # Logic flow:
+        # 1. If recency disabled → 1.0
+        # 2. If no timestamp (get_timestamp=0) → decay_to (treat as very old)
+        # 3. If age >= scale + offset → decay_to (very old, beyond decay range)
+        # 4. If age >= offset → compute decay score
+        # 5. If grow disabled → 1.0 (future timestamp, no penalty)
+        # 6. If age >= -growOffset → 1.0 (future, within plateau)
+        # 7. If age >= -growOffset - growScale → compute grow score
+        # 8. Else → grow_from (far future)
         function recency_score() {
             expression {
-                if (query(marqo__recency_should_calculate_score) != 0,
-                    if (get_timestamp() <= now(),
-                        recency_score_router(),
-                        grow_score()),
-                    1.0)
+                if (query(marqo__recency_should_calculate_score) == 0,
+                    1.0,
+                    if (get_timestamp() == 0,
+                        query(marqo__recency_decay_to),
+                        if (age_in_seconds() >= query(marqo__recency_scale_seconds) + query(marqo__recency_offset_seconds),
+                            query(marqo__recency_decay_to),
+                            if (age_in_seconds() >= query(marqo__recency_offset_seconds),
+                                compute_score(
+                                    age_in_seconds() - query(marqo__recency_offset_seconds),
+                                    query(marqo__recency_scale_seconds),
+                                    query(marqo__recency_decay_to),
+                                    query(marqo__recency_decay_function_type)),
+                                if (query(marqo__recency_grow_enabled) == 0,
+                                    1.0,
+                                    if (age_in_seconds() >= -query(marqo__recency_grow_offset_seconds),
+                                        1.0,
+                                        if (age_in_seconds() >= -query(marqo__recency_grow_offset_seconds) - query(marqo__recency_grow_scale_seconds),
+                                            compute_score(
+                                                -age_in_seconds() - query(marqo__recency_grow_offset_seconds),
+                                                query(marqo__recency_grow_scale_seconds),
+                                                query(marqo__recency_grow_from),
+                                                query(marqo__recency_grow_function_type)),
+                                            query(marqo__recency_grow_from))))))))
             }
         }
 

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2
@@ -161,6 +161,7 @@ schema {{ index.schema_name }} {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_add_to_score_weight) double: 0.0
         }
 
         # Recency scoring functions
@@ -259,10 +260,6 @@ schema {{ index.schema_name }} {
             expression: if(query(marqo__recency_should_calculate_score) != 0, recency_score_router(), 1.0)
         }
 
-        function recency_multiplier() {
-            expression: if(query(marqo__recency_should_apply_score) != 0, recency_score(), 1.0)
-        }
-
         function mult_modifier(mult_weights) {
             expression: if (count(mult_weights * attribute(marqo__score_modifiers)) == 0,   1, reduce(mult_weights * attribute(marqo__score_modifiers), prod))
         }
@@ -270,7 +267,13 @@ schema {{ index.schema_name }} {
             expression: reduce(add_weights * attribute(marqo__score_modifiers), sum)
         }
         function modify(score, mult_weights, add_weights) {
-            expression: (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_multiplier()
+            expression {
+                if (query(marqo__recency_should_apply_score) != 0,
+                    if (query(marqo__recency_add_to_score_weight) > 0,
+                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) + recency_score() * query(marqo__recency_add_to_score_weight),
+                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_score()),
+                    mult_modifier(mult_weights) * score + add_modifier(add_weights))
+            }
         }
         function global_mult_modifier() {
             expression: mult_modifier(query(marqo__mult_weights_global))
@@ -433,6 +436,7 @@ schema {{ index.schema_name }} {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_add_to_score_weight) double: 0.0
         }
     }
 

--- a/src/marqo/tensor_search/models/recency_parameters.py
+++ b/src/marqo/tensor_search/models/recency_parameters.py
@@ -1,6 +1,7 @@
 """Recency parameters for time-based score boosting."""
 
 from enum import Enum
+from typing import Optional
 from pydantic.v1 import BaseModel, Field, validator
 from marqo.core.utils.duration_parser import parse_duration_to_seconds
 
@@ -93,6 +94,16 @@ class RecencyParameters(BaseModel):
             "- 'all': Apply in all ranking phases (Vespa rank profile and global phase reranking) (default)\n"
             "- 'only-global': Calculate recency score in Vespa but only apply it during global phase reranking\n"
             "- 'exclude-global': Apply recency in Vespa rank profile only, exclude from global phase reranking"
+        )
+    )
+
+    add_to_score_weight: Optional[float] = Field(
+        default=None,
+        gt=0.0,
+        alias="addToScoreWeight",
+        description=(
+            "If provided, applies recency as an additive factor instead of multiplicative. "
+            "Formula: final_score = modified_score + (recency_score * addToScoreWeight)."
         )
     )
 

--- a/src/marqo/tensor_search/models/recency_parameters.py
+++ b/src/marqo/tensor_search/models/recency_parameters.py
@@ -2,7 +2,7 @@
 
 from enum import Enum
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, validator
+from pydantic.v1 import BaseModel, Field, validator, root_validator
 from marqo.core.utils.duration_parser import parse_duration_to_seconds
 
 
@@ -114,8 +114,9 @@ class RecencyParameters(BaseModel):
         alias="growFrom",
         description=(
             "Starting score for documents with timestamps far in the future. "
-            "When set, enables growth function for future timestamps. "
-            "Must be in range (0.0, 1.0]. If not provided, future timestamps get score 1.0."
+            "Must be in range (0.0, 1.0]. "
+            "NOTE: All grow parameters (growFrom, growFunction, growScale, growOffset) must be "
+            "provided together or all omitted. If omitted, future timestamps get score 1.0."
         )
     )
 
@@ -124,7 +125,7 @@ class RecencyParameters(BaseModel):
         alias="growFunction",
         description=(
             "Type of growth function for future timestamps: exponential, linear, gaussian, binary. "
-            "If not provided, defaults to the same as decayFunction."
+            "NOTE: All grow parameters must be provided together or all omitted."
         )
     )
 
@@ -133,7 +134,7 @@ class RecencyParameters(BaseModel):
         alias="growScale",
         description=(
             "Time scale for growth function. Format: {number}{unit} where unit is 'd' (days) or 'h' (hours). "
-            "If not provided, defaults to the same as scale."
+            "NOTE: All grow parameters must be provided together or all omitted."
         )
     )
 
@@ -144,7 +145,7 @@ class RecencyParameters(BaseModel):
             "Time offset before growth function starts. Documents with timestamps between now() "
             "and now() + growOffset get score 1.0 (plateau). Growth function applies to timestamps "
             "beyond now() + growOffset. Format: {number}{unit} where unit is 'd' (days) or 'h' (hours). "
-            "If not provided, defaults to '0d' (no plateau)."
+            "NOTE: All grow parameters must be provided together or all omitted."
         )
     )
 
@@ -225,3 +226,31 @@ class RecencyParameters(BaseModel):
             raise ValueError(f"grow_offset must be greater than or equal to 0, got: {v} ({seconds} seconds)")
 
         return v
+
+    @root_validator
+    def validate_grow_params_all_or_nothing(cls, values):
+        """Validate that grow parameters are either all provided or all omitted.
+
+        If any grow parameter is provided, all must be provided. If none are provided,
+        grow functionality is disabled and future timestamps get score 1.0.
+        """
+        grow_params = {
+            'growFrom': values.get('grow_from'),
+            'growFunction': values.get('grow_function'),
+            'growScale': values.get('grow_scale'),
+            'growOffset': values.get('grow_offset'),
+        }
+
+        provided = [k for k, v in grow_params.items() if v is not None]
+        missing = [k for k, v in grow_params.items() if v is None]
+
+        # If some but not all are provided, raise error
+        if provided and missing:
+            provided_names = ', '.join(sorted(provided))
+            missing_names = ', '.join(sorted(missing))
+            raise ValueError(
+                f"Grow parameters must be either all provided or all omitted. "
+                f"Provided: [{provided_names}]. Missing: [{missing_names}]."
+            )
+
+        return values

--- a/src/marqo/tensor_search/models/recency_parameters.py
+++ b/src/marqo/tensor_search/models/recency_parameters.py
@@ -120,7 +120,7 @@ class RecencyParameters(BaseModel):
         )
     )
 
-    grow_function: Optional[str] = Field(
+    grow_function: Optional[DecayFunction] = Field(
         default=None,
         alias="growFunction",
         description=(
@@ -185,16 +185,6 @@ class RecencyParameters(BaseModel):
         if seconds < 0:
             raise ValueError(f"offset must be greater than or equal to 0, got: {v} ({seconds} seconds)")
 
-        return v
-
-    @validator('grow_function')
-    def validate_grow_function(cls, v: Optional[str]) -> Optional[str]:
-        """Validate grow_function is a valid decay function name."""
-        if v is None:
-            return v
-        valid_functions = [f.value for f in DecayFunction]
-        if v not in valid_functions:
-            raise ValueError(f"Invalid grow_function '{v}'. Must be one of: {', '.join(valid_functions)}")
         return v
 
     @validator('grow_scale')

--- a/src/marqo/tensor_search/models/recency_parameters.py
+++ b/src/marqo/tensor_search/models/recency_parameters.py
@@ -107,6 +107,47 @@ class RecencyParameters(BaseModel):
         )
     )
 
+    grow_from: Optional[float] = Field(
+        default=None,
+        gt=0.0,
+        le=1.0,
+        alias="growFrom",
+        description=(
+            "Starting score for documents with timestamps far in the future. "
+            "When set, enables growth function for future timestamps. "
+            "Must be in range (0.0, 1.0]. If not provided, future timestamps get score 1.0."
+        )
+    )
+
+    grow_function: Optional[str] = Field(
+        default=None,
+        alias="growFunction",
+        description=(
+            "Type of growth function for future timestamps: exponential, linear, gaussian, binary. "
+            "If not provided, defaults to the same as decayFunction."
+        )
+    )
+
+    grow_scale: Optional[str] = Field(
+        default=None,
+        alias="growScale",
+        description=(
+            "Time scale for growth function. Format: {number}{unit} where unit is 'd' (days) or 'h' (hours). "
+            "If not provided, defaults to the same as scale."
+        )
+    )
+
+    grow_offset: Optional[str] = Field(
+        default=None,
+        alias="growOffset",
+        description=(
+            "Time offset before growth function starts. Documents with timestamps between now() "
+            "and now() + growOffset get score 1.0 (plateau). Growth function applies to timestamps "
+            "beyond now() + growOffset. Format: {number}{unit} where unit is 'd' (days) or 'h' (hours). "
+            "If not provided, defaults to '0d' (no plateau)."
+        )
+    )
+
     class Config:
         extra: str = "forbid"
         allow_population_by_field_name = True
@@ -142,5 +183,45 @@ class RecencyParameters(BaseModel):
 
         if seconds < 0:
             raise ValueError(f"offset must be greater than or equal to 0, got: {v} ({seconds} seconds)")
+
+        return v
+
+    @validator('grow_function')
+    def validate_grow_function(cls, v: Optional[str]) -> Optional[str]:
+        """Validate grow_function is a valid decay function name."""
+        if v is None:
+            return v
+        valid_functions = [f.value for f in DecayFunction]
+        if v not in valid_functions:
+            raise ValueError(f"Invalid grow_function '{v}'. Must be one of: {', '.join(valid_functions)}")
+        return v
+
+    @validator('grow_scale')
+    def validate_grow_scale(cls, v: Optional[str]) -> Optional[str]:
+        """Validate grow_scale duration string format and constraints."""
+        if v is None:
+            return v
+        try:
+            seconds = parse_duration_to_seconds(v)
+        except ValueError as e:
+            raise ValueError(f"Invalid grow_scale format: {e}")
+
+        if seconds <= 0:
+            raise ValueError(f"grow_scale must be greater than 0, got: {v} ({seconds} seconds)")
+
+        return v
+
+    @validator('grow_offset')
+    def validate_grow_offset(cls, v: Optional[str]) -> Optional[str]:
+        """Validate grow_offset duration string format and constraints."""
+        if v is None:
+            return v
+        try:
+            seconds = parse_duration_to_seconds(v)
+        except ValueError as e:
+            raise ValueError(f"Invalid grow_offset format: {e}")
+
+        if seconds < 0:
+            raise ValueError(f"grow_offset must be greater than or equal to 0, got: {v} ({seconds} seconds)")
 
         return v

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.24.8"
+__version__ = "2.24.9"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/tests/api_tests/v1/tests/api_tests/test_base64_image_search.py
+++ b/tests/api_tests/v1/tests/api_tests/test_base64_image_search.py
@@ -76,7 +76,7 @@ class TestBase64ImageSearch(MarqoTestCase):
                     },
                     {
                         "_id": "coco_doc",
-                        "image": TestImageUrls.COCO.value,
+                        "image": TestImageUrls.IMAGE1.value,
                         "title": "COCO dataset image"
                     }
                 ]
@@ -152,7 +152,7 @@ class TestBase64ImageSearch(MarqoTestCase):
             },
             {
                 "_id": "coco_doc",
-                "image": TestImageUrls.COCO.value,
+                "image": TestImageUrls.IMAGE1.value,
                 "title": "COCO dataset image"
             }
         ]
@@ -205,7 +205,7 @@ class TestBase64ImageSearch(MarqoTestCase):
                     },
                     {
                         "_id": "coco_doc",
-                        "image": TestImageUrls.COCO.value,
+                        "image": TestImageUrls.IMAGE1.value,
                         "title": "COCO dataset image with various objects"
                     },
                     {
@@ -308,7 +308,7 @@ class TestBase64ImageSearch(MarqoTestCase):
                     },
                     {
                         "_id": "coco_doc",
-                        "image": TestImageUrls.COCO.value,
+                        "image": TestImageUrls.IMAGE1.value,
                         "title": "COCO dataset image with various objects"
                     },
                     {

--- a/tests/api_tests/v1/tests/api_tests/test_recency_scoring.py
+++ b/tests/api_tests/v1/tests/api_tests/test_recency_scoring.py
@@ -349,3 +349,270 @@ class TestRecencyScoring(MarqoTestCase):
         # Check error message mentions recency is not supported for structured indexes
         self.assertIn("message", error_response)
         self.assertIn("unstructured", error_response["message"].lower())
+
+    def test_grow_function_penalizes_future_documents(self):
+        """Test that growFrom/growFunction penalizes documents with future timestamps."""
+        index_name = self.unstructured_index_name
+
+        # Add documents with future timestamps
+        now = datetime.now()
+        docs = [
+            {
+                "_id": "present",
+                "title": "laptop computer device",
+                "description": "tech gadget product",
+                "created_at": int(now.timestamp())
+            },
+            {
+                "_id": "near-future",
+                "title": "laptop computer device",
+                "description": "tech gadget product",
+                "created_at": int((now + timedelta(days=3)).timestamp())
+            },
+            {
+                "_id": "far-future",
+                "title": "laptop computer device",
+                "description": "tech gadget product",
+                "created_at": int((now + timedelta(days=30)).timestamp())
+            }
+        ]
+
+        self.client.index(index_name).add_documents(docs, tensor_fields=["title", "description"])
+
+        # Search with grow function enabled
+        search_body = {
+            "q": "laptop",
+            "searchMethod": "HYBRID",
+            "limit": 10,
+            "recencyParameters": {
+                "recencyField": "created_at",
+                "scale": "7d",
+                "offset": "0d",
+                "decayFunction": "exponential",
+                "decayTo": 0.5,
+                "growFrom": 0.3,  # Future docs start at 0.3 and grow toward 1.0
+                "growFunction": "exponential",
+                "growScale": "7d",
+                "growOffset": "0d",
+                "applyInRankingPhase": "all"
+            }
+        }
+
+        response = requests.post(
+            f"{self._MARQO_URL}/indexes/{index_name}/search",
+            headers={"Content-Type": "application/json"},
+            data=json.dumps(search_body)
+        )
+
+        self.assertEqual(response.status_code, 200)
+        hits = response.json()["hits"]
+
+        present_doc = next((h for h in hits if h["_id"] == "present"), None)
+        near_future_doc = next((h for h in hits if h["_id"] == "near-future"), None)
+        far_future_doc = next((h for h in hits if h["_id"] == "far-future"), None)
+
+        # All documents should be found
+        self.assertIsNotNone(present_doc, "Present document should be in results")
+        self.assertIsNotNone(near_future_doc, "Near-future document should be in results")
+        self.assertIsNotNone(far_future_doc, "Far-future document should be in results")
+
+        # Present document should score highest (score = 1.0)
+        # Far future document should score lowest (penalized most)
+        self.assertGreater(
+            present_doc["_score"],
+            far_future_doc["_score"],
+            f"Present document (score={present_doc['_score']:.6f}) should score higher "
+            f"than far-future document (score={far_future_doc['_score']:.6f})"
+        )
+
+        # Near future should be between present and far future
+        self.assertGreater(
+            near_future_doc["_score"],
+            far_future_doc["_score"],
+            f"Near-future document (score={near_future_doc['_score']:.6f}) should score higher "
+            f"than far-future document (score={far_future_doc['_score']:.6f})"
+        )
+
+    def test_grow_offset_creates_future_plateau(self):
+        """Test that growOffset creates a plateau where future docs get score 1.0."""
+        index_name = self.unstructured_index_name
+
+        now = datetime.now()
+        docs = [
+            {
+                "_id": "present",
+                "title": "camera photography device",
+                "description": "digital equipment gear",
+                "created_at": int(now.timestamp())
+            },
+            {
+                "_id": "within-grow-offset",
+                "title": "camera photography device",
+                "description": "digital equipment gear",
+                "created_at": int((now + timedelta(days=2)).timestamp())  # Within 3-day offset
+            },
+            {
+                "_id": "beyond-grow-offset",
+                "title": "camera photography device",
+                "description": "digital equipment gear",
+                "created_at": int((now + timedelta(days=10)).timestamp())  # Beyond 3-day offset
+            }
+        ]
+
+        self.client.index(index_name).add_documents(docs, tensor_fields=["title", "description"])
+
+        # Search with 3-day grow offset (plateau)
+        search_body = {
+            "q": "camera",
+            "searchMethod": "HYBRID",
+            "limit": 10,
+            "recencyParameters": {
+                "recencyField": "created_at",
+                "scale": "7d",
+                "offset": "0d",
+                "decayFunction": "exponential",
+                "decayTo": 0.5,
+                "growFrom": 0.2,
+                "growFunction": "exponential",
+                "growScale": "7d",
+                "growOffset": "3d",  # 3-day plateau for future timestamps
+                "applyInRankingPhase": "all"
+            }
+        }
+
+        response = requests.post(
+            f"{self._MARQO_URL}/indexes/{index_name}/search",
+            headers={"Content-Type": "application/json"},
+            data=json.dumps(search_body)
+        )
+
+        self.assertEqual(response.status_code, 200)
+        hits = response.json()["hits"]
+
+        present = next((h for h in hits if h["_id"] == "present"), None)
+        within_offset = next((h for h in hits if h["_id"] == "within-grow-offset"), None)
+        beyond_offset = next((h for h in hits if h["_id"] == "beyond-grow-offset"), None)
+
+        self.assertIsNotNone(present)
+        self.assertIsNotNone(within_offset)
+        self.assertIsNotNone(beyond_offset)
+
+        # Present and within-offset should have similar scores (both get 1.0 recency)
+        # Beyond-offset should be penalized
+        self.assertGreater(
+            within_offset["_score"],
+            beyond_offset["_score"],
+            f"Doc within grow offset (score={within_offset['_score']:.6f}) should score higher "
+            f"than doc beyond offset (score={beyond_offset['_score']:.6f})"
+        )
+
+    def test_add_to_score_weight_additive_mode(self):
+        """Test that addToScoreWeight applies recency as additive instead of multiplicative."""
+        index_name = self.unstructured_index_name
+
+        now = datetime.now()
+        docs = [
+            {
+                "_id": "recent-additive",
+                "title": "headphones audio device",
+                "description": "music listening gear",
+                "created_at": int(now.timestamp())
+            },
+            {
+                "_id": "old-additive",
+                "title": "headphones audio device",
+                "description": "music listening gear",
+                "created_at": int((now - timedelta(days=30)).timestamp())
+            }
+        ]
+
+        self.client.index(index_name).add_documents(docs, tensor_fields=["title", "description"])
+
+        # Search with additive recency scoring
+        search_body = {
+            "q": "headphones",
+            "searchMethod": "HYBRID",
+            "limit": 10,
+            "recencyParameters": {
+                "recencyField": "created_at",
+                "scale": "7d",
+                "offset": "0d",
+                "decayFunction": "exponential",
+                "decayTo": 0.1,
+                "addToScoreWeight": 0.5,  # Add recency_score * 0.5 to the base score
+                "applyInRankingPhase": "all"
+            }
+        }
+
+        response = requests.post(
+            f"{self._MARQO_URL}/indexes/{index_name}/search",
+            headers={"Content-Type": "application/json"},
+            data=json.dumps(search_body)
+        )
+
+        self.assertEqual(response.status_code, 200)
+        hits = response.json()["hits"]
+
+        recent = next((h for h in hits if h["_id"] == "recent-additive"), None)
+        old = next((h for h in hits if h["_id"] == "old-additive"), None)
+
+        self.assertIsNotNone(recent, "Recent document should be in results")
+        self.assertIsNotNone(old, "Old document should be in results")
+
+        # Recent document should score higher due to additive recency boost
+        self.assertGreater(
+            recent["_score"],
+            old["_score"],
+            f"Recent document (score={recent['_score']:.6f}) should score higher "
+            f"than old document (score={old['_score']:.6f}) with additive recency"
+        )
+
+        # The difference should be noticeable since we're adding recency_score * 0.5
+        # Recent doc: base_score + 1.0 * 0.5
+        # Old doc: base_score + 0.1 * 0.5
+        # The absolute difference depends on base scores from hybrid search
+        score_difference = recent["_score"] - old["_score"]
+        self.assertGreater(
+            score_difference,
+            0.01,  # Should have meaningful difference due to additive boost
+            f"Score difference ({score_difference:.6f}) should be meaningful with additive scoring"
+        )
+
+    def test_gaussian_decay_function(self):
+        """Test that gaussian decay function works correctly."""
+        index_name = self.unstructured_index_name
+        self._add_test_documents(index_name)
+
+        search_body = {
+            "q": "product",
+            "searchMethod": "HYBRID",
+            "limit": 10,
+            "recencyParameters": {
+                "recencyField": "created_at",
+                "scale": "14d",
+                "offset": "0d",
+                "decayFunction": "gaussian",
+                "decayTo": 0.3,
+                "applyInRankingPhase": "all"
+            }
+        }
+
+        response = requests.post(
+            f"{self._MARQO_URL}/indexes/{index_name}/search",
+            headers={"Content-Type": "application/json"},
+            data=json.dumps(search_body)
+        )
+
+        self.assertEqual(response.status_code, 200)
+        hits = response.json()["hits"]
+
+        recent_doc = next((h for h in hits if h["_id"] == "recent"), None)
+        month_old_doc = next((h for h in hits if h["_id"] == "month-old"), None)
+
+        # Verify gaussian decay gives recent docs higher scores
+        if recent_doc and month_old_doc:
+            self.assertGreater(
+                recent_doc["_score"],
+                month_old_doc["_score"],
+                "Gaussian decay should give recent documents higher scores"
+            )

--- a/tests/compatibility_tests/search/test_search.py
+++ b/tests/compatibility_tests/search/test_search.py
@@ -97,7 +97,7 @@ class TestSearch(BaseCompatibilityTestCase):
         {
             "_id": f"example_doc_6",
             "text_field": "Woman skiing",
-            "image_field": "https://raw.githubusercontent.com/marqo-ai/marqo-clip-onnx/main/examples/coco.jpg",
+            "image_field": "https://raw.githubusercontent.com/marqo-ai/marqo/mainline/examples/ImageSearchGuide/data/image1.jpg",
             'tags': ['ski'],
             'caption': 'example_doc_6'
         },

--- a/tests/compatibility_tests/search/unstructured/test_hybrid_search_unstructured.py
+++ b/tests/compatibility_tests/search/unstructured/test_hybrid_search_unstructured.py
@@ -81,7 +81,7 @@ class TestHybridSearchUnstructured(BaseCompatibilityTestCase):
         {
             "_id": f"example_doc_6",
             "text_field": "Woman skiing",
-            "image_field": "https://raw.githubusercontent.com/marqo-ai/marqo-clip-onnx/main/examples/coco.jpg",
+            "image_field": "https://raw.githubusercontent.com/marqo-ai/marqo/mainline/examples/ImageSearchGuide/data/image1.jpg",
             'tags': ['ski'],
             'caption': 'example_doc_6'
         },

--- a/tests/compatibility_tests/search/unstructured/test_hybrid_search_unstructured_sort_by_feature.py
+++ b/tests/compatibility_tests/search/unstructured/test_hybrid_search_unstructured_sort_by_feature.py
@@ -87,7 +87,7 @@ class TestHybridSearchUnstructuredSortByFeature(BaseCompatibilityTestCase):
         {
             "_id": f"example_doc_6",
             "text_field": "Woman skiing",
-            "image_field": "https://raw.githubusercontent.com/marqo-ai/marqo-clip-onnx/main/examples/coco.jpg",
+            "image_field": "https://raw.githubusercontent.com/marqo-ai/marqo/mainline/examples/ImageSearchGuide/data/image1.jpg",
             'tags': ['ski'],
             'caption': 'example_doc_6'
         },

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_fields_with_collapse_fields.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_fields_with_collapse_fields.sd
@@ -155,6 +155,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_add_to_score_weight) double: 0.0
         }
 
         # Recency scoring functions
@@ -253,10 +254,6 @@ schema marqo__test_00semi_00structured_00schema {
             expression: if(query(marqo__recency_should_calculate_score) != 0, recency_score_router(), 1.0)
         }
 
-        function recency_multiplier() {
-            expression: if(query(marqo__recency_should_apply_score) != 0, recency_score(), 1.0)
-        }
-
         function mult_modifier(mult_weights) {
             expression: if (count(mult_weights * attribute(marqo__score_modifiers)) == 0,   1, reduce(mult_weights * attribute(marqo__score_modifiers), prod))
         }
@@ -264,7 +261,13 @@ schema marqo__test_00semi_00structured_00schema {
             expression: reduce(add_weights * attribute(marqo__score_modifiers), sum)
         }
         function modify(score, mult_weights, add_weights) {
-            expression: (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_multiplier()
+            expression {
+                if (query(marqo__recency_should_apply_score) != 0,
+                    if (query(marqo__recency_add_to_score_weight) > 0,
+                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) + recency_score() * query(marqo__recency_add_to_score_weight),
+                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_score()),
+                    mult_modifier(mult_weights) * score + add_modifier(add_weights))
+            }
         }
         function global_mult_modifier() {
             expression: mult_modifier(query(marqo__mult_weights_global))
@@ -379,6 +382,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_add_to_score_weight) double: 0.0
         }
     }
 

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_fields_with_collapse_fields.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_fields_with_collapse_fields.sd
@@ -165,167 +165,68 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_grow_offset_seconds) double: 0.0
         }
 
-        # Recency scoring functions
+        # ============ RECENCY SCORING FUNCTIONS (OPTIMIZED) ============
         function get_timestamp() {
-            expression {
-                if (count(query(marqo__recency_timestamp_key)) > 0,
-                    reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum),
-                    0)
-            }
+            expression: reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum)
         }
 
         function age_in_seconds() {
-            expression: max(0, now() - get_timestamp())
+            expression: now() - get_timestamp()
         }
 
-        # Effective age after applying offset (grace period)
-        # Documents within offset period get 0 effective age (perfect score)
-        function effective_age() {
-            expression: max(0, age_in_seconds() - query(marqo__recency_offset_seconds))
+        function score_exponential(age, scale, floor_val) {
+            expression: max(floor_val, exp(log(floor_val) * age / scale))
         }
 
-        # Future offset: how far timestamp is beyond now() (for grow functions)
-        function future_offset_in_seconds() {
-            expression: max(0, get_timestamp() - now())
+        function score_linear(age, scale, floor_val) {
+            expression: max(floor_val, (scale - age * (1.0 - floor_val)) / scale)
         }
 
-        # Future age after subtracting growOffset (for growth function calculation)
-        # Returns 0 if within the plateau zone (timestamp between now() and now() + growOffset)
-        function future_age_in_seconds() {
-            expression: max(0, future_offset_in_seconds() - query(marqo__recency_grow_offset_seconds))
+        function score_gaussian(age, scale, floor_val) {
+            expression: max(floor_val, exp(pow(age, 2) * log(floor_val) / pow(scale, 2)))
         }
 
-        # Exponential decay (Elasticsearch-compatible)
-        # Formula: λ = ln(decay_to) / scale
-        #          score = max(decay_to, exp(λ × age))
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        function recency_score_exponential(age, scale, decay_to) {
+        function score_binary(age, scale, floor_val) {
+            expression: if(age < scale, 1.0, floor_val)
+        }
+
+        function compute_score(age, scale, floor_val, func_type) {
             expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, exp(log(decay_to) * age / scale)))
+                if (func_type == 0,
+                    score_exponential(age, scale, floor_val),
+                    if (func_type == 1,
+                        score_linear(age, scale, floor_val),
+                        if (func_type == 2,
+                            score_gaussian(age, scale, floor_val),
+                            score_binary(age, scale, floor_val))))
             }
-        }
-
-        # Linear decay (Elasticsearch-compatible)
-        # Formula: score = max(decay_to, (scale - age × (1 - decay_to)) / scale)
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        function recency_score_linear(age, scale, decay_to) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, (scale - age * (1.0 - decay_to)) / scale))
-            }
-        }
-
-        # Gaussian decay (Elasticsearch-compatible)
-        # Formula: σ² = -scale² / (2 × ln(decay_to))
-        #          score = max(decay_to, exp(-age² / (2σ²)))
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        # Formula: score = exp(age² × ln(decay_to) / scale²)
-        function recency_score_gaussian(age, scale, decay_to) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, exp(pow(age, 2) * log(decay_to) / pow(scale, 2))))
-            }
-        }
-
-        # Binary decay (step function)
-        # Score is 1.0 until age >= scale, then drops to decay_to
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: threshold in seconds
-        #   decay_to: score after threshold
-        function recency_score_binary(age, scale, decay_to) {
-            expression: if(age < scale, 1.0, decay_to)
-        }
-
-        function recency_score_router() {
-            expression {
-                if (query(marqo__recency_decay_function_type) == 0,
-                    recency_score_exponential(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                    if (query(marqo__recency_decay_function_type) == 1,
-                        recency_score_linear(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                        if (query(marqo__recency_decay_function_type) == 2,
-                            recency_score_gaussian(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                            recency_score_binary(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)))))
-            }
-        }
-
-        # Grow functions for future timestamps (mirror of decay functions)
-        # Exponential grow
-        # At future_age = 0 (within plateau): score = 1.0
-        # At future_age = scale: score = grow_from
-        function recency_grow_score_exponential(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * exp(log(1.0 - grow_from) * age / scale)))
-            }
-        }
-
-        # Linear grow
-        function recency_grow_score_linear(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * age / scale))
-            }
-        }
-
-        # Gaussian grow
-        function recency_grow_score_gaussian(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * (1.0 - exp(pow(age, 2) * log(grow_from) / pow(scale, 2)))))
-            }
-        }
-
-        # Binary grow (step function)
-        function recency_grow_score_binary(age, scale, grow_from) {
-            expression: if(age < scale, 1.0, grow_from)
-        }
-
-        function recency_grow_score_router() {
-            expression {
-                if (query(marqo__recency_grow_function_type) == 0,
-                    recency_grow_score_exponential(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                    if (query(marqo__recency_grow_function_type) == 1,
-                        recency_grow_score_linear(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                        if (query(marqo__recency_grow_function_type) == 2,
-                            recency_grow_score_gaussian(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                            recency_grow_score_binary(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)))))
-            }
-        }
-
-        function grow_score() {
-            expression: if(query(marqo__recency_grow_enabled) != 0, recency_grow_score_router(), 1.0)
         }
 
         function recency_score() {
             expression {
-                if (query(marqo__recency_should_calculate_score) != 0,
-                    if (get_timestamp() <= now(),
-                        recency_score_router(),
-                        grow_score()),
-                    1.0)
+                if (query(marqo__recency_should_calculate_score) == 0,
+                    1.0,
+                    if (get_timestamp() == 0,
+                        query(marqo__recency_decay_to),
+                        if (age_in_seconds() >= query(marqo__recency_scale_seconds) + query(marqo__recency_offset_seconds),
+                            query(marqo__recency_decay_to),
+                            if (age_in_seconds() >= query(marqo__recency_offset_seconds),
+                                compute_score(
+                                    age_in_seconds() - query(marqo__recency_offset_seconds),
+                                    query(marqo__recency_scale_seconds),
+                                    query(marqo__recency_decay_to),
+                                    query(marqo__recency_decay_function_type)),
+                                if (query(marqo__recency_grow_enabled) == 0,
+                                    1.0,
+                                    if (age_in_seconds() >= -query(marqo__recency_grow_offset_seconds),
+                                        1.0,
+                                        if (age_in_seconds() >= -query(marqo__recency_grow_offset_seconds) - query(marqo__recency_grow_scale_seconds),
+                                            compute_score(
+                                                -age_in_seconds() - query(marqo__recency_grow_offset_seconds),
+                                                query(marqo__recency_grow_scale_seconds),
+                                                query(marqo__recency_grow_from),
+                                                query(marqo__recency_grow_function_type)),
+                                            query(marqo__recency_grow_from))))))))
             }
         }
 

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_fields_with_collapse_fields.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_fields_with_collapse_fields.sd
@@ -156,6 +156,13 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
             query(marqo__recency_add_to_score_weight) double: 0.0
+
+            # Grow parameters for future timestamp scoring
+            query(marqo__recency_grow_enabled): 0
+            query(marqo__recency_grow_from) double: 1.0
+            query(marqo__recency_grow_function_type): 0
+            query(marqo__recency_grow_scale_seconds) double: 604800.0
+            query(marqo__recency_grow_offset_seconds) double: 0.0
         }
 
         # Recency scoring functions
@@ -175,6 +182,17 @@ schema marqo__test_00semi_00structured_00schema {
         # Documents within offset period get 0 effective age (perfect score)
         function effective_age() {
             expression: max(0, age_in_seconds() - query(marqo__recency_offset_seconds))
+        }
+
+        # Future offset: how far timestamp is beyond now() (for grow functions)
+        function future_offset_in_seconds() {
+            expression: max(0, get_timestamp() - now())
+        }
+
+        # Future age after subtracting growOffset (for growth function calculation)
+        # Returns 0 if within the plateau zone (timestamp between now() and now() + growOffset)
+        function future_age_in_seconds() {
+            expression: max(0, future_offset_in_seconds() - query(marqo__recency_grow_offset_seconds))
         }
 
         # Exponential decay (Elasticsearch-compatible)
@@ -250,8 +268,65 @@ schema marqo__test_00semi_00structured_00schema {
             }
         }
 
+        # Grow functions for future timestamps (mirror of decay functions)
+        # Exponential grow
+        # At future_age = 0 (within plateau): score = 1.0
+        # At future_age = scale: score = grow_from
+        function recency_grow_score_exponential(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * exp(log(1.0 - grow_from) * age / scale)))
+            }
+        }
+
+        # Linear grow
+        function recency_grow_score_linear(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * age / scale))
+            }
+        }
+
+        # Gaussian grow
+        function recency_grow_score_gaussian(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * (1.0 - exp(pow(age, 2) * log(grow_from) / pow(scale, 2)))))
+            }
+        }
+
+        # Binary grow (step function)
+        function recency_grow_score_binary(age, scale, grow_from) {
+            expression: if(age < scale, 1.0, grow_from)
+        }
+
+        function recency_grow_score_router() {
+            expression {
+                if (query(marqo__recency_grow_function_type) == 0,
+                    recency_grow_score_exponential(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                    if (query(marqo__recency_grow_function_type) == 1,
+                        recency_grow_score_linear(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                        if (query(marqo__recency_grow_function_type) == 2,
+                            recency_grow_score_gaussian(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                            recency_grow_score_binary(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)))))
+            }
+        }
+
+        function grow_score() {
+            expression: if(query(marqo__recency_grow_enabled) != 0, recency_grow_score_router(), 1.0)
+        }
+
         function recency_score() {
-            expression: if(query(marqo__recency_should_calculate_score) != 0, recency_score_router(), 1.0)
+            expression {
+                if (query(marqo__recency_should_calculate_score) != 0,
+                    if (get_timestamp() <= now(),
+                        recency_score_router(),
+                        grow_score()),
+                    1.0)
+            }
         }
 
         function mult_modifier(mult_weights) {

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_fields_with_collapse_fields.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_fields_with_collapse_fields.sd
@@ -148,24 +148,23 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__sort_field_weights_1) tensor<double>(p{})
             query(marqo__sort_field_weights_2) tensor<double>(p{})
 
+            # Recency parameters
             query(marqo__recency_should_calculate_score): 0
             query(marqo__recency_should_apply_score): 0
-            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_timestamp_key) tensor<double>(p{})
+            query(marqo__recency_add_to_score_weight) double: 0.0
+            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
-            query(marqo__recency_add_to_score_weight) double: 0.0
-
-            # Grow parameters for future timestamp scoring
             query(marqo__recency_grow_enabled): 0
-            query(marqo__recency_grow_from) double: 1.0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0
             query(marqo__recency_grow_offset_seconds) double: 0.0
+            query(marqo__recency_grow_from) double: 0.5
         }
 
-        # ============ RECENCY SCORING FUNCTIONS (OPTIMIZED) ============
+        # ============ RECENCY SCORING FUNCTIONS ============
         function get_timestamp() {
             expression: reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum)
         }
@@ -173,6 +172,12 @@ schema marqo__test_00semi_00structured_00schema {
         function age_in_seconds() {
             expression: now() - get_timestamp()
         }
+
+        # ============ UNIFIED SCORING FUNCTIONS ============
+        # These work for both decay (past) and grow (future) by taking (age, scale, floor_val):
+        # - At age=0: returns 1.0
+        # - At age=scale: returns floor_val
+        # - Beyond scale: clamps to floor_val
 
         function score_exponential(age, scale, floor_val) {
             expression: max(floor_val, exp(log(floor_val) * age / scale))
@@ -190,6 +195,7 @@ schema marqo__test_00semi_00structured_00schema {
             expression: if(age < scale, 1.0, floor_val)
         }
 
+        # Router: selects function based on type (0=exp, 1=linear, 2=gaussian, 3=binary)
         function compute_score(age, scale, floor_val, func_type) {
             expression {
                 if (func_type == 0,
@@ -202,6 +208,17 @@ schema marqo__test_00semi_00structured_00schema {
             }
         }
 
+        # ============ UNIFIED RECENCY SCORE ============
+        # Single entry point with early exits for performance
+        # Logic flow:
+        # 1. If recency disabled → 1.0
+        # 2. Elif no timestamp (get_timestamp=0) → decay_to (treat as very old)
+        # 3. Elif age >= scale + offset → decay_to (very old, beyond decay range)
+        # 4. Elif age >= offset → compute decay score
+        # 5. Elif grow disabled → 1.0 (future timestamp, no penalty when grow is disabled)
+        # 6. Elif age >= -growOffset → 1.0 (future, within plateau)
+        # 7. Elif age >= -growOffset - growScale → compute grow score
+        # 8. Else → grow_from (far future)
         function recency_score() {
             expression {
                 if (query(marqo__recency_should_calculate_score) == 0,
@@ -236,13 +253,21 @@ schema marqo__test_00semi_00structured_00schema {
         function add_modifier(add_weights) {
             expression: reduce(add_weights * attribute(marqo__score_modifiers), sum)
         }
+        function apply_score_modifiers(score, mult_weights, add_weights) {
+            expression: mult_modifier(mult_weights) * score + add_modifier(add_weights)
+        }
+        function apply_recency_score(original_score) {
+            expression {
+                if (query(marqo__recency_add_to_score_weight) > 0,
+                    original_score + recency_score() * query(marqo__recency_add_to_score_weight),
+                    original_score * recency_score())
+            }
+        }
         function modify(score, mult_weights, add_weights) {
             expression {
-                if (query(marqo__recency_should_apply_score) != 0,
-                    if (query(marqo__recency_add_to_score_weight) > 0,
-                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) + recency_score() * query(marqo__recency_add_to_score_weight),
-                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_score()),
-                    mult_modifier(mult_weights) * score + add_modifier(add_weights))
+                if (query(marqo__recency_should_apply_score) == 0,
+                    apply_score_modifiers(score, mult_weights, add_weights),
+                    apply_recency_score(apply_score_modifiers(score, mult_weights, add_weights)))
             }
         }
         function global_mult_modifier() {
@@ -351,14 +376,20 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__sort_field_weights_1) tensor<double>(p{})
             query(marqo__sort_field_weights_2) tensor<double>(p{})
 
+            # Recency parameters
             query(marqo__recency_should_calculate_score): 0
             query(marqo__recency_should_apply_score): 0
-            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_timestamp_key) tensor<double>(p{})
+            query(marqo__recency_add_to_score_weight) double: 0.0
+            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
-            query(marqo__recency_add_to_score_weight) double: 0.0
+            query(marqo__recency_grow_enabled): 0
+            query(marqo__recency_grow_function_type): 0
+            query(marqo__recency_grow_scale_seconds) double: 604800.0
+            query(marqo__recency_grow_offset_seconds) double: 0.0
+            query(marqo__recency_grow_from) double: 0.5
         }
     }
 

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_lexical_tensor_and_string_array_fields.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_lexical_tensor_and_string_array_fields.sd
@@ -150,6 +150,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_add_to_score_weight) double: 0.0
         }
 
         # Recency scoring functions
@@ -248,10 +249,6 @@ schema marqo__test_00semi_00structured_00schema {
             expression: if(query(marqo__recency_should_calculate_score) != 0, recency_score_router(), 1.0)
         }
 
-        function recency_multiplier() {
-            expression: if(query(marqo__recency_should_apply_score) != 0, recency_score(), 1.0)
-        }
-
         function mult_modifier(mult_weights) {
             expression: if (count(mult_weights * attribute(marqo__score_modifiers)) == 0,   1, reduce(mult_weights * attribute(marqo__score_modifiers), prod))
         }
@@ -259,7 +256,13 @@ schema marqo__test_00semi_00structured_00schema {
             expression: reduce(add_weights * attribute(marqo__score_modifiers), sum)
         }
         function modify(score, mult_weights, add_weights) {
-            expression: (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_multiplier()
+            expression {
+                if (query(marqo__recency_should_apply_score) != 0,
+                    if (query(marqo__recency_add_to_score_weight) > 0,
+                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) + recency_score() * query(marqo__recency_add_to_score_weight),
+                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_score()),
+                    mult_modifier(mult_weights) * score + add_modifier(add_weights))
+            }
         }
         function global_mult_modifier() {
             expression: mult_modifier(query(marqo__mult_weights_global))
@@ -353,6 +356,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_add_to_score_weight) double: 0.0
         }
     }
 

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_lexical_tensor_and_string_array_fields.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_lexical_tensor_and_string_array_fields.sd
@@ -143,24 +143,23 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__sort_field_weights_1) tensor<double>(p{})
             query(marqo__sort_field_weights_2) tensor<double>(p{})
 
+            # Recency parameters
             query(marqo__recency_should_calculate_score): 0
             query(marqo__recency_should_apply_score): 0
-            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_timestamp_key) tensor<double>(p{})
+            query(marqo__recency_add_to_score_weight) double: 0.0
+            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
-            query(marqo__recency_add_to_score_weight) double: 0.0
-
-            # Grow parameters for future timestamp scoring
             query(marqo__recency_grow_enabled): 0
-            query(marqo__recency_grow_from) double: 1.0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0
             query(marqo__recency_grow_offset_seconds) double: 0.0
+            query(marqo__recency_grow_from) double: 0.5
         }
 
-        # ============ RECENCY SCORING FUNCTIONS (OPTIMIZED) ============
+        # ============ RECENCY SCORING FUNCTIONS ============
         function get_timestamp() {
             expression: reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum)
         }
@@ -168,6 +167,12 @@ schema marqo__test_00semi_00structured_00schema {
         function age_in_seconds() {
             expression: now() - get_timestamp()
         }
+
+        # ============ UNIFIED SCORING FUNCTIONS ============
+        # These work for both decay (past) and grow (future) by taking (age, scale, floor_val):
+        # - At age=0: returns 1.0
+        # - At age=scale: returns floor_val
+        # - Beyond scale: clamps to floor_val
 
         function score_exponential(age, scale, floor_val) {
             expression: max(floor_val, exp(log(floor_val) * age / scale))
@@ -185,6 +190,7 @@ schema marqo__test_00semi_00structured_00schema {
             expression: if(age < scale, 1.0, floor_val)
         }
 
+        # Router: selects function based on type (0=exp, 1=linear, 2=gaussian, 3=binary)
         function compute_score(age, scale, floor_val, func_type) {
             expression {
                 if (func_type == 0,
@@ -197,6 +203,17 @@ schema marqo__test_00semi_00structured_00schema {
             }
         }
 
+        # ============ UNIFIED RECENCY SCORE ============
+        # Single entry point with early exits for performance
+        # Logic flow:
+        # 1. If recency disabled → 1.0
+        # 2. Elif no timestamp (get_timestamp=0) → decay_to (treat as very old)
+        # 3. Elif age >= scale + offset → decay_to (very old, beyond decay range)
+        # 4. Elif age >= offset → compute decay score
+        # 5. Elif grow disabled → 1.0 (future timestamp, no penalty when grow is disabled)
+        # 6. Elif age >= -growOffset → 1.0 (future, within plateau)
+        # 7. Elif age >= -growOffset - growScale → compute grow score
+        # 8. Else → grow_from (far future)
         function recency_score() {
             expression {
                 if (query(marqo__recency_should_calculate_score) == 0,
@@ -231,13 +248,21 @@ schema marqo__test_00semi_00structured_00schema {
         function add_modifier(add_weights) {
             expression: reduce(add_weights * attribute(marqo__score_modifiers), sum)
         }
+        function apply_score_modifiers(score, mult_weights, add_weights) {
+            expression: mult_modifier(mult_weights) * score + add_modifier(add_weights)
+        }
+        function apply_recency_score(original_score) {
+            expression {
+                if (query(marqo__recency_add_to_score_weight) > 0,
+                    original_score + recency_score() * query(marqo__recency_add_to_score_weight),
+                    original_score * recency_score())
+            }
+        }
         function modify(score, mult_weights, add_weights) {
             expression {
-                if (query(marqo__recency_should_apply_score) != 0,
-                    if (query(marqo__recency_add_to_score_weight) > 0,
-                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) + recency_score() * query(marqo__recency_add_to_score_weight),
-                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_score()),
-                    mult_modifier(mult_weights) * score + add_modifier(add_weights))
+                if (query(marqo__recency_should_apply_score) == 0,
+                    apply_score_modifiers(score, mult_weights, add_weights),
+                    apply_recency_score(apply_score_modifiers(score, mult_weights, add_weights)))
             }
         }
         function global_mult_modifier() {
@@ -325,14 +350,20 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__sort_field_weights_1) tensor<double>(p{})
             query(marqo__sort_field_weights_2) tensor<double>(p{})
 
+            # Recency parameters
             query(marqo__recency_should_calculate_score): 0
             query(marqo__recency_should_apply_score): 0
-            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_timestamp_key) tensor<double>(p{})
+            query(marqo__recency_add_to_score_weight) double: 0.0
+            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
-            query(marqo__recency_add_to_score_weight) double: 0.0
+            query(marqo__recency_grow_enabled): 0
+            query(marqo__recency_grow_function_type): 0
+            query(marqo__recency_grow_scale_seconds) double: 604800.0
+            query(marqo__recency_grow_offset_seconds) double: 0.0
+            query(marqo__recency_grow_from) double: 0.5
         }
     }
 

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_lexical_tensor_and_string_array_fields.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_lexical_tensor_and_string_array_fields.sd
@@ -160,167 +160,68 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_grow_offset_seconds) double: 0.0
         }
 
-        # Recency scoring functions
+        # ============ RECENCY SCORING FUNCTIONS (OPTIMIZED) ============
         function get_timestamp() {
-            expression {
-                if (count(query(marqo__recency_timestamp_key)) > 0,
-                    reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum),
-                    0)
-            }
+            expression: reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum)
         }
 
         function age_in_seconds() {
-            expression: max(0, now() - get_timestamp())
+            expression: now() - get_timestamp()
         }
 
-        # Effective age after applying offset (grace period)
-        # Documents within offset period get 0 effective age (perfect score)
-        function effective_age() {
-            expression: max(0, age_in_seconds() - query(marqo__recency_offset_seconds))
+        function score_exponential(age, scale, floor_val) {
+            expression: max(floor_val, exp(log(floor_val) * age / scale))
         }
 
-        # Future offset: how far timestamp is beyond now() (for grow functions)
-        function future_offset_in_seconds() {
-            expression: max(0, get_timestamp() - now())
+        function score_linear(age, scale, floor_val) {
+            expression: max(floor_val, (scale - age * (1.0 - floor_val)) / scale)
         }
 
-        # Future age after subtracting growOffset (for growth function calculation)
-        # Returns 0 if within the plateau zone (timestamp between now() and now() + growOffset)
-        function future_age_in_seconds() {
-            expression: max(0, future_offset_in_seconds() - query(marqo__recency_grow_offset_seconds))
+        function score_gaussian(age, scale, floor_val) {
+            expression: max(floor_val, exp(pow(age, 2) * log(floor_val) / pow(scale, 2)))
         }
 
-        # Exponential decay (Elasticsearch-compatible)
-        # Formula: λ = ln(decay_to) / scale
-        #          score = max(decay_to, exp(λ × age))
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        function recency_score_exponential(age, scale, decay_to) {
+        function score_binary(age, scale, floor_val) {
+            expression: if(age < scale, 1.0, floor_val)
+        }
+
+        function compute_score(age, scale, floor_val, func_type) {
             expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, exp(log(decay_to) * age / scale)))
+                if (func_type == 0,
+                    score_exponential(age, scale, floor_val),
+                    if (func_type == 1,
+                        score_linear(age, scale, floor_val),
+                        if (func_type == 2,
+                            score_gaussian(age, scale, floor_val),
+                            score_binary(age, scale, floor_val))))
             }
-        }
-
-        # Linear decay (Elasticsearch-compatible)
-        # Formula: score = max(decay_to, (scale - age × (1 - decay_to)) / scale)
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        function recency_score_linear(age, scale, decay_to) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, (scale - age * (1.0 - decay_to)) / scale))
-            }
-        }
-
-        # Gaussian decay (Elasticsearch-compatible)
-        # Formula: σ² = -scale² / (2 × ln(decay_to))
-        #          score = max(decay_to, exp(-age² / (2σ²)))
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        # Formula: score = exp(age² × ln(decay_to) / scale²)
-        function recency_score_gaussian(age, scale, decay_to) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, exp(pow(age, 2) * log(decay_to) / pow(scale, 2))))
-            }
-        }
-
-        # Binary decay (step function)
-        # Score is 1.0 until age >= scale, then drops to decay_to
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: threshold in seconds
-        #   decay_to: score after threshold
-        function recency_score_binary(age, scale, decay_to) {
-            expression: if(age < scale, 1.0, decay_to)
-        }
-
-        function recency_score_router() {
-            expression {
-                if (query(marqo__recency_decay_function_type) == 0,
-                    recency_score_exponential(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                    if (query(marqo__recency_decay_function_type) == 1,
-                        recency_score_linear(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                        if (query(marqo__recency_decay_function_type) == 2,
-                            recency_score_gaussian(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                            recency_score_binary(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)))))
-            }
-        }
-
-        # Grow functions for future timestamps (mirror of decay functions)
-        # Exponential grow
-        # At future_age = 0 (within plateau): score = 1.0
-        # At future_age = scale: score = grow_from
-        function recency_grow_score_exponential(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * exp(log(1.0 - grow_from) * age / scale)))
-            }
-        }
-
-        # Linear grow
-        function recency_grow_score_linear(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * age / scale))
-            }
-        }
-
-        # Gaussian grow
-        function recency_grow_score_gaussian(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * (1.0 - exp(pow(age, 2) * log(grow_from) / pow(scale, 2)))))
-            }
-        }
-
-        # Binary grow (step function)
-        function recency_grow_score_binary(age, scale, grow_from) {
-            expression: if(age < scale, 1.0, grow_from)
-        }
-
-        function recency_grow_score_router() {
-            expression {
-                if (query(marqo__recency_grow_function_type) == 0,
-                    recency_grow_score_exponential(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                    if (query(marqo__recency_grow_function_type) == 1,
-                        recency_grow_score_linear(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                        if (query(marqo__recency_grow_function_type) == 2,
-                            recency_grow_score_gaussian(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                            recency_grow_score_binary(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)))))
-            }
-        }
-
-        function grow_score() {
-            expression: if(query(marqo__recency_grow_enabled) != 0, recency_grow_score_router(), 1.0)
         }
 
         function recency_score() {
             expression {
-                if (query(marqo__recency_should_calculate_score) != 0,
-                    if (get_timestamp() <= now(),
-                        recency_score_router(),
-                        grow_score()),
-                    1.0)
+                if (query(marqo__recency_should_calculate_score) == 0,
+                    1.0,
+                    if (get_timestamp() == 0,
+                        query(marqo__recency_decay_to),
+                        if (age_in_seconds() >= query(marqo__recency_scale_seconds) + query(marqo__recency_offset_seconds),
+                            query(marqo__recency_decay_to),
+                            if (age_in_seconds() >= query(marqo__recency_offset_seconds),
+                                compute_score(
+                                    age_in_seconds() - query(marqo__recency_offset_seconds),
+                                    query(marqo__recency_scale_seconds),
+                                    query(marqo__recency_decay_to),
+                                    query(marqo__recency_decay_function_type)),
+                                if (query(marqo__recency_grow_enabled) == 0,
+                                    1.0,
+                                    if (age_in_seconds() >= -query(marqo__recency_grow_offset_seconds),
+                                        1.0,
+                                        if (age_in_seconds() >= -query(marqo__recency_grow_offset_seconds) - query(marqo__recency_grow_scale_seconds),
+                                            compute_score(
+                                                -age_in_seconds() - query(marqo__recency_grow_offset_seconds),
+                                                query(marqo__recency_grow_scale_seconds),
+                                                query(marqo__recency_grow_from),
+                                                query(marqo__recency_grow_function_type)),
+                                            query(marqo__recency_grow_from))))))))
             }
         }
 

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_lexical_tensor_and_string_array_fields.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_lexical_tensor_and_string_array_fields.sd
@@ -151,6 +151,13 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
             query(marqo__recency_add_to_score_weight) double: 0.0
+
+            # Grow parameters for future timestamp scoring
+            query(marqo__recency_grow_enabled): 0
+            query(marqo__recency_grow_from) double: 1.0
+            query(marqo__recency_grow_function_type): 0
+            query(marqo__recency_grow_scale_seconds) double: 604800.0
+            query(marqo__recency_grow_offset_seconds) double: 0.0
         }
 
         # Recency scoring functions
@@ -170,6 +177,17 @@ schema marqo__test_00semi_00structured_00schema {
         # Documents within offset period get 0 effective age (perfect score)
         function effective_age() {
             expression: max(0, age_in_seconds() - query(marqo__recency_offset_seconds))
+        }
+
+        # Future offset: how far timestamp is beyond now() (for grow functions)
+        function future_offset_in_seconds() {
+            expression: max(0, get_timestamp() - now())
+        }
+
+        # Future age after subtracting growOffset (for growth function calculation)
+        # Returns 0 if within the plateau zone (timestamp between now() and now() + growOffset)
+        function future_age_in_seconds() {
+            expression: max(0, future_offset_in_seconds() - query(marqo__recency_grow_offset_seconds))
         }
 
         # Exponential decay (Elasticsearch-compatible)
@@ -245,8 +263,65 @@ schema marqo__test_00semi_00structured_00schema {
             }
         }
 
+        # Grow functions for future timestamps (mirror of decay functions)
+        # Exponential grow
+        # At future_age = 0 (within plateau): score = 1.0
+        # At future_age = scale: score = grow_from
+        function recency_grow_score_exponential(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * exp(log(1.0 - grow_from) * age / scale)))
+            }
+        }
+
+        # Linear grow
+        function recency_grow_score_linear(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * age / scale))
+            }
+        }
+
+        # Gaussian grow
+        function recency_grow_score_gaussian(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * (1.0 - exp(pow(age, 2) * log(grow_from) / pow(scale, 2)))))
+            }
+        }
+
+        # Binary grow (step function)
+        function recency_grow_score_binary(age, scale, grow_from) {
+            expression: if(age < scale, 1.0, grow_from)
+        }
+
+        function recency_grow_score_router() {
+            expression {
+                if (query(marqo__recency_grow_function_type) == 0,
+                    recency_grow_score_exponential(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                    if (query(marqo__recency_grow_function_type) == 1,
+                        recency_grow_score_linear(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                        if (query(marqo__recency_grow_function_type) == 2,
+                            recency_grow_score_gaussian(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                            recency_grow_score_binary(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)))))
+            }
+        }
+
+        function grow_score() {
+            expression: if(query(marqo__recency_grow_enabled) != 0, recency_grow_score_router(), 1.0)
+        }
+
         function recency_score() {
-            expression: if(query(marqo__recency_should_calculate_score) != 0, recency_score_router(), 1.0)
+            expression {
+                if (query(marqo__recency_should_calculate_score) != 0,
+                    if (get_timestamp() <= now(),
+                        recency_score_router(),
+                        grow_score()),
+                    1.0)
+            }
         }
 
         function mult_modifier(mult_weights) {

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_lexical_tensor_fields.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_lexical_tensor_fields.sd
@@ -133,24 +133,23 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__sort_field_weights_1) tensor<double>(p{})
             query(marqo__sort_field_weights_2) tensor<double>(p{})
 
+            # Recency parameters
             query(marqo__recency_should_calculate_score): 0
             query(marqo__recency_should_apply_score): 0
-            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_timestamp_key) tensor<double>(p{})
+            query(marqo__recency_add_to_score_weight) double: 0.0
+            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
-            query(marqo__recency_add_to_score_weight) double: 0.0
-
-            # Grow parameters for future timestamp scoring
             query(marqo__recency_grow_enabled): 0
-            query(marqo__recency_grow_from) double: 1.0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0
             query(marqo__recency_grow_offset_seconds) double: 0.0
+            query(marqo__recency_grow_from) double: 0.5
         }
 
-        # ============ RECENCY SCORING FUNCTIONS (OPTIMIZED) ============
+        # ============ RECENCY SCORING FUNCTIONS ============
         function get_timestamp() {
             expression: reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum)
         }
@@ -158,6 +157,12 @@ schema marqo__test_00semi_00structured_00schema {
         function age_in_seconds() {
             expression: now() - get_timestamp()
         }
+
+        # ============ UNIFIED SCORING FUNCTIONS ============
+        # These work for both decay (past) and grow (future) by taking (age, scale, floor_val):
+        # - At age=0: returns 1.0
+        # - At age=scale: returns floor_val
+        # - Beyond scale: clamps to floor_val
 
         function score_exponential(age, scale, floor_val) {
             expression: max(floor_val, exp(log(floor_val) * age / scale))
@@ -175,6 +180,7 @@ schema marqo__test_00semi_00structured_00schema {
             expression: if(age < scale, 1.0, floor_val)
         }
 
+        # Router: selects function based on type (0=exp, 1=linear, 2=gaussian, 3=binary)
         function compute_score(age, scale, floor_val, func_type) {
             expression {
                 if (func_type == 0,
@@ -187,6 +193,17 @@ schema marqo__test_00semi_00structured_00schema {
             }
         }
 
+        # ============ UNIFIED RECENCY SCORE ============
+        # Single entry point with early exits for performance
+        # Logic flow:
+        # 1. If recency disabled → 1.0
+        # 2. Elif no timestamp (get_timestamp=0) → decay_to (treat as very old)
+        # 3. Elif age >= scale + offset → decay_to (very old, beyond decay range)
+        # 4. Elif age >= offset → compute decay score
+        # 5. Elif grow disabled → 1.0 (future timestamp, no penalty when grow is disabled)
+        # 6. Elif age >= -growOffset → 1.0 (future, within plateau)
+        # 7. Elif age >= -growOffset - growScale → compute grow score
+        # 8. Else → grow_from (far future)
         function recency_score() {
             expression {
                 if (query(marqo__recency_should_calculate_score) == 0,
@@ -221,13 +238,21 @@ schema marqo__test_00semi_00structured_00schema {
         function add_modifier(add_weights) {
             expression: reduce(add_weights * attribute(marqo__score_modifiers), sum)
         }
+        function apply_score_modifiers(score, mult_weights, add_weights) {
+            expression: mult_modifier(mult_weights) * score + add_modifier(add_weights)
+        }
+        function apply_recency_score(original_score) {
+            expression {
+                if (query(marqo__recency_add_to_score_weight) > 0,
+                    original_score + recency_score() * query(marqo__recency_add_to_score_weight),
+                    original_score * recency_score())
+            }
+        }
         function modify(score, mult_weights, add_weights) {
             expression {
-                if (query(marqo__recency_should_apply_score) != 0,
-                    if (query(marqo__recency_add_to_score_weight) > 0,
-                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) + recency_score() * query(marqo__recency_add_to_score_weight),
-                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_score()),
-                    mult_modifier(mult_weights) * score + add_modifier(add_weights))
+                if (query(marqo__recency_should_apply_score) == 0,
+                    apply_score_modifiers(score, mult_weights, add_weights),
+                    apply_recency_score(apply_score_modifiers(score, mult_weights, add_weights)))
             }
         }
         function global_mult_modifier() {
@@ -315,14 +340,20 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__sort_field_weights_1) tensor<double>(p{})
             query(marqo__sort_field_weights_2) tensor<double>(p{})
 
+            # Recency parameters
             query(marqo__recency_should_calculate_score): 0
             query(marqo__recency_should_apply_score): 0
-            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_timestamp_key) tensor<double>(p{})
+            query(marqo__recency_add_to_score_weight) double: 0.0
+            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
-            query(marqo__recency_add_to_score_weight) double: 0.0
+            query(marqo__recency_grow_enabled): 0
+            query(marqo__recency_grow_function_type): 0
+            query(marqo__recency_grow_scale_seconds) double: 604800.0
+            query(marqo__recency_grow_offset_seconds) double: 0.0
+            query(marqo__recency_grow_from) double: 0.5
         }
     }
 

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_lexical_tensor_fields.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_lexical_tensor_fields.sd
@@ -140,6 +140,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_add_to_score_weight) double: 0.0
         }
 
         # Recency scoring functions
@@ -238,10 +239,6 @@ schema marqo__test_00semi_00structured_00schema {
             expression: if(query(marqo__recency_should_calculate_score) != 0, recency_score_router(), 1.0)
         }
 
-        function recency_multiplier() {
-            expression: if(query(marqo__recency_should_apply_score) != 0, recency_score(), 1.0)
-        }
-
         function mult_modifier(mult_weights) {
             expression: if (count(mult_weights * attribute(marqo__score_modifiers)) == 0,   1, reduce(mult_weights * attribute(marqo__score_modifiers), prod))
         }
@@ -249,7 +246,13 @@ schema marqo__test_00semi_00structured_00schema {
             expression: reduce(add_weights * attribute(marqo__score_modifiers), sum)
         }
         function modify(score, mult_weights, add_weights) {
-            expression: (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_multiplier()
+            expression {
+                if (query(marqo__recency_should_apply_score) != 0,
+                    if (query(marqo__recency_add_to_score_weight) > 0,
+                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) + recency_score() * query(marqo__recency_add_to_score_weight),
+                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_score()),
+                    mult_modifier(mult_weights) * score + add_modifier(add_weights))
+            }
         }
         function global_mult_modifier() {
             expression: mult_modifier(query(marqo__mult_weights_global))
@@ -343,6 +346,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_add_to_score_weight) double: 0.0
         }
     }
 

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_lexical_tensor_fields.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_lexical_tensor_fields.sd
@@ -150,167 +150,68 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_grow_offset_seconds) double: 0.0
         }
 
-        # Recency scoring functions
+        # ============ RECENCY SCORING FUNCTIONS (OPTIMIZED) ============
         function get_timestamp() {
-            expression {
-                if (count(query(marqo__recency_timestamp_key)) > 0,
-                    reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum),
-                    0)
-            }
+            expression: reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum)
         }
 
         function age_in_seconds() {
-            expression: max(0, now() - get_timestamp())
+            expression: now() - get_timestamp()
         }
 
-        # Effective age after applying offset (grace period)
-        # Documents within offset period get 0 effective age (perfect score)
-        function effective_age() {
-            expression: max(0, age_in_seconds() - query(marqo__recency_offset_seconds))
+        function score_exponential(age, scale, floor_val) {
+            expression: max(floor_val, exp(log(floor_val) * age / scale))
         }
 
-        # Future offset: how far timestamp is beyond now() (for grow functions)
-        function future_offset_in_seconds() {
-            expression: max(0, get_timestamp() - now())
+        function score_linear(age, scale, floor_val) {
+            expression: max(floor_val, (scale - age * (1.0 - floor_val)) / scale)
         }
 
-        # Future age after subtracting growOffset (for growth function calculation)
-        # Returns 0 if within the plateau zone (timestamp between now() and now() + growOffset)
-        function future_age_in_seconds() {
-            expression: max(0, future_offset_in_seconds() - query(marqo__recency_grow_offset_seconds))
+        function score_gaussian(age, scale, floor_val) {
+            expression: max(floor_val, exp(pow(age, 2) * log(floor_val) / pow(scale, 2)))
         }
 
-        # Exponential decay (Elasticsearch-compatible)
-        # Formula: λ = ln(decay_to) / scale
-        #          score = max(decay_to, exp(λ × age))
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        function recency_score_exponential(age, scale, decay_to) {
+        function score_binary(age, scale, floor_val) {
+            expression: if(age < scale, 1.0, floor_val)
+        }
+
+        function compute_score(age, scale, floor_val, func_type) {
             expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, exp(log(decay_to) * age / scale)))
+                if (func_type == 0,
+                    score_exponential(age, scale, floor_val),
+                    if (func_type == 1,
+                        score_linear(age, scale, floor_val),
+                        if (func_type == 2,
+                            score_gaussian(age, scale, floor_val),
+                            score_binary(age, scale, floor_val))))
             }
-        }
-
-        # Linear decay (Elasticsearch-compatible)
-        # Formula: score = max(decay_to, (scale - age × (1 - decay_to)) / scale)
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        function recency_score_linear(age, scale, decay_to) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, (scale - age * (1.0 - decay_to)) / scale))
-            }
-        }
-
-        # Gaussian decay (Elasticsearch-compatible)
-        # Formula: σ² = -scale² / (2 × ln(decay_to))
-        #          score = max(decay_to, exp(-age² / (2σ²)))
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        # Formula: score = exp(age² × ln(decay_to) / scale²)
-        function recency_score_gaussian(age, scale, decay_to) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, exp(pow(age, 2) * log(decay_to) / pow(scale, 2))))
-            }
-        }
-
-        # Binary decay (step function)
-        # Score is 1.0 until age >= scale, then drops to decay_to
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: threshold in seconds
-        #   decay_to: score after threshold
-        function recency_score_binary(age, scale, decay_to) {
-            expression: if(age < scale, 1.0, decay_to)
-        }
-
-        function recency_score_router() {
-            expression {
-                if (query(marqo__recency_decay_function_type) == 0,
-                    recency_score_exponential(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                    if (query(marqo__recency_decay_function_type) == 1,
-                        recency_score_linear(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                        if (query(marqo__recency_decay_function_type) == 2,
-                            recency_score_gaussian(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                            recency_score_binary(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)))))
-            }
-        }
-
-        # Grow functions for future timestamps (mirror of decay functions)
-        # Exponential grow
-        # At future_age = 0 (within plateau): score = 1.0
-        # At future_age = scale: score = grow_from
-        function recency_grow_score_exponential(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * exp(log(1.0 - grow_from) * age / scale)))
-            }
-        }
-
-        # Linear grow
-        function recency_grow_score_linear(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * age / scale))
-            }
-        }
-
-        # Gaussian grow
-        function recency_grow_score_gaussian(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * (1.0 - exp(pow(age, 2) * log(grow_from) / pow(scale, 2)))))
-            }
-        }
-
-        # Binary grow (step function)
-        function recency_grow_score_binary(age, scale, grow_from) {
-            expression: if(age < scale, 1.0, grow_from)
-        }
-
-        function recency_grow_score_router() {
-            expression {
-                if (query(marqo__recency_grow_function_type) == 0,
-                    recency_grow_score_exponential(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                    if (query(marqo__recency_grow_function_type) == 1,
-                        recency_grow_score_linear(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                        if (query(marqo__recency_grow_function_type) == 2,
-                            recency_grow_score_gaussian(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                            recency_grow_score_binary(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)))))
-            }
-        }
-
-        function grow_score() {
-            expression: if(query(marqo__recency_grow_enabled) != 0, recency_grow_score_router(), 1.0)
         }
 
         function recency_score() {
             expression {
-                if (query(marqo__recency_should_calculate_score) != 0,
-                    if (get_timestamp() <= now(),
-                        recency_score_router(),
-                        grow_score()),
-                    1.0)
+                if (query(marqo__recency_should_calculate_score) == 0,
+                    1.0,
+                    if (get_timestamp() == 0,
+                        query(marqo__recency_decay_to),
+                        if (age_in_seconds() >= query(marqo__recency_scale_seconds) + query(marqo__recency_offset_seconds),
+                            query(marqo__recency_decay_to),
+                            if (age_in_seconds() >= query(marqo__recency_offset_seconds),
+                                compute_score(
+                                    age_in_seconds() - query(marqo__recency_offset_seconds),
+                                    query(marqo__recency_scale_seconds),
+                                    query(marqo__recency_decay_to),
+                                    query(marqo__recency_decay_function_type)),
+                                if (query(marqo__recency_grow_enabled) == 0,
+                                    1.0,
+                                    if (age_in_seconds() >= -query(marqo__recency_grow_offset_seconds),
+                                        1.0,
+                                        if (age_in_seconds() >= -query(marqo__recency_grow_offset_seconds) - query(marqo__recency_grow_scale_seconds),
+                                            compute_score(
+                                                -age_in_seconds() - query(marqo__recency_grow_offset_seconds),
+                                                query(marqo__recency_grow_scale_seconds),
+                                                query(marqo__recency_grow_from),
+                                                query(marqo__recency_grow_function_type)),
+                                            query(marqo__recency_grow_from))))))))
             }
         }
 

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_lexical_tensor_fields.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_lexical_tensor_fields.sd
@@ -141,6 +141,13 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
             query(marqo__recency_add_to_score_weight) double: 0.0
+
+            # Grow parameters for future timestamp scoring
+            query(marqo__recency_grow_enabled): 0
+            query(marqo__recency_grow_from) double: 1.0
+            query(marqo__recency_grow_function_type): 0
+            query(marqo__recency_grow_scale_seconds) double: 604800.0
+            query(marqo__recency_grow_offset_seconds) double: 0.0
         }
 
         # Recency scoring functions
@@ -160,6 +167,17 @@ schema marqo__test_00semi_00structured_00schema {
         # Documents within offset period get 0 effective age (perfect score)
         function effective_age() {
             expression: max(0, age_in_seconds() - query(marqo__recency_offset_seconds))
+        }
+
+        # Future offset: how far timestamp is beyond now() (for grow functions)
+        function future_offset_in_seconds() {
+            expression: max(0, get_timestamp() - now())
+        }
+
+        # Future age after subtracting growOffset (for growth function calculation)
+        # Returns 0 if within the plateau zone (timestamp between now() and now() + growOffset)
+        function future_age_in_seconds() {
+            expression: max(0, future_offset_in_seconds() - query(marqo__recency_grow_offset_seconds))
         }
 
         # Exponential decay (Elasticsearch-compatible)
@@ -235,8 +253,65 @@ schema marqo__test_00semi_00structured_00schema {
             }
         }
 
+        # Grow functions for future timestamps (mirror of decay functions)
+        # Exponential grow
+        # At future_age = 0 (within plateau): score = 1.0
+        # At future_age = scale: score = grow_from
+        function recency_grow_score_exponential(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * exp(log(1.0 - grow_from) * age / scale)))
+            }
+        }
+
+        # Linear grow
+        function recency_grow_score_linear(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * age / scale))
+            }
+        }
+
+        # Gaussian grow
+        function recency_grow_score_gaussian(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * (1.0 - exp(pow(age, 2) * log(grow_from) / pow(scale, 2)))))
+            }
+        }
+
+        # Binary grow (step function)
+        function recency_grow_score_binary(age, scale, grow_from) {
+            expression: if(age < scale, 1.0, grow_from)
+        }
+
+        function recency_grow_score_router() {
+            expression {
+                if (query(marqo__recency_grow_function_type) == 0,
+                    recency_grow_score_exponential(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                    if (query(marqo__recency_grow_function_type) == 1,
+                        recency_grow_score_linear(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                        if (query(marqo__recency_grow_function_type) == 2,
+                            recency_grow_score_gaussian(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                            recency_grow_score_binary(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)))))
+            }
+        }
+
+        function grow_score() {
+            expression: if(query(marqo__recency_grow_enabled) != 0, recency_grow_score_router(), 1.0)
+        }
+
         function recency_score() {
-            expression: if(query(marqo__recency_should_calculate_score) != 0, recency_score_router(), 1.0)
+            expression {
+                if (query(marqo__recency_should_calculate_score) != 0,
+                    if (get_timestamp() <= now(),
+                        recency_score_router(),
+                        grow_score()),
+                    1.0)
+            }
         }
 
         function mult_modifier(mult_weights) {

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_no_field.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_no_field.sd
@@ -94,6 +94,13 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
             query(marqo__recency_add_to_score_weight) double: 0.0
+
+            # Grow parameters for future timestamp scoring
+            query(marqo__recency_grow_enabled): 0
+            query(marqo__recency_grow_from) double: 1.0
+            query(marqo__recency_grow_function_type): 0
+            query(marqo__recency_grow_scale_seconds) double: 604800.0
+            query(marqo__recency_grow_offset_seconds) double: 0.0
         }
 
         # Recency scoring functions
@@ -113,6 +120,17 @@ schema marqo__test_00semi_00structured_00schema {
         # Documents within offset period get 0 effective age (perfect score)
         function effective_age() {
             expression: max(0, age_in_seconds() - query(marqo__recency_offset_seconds))
+        }
+
+        # Future offset: how far timestamp is beyond now() (for grow functions)
+        function future_offset_in_seconds() {
+            expression: max(0, get_timestamp() - now())
+        }
+
+        # Future age after subtracting growOffset (for growth function calculation)
+        # Returns 0 if within the plateau zone (timestamp between now() and now() + growOffset)
+        function future_age_in_seconds() {
+            expression: max(0, future_offset_in_seconds() - query(marqo__recency_grow_offset_seconds))
         }
 
         # Exponential decay (Elasticsearch-compatible)
@@ -188,8 +206,59 @@ schema marqo__test_00semi_00structured_00schema {
             }
         }
 
+        # Grow functions for future timestamps (mirror of decay functions)
+        function recency_grow_score_exponential(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * exp(log(1.0 - grow_from) * age / scale)))
+            }
+        }
+
+        function recency_grow_score_linear(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * age / scale))
+            }
+        }
+
+        function recency_grow_score_gaussian(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * (1.0 - exp(pow(age, 2) * log(grow_from) / pow(scale, 2)))))
+            }
+        }
+
+        function recency_grow_score_binary(age, scale, grow_from) {
+            expression: if(age < scale, 1.0, grow_from)
+        }
+
+        function recency_grow_score_router() {
+            expression {
+                if (query(marqo__recency_grow_function_type) == 0,
+                    recency_grow_score_exponential(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                    if (query(marqo__recency_grow_function_type) == 1,
+                        recency_grow_score_linear(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                        if (query(marqo__recency_grow_function_type) == 2,
+                            recency_grow_score_gaussian(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                            recency_grow_score_binary(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)))))
+            }
+        }
+
+        function grow_score() {
+            expression: if(query(marqo__recency_grow_enabled) != 0, recency_grow_score_router(), 1.0)
+        }
+
         function recency_score() {
-            expression: if(query(marqo__recency_should_calculate_score) != 0, recency_score_router(), 1.0)
+            expression {
+                if (query(marqo__recency_should_calculate_score) != 0,
+                    if (get_timestamp() <= now(),
+                        recency_score_router(),
+                        grow_score()),
+                    1.0)
+            }
         }
 
         function mult_modifier(mult_weights) {

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_no_field.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_no_field.sd
@@ -86,24 +86,23 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__sort_field_weights_1) tensor<double>(p{})
             query(marqo__sort_field_weights_2) tensor<double>(p{})
 
+            # Recency parameters
             query(marqo__recency_should_calculate_score): 0
             query(marqo__recency_should_apply_score): 0
-            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_timestamp_key) tensor<double>(p{})
+            query(marqo__recency_add_to_score_weight) double: 0.0
+            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
-            query(marqo__recency_add_to_score_weight) double: 0.0
-
-            # Grow parameters for future timestamp scoring
             query(marqo__recency_grow_enabled): 0
-            query(marqo__recency_grow_from) double: 1.0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0
             query(marqo__recency_grow_offset_seconds) double: 0.0
+            query(marqo__recency_grow_from) double: 0.5
         }
 
-        # ============ RECENCY SCORING FUNCTIONS (OPTIMIZED) ============
+        # ============ RECENCY SCORING FUNCTIONS ============
         function get_timestamp() {
             expression: reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum)
         }
@@ -111,6 +110,12 @@ schema marqo__test_00semi_00structured_00schema {
         function age_in_seconds() {
             expression: now() - get_timestamp()
         }
+
+        # ============ UNIFIED SCORING FUNCTIONS ============
+        # These work for both decay (past) and grow (future) by taking (age, scale, floor_val):
+        # - At age=0: returns 1.0
+        # - At age=scale: returns floor_val
+        # - Beyond scale: clamps to floor_val
 
         function score_exponential(age, scale, floor_val) {
             expression: max(floor_val, exp(log(floor_val) * age / scale))
@@ -128,6 +133,7 @@ schema marqo__test_00semi_00structured_00schema {
             expression: if(age < scale, 1.0, floor_val)
         }
 
+        # Router: selects function based on type (0=exp, 1=linear, 2=gaussian, 3=binary)
         function compute_score(age, scale, floor_val, func_type) {
             expression {
                 if (func_type == 0,
@@ -140,6 +146,17 @@ schema marqo__test_00semi_00structured_00schema {
             }
         }
 
+        # ============ UNIFIED RECENCY SCORE ============
+        # Single entry point with early exits for performance
+        # Logic flow:
+        # 1. If recency disabled → 1.0
+        # 2. Elif no timestamp (get_timestamp=0) → decay_to (treat as very old)
+        # 3. Elif age >= scale + offset → decay_to (very old, beyond decay range)
+        # 4. Elif age >= offset → compute decay score
+        # 5. Elif grow disabled → 1.0 (future timestamp, no penalty when grow is disabled)
+        # 6. Elif age >= -growOffset → 1.0 (future, within plateau)
+        # 7. Elif age >= -growOffset - growScale → compute grow score
+        # 8. Else → grow_from (far future)
         function recency_score() {
             expression {
                 if (query(marqo__recency_should_calculate_score) == 0,
@@ -174,13 +191,21 @@ schema marqo__test_00semi_00structured_00schema {
         function add_modifier(add_weights) {
             expression: reduce(add_weights * attribute(marqo__score_modifiers), sum)
         }
+        function apply_score_modifiers(score, mult_weights, add_weights) {
+            expression: mult_modifier(mult_weights) * score + add_modifier(add_weights)
+        }
+        function apply_recency_score(original_score) {
+            expression {
+                if (query(marqo__recency_add_to_score_weight) > 0,
+                    original_score + recency_score() * query(marqo__recency_add_to_score_weight),
+                    original_score * recency_score())
+            }
+        }
         function modify(score, mult_weights, add_weights) {
             expression {
-                if (query(marqo__recency_should_apply_score) != 0,
-                    if (query(marqo__recency_add_to_score_weight) > 0,
-                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) + recency_score() * query(marqo__recency_add_to_score_weight),
-                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_score()),
-                    mult_modifier(mult_weights) * score + add_modifier(add_weights))
+                if (query(marqo__recency_should_apply_score) == 0,
+                    apply_score_modifiers(score, mult_weights, add_weights),
+                    apply_recency_score(apply_score_modifiers(score, mult_weights, add_weights)))
             }
         }
         function global_mult_modifier() {

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_no_field.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_no_field.sd
@@ -103,161 +103,68 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_grow_offset_seconds) double: 0.0
         }
 
-        # Recency scoring functions
+        # ============ RECENCY SCORING FUNCTIONS (OPTIMIZED) ============
         function get_timestamp() {
-            expression {
-                if (count(query(marqo__recency_timestamp_key)) > 0,
-                    reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum),
-                    0)
-            }
+            expression: reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum)
         }
 
         function age_in_seconds() {
-            expression: max(0, now() - get_timestamp())
+            expression: now() - get_timestamp()
         }
 
-        # Effective age after applying offset (grace period)
-        # Documents within offset period get 0 effective age (perfect score)
-        function effective_age() {
-            expression: max(0, age_in_seconds() - query(marqo__recency_offset_seconds))
+        function score_exponential(age, scale, floor_val) {
+            expression: max(floor_val, exp(log(floor_val) * age / scale))
         }
 
-        # Future offset: how far timestamp is beyond now() (for grow functions)
-        function future_offset_in_seconds() {
-            expression: max(0, get_timestamp() - now())
+        function score_linear(age, scale, floor_val) {
+            expression: max(floor_val, (scale - age * (1.0 - floor_val)) / scale)
         }
 
-        # Future age after subtracting growOffset (for growth function calculation)
-        # Returns 0 if within the plateau zone (timestamp between now() and now() + growOffset)
-        function future_age_in_seconds() {
-            expression: max(0, future_offset_in_seconds() - query(marqo__recency_grow_offset_seconds))
+        function score_gaussian(age, scale, floor_val) {
+            expression: max(floor_val, exp(pow(age, 2) * log(floor_val) / pow(scale, 2)))
         }
 
-        # Exponential decay (Elasticsearch-compatible)
-        # Formula: λ = ln(decay_to) / scale
-        #          score = max(decay_to, exp(λ × age))
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        function recency_score_exponential(age, scale, decay_to) {
+        function score_binary(age, scale, floor_val) {
+            expression: if(age < scale, 1.0, floor_val)
+        }
+
+        function compute_score(age, scale, floor_val, func_type) {
             expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, exp(log(decay_to) * age / scale)))
+                if (func_type == 0,
+                    score_exponential(age, scale, floor_val),
+                    if (func_type == 1,
+                        score_linear(age, scale, floor_val),
+                        if (func_type == 2,
+                            score_gaussian(age, scale, floor_val),
+                            score_binary(age, scale, floor_val))))
             }
-        }
-
-        # Linear decay (Elasticsearch-compatible)
-        # Formula: score = max(decay_to, (scale - age × (1 - decay_to)) / scale)
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        function recency_score_linear(age, scale, decay_to) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, (scale - age * (1.0 - decay_to)) / scale))
-            }
-        }
-
-        # Gaussian decay (Elasticsearch-compatible)
-        # Formula: σ² = -scale² / (2 × ln(decay_to))
-        #          score = max(decay_to, exp(-age² / (2σ²)))
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        # Formula: score = exp(age² × ln(decay_to) / scale²)
-        function recency_score_gaussian(age, scale, decay_to) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, exp(pow(age, 2) * log(decay_to) / pow(scale, 2))))
-            }
-        }
-
-        # Binary decay (step function)
-        # Score is 1.0 until age >= scale, then drops to decay_to
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: threshold in seconds
-        #   decay_to: score after threshold
-        function recency_score_binary(age, scale, decay_to) {
-            expression: if(age < scale, 1.0, decay_to)
-        }
-
-        function recency_score_router() {
-            expression {
-                if (query(marqo__recency_decay_function_type) == 0,
-                    recency_score_exponential(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                    if (query(marqo__recency_decay_function_type) == 1,
-                        recency_score_linear(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                        if (query(marqo__recency_decay_function_type) == 2,
-                            recency_score_gaussian(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                            recency_score_binary(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)))))
-            }
-        }
-
-        # Grow functions for future timestamps (mirror of decay functions)
-        function recency_grow_score_exponential(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * exp(log(1.0 - grow_from) * age / scale)))
-            }
-        }
-
-        function recency_grow_score_linear(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * age / scale))
-            }
-        }
-
-        function recency_grow_score_gaussian(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * (1.0 - exp(pow(age, 2) * log(grow_from) / pow(scale, 2)))))
-            }
-        }
-
-        function recency_grow_score_binary(age, scale, grow_from) {
-            expression: if(age < scale, 1.0, grow_from)
-        }
-
-        function recency_grow_score_router() {
-            expression {
-                if (query(marqo__recency_grow_function_type) == 0,
-                    recency_grow_score_exponential(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                    if (query(marqo__recency_grow_function_type) == 1,
-                        recency_grow_score_linear(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                        if (query(marqo__recency_grow_function_type) == 2,
-                            recency_grow_score_gaussian(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                            recency_grow_score_binary(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)))))
-            }
-        }
-
-        function grow_score() {
-            expression: if(query(marqo__recency_grow_enabled) != 0, recency_grow_score_router(), 1.0)
         }
 
         function recency_score() {
             expression {
-                if (query(marqo__recency_should_calculate_score) != 0,
-                    if (get_timestamp() <= now(),
-                        recency_score_router(),
-                        grow_score()),
-                    1.0)
+                if (query(marqo__recency_should_calculate_score) == 0,
+                    1.0,
+                    if (get_timestamp() == 0,
+                        query(marqo__recency_decay_to),
+                        if (age_in_seconds() >= query(marqo__recency_scale_seconds) + query(marqo__recency_offset_seconds),
+                            query(marqo__recency_decay_to),
+                            if (age_in_seconds() >= query(marqo__recency_offset_seconds),
+                                compute_score(
+                                    age_in_seconds() - query(marqo__recency_offset_seconds),
+                                    query(marqo__recency_scale_seconds),
+                                    query(marqo__recency_decay_to),
+                                    query(marqo__recency_decay_function_type)),
+                                if (query(marqo__recency_grow_enabled) == 0,
+                                    1.0,
+                                    if (age_in_seconds() >= -query(marqo__recency_grow_offset_seconds),
+                                        1.0,
+                                        if (age_in_seconds() >= -query(marqo__recency_grow_offset_seconds) - query(marqo__recency_grow_scale_seconds),
+                                            compute_score(
+                                                -age_in_seconds() - query(marqo__recency_grow_offset_seconds),
+                                                query(marqo__recency_grow_scale_seconds),
+                                                query(marqo__recency_grow_from),
+                                                query(marqo__recency_grow_function_type)),
+                                            query(marqo__recency_grow_from))))))))
             }
         }
 

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_no_field.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_no_field.sd
@@ -93,6 +93,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_add_to_score_weight) double: 0.0
         }
 
         # Recency scoring functions
@@ -191,10 +192,6 @@ schema marqo__test_00semi_00structured_00schema {
             expression: if(query(marqo__recency_should_calculate_score) != 0, recency_score_router(), 1.0)
         }
 
-        function recency_multiplier() {
-            expression: if(query(marqo__recency_should_apply_score) != 0, recency_score(), 1.0)
-        }
-
         function mult_modifier(mult_weights) {
             expression: if (count(mult_weights * attribute(marqo__score_modifiers)) == 0,   1, reduce(mult_weights * attribute(marqo__score_modifiers), prod))
         }
@@ -202,7 +199,13 @@ schema marqo__test_00semi_00structured_00schema {
             expression: reduce(add_weights * attribute(marqo__score_modifiers), sum)
         }
         function modify(score, mult_weights, add_weights) {
-            expression: (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_multiplier()
+            expression {
+                if (query(marqo__recency_should_apply_score) != 0,
+                    if (query(marqo__recency_add_to_score_weight) > 0,
+                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) + recency_score() * query(marqo__recency_add_to_score_weight),
+                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_score()),
+                    mult_modifier(mult_weights) * score + add_modifier(add_weights))
+            }
         }
         function global_mult_modifier() {
             expression: mult_modifier(query(marqo__mult_weights_global))

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_field.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_field.sd
@@ -102,6 +102,13 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
             query(marqo__recency_add_to_score_weight) double: 0.0
+
+            # Grow parameters for future timestamp scoring
+            query(marqo__recency_grow_enabled): 0
+            query(marqo__recency_grow_from) double: 1.0
+            query(marqo__recency_grow_function_type): 0
+            query(marqo__recency_grow_scale_seconds) double: 604800.0
+            query(marqo__recency_grow_offset_seconds) double: 0.0
         }
 
         # Recency scoring functions
@@ -121,6 +128,17 @@ schema marqo__test_00semi_00structured_00schema {
         # Documents within offset period get 0 effective age (perfect score)
         function effective_age() {
             expression: max(0, age_in_seconds() - query(marqo__recency_offset_seconds))
+        }
+
+        # Future offset: how far timestamp is beyond now() (for grow functions)
+        function future_offset_in_seconds() {
+            expression: max(0, get_timestamp() - now())
+        }
+
+        # Future age after subtracting growOffset (for growth function calculation)
+        # Returns 0 if within the plateau zone (timestamp between now() and now() + growOffset)
+        function future_age_in_seconds() {
+            expression: max(0, future_offset_in_seconds() - query(marqo__recency_grow_offset_seconds))
         }
 
         # Exponential decay (Elasticsearch-compatible)
@@ -196,8 +214,67 @@ schema marqo__test_00semi_00structured_00schema {
             }
         }
 
+        # Grow functions for future timestamps (mirror of decay functions)
+        # These apply when timestamp > now(), with score increasing toward 1.0 as timestamp approaches now()
+
+        # Exponential grow
+        function recency_grow_score_exponential(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * exp(log(1.0 - grow_from) * age / scale)))
+            }
+        }
+
+        # Linear grow
+        function recency_grow_score_linear(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * age / scale))
+            }
+        }
+
+        # Gaussian grow
+        function recency_grow_score_gaussian(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * (1.0 - exp(pow(age, 2) * log(grow_from) / pow(scale, 2)))))
+            }
+        }
+
+        # Binary grow (step function)
+        function recency_grow_score_binary(age, scale, grow_from) {
+            expression: if(age < scale, 1.0, grow_from)
+        }
+
+        function recency_grow_score_router() {
+            expression {
+                if (query(marqo__recency_grow_function_type) == 0,
+                    recency_grow_score_exponential(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                    if (query(marqo__recency_grow_function_type) == 1,
+                        recency_grow_score_linear(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                        if (query(marqo__recency_grow_function_type) == 2,
+                            recency_grow_score_gaussian(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                            recency_grow_score_binary(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)))))
+            }
+        }
+
+        # Grow score: applies to future timestamps when grow is enabled
+        function grow_score() {
+            expression: if(query(marqo__recency_grow_enabled) != 0, recency_grow_score_router(), 1.0)
+        }
+
+        # Combined recency score: routes between decay (past) and grow (future)
         function recency_score() {
-            expression: if(query(marqo__recency_should_calculate_score) != 0, recency_score_router(), 1.0)
+            expression {
+                if (query(marqo__recency_should_calculate_score) != 0,
+                    if (get_timestamp() <= now(),
+                        recency_score_router(),
+                        grow_score()),
+                    1.0)
+            }
         }
 
         function mult_modifier(mult_weights) {

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_field.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_field.sd
@@ -101,6 +101,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_add_to_score_weight) double: 0.0
         }
 
         # Recency scoring functions
@@ -199,10 +200,6 @@ schema marqo__test_00semi_00structured_00schema {
             expression: if(query(marqo__recency_should_calculate_score) != 0, recency_score_router(), 1.0)
         }
 
-        function recency_multiplier() {
-            expression: if(query(marqo__recency_should_apply_score) != 0, recency_score(), 1.0)
-        }
-
         function mult_modifier(mult_weights) {
             expression: if (count(mult_weights * attribute(marqo__score_modifiers)) == 0,   1, reduce(mult_weights * attribute(marqo__score_modifiers), prod))
         }
@@ -210,7 +207,13 @@ schema marqo__test_00semi_00structured_00schema {
             expression: reduce(add_weights * attribute(marqo__score_modifiers), sum)
         }
         function modify(score, mult_weights, add_weights) {
-            expression: (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_multiplier()
+            expression {
+                if (query(marqo__recency_should_apply_score) != 0,
+                    if (query(marqo__recency_add_to_score_weight) > 0,
+                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) + recency_score() * query(marqo__recency_add_to_score_weight),
+                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_score()),
+                    mult_modifier(mult_weights) * score + add_modifier(add_weights))
+            }
         }
         function global_mult_modifier() {
             expression: mult_modifier(query(marqo__mult_weights_global))

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_field.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_field.sd
@@ -94,24 +94,23 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__sort_field_weights_1) tensor<double>(p{})
             query(marqo__sort_field_weights_2) tensor<double>(p{})
 
+            # Recency parameters
             query(marqo__recency_should_calculate_score): 0
             query(marqo__recency_should_apply_score): 0
-            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_timestamp_key) tensor<double>(p{})
+            query(marqo__recency_add_to_score_weight) double: 0.0
+            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
-            query(marqo__recency_add_to_score_weight) double: 0.0
-
-            # Grow parameters for future timestamp scoring
             query(marqo__recency_grow_enabled): 0
-            query(marqo__recency_grow_from) double: 1.0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0
             query(marqo__recency_grow_offset_seconds) double: 0.0
+            query(marqo__recency_grow_from) double: 0.5
         }
 
-        # ============ RECENCY SCORING FUNCTIONS (OPTIMIZED) ============
+        # ============ RECENCY SCORING FUNCTIONS ============
         function get_timestamp() {
             expression: reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum)
         }
@@ -119,6 +118,12 @@ schema marqo__test_00semi_00structured_00schema {
         function age_in_seconds() {
             expression: now() - get_timestamp()
         }
+
+        # ============ UNIFIED SCORING FUNCTIONS ============
+        # These work for both decay (past) and grow (future) by taking (age, scale, floor_val):
+        # - At age=0: returns 1.0
+        # - At age=scale: returns floor_val
+        # - Beyond scale: clamps to floor_val
 
         function score_exponential(age, scale, floor_val) {
             expression: max(floor_val, exp(log(floor_val) * age / scale))
@@ -136,6 +141,7 @@ schema marqo__test_00semi_00structured_00schema {
             expression: if(age < scale, 1.0, floor_val)
         }
 
+        # Router: selects function based on type (0=exp, 1=linear, 2=gaussian, 3=binary)
         function compute_score(age, scale, floor_val, func_type) {
             expression {
                 if (func_type == 0,
@@ -148,6 +154,17 @@ schema marqo__test_00semi_00structured_00schema {
             }
         }
 
+        # ============ UNIFIED RECENCY SCORE ============
+        # Single entry point with early exits for performance
+        # Logic flow:
+        # 1. If recency disabled → 1.0
+        # 2. Elif no timestamp (get_timestamp=0) → decay_to (treat as very old)
+        # 3. Elif age >= scale + offset → decay_to (very old, beyond decay range)
+        # 4. Elif age >= offset → compute decay score
+        # 5. Elif grow disabled → 1.0 (future timestamp, no penalty when grow is disabled)
+        # 6. Elif age >= -growOffset → 1.0 (future, within plateau)
+        # 7. Elif age >= -growOffset - growScale → compute grow score
+        # 8. Else → grow_from (far future)
         function recency_score() {
             expression {
                 if (query(marqo__recency_should_calculate_score) == 0,
@@ -182,13 +199,21 @@ schema marqo__test_00semi_00structured_00schema {
         function add_modifier(add_weights) {
             expression: reduce(add_weights * attribute(marqo__score_modifiers), sum)
         }
+        function apply_score_modifiers(score, mult_weights, add_weights) {
+            expression: mult_modifier(mult_weights) * score + add_modifier(add_weights)
+        }
+        function apply_recency_score(original_score) {
+            expression {
+                if (query(marqo__recency_add_to_score_weight) > 0,
+                    original_score + recency_score() * query(marqo__recency_add_to_score_weight),
+                    original_score * recency_score())
+            }
+        }
         function modify(score, mult_weights, add_weights) {
             expression {
-                if (query(marqo__recency_should_apply_score) != 0,
-                    if (query(marqo__recency_add_to_score_weight) > 0,
-                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) + recency_score() * query(marqo__recency_add_to_score_weight),
-                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_score()),
-                    mult_modifier(mult_weights) * score + add_modifier(add_weights))
+                if (query(marqo__recency_should_apply_score) == 0,
+                    apply_score_modifiers(score, mult_weights, add_weights),
+                    apply_recency_score(apply_score_modifiers(score, mult_weights, add_weights)))
             }
         }
         function global_mult_modifier() {

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_field.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_field.sd
@@ -111,169 +111,68 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_grow_offset_seconds) double: 0.0
         }
 
-        # Recency scoring functions
+        # ============ RECENCY SCORING FUNCTIONS (OPTIMIZED) ============
         function get_timestamp() {
-            expression {
-                if (count(query(marqo__recency_timestamp_key)) > 0,
-                    reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum),
-                    0)
-            }
+            expression: reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum)
         }
 
         function age_in_seconds() {
-            expression: max(0, now() - get_timestamp())
+            expression: now() - get_timestamp()
         }
 
-        # Effective age after applying offset (grace period)
-        # Documents within offset period get 0 effective age (perfect score)
-        function effective_age() {
-            expression: max(0, age_in_seconds() - query(marqo__recency_offset_seconds))
+        function score_exponential(age, scale, floor_val) {
+            expression: max(floor_val, exp(log(floor_val) * age / scale))
         }
 
-        # Future offset: how far timestamp is beyond now() (for grow functions)
-        function future_offset_in_seconds() {
-            expression: max(0, get_timestamp() - now())
+        function score_linear(age, scale, floor_val) {
+            expression: max(floor_val, (scale - age * (1.0 - floor_val)) / scale)
         }
 
-        # Future age after subtracting growOffset (for growth function calculation)
-        # Returns 0 if within the plateau zone (timestamp between now() and now() + growOffset)
-        function future_age_in_seconds() {
-            expression: max(0, future_offset_in_seconds() - query(marqo__recency_grow_offset_seconds))
+        function score_gaussian(age, scale, floor_val) {
+            expression: max(floor_val, exp(pow(age, 2) * log(floor_val) / pow(scale, 2)))
         }
 
-        # Exponential decay (Elasticsearch-compatible)
-        # Formula: λ = ln(decay_to) / scale
-        #          score = max(decay_to, exp(λ × age))
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        function recency_score_exponential(age, scale, decay_to) {
+        function score_binary(age, scale, floor_val) {
+            expression: if(age < scale, 1.0, floor_val)
+        }
+
+        function compute_score(age, scale, floor_val, func_type) {
             expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, exp(log(decay_to) * age / scale)))
+                if (func_type == 0,
+                    score_exponential(age, scale, floor_val),
+                    if (func_type == 1,
+                        score_linear(age, scale, floor_val),
+                        if (func_type == 2,
+                            score_gaussian(age, scale, floor_val),
+                            score_binary(age, scale, floor_val))))
             }
         }
 
-        # Linear decay (Elasticsearch-compatible)
-        # Formula: score = max(decay_to, (scale - age × (1 - decay_to)) / scale)
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        function recency_score_linear(age, scale, decay_to) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, (scale - age * (1.0 - decay_to)) / scale))
-            }
-        }
-
-        # Gaussian decay (Elasticsearch-compatible)
-        # Formula: σ² = -scale² / (2 × ln(decay_to))
-        #          score = max(decay_to, exp(-age² / (2σ²)))
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        # Formula: score = exp(age² × ln(decay_to) / scale²)
-        function recency_score_gaussian(age, scale, decay_to) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, exp(pow(age, 2) * log(decay_to) / pow(scale, 2))))
-            }
-        }
-
-        # Binary decay (step function)
-        # Score is 1.0 until age >= scale, then drops to decay_to
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: threshold in seconds
-        #   decay_to: score after threshold
-        function recency_score_binary(age, scale, decay_to) {
-            expression: if(age < scale, 1.0, decay_to)
-        }
-
-        function recency_score_router() {
-            expression {
-                if (query(marqo__recency_decay_function_type) == 0,
-                    recency_score_exponential(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                    if (query(marqo__recency_decay_function_type) == 1,
-                        recency_score_linear(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                        if (query(marqo__recency_decay_function_type) == 2,
-                            recency_score_gaussian(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                            recency_score_binary(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)))))
-            }
-        }
-
-        # Grow functions for future timestamps (mirror of decay functions)
-        # These apply when timestamp > now(), with score increasing toward 1.0 as timestamp approaches now()
-
-        # Exponential grow
-        function recency_grow_score_exponential(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * exp(log(1.0 - grow_from) * age / scale)))
-            }
-        }
-
-        # Linear grow
-        function recency_grow_score_linear(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * age / scale))
-            }
-        }
-
-        # Gaussian grow
-        function recency_grow_score_gaussian(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * (1.0 - exp(pow(age, 2) * log(grow_from) / pow(scale, 2)))))
-            }
-        }
-
-        # Binary grow (step function)
-        function recency_grow_score_binary(age, scale, grow_from) {
-            expression: if(age < scale, 1.0, grow_from)
-        }
-
-        function recency_grow_score_router() {
-            expression {
-                if (query(marqo__recency_grow_function_type) == 0,
-                    recency_grow_score_exponential(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                    if (query(marqo__recency_grow_function_type) == 1,
-                        recency_grow_score_linear(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                        if (query(marqo__recency_grow_function_type) == 2,
-                            recency_grow_score_gaussian(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                            recency_grow_score_binary(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)))))
-            }
-        }
-
-        # Grow score: applies to future timestamps when grow is enabled
-        function grow_score() {
-            expression: if(query(marqo__recency_grow_enabled) != 0, recency_grow_score_router(), 1.0)
-        }
-
-        # Combined recency score: routes between decay (past) and grow (future)
         function recency_score() {
             expression {
-                if (query(marqo__recency_should_calculate_score) != 0,
-                    if (get_timestamp() <= now(),
-                        recency_score_router(),
-                        grow_score()),
-                    1.0)
+                if (query(marqo__recency_should_calculate_score) == 0,
+                    1.0,
+                    if (get_timestamp() == 0,
+                        query(marqo__recency_decay_to),
+                        if (age_in_seconds() >= query(marqo__recency_scale_seconds) + query(marqo__recency_offset_seconds),
+                            query(marqo__recency_decay_to),
+                            if (age_in_seconds() >= query(marqo__recency_offset_seconds),
+                                compute_score(
+                                    age_in_seconds() - query(marqo__recency_offset_seconds),
+                                    query(marqo__recency_scale_seconds),
+                                    query(marqo__recency_decay_to),
+                                    query(marqo__recency_decay_function_type)),
+                                if (query(marqo__recency_grow_enabled) == 0,
+                                    1.0,
+                                    if (age_in_seconds() >= -query(marqo__recency_grow_offset_seconds),
+                                        1.0,
+                                        if (age_in_seconds() >= -query(marqo__recency_grow_offset_seconds) - query(marqo__recency_grow_scale_seconds),
+                                            compute_score(
+                                                -age_in_seconds() - query(marqo__recency_grow_offset_seconds),
+                                                query(marqo__recency_grow_scale_seconds),
+                                                query(marqo__recency_grow_from),
+                                                query(marqo__recency_grow_function_type)),
+                                            query(marqo__recency_grow_from))))))))
             }
         }
 

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_one_tensor_field.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_one_tensor_field.sd
@@ -119,6 +119,13 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
             query(marqo__recency_add_to_score_weight) double: 0.0
+
+            # Grow parameters for future timestamp scoring
+            query(marqo__recency_grow_enabled): 0
+            query(marqo__recency_grow_from) double: 1.0
+            query(marqo__recency_grow_function_type): 0
+            query(marqo__recency_grow_scale_seconds) double: 604800.0
+            query(marqo__recency_grow_offset_seconds) double: 0.0
         }
 
         # Recency scoring functions
@@ -138,6 +145,17 @@ schema marqo__test_00semi_00structured_00schema {
         # Documents within offset period get 0 effective age (perfect score)
         function effective_age() {
             expression: max(0, age_in_seconds() - query(marqo__recency_offset_seconds))
+        }
+
+        # Future offset: how far timestamp is beyond now() (for grow functions)
+        function future_offset_in_seconds() {
+            expression: max(0, get_timestamp() - now())
+        }
+
+        # Future age after subtracting growOffset (for growth function calculation)
+        # Returns 0 if within the plateau zone (timestamp between now() and now() + growOffset)
+        function future_age_in_seconds() {
+            expression: max(0, future_offset_in_seconds() - query(marqo__recency_grow_offset_seconds))
         }
 
         # Exponential decay (Elasticsearch-compatible)
@@ -213,8 +231,59 @@ schema marqo__test_00semi_00structured_00schema {
             }
         }
 
+        # Grow functions for future timestamps (mirror of decay functions)
+        function recency_grow_score_exponential(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * exp(log(1.0 - grow_from) * age / scale)))
+            }
+        }
+
+        function recency_grow_score_linear(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * age / scale))
+            }
+        }
+
+        function recency_grow_score_gaussian(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * (1.0 - exp(pow(age, 2) * log(grow_from) / pow(scale, 2)))))
+            }
+        }
+
+        function recency_grow_score_binary(age, scale, grow_from) {
+            expression: if(age < scale, 1.0, grow_from)
+        }
+
+        function recency_grow_score_router() {
+            expression {
+                if (query(marqo__recency_grow_function_type) == 0,
+                    recency_grow_score_exponential(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                    if (query(marqo__recency_grow_function_type) == 1,
+                        recency_grow_score_linear(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                        if (query(marqo__recency_grow_function_type) == 2,
+                            recency_grow_score_gaussian(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                            recency_grow_score_binary(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)))))
+            }
+        }
+
+        function grow_score() {
+            expression: if(query(marqo__recency_grow_enabled) != 0, recency_grow_score_router(), 1.0)
+        }
+
         function recency_score() {
-            expression: if(query(marqo__recency_should_calculate_score) != 0, recency_score_router(), 1.0)
+            expression {
+                if (query(marqo__recency_should_calculate_score) != 0,
+                    if (get_timestamp() <= now(),
+                        recency_score_router(),
+                        grow_score()),
+                    1.0)
+            }
         }
 
         function mult_modifier(mult_weights) {

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_one_tensor_field.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_one_tensor_field.sd
@@ -118,6 +118,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_add_to_score_weight) double: 0.0
         }
 
         # Recency scoring functions
@@ -216,10 +217,6 @@ schema marqo__test_00semi_00structured_00schema {
             expression: if(query(marqo__recency_should_calculate_score) != 0, recency_score_router(), 1.0)
         }
 
-        function recency_multiplier() {
-            expression: if(query(marqo__recency_should_apply_score) != 0, recency_score(), 1.0)
-        }
-
         function mult_modifier(mult_weights) {
             expression: if (count(mult_weights * attribute(marqo__score_modifiers)) == 0,   1, reduce(mult_weights * attribute(marqo__score_modifiers), prod))
         }
@@ -227,7 +224,13 @@ schema marqo__test_00semi_00structured_00schema {
             expression: reduce(add_weights * attribute(marqo__score_modifiers), sum)
         }
         function modify(score, mult_weights, add_weights) {
-            expression: (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_multiplier()
+            expression {
+                if (query(marqo__recency_should_apply_score) != 0,
+                    if (query(marqo__recency_add_to_score_weight) > 0,
+                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) + recency_score() * query(marqo__recency_add_to_score_weight),
+                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_score()),
+                    mult_modifier(mult_weights) * score + add_modifier(add_weights))
+            }
         }
         function global_mult_modifier() {
             expression: mult_modifier(query(marqo__mult_weights_global))
@@ -319,6 +322,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_add_to_score_weight) double: 0.0
         }
     }
 

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_one_tensor_field.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_one_tensor_field.sd
@@ -128,161 +128,68 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_grow_offset_seconds) double: 0.0
         }
 
-        # Recency scoring functions
+        # ============ RECENCY SCORING FUNCTIONS (OPTIMIZED) ============
         function get_timestamp() {
-            expression {
-                if (count(query(marqo__recency_timestamp_key)) > 0,
-                    reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum),
-                    0)
-            }
+            expression: reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum)
         }
 
         function age_in_seconds() {
-            expression: max(0, now() - get_timestamp())
+            expression: now() - get_timestamp()
         }
 
-        # Effective age after applying offset (grace period)
-        # Documents within offset period get 0 effective age (perfect score)
-        function effective_age() {
-            expression: max(0, age_in_seconds() - query(marqo__recency_offset_seconds))
+        function score_exponential(age, scale, floor_val) {
+            expression: max(floor_val, exp(log(floor_val) * age / scale))
         }
 
-        # Future offset: how far timestamp is beyond now() (for grow functions)
-        function future_offset_in_seconds() {
-            expression: max(0, get_timestamp() - now())
+        function score_linear(age, scale, floor_val) {
+            expression: max(floor_val, (scale - age * (1.0 - floor_val)) / scale)
         }
 
-        # Future age after subtracting growOffset (for growth function calculation)
-        # Returns 0 if within the plateau zone (timestamp between now() and now() + growOffset)
-        function future_age_in_seconds() {
-            expression: max(0, future_offset_in_seconds() - query(marqo__recency_grow_offset_seconds))
+        function score_gaussian(age, scale, floor_val) {
+            expression: max(floor_val, exp(pow(age, 2) * log(floor_val) / pow(scale, 2)))
         }
 
-        # Exponential decay (Elasticsearch-compatible)
-        # Formula: λ = ln(decay_to) / scale
-        #          score = max(decay_to, exp(λ × age))
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        function recency_score_exponential(age, scale, decay_to) {
+        function score_binary(age, scale, floor_val) {
+            expression: if(age < scale, 1.0, floor_val)
+        }
+
+        function compute_score(age, scale, floor_val, func_type) {
             expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, exp(log(decay_to) * age / scale)))
+                if (func_type == 0,
+                    score_exponential(age, scale, floor_val),
+                    if (func_type == 1,
+                        score_linear(age, scale, floor_val),
+                        if (func_type == 2,
+                            score_gaussian(age, scale, floor_val),
+                            score_binary(age, scale, floor_val))))
             }
-        }
-
-        # Linear decay (Elasticsearch-compatible)
-        # Formula: score = max(decay_to, (scale - age × (1 - decay_to)) / scale)
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        function recency_score_linear(age, scale, decay_to) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, (scale - age * (1.0 - decay_to)) / scale))
-            }
-        }
-
-        # Gaussian decay (Elasticsearch-compatible)
-        # Formula: σ² = -scale² / (2 × ln(decay_to))
-        #          score = max(decay_to, exp(-age² / (2σ²)))
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        # Formula: score = exp(age² × ln(decay_to) / scale²)
-        function recency_score_gaussian(age, scale, decay_to) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, exp(pow(age, 2) * log(decay_to) / pow(scale, 2))))
-            }
-        }
-
-        # Binary decay (step function)
-        # Score is 1.0 until age >= scale, then drops to decay_to
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: threshold in seconds
-        #   decay_to: score after threshold
-        function recency_score_binary(age, scale, decay_to) {
-            expression: if(age < scale, 1.0, decay_to)
-        }
-
-        function recency_score_router() {
-            expression {
-                if (query(marqo__recency_decay_function_type) == 0,
-                    recency_score_exponential(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                    if (query(marqo__recency_decay_function_type) == 1,
-                        recency_score_linear(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                        if (query(marqo__recency_decay_function_type) == 2,
-                            recency_score_gaussian(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                            recency_score_binary(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)))))
-            }
-        }
-
-        # Grow functions for future timestamps (mirror of decay functions)
-        function recency_grow_score_exponential(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * exp(log(1.0 - grow_from) * age / scale)))
-            }
-        }
-
-        function recency_grow_score_linear(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * age / scale))
-            }
-        }
-
-        function recency_grow_score_gaussian(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * (1.0 - exp(pow(age, 2) * log(grow_from) / pow(scale, 2)))))
-            }
-        }
-
-        function recency_grow_score_binary(age, scale, grow_from) {
-            expression: if(age < scale, 1.0, grow_from)
-        }
-
-        function recency_grow_score_router() {
-            expression {
-                if (query(marqo__recency_grow_function_type) == 0,
-                    recency_grow_score_exponential(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                    if (query(marqo__recency_grow_function_type) == 1,
-                        recency_grow_score_linear(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                        if (query(marqo__recency_grow_function_type) == 2,
-                            recency_grow_score_gaussian(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                            recency_grow_score_binary(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)))))
-            }
-        }
-
-        function grow_score() {
-            expression: if(query(marqo__recency_grow_enabled) != 0, recency_grow_score_router(), 1.0)
         }
 
         function recency_score() {
             expression {
-                if (query(marqo__recency_should_calculate_score) != 0,
-                    if (get_timestamp() <= now(),
-                        recency_score_router(),
-                        grow_score()),
-                    1.0)
+                if (query(marqo__recency_should_calculate_score) == 0,
+                    1.0,
+                    if (get_timestamp() == 0,
+                        query(marqo__recency_decay_to),
+                        if (age_in_seconds() >= query(marqo__recency_scale_seconds) + query(marqo__recency_offset_seconds),
+                            query(marqo__recency_decay_to),
+                            if (age_in_seconds() >= query(marqo__recency_offset_seconds),
+                                compute_score(
+                                    age_in_seconds() - query(marqo__recency_offset_seconds),
+                                    query(marqo__recency_scale_seconds),
+                                    query(marqo__recency_decay_to),
+                                    query(marqo__recency_decay_function_type)),
+                                if (query(marqo__recency_grow_enabled) == 0,
+                                    1.0,
+                                    if (age_in_seconds() >= -query(marqo__recency_grow_offset_seconds),
+                                        1.0,
+                                        if (age_in_seconds() >= -query(marqo__recency_grow_offset_seconds) - query(marqo__recency_grow_scale_seconds),
+                                            compute_score(
+                                                -age_in_seconds() - query(marqo__recency_grow_offset_seconds),
+                                                query(marqo__recency_grow_scale_seconds),
+                                                query(marqo__recency_grow_from),
+                                                query(marqo__recency_grow_function_type)),
+                                            query(marqo__recency_grow_from))))))))
             }
         }
 

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_one_tensor_field.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_one_tensor_field.sd
@@ -111,24 +111,23 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__sort_field_weights_1) tensor<double>(p{})
             query(marqo__sort_field_weights_2) tensor<double>(p{})
 
+            # Recency parameters
             query(marqo__recency_should_calculate_score): 0
             query(marqo__recency_should_apply_score): 0
-            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_timestamp_key) tensor<double>(p{})
+            query(marqo__recency_add_to_score_weight) double: 0.0
+            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
-            query(marqo__recency_add_to_score_weight) double: 0.0
-
-            # Grow parameters for future timestamp scoring
             query(marqo__recency_grow_enabled): 0
-            query(marqo__recency_grow_from) double: 1.0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0
             query(marqo__recency_grow_offset_seconds) double: 0.0
+            query(marqo__recency_grow_from) double: 0.5
         }
 
-        # ============ RECENCY SCORING FUNCTIONS (OPTIMIZED) ============
+        # ============ RECENCY SCORING FUNCTIONS ============
         function get_timestamp() {
             expression: reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum)
         }
@@ -136,6 +135,12 @@ schema marqo__test_00semi_00structured_00schema {
         function age_in_seconds() {
             expression: now() - get_timestamp()
         }
+
+        # ============ UNIFIED SCORING FUNCTIONS ============
+        # These work for both decay (past) and grow (future) by taking (age, scale, floor_val):
+        # - At age=0: returns 1.0
+        # - At age=scale: returns floor_val
+        # - Beyond scale: clamps to floor_val
 
         function score_exponential(age, scale, floor_val) {
             expression: max(floor_val, exp(log(floor_val) * age / scale))
@@ -153,6 +158,7 @@ schema marqo__test_00semi_00structured_00schema {
             expression: if(age < scale, 1.0, floor_val)
         }
 
+        # Router: selects function based on type (0=exp, 1=linear, 2=gaussian, 3=binary)
         function compute_score(age, scale, floor_val, func_type) {
             expression {
                 if (func_type == 0,
@@ -165,6 +171,17 @@ schema marqo__test_00semi_00structured_00schema {
             }
         }
 
+        # ============ UNIFIED RECENCY SCORE ============
+        # Single entry point with early exits for performance
+        # Logic flow:
+        # 1. If recency disabled → 1.0
+        # 2. Elif no timestamp (get_timestamp=0) → decay_to (treat as very old)
+        # 3. Elif age >= scale + offset → decay_to (very old, beyond decay range)
+        # 4. Elif age >= offset → compute decay score
+        # 5. Elif grow disabled → 1.0 (future timestamp, no penalty when grow is disabled)
+        # 6. Elif age >= -growOffset → 1.0 (future, within plateau)
+        # 7. Elif age >= -growOffset - growScale → compute grow score
+        # 8. Else → grow_from (far future)
         function recency_score() {
             expression {
                 if (query(marqo__recency_should_calculate_score) == 0,
@@ -199,13 +216,21 @@ schema marqo__test_00semi_00structured_00schema {
         function add_modifier(add_weights) {
             expression: reduce(add_weights * attribute(marqo__score_modifiers), sum)
         }
+        function apply_score_modifiers(score, mult_weights, add_weights) {
+            expression: mult_modifier(mult_weights) * score + add_modifier(add_weights)
+        }
+        function apply_recency_score(original_score) {
+            expression {
+                if (query(marqo__recency_add_to_score_weight) > 0,
+                    original_score + recency_score() * query(marqo__recency_add_to_score_weight),
+                    original_score * recency_score())
+            }
+        }
         function modify(score, mult_weights, add_weights) {
             expression {
-                if (query(marqo__recency_should_apply_score) != 0,
-                    if (query(marqo__recency_add_to_score_weight) > 0,
-                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) + recency_score() * query(marqo__recency_add_to_score_weight),
-                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_score()),
-                    mult_modifier(mult_weights) * score + add_modifier(add_weights))
+                if (query(marqo__recency_should_apply_score) == 0,
+                    apply_score_modifiers(score, mult_weights, add_weights),
+                    apply_recency_score(apply_score_modifiers(score, mult_weights, add_weights)))
             }
         }
         function global_mult_modifier() {
@@ -291,14 +316,20 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__sort_field_weights_1) tensor<double>(p{})
             query(marqo__sort_field_weights_2) tensor<double>(p{})
 
+            # Recency parameters
             query(marqo__recency_should_calculate_score): 0
             query(marqo__recency_should_apply_score): 0
-            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_timestamp_key) tensor<double>(p{})
+            query(marqo__recency_add_to_score_weight) double: 0.0
+            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
-            query(marqo__recency_add_to_score_weight) double: 0.0
+            query(marqo__recency_grow_enabled): 0
+            query(marqo__recency_grow_function_type): 0
+            query(marqo__recency_grow_scale_seconds) double: 604800.0
+            query(marqo__recency_grow_offset_seconds) double: 0.0
+            query(marqo__recency_grow_from) double: 0.5
         }
     }
 

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_one_tensor_one_string_array_field.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_one_tensor_one_string_array_field.sd
@@ -124,6 +124,13 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
             query(marqo__recency_add_to_score_weight) double: 0.0
+
+            # Grow parameters for future timestamp scoring
+            query(marqo__recency_grow_enabled): 0
+            query(marqo__recency_grow_from) double: 1.0
+            query(marqo__recency_grow_function_type): 0
+            query(marqo__recency_grow_scale_seconds) double: 604800.0
+            query(marqo__recency_grow_offset_seconds) double: 0.0
         }
 
         # Recency scoring functions
@@ -143,6 +150,17 @@ schema marqo__test_00semi_00structured_00schema {
         # Documents within offset period get 0 effective age (perfect score)
         function effective_age() {
             expression: max(0, age_in_seconds() - query(marqo__recency_offset_seconds))
+        }
+
+        # Future offset: how far timestamp is beyond now() (for grow functions)
+        function future_offset_in_seconds() {
+            expression: max(0, get_timestamp() - now())
+        }
+
+        # Future age after subtracting growOffset (for growth function calculation)
+        # Returns 0 if within the plateau zone (timestamp between now() and now() + growOffset)
+        function future_age_in_seconds() {
+            expression: max(0, future_offset_in_seconds() - query(marqo__recency_grow_offset_seconds))
         }
 
         # Exponential decay (Elasticsearch-compatible)
@@ -218,8 +236,59 @@ schema marqo__test_00semi_00structured_00schema {
             }
         }
 
+        # Grow functions for future timestamps (mirror of decay functions)
+        function recency_grow_score_exponential(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * exp(log(1.0 - grow_from) * age / scale)))
+            }
+        }
+
+        function recency_grow_score_linear(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * age / scale))
+            }
+        }
+
+        function recency_grow_score_gaussian(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * (1.0 - exp(pow(age, 2) * log(grow_from) / pow(scale, 2)))))
+            }
+        }
+
+        function recency_grow_score_binary(age, scale, grow_from) {
+            expression: if(age < scale, 1.0, grow_from)
+        }
+
+        function recency_grow_score_router() {
+            expression {
+                if (query(marqo__recency_grow_function_type) == 0,
+                    recency_grow_score_exponential(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                    if (query(marqo__recency_grow_function_type) == 1,
+                        recency_grow_score_linear(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                        if (query(marqo__recency_grow_function_type) == 2,
+                            recency_grow_score_gaussian(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                            recency_grow_score_binary(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)))))
+            }
+        }
+
+        function grow_score() {
+            expression: if(query(marqo__recency_grow_enabled) != 0, recency_grow_score_router(), 1.0)
+        }
+
         function recency_score() {
-            expression: if(query(marqo__recency_should_calculate_score) != 0, recency_score_router(), 1.0)
+            expression {
+                if (query(marqo__recency_should_calculate_score) != 0,
+                    if (get_timestamp() <= now(),
+                        recency_score_router(),
+                        grow_score()),
+                    1.0)
+            }
         }
 
         function mult_modifier(mult_weights) {

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_one_tensor_one_string_array_field.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_one_tensor_one_string_array_field.sd
@@ -123,6 +123,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_add_to_score_weight) double: 0.0
         }
 
         # Recency scoring functions
@@ -221,10 +222,6 @@ schema marqo__test_00semi_00structured_00schema {
             expression: if(query(marqo__recency_should_calculate_score) != 0, recency_score_router(), 1.0)
         }
 
-        function recency_multiplier() {
-            expression: if(query(marqo__recency_should_apply_score) != 0, recency_score(), 1.0)
-        }
-
         function mult_modifier(mult_weights) {
             expression: if (count(mult_weights * attribute(marqo__score_modifiers)) == 0,   1, reduce(mult_weights * attribute(marqo__score_modifiers), prod))
         }
@@ -232,7 +229,13 @@ schema marqo__test_00semi_00structured_00schema {
             expression: reduce(add_weights * attribute(marqo__score_modifiers), sum)
         }
         function modify(score, mult_weights, add_weights) {
-            expression: (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_multiplier()
+            expression {
+                if (query(marqo__recency_should_apply_score) != 0,
+                    if (query(marqo__recency_add_to_score_weight) > 0,
+                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) + recency_score() * query(marqo__recency_add_to_score_weight),
+                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_score()),
+                    mult_modifier(mult_weights) * score + add_modifier(add_weights))
+            }
         }
         function global_mult_modifier() {
             expression: mult_modifier(query(marqo__mult_weights_global))
@@ -324,6 +327,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_add_to_score_weight) double: 0.0
         }
     }
 

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_one_tensor_one_string_array_field.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_one_tensor_one_string_array_field.sd
@@ -116,24 +116,23 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__sort_field_weights_1) tensor<double>(p{})
             query(marqo__sort_field_weights_2) tensor<double>(p{})
 
+            # Recency parameters
             query(marqo__recency_should_calculate_score): 0
             query(marqo__recency_should_apply_score): 0
-            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_timestamp_key) tensor<double>(p{})
+            query(marqo__recency_add_to_score_weight) double: 0.0
+            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
-            query(marqo__recency_add_to_score_weight) double: 0.0
-
-            # Grow parameters for future timestamp scoring
             query(marqo__recency_grow_enabled): 0
-            query(marqo__recency_grow_from) double: 1.0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0
             query(marqo__recency_grow_offset_seconds) double: 0.0
+            query(marqo__recency_grow_from) double: 0.5
         }
 
-        # ============ RECENCY SCORING FUNCTIONS (OPTIMIZED) ============
+        # ============ RECENCY SCORING FUNCTIONS ============
         function get_timestamp() {
             expression: reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum)
         }
@@ -141,6 +140,12 @@ schema marqo__test_00semi_00structured_00schema {
         function age_in_seconds() {
             expression: now() - get_timestamp()
         }
+
+        # ============ UNIFIED SCORING FUNCTIONS ============
+        # These work for both decay (past) and grow (future) by taking (age, scale, floor_val):
+        # - At age=0: returns 1.0
+        # - At age=scale: returns floor_val
+        # - Beyond scale: clamps to floor_val
 
         function score_exponential(age, scale, floor_val) {
             expression: max(floor_val, exp(log(floor_val) * age / scale))
@@ -158,6 +163,7 @@ schema marqo__test_00semi_00structured_00schema {
             expression: if(age < scale, 1.0, floor_val)
         }
 
+        # Router: selects function based on type (0=exp, 1=linear, 2=gaussian, 3=binary)
         function compute_score(age, scale, floor_val, func_type) {
             expression {
                 if (func_type == 0,
@@ -170,6 +176,17 @@ schema marqo__test_00semi_00structured_00schema {
             }
         }
 
+        # ============ UNIFIED RECENCY SCORE ============
+        # Single entry point with early exits for performance
+        # Logic flow:
+        # 1. If recency disabled → 1.0
+        # 2. Elif no timestamp (get_timestamp=0) → decay_to (treat as very old)
+        # 3. Elif age >= scale + offset → decay_to (very old, beyond decay range)
+        # 4. Elif age >= offset → compute decay score
+        # 5. Elif grow disabled → 1.0 (future timestamp, no penalty when grow is disabled)
+        # 6. Elif age >= -growOffset → 1.0 (future, within plateau)
+        # 7. Elif age >= -growOffset - growScale → compute grow score
+        # 8. Else → grow_from (far future)
         function recency_score() {
             expression {
                 if (query(marqo__recency_should_calculate_score) == 0,
@@ -204,13 +221,21 @@ schema marqo__test_00semi_00structured_00schema {
         function add_modifier(add_weights) {
             expression: reduce(add_weights * attribute(marqo__score_modifiers), sum)
         }
+        function apply_score_modifiers(score, mult_weights, add_weights) {
+            expression: mult_modifier(mult_weights) * score + add_modifier(add_weights)
+        }
+        function apply_recency_score(original_score) {
+            expression {
+                if (query(marqo__recency_add_to_score_weight) > 0,
+                    original_score + recency_score() * query(marqo__recency_add_to_score_weight),
+                    original_score * recency_score())
+            }
+        }
         function modify(score, mult_weights, add_weights) {
             expression {
-                if (query(marqo__recency_should_apply_score) != 0,
-                    if (query(marqo__recency_add_to_score_weight) > 0,
-                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) + recency_score() * query(marqo__recency_add_to_score_weight),
-                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_score()),
-                    mult_modifier(mult_weights) * score + add_modifier(add_weights))
+                if (query(marqo__recency_should_apply_score) == 0,
+                    apply_score_modifiers(score, mult_weights, add_weights),
+                    apply_recency_score(apply_score_modifiers(score, mult_weights, add_weights)))
             }
         }
         function global_mult_modifier() {
@@ -296,14 +321,20 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__sort_field_weights_1) tensor<double>(p{})
             query(marqo__sort_field_weights_2) tensor<double>(p{})
 
+            # Recency parameters
             query(marqo__recency_should_calculate_score): 0
             query(marqo__recency_should_apply_score): 0
-            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_timestamp_key) tensor<double>(p{})
+            query(marqo__recency_add_to_score_weight) double: 0.0
+            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
-            query(marqo__recency_add_to_score_weight) double: 0.0
+            query(marqo__recency_grow_enabled): 0
+            query(marqo__recency_grow_function_type): 0
+            query(marqo__recency_grow_scale_seconds) double: 604800.0
+            query(marqo__recency_grow_offset_seconds) double: 0.0
+            query(marqo__recency_grow_from) double: 0.5
         }
     }
 

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_one_tensor_one_string_array_field.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_one_tensor_one_string_array_field.sd
@@ -133,161 +133,68 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_grow_offset_seconds) double: 0.0
         }
 
-        # Recency scoring functions
+        # ============ RECENCY SCORING FUNCTIONS (OPTIMIZED) ============
         function get_timestamp() {
-            expression {
-                if (count(query(marqo__recency_timestamp_key)) > 0,
-                    reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum),
-                    0)
-            }
+            expression: reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum)
         }
 
         function age_in_seconds() {
-            expression: max(0, now() - get_timestamp())
+            expression: now() - get_timestamp()
         }
 
-        # Effective age after applying offset (grace period)
-        # Documents within offset period get 0 effective age (perfect score)
-        function effective_age() {
-            expression: max(0, age_in_seconds() - query(marqo__recency_offset_seconds))
+        function score_exponential(age, scale, floor_val) {
+            expression: max(floor_val, exp(log(floor_val) * age / scale))
         }
 
-        # Future offset: how far timestamp is beyond now() (for grow functions)
-        function future_offset_in_seconds() {
-            expression: max(0, get_timestamp() - now())
+        function score_linear(age, scale, floor_val) {
+            expression: max(floor_val, (scale - age * (1.0 - floor_val)) / scale)
         }
 
-        # Future age after subtracting growOffset (for growth function calculation)
-        # Returns 0 if within the plateau zone (timestamp between now() and now() + growOffset)
-        function future_age_in_seconds() {
-            expression: max(0, future_offset_in_seconds() - query(marqo__recency_grow_offset_seconds))
+        function score_gaussian(age, scale, floor_val) {
+            expression: max(floor_val, exp(pow(age, 2) * log(floor_val) / pow(scale, 2)))
         }
 
-        # Exponential decay (Elasticsearch-compatible)
-        # Formula: λ = ln(decay_to) / scale
-        #          score = max(decay_to, exp(λ × age))
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        function recency_score_exponential(age, scale, decay_to) {
+        function score_binary(age, scale, floor_val) {
+            expression: if(age < scale, 1.0, floor_val)
+        }
+
+        function compute_score(age, scale, floor_val, func_type) {
             expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, exp(log(decay_to) * age / scale)))
+                if (func_type == 0,
+                    score_exponential(age, scale, floor_val),
+                    if (func_type == 1,
+                        score_linear(age, scale, floor_val),
+                        if (func_type == 2,
+                            score_gaussian(age, scale, floor_val),
+                            score_binary(age, scale, floor_val))))
             }
-        }
-
-        # Linear decay (Elasticsearch-compatible)
-        # Formula: score = max(decay_to, (scale - age × (1 - decay_to)) / scale)
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        function recency_score_linear(age, scale, decay_to) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, (scale - age * (1.0 - decay_to)) / scale))
-            }
-        }
-
-        # Gaussian decay (Elasticsearch-compatible)
-        # Formula: σ² = -scale² / (2 × ln(decay_to))
-        #          score = max(decay_to, exp(-age² / (2σ²)))
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        # Formula: score = exp(age² × ln(decay_to) / scale²)
-        function recency_score_gaussian(age, scale, decay_to) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, exp(pow(age, 2) * log(decay_to) / pow(scale, 2))))
-            }
-        }
-
-        # Binary decay (step function)
-        # Score is 1.0 until age >= scale, then drops to decay_to
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: threshold in seconds
-        #   decay_to: score after threshold
-        function recency_score_binary(age, scale, decay_to) {
-            expression: if(age < scale, 1.0, decay_to)
-        }
-
-        function recency_score_router() {
-            expression {
-                if (query(marqo__recency_decay_function_type) == 0,
-                    recency_score_exponential(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                    if (query(marqo__recency_decay_function_type) == 1,
-                        recency_score_linear(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                        if (query(marqo__recency_decay_function_type) == 2,
-                            recency_score_gaussian(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                            recency_score_binary(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)))))
-            }
-        }
-
-        # Grow functions for future timestamps (mirror of decay functions)
-        function recency_grow_score_exponential(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * exp(log(1.0 - grow_from) * age / scale)))
-            }
-        }
-
-        function recency_grow_score_linear(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * age / scale))
-            }
-        }
-
-        function recency_grow_score_gaussian(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * (1.0 - exp(pow(age, 2) * log(grow_from) / pow(scale, 2)))))
-            }
-        }
-
-        function recency_grow_score_binary(age, scale, grow_from) {
-            expression: if(age < scale, 1.0, grow_from)
-        }
-
-        function recency_grow_score_router() {
-            expression {
-                if (query(marqo__recency_grow_function_type) == 0,
-                    recency_grow_score_exponential(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                    if (query(marqo__recency_grow_function_type) == 1,
-                        recency_grow_score_linear(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                        if (query(marqo__recency_grow_function_type) == 2,
-                            recency_grow_score_gaussian(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                            recency_grow_score_binary(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)))))
-            }
-        }
-
-        function grow_score() {
-            expression: if(query(marqo__recency_grow_enabled) != 0, recency_grow_score_router(), 1.0)
         }
 
         function recency_score() {
             expression {
-                if (query(marqo__recency_should_calculate_score) != 0,
-                    if (get_timestamp() <= now(),
-                        recency_score_router(),
-                        grow_score()),
-                    1.0)
+                if (query(marqo__recency_should_calculate_score) == 0,
+                    1.0,
+                    if (get_timestamp() == 0,
+                        query(marqo__recency_decay_to),
+                        if (age_in_seconds() >= query(marqo__recency_scale_seconds) + query(marqo__recency_offset_seconds),
+                            query(marqo__recency_decay_to),
+                            if (age_in_seconds() >= query(marqo__recency_offset_seconds),
+                                compute_score(
+                                    age_in_seconds() - query(marqo__recency_offset_seconds),
+                                    query(marqo__recency_scale_seconds),
+                                    query(marqo__recency_decay_to),
+                                    query(marqo__recency_decay_function_type)),
+                                if (query(marqo__recency_grow_enabled) == 0,
+                                    1.0,
+                                    if (age_in_seconds() >= -query(marqo__recency_grow_offset_seconds),
+                                        1.0,
+                                        if (age_in_seconds() >= -query(marqo__recency_grow_offset_seconds) - query(marqo__recency_grow_scale_seconds),
+                                            compute_score(
+                                                -age_in_seconds() - query(marqo__recency_grow_offset_seconds),
+                                                query(marqo__recency_grow_scale_seconds),
+                                                query(marqo__recency_grow_from),
+                                                query(marqo__recency_grow_function_type)),
+                                            query(marqo__recency_grow_from))))))))
             }
         }
 

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_string_array_field.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_string_array_field.sd
@@ -98,6 +98,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_add_to_score_weight) double: 0.0
         }
 
         # Recency scoring functions
@@ -196,10 +197,6 @@ schema marqo__test_00semi_00structured_00schema {
             expression: if(query(marqo__recency_should_calculate_score) != 0, recency_score_router(), 1.0)
         }
 
-        function recency_multiplier() {
-            expression: if(query(marqo__recency_should_apply_score) != 0, recency_score(), 1.0)
-        }
-
         function mult_modifier(mult_weights) {
             expression: if (count(mult_weights * attribute(marqo__score_modifiers)) == 0,   1, reduce(mult_weights * attribute(marqo__score_modifiers), prod))
         }
@@ -207,7 +204,13 @@ schema marqo__test_00semi_00structured_00schema {
             expression: reduce(add_weights * attribute(marqo__score_modifiers), sum)
         }
         function modify(score, mult_weights, add_weights) {
-            expression: (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_multiplier()
+            expression {
+                if (query(marqo__recency_should_apply_score) != 0,
+                    if (query(marqo__recency_add_to_score_weight) > 0,
+                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) + recency_score() * query(marqo__recency_add_to_score_weight),
+                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_score()),
+                    mult_modifier(mult_weights) * score + add_modifier(add_weights))
+            }
         }
         function global_mult_modifier() {
             expression: mult_modifier(query(marqo__mult_weights_global))

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_string_array_field.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_string_array_field.sd
@@ -108,161 +108,68 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_grow_offset_seconds) double: 0.0
         }
 
-        # Recency scoring functions
+        # ============ RECENCY SCORING FUNCTIONS (OPTIMIZED) ============
         function get_timestamp() {
-            expression {
-                if (count(query(marqo__recency_timestamp_key)) > 0,
-                    reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum),
-                    0)
-            }
+            expression: reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum)
         }
 
         function age_in_seconds() {
-            expression: max(0, now() - get_timestamp())
+            expression: now() - get_timestamp()
         }
 
-        # Effective age after applying offset (grace period)
-        # Documents within offset period get 0 effective age (perfect score)
-        function effective_age() {
-            expression: max(0, age_in_seconds() - query(marqo__recency_offset_seconds))
+        function score_exponential(age, scale, floor_val) {
+            expression: max(floor_val, exp(log(floor_val) * age / scale))
         }
 
-        # Future offset: how far timestamp is beyond now() (for grow functions)
-        function future_offset_in_seconds() {
-            expression: max(0, get_timestamp() - now())
+        function score_linear(age, scale, floor_val) {
+            expression: max(floor_val, (scale - age * (1.0 - floor_val)) / scale)
         }
 
-        # Future age after subtracting growOffset (for growth function calculation)
-        # Returns 0 if within the plateau zone (timestamp between now() and now() + growOffset)
-        function future_age_in_seconds() {
-            expression: max(0, future_offset_in_seconds() - query(marqo__recency_grow_offset_seconds))
+        function score_gaussian(age, scale, floor_val) {
+            expression: max(floor_val, exp(pow(age, 2) * log(floor_val) / pow(scale, 2)))
         }
 
-        # Exponential decay (Elasticsearch-compatible)
-        # Formula: λ = ln(decay_to) / scale
-        #          score = max(decay_to, exp(λ × age))
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        function recency_score_exponential(age, scale, decay_to) {
+        function score_binary(age, scale, floor_val) {
+            expression: if(age < scale, 1.0, floor_val)
+        }
+
+        function compute_score(age, scale, floor_val, func_type) {
             expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, exp(log(decay_to) * age / scale)))
+                if (func_type == 0,
+                    score_exponential(age, scale, floor_val),
+                    if (func_type == 1,
+                        score_linear(age, scale, floor_val),
+                        if (func_type == 2,
+                            score_gaussian(age, scale, floor_val),
+                            score_binary(age, scale, floor_val))))
             }
-        }
-
-        # Linear decay (Elasticsearch-compatible)
-        # Formula: score = max(decay_to, (scale - age × (1 - decay_to)) / scale)
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        function recency_score_linear(age, scale, decay_to) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, (scale - age * (1.0 - decay_to)) / scale))
-            }
-        }
-
-        # Gaussian decay (Elasticsearch-compatible)
-        # Formula: σ² = -scale² / (2 × ln(decay_to))
-        #          score = max(decay_to, exp(-age² / (2σ²)))
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        # Formula: score = exp(age² × ln(decay_to) / scale²)
-        function recency_score_gaussian(age, scale, decay_to) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, exp(pow(age, 2) * log(decay_to) / pow(scale, 2))))
-            }
-        }
-
-        # Binary decay (step function)
-        # Score is 1.0 until age >= scale, then drops to decay_to
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: threshold in seconds
-        #   decay_to: score after threshold
-        function recency_score_binary(age, scale, decay_to) {
-            expression: if(age < scale, 1.0, decay_to)
-        }
-
-        function recency_score_router() {
-            expression {
-                if (query(marqo__recency_decay_function_type) == 0,
-                    recency_score_exponential(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                    if (query(marqo__recency_decay_function_type) == 1,
-                        recency_score_linear(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                        if (query(marqo__recency_decay_function_type) == 2,
-                            recency_score_gaussian(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                            recency_score_binary(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)))))
-            }
-        }
-
-        # Grow functions for future timestamps (mirror of decay functions)
-        function recency_grow_score_exponential(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * exp(log(1.0 - grow_from) * age / scale)))
-            }
-        }
-
-        function recency_grow_score_linear(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * age / scale))
-            }
-        }
-
-        function recency_grow_score_gaussian(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * (1.0 - exp(pow(age, 2) * log(grow_from) / pow(scale, 2)))))
-            }
-        }
-
-        function recency_grow_score_binary(age, scale, grow_from) {
-            expression: if(age < scale, 1.0, grow_from)
-        }
-
-        function recency_grow_score_router() {
-            expression {
-                if (query(marqo__recency_grow_function_type) == 0,
-                    recency_grow_score_exponential(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                    if (query(marqo__recency_grow_function_type) == 1,
-                        recency_grow_score_linear(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                        if (query(marqo__recency_grow_function_type) == 2,
-                            recency_grow_score_gaussian(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                            recency_grow_score_binary(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)))))
-            }
-        }
-
-        function grow_score() {
-            expression: if(query(marqo__recency_grow_enabled) != 0, recency_grow_score_router(), 1.0)
         }
 
         function recency_score() {
             expression {
-                if (query(marqo__recency_should_calculate_score) != 0,
-                    if (get_timestamp() <= now(),
-                        recency_score_router(),
-                        grow_score()),
-                    1.0)
+                if (query(marqo__recency_should_calculate_score) == 0,
+                    1.0,
+                    if (get_timestamp() == 0,
+                        query(marqo__recency_decay_to),
+                        if (age_in_seconds() >= query(marqo__recency_scale_seconds) + query(marqo__recency_offset_seconds),
+                            query(marqo__recency_decay_to),
+                            if (age_in_seconds() >= query(marqo__recency_offset_seconds),
+                                compute_score(
+                                    age_in_seconds() - query(marqo__recency_offset_seconds),
+                                    query(marqo__recency_scale_seconds),
+                                    query(marqo__recency_decay_to),
+                                    query(marqo__recency_decay_function_type)),
+                                if (query(marqo__recency_grow_enabled) == 0,
+                                    1.0,
+                                    if (age_in_seconds() >= -query(marqo__recency_grow_offset_seconds),
+                                        1.0,
+                                        if (age_in_seconds() >= -query(marqo__recency_grow_offset_seconds) - query(marqo__recency_grow_scale_seconds),
+                                            compute_score(
+                                                -age_in_seconds() - query(marqo__recency_grow_offset_seconds),
+                                                query(marqo__recency_grow_scale_seconds),
+                                                query(marqo__recency_grow_from),
+                                                query(marqo__recency_grow_function_type)),
+                                            query(marqo__recency_grow_from))))))))
             }
         }
 

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_string_array_field.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_string_array_field.sd
@@ -91,24 +91,23 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__sort_field_weights_1) tensor<double>(p{})
             query(marqo__sort_field_weights_2) tensor<double>(p{})
 
+            # Recency parameters
             query(marqo__recency_should_calculate_score): 0
             query(marqo__recency_should_apply_score): 0
-            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_timestamp_key) tensor<double>(p{})
+            query(marqo__recency_add_to_score_weight) double: 0.0
+            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
-            query(marqo__recency_add_to_score_weight) double: 0.0
-
-            # Grow parameters for future timestamp scoring
             query(marqo__recency_grow_enabled): 0
-            query(marqo__recency_grow_from) double: 1.0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0
             query(marqo__recency_grow_offset_seconds) double: 0.0
+            query(marqo__recency_grow_from) double: 0.5
         }
 
-        # ============ RECENCY SCORING FUNCTIONS (OPTIMIZED) ============
+        # ============ RECENCY SCORING FUNCTIONS ============
         function get_timestamp() {
             expression: reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum)
         }
@@ -116,6 +115,12 @@ schema marqo__test_00semi_00structured_00schema {
         function age_in_seconds() {
             expression: now() - get_timestamp()
         }
+
+        # ============ UNIFIED SCORING FUNCTIONS ============
+        # These work for both decay (past) and grow (future) by taking (age, scale, floor_val):
+        # - At age=0: returns 1.0
+        # - At age=scale: returns floor_val
+        # - Beyond scale: clamps to floor_val
 
         function score_exponential(age, scale, floor_val) {
             expression: max(floor_val, exp(log(floor_val) * age / scale))
@@ -133,6 +138,7 @@ schema marqo__test_00semi_00structured_00schema {
             expression: if(age < scale, 1.0, floor_val)
         }
 
+        # Router: selects function based on type (0=exp, 1=linear, 2=gaussian, 3=binary)
         function compute_score(age, scale, floor_val, func_type) {
             expression {
                 if (func_type == 0,
@@ -145,6 +151,17 @@ schema marqo__test_00semi_00structured_00schema {
             }
         }
 
+        # ============ UNIFIED RECENCY SCORE ============
+        # Single entry point with early exits for performance
+        # Logic flow:
+        # 1. If recency disabled → 1.0
+        # 2. Elif no timestamp (get_timestamp=0) → decay_to (treat as very old)
+        # 3. Elif age >= scale + offset → decay_to (very old, beyond decay range)
+        # 4. Elif age >= offset → compute decay score
+        # 5. Elif grow disabled → 1.0 (future timestamp, no penalty when grow is disabled)
+        # 6. Elif age >= -growOffset → 1.0 (future, within plateau)
+        # 7. Elif age >= -growOffset - growScale → compute grow score
+        # 8. Else → grow_from (far future)
         function recency_score() {
             expression {
                 if (query(marqo__recency_should_calculate_score) == 0,
@@ -179,13 +196,21 @@ schema marqo__test_00semi_00structured_00schema {
         function add_modifier(add_weights) {
             expression: reduce(add_weights * attribute(marqo__score_modifiers), sum)
         }
+        function apply_score_modifiers(score, mult_weights, add_weights) {
+            expression: mult_modifier(mult_weights) * score + add_modifier(add_weights)
+        }
+        function apply_recency_score(original_score) {
+            expression {
+                if (query(marqo__recency_add_to_score_weight) > 0,
+                    original_score + recency_score() * query(marqo__recency_add_to_score_weight),
+                    original_score * recency_score())
+            }
+        }
         function modify(score, mult_weights, add_weights) {
             expression {
-                if (query(marqo__recency_should_apply_score) != 0,
-                    if (query(marqo__recency_add_to_score_weight) > 0,
-                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) + recency_score() * query(marqo__recency_add_to_score_weight),
-                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_score()),
-                    mult_modifier(mult_weights) * score + add_modifier(add_weights))
+                if (query(marqo__recency_should_apply_score) == 0,
+                    apply_score_modifiers(score, mult_weights, add_weights),
+                    apply_recency_score(apply_score_modifiers(score, mult_weights, add_weights)))
             }
         }
         function global_mult_modifier() {

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_string_array_field.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_string_array_field.sd
@@ -99,6 +99,13 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
             query(marqo__recency_add_to_score_weight) double: 0.0
+
+            # Grow parameters for future timestamp scoring
+            query(marqo__recency_grow_enabled): 0
+            query(marqo__recency_grow_from) double: 1.0
+            query(marqo__recency_grow_function_type): 0
+            query(marqo__recency_grow_scale_seconds) double: 604800.0
+            query(marqo__recency_grow_offset_seconds) double: 0.0
         }
 
         # Recency scoring functions
@@ -118,6 +125,17 @@ schema marqo__test_00semi_00structured_00schema {
         # Documents within offset period get 0 effective age (perfect score)
         function effective_age() {
             expression: max(0, age_in_seconds() - query(marqo__recency_offset_seconds))
+        }
+
+        # Future offset: how far timestamp is beyond now() (for grow functions)
+        function future_offset_in_seconds() {
+            expression: max(0, get_timestamp() - now())
+        }
+
+        # Future age after subtracting growOffset (for growth function calculation)
+        # Returns 0 if within the plateau zone (timestamp between now() and now() + growOffset)
+        function future_age_in_seconds() {
+            expression: max(0, future_offset_in_seconds() - query(marqo__recency_grow_offset_seconds))
         }
 
         # Exponential decay (Elasticsearch-compatible)
@@ -193,8 +211,59 @@ schema marqo__test_00semi_00structured_00schema {
             }
         }
 
+        # Grow functions for future timestamps (mirror of decay functions)
+        function recency_grow_score_exponential(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * exp(log(1.0 - grow_from) * age / scale)))
+            }
+        }
+
+        function recency_grow_score_linear(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * age / scale))
+            }
+        }
+
+        function recency_grow_score_gaussian(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * (1.0 - exp(pow(age, 2) * log(grow_from) / pow(scale, 2)))))
+            }
+        }
+
+        function recency_grow_score_binary(age, scale, grow_from) {
+            expression: if(age < scale, 1.0, grow_from)
+        }
+
+        function recency_grow_score_router() {
+            expression {
+                if (query(marqo__recency_grow_function_type) == 0,
+                    recency_grow_score_exponential(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                    if (query(marqo__recency_grow_function_type) == 1,
+                        recency_grow_score_linear(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                        if (query(marqo__recency_grow_function_type) == 2,
+                            recency_grow_score_gaussian(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                            recency_grow_score_binary(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)))))
+            }
+        }
+
+        function grow_score() {
+            expression: if(query(marqo__recency_grow_enabled) != 0, recency_grow_score_router(), 1.0)
+        }
+
         function recency_score() {
-            expression: if(query(marqo__recency_should_calculate_score) != 0, recency_score_router(), 1.0)
+            expression {
+                if (query(marqo__recency_should_calculate_score) != 0,
+                    if (get_timestamp() <= now(),
+                        recency_score_router(),
+                        grow_score()),
+                    1.0)
+            }
         }
 
         function mult_modifier(mult_weights) {

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_tensor_field.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_tensor_field.sd
@@ -110,6 +110,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_add_to_score_weight) double: 0.0
         }
 
         # Recency scoring functions
@@ -208,10 +209,6 @@ schema marqo__test_00semi_00structured_00schema {
             expression: if(query(marqo__recency_should_calculate_score) != 0, recency_score_router(), 1.0)
         }
 
-        function recency_multiplier() {
-            expression: if(query(marqo__recency_should_apply_score) != 0, recency_score(), 1.0)
-        }
-
         function mult_modifier(mult_weights) {
             expression: if (count(mult_weights * attribute(marqo__score_modifiers)) == 0,   1, reduce(mult_weights * attribute(marqo__score_modifiers), prod))
         }
@@ -219,7 +216,13 @@ schema marqo__test_00semi_00structured_00schema {
             expression: reduce(add_weights * attribute(marqo__score_modifiers), sum)
         }
         function modify(score, mult_weights, add_weights) {
-            expression: (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_multiplier()
+            expression {
+                if (query(marqo__recency_should_apply_score) != 0,
+                    if (query(marqo__recency_add_to_score_weight) > 0,
+                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) + recency_score() * query(marqo__recency_add_to_score_weight),
+                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_score()),
+                    mult_modifier(mult_weights) * score + add_modifier(add_weights))
+            }
         }
         function global_mult_modifier() {
             expression: mult_modifier(query(marqo__mult_weights_global))

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_tensor_field.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_tensor_field.sd
@@ -103,24 +103,23 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__sort_field_weights_1) tensor<double>(p{})
             query(marqo__sort_field_weights_2) tensor<double>(p{})
 
+            # Recency parameters
             query(marqo__recency_should_calculate_score): 0
             query(marqo__recency_should_apply_score): 0
-            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_timestamp_key) tensor<double>(p{})
+            query(marqo__recency_add_to_score_weight) double: 0.0
+            query(marqo__recency_decay_function_type): 0
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
-            query(marqo__recency_add_to_score_weight) double: 0.0
-
-            # Grow parameters for future timestamp scoring
             query(marqo__recency_grow_enabled): 0
-            query(marqo__recency_grow_from) double: 1.0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0
             query(marqo__recency_grow_offset_seconds) double: 0.0
+            query(marqo__recency_grow_from) double: 0.5
         }
 
-        # ============ RECENCY SCORING FUNCTIONS (OPTIMIZED) ============
+        # ============ RECENCY SCORING FUNCTIONS ============
         function get_timestamp() {
             expression: reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum)
         }
@@ -128,6 +127,12 @@ schema marqo__test_00semi_00structured_00schema {
         function age_in_seconds() {
             expression: now() - get_timestamp()
         }
+
+        # ============ UNIFIED SCORING FUNCTIONS ============
+        # These work for both decay (past) and grow (future) by taking (age, scale, floor_val):
+        # - At age=0: returns 1.0
+        # - At age=scale: returns floor_val
+        # - Beyond scale: clamps to floor_val
 
         function score_exponential(age, scale, floor_val) {
             expression: max(floor_val, exp(log(floor_val) * age / scale))
@@ -145,6 +150,7 @@ schema marqo__test_00semi_00structured_00schema {
             expression: if(age < scale, 1.0, floor_val)
         }
 
+        # Router: selects function based on type (0=exp, 1=linear, 2=gaussian, 3=binary)
         function compute_score(age, scale, floor_val, func_type) {
             expression {
                 if (func_type == 0,
@@ -157,6 +163,17 @@ schema marqo__test_00semi_00structured_00schema {
             }
         }
 
+        # ============ UNIFIED RECENCY SCORE ============
+        # Single entry point with early exits for performance
+        # Logic flow:
+        # 1. If recency disabled → 1.0
+        # 2. Elif no timestamp (get_timestamp=0) → decay_to (treat as very old)
+        # 3. Elif age >= scale + offset → decay_to (very old, beyond decay range)
+        # 4. Elif age >= offset → compute decay score
+        # 5. Elif grow disabled → 1.0 (future timestamp, no penalty when grow is disabled)
+        # 6. Elif age >= -growOffset → 1.0 (future, within plateau)
+        # 7. Elif age >= -growOffset - growScale → compute grow score
+        # 8. Else → grow_from (far future)
         function recency_score() {
             expression {
                 if (query(marqo__recency_should_calculate_score) == 0,
@@ -191,13 +208,21 @@ schema marqo__test_00semi_00structured_00schema {
         function add_modifier(add_weights) {
             expression: reduce(add_weights * attribute(marqo__score_modifiers), sum)
         }
+        function apply_score_modifiers(score, mult_weights, add_weights) {
+            expression: mult_modifier(mult_weights) * score + add_modifier(add_weights)
+        }
+        function apply_recency_score(original_score) {
+            expression {
+                if (query(marqo__recency_add_to_score_weight) > 0,
+                    original_score + recency_score() * query(marqo__recency_add_to_score_weight),
+                    original_score * recency_score())
+            }
+        }
         function modify(score, mult_weights, add_weights) {
             expression {
-                if (query(marqo__recency_should_apply_score) != 0,
-                    if (query(marqo__recency_add_to_score_weight) > 0,
-                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) + recency_score() * query(marqo__recency_add_to_score_weight),
-                        (mult_modifier(mult_weights) * score + add_modifier(add_weights)) * recency_score()),
-                    mult_modifier(mult_weights) * score + add_modifier(add_weights))
+                if (query(marqo__recency_should_apply_score) == 0,
+                    apply_score_modifiers(score, mult_weights, add_weights),
+                    apply_recency_score(apply_score_modifiers(score, mult_weights, add_weights)))
             }
         }
         function global_mult_modifier() {

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_tensor_field.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_tensor_field.sd
@@ -120,169 +120,68 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_grow_offset_seconds) double: 0.0
         }
 
-        # Recency scoring functions
+        # ============ RECENCY SCORING FUNCTIONS (OPTIMIZED) ============
         function get_timestamp() {
-            expression {
-                if (count(query(marqo__recency_timestamp_key)) > 0,
-                    reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum),
-                    0)
-            }
+            expression: reduce(attribute(marqo__score_modifiers) * query(marqo__recency_timestamp_key), sum)
         }
 
         function age_in_seconds() {
-            expression: max(0, now() - get_timestamp())
+            expression: now() - get_timestamp()
         }
 
-        # Effective age after applying offset (grace period)
-        # Documents within offset period get 0 effective age (perfect score)
-        function effective_age() {
-            expression: max(0, age_in_seconds() - query(marqo__recency_offset_seconds))
+        function score_exponential(age, scale, floor_val) {
+            expression: max(floor_val, exp(log(floor_val) * age / scale))
         }
 
-        # Future offset: how far timestamp is beyond now() (for grow functions)
-        function future_offset_in_seconds() {
-            expression: max(0, get_timestamp() - now())
+        function score_linear(age, scale, floor_val) {
+            expression: max(floor_val, (scale - age * (1.0 - floor_val)) / scale)
         }
 
-        # Future age after subtracting growOffset (for growth function calculation)
-        # Returns 0 if within the plateau zone (timestamp between now() and now() + growOffset)
-        function future_age_in_seconds() {
-            expression: max(0, future_offset_in_seconds() - query(marqo__recency_grow_offset_seconds))
+        function score_gaussian(age, scale, floor_val) {
+            expression: max(floor_val, exp(pow(age, 2) * log(floor_val) / pow(scale, 2)))
         }
 
-        # Exponential decay (Elasticsearch-compatible)
-        # Formula: λ = ln(decay_to) / scale
-        #          score = max(decay_to, exp(λ × age))
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        function recency_score_exponential(age, scale, decay_to) {
+        function score_binary(age, scale, floor_val) {
+            expression: if(age < scale, 1.0, floor_val)
+        }
+
+        function compute_score(age, scale, floor_val, func_type) {
             expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, exp(log(decay_to) * age / scale)))
+                if (func_type == 0,
+                    score_exponential(age, scale, floor_val),
+                    if (func_type == 1,
+                        score_linear(age, scale, floor_val),
+                        if (func_type == 2,
+                            score_gaussian(age, scale, floor_val),
+                            score_binary(age, scale, floor_val))))
             }
         }
 
-        # Linear decay (Elasticsearch-compatible)
-        # Formula: score = max(decay_to, (scale - age × (1 - decay_to)) / scale)
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        function recency_score_linear(age, scale, decay_to) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, (scale - age * (1.0 - decay_to)) / scale))
-            }
-        }
-
-        # Gaussian decay (Elasticsearch-compatible)
-        # Formula: σ² = -scale² / (2 × ln(decay_to))
-        #          score = max(decay_to, exp(-age² / (2σ²)))
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: scale in seconds
-        #   decay_to: target score at age=scale, also acts as floor
-        # At age = 0: score = 1.0
-        # At age = scale: score = decay_to
-        # Formula: score = exp(age² × ln(decay_to) / scale²)
-        function recency_score_gaussian(age, scale, decay_to) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(decay_to, exp(pow(age, 2) * log(decay_to) / pow(scale, 2))))
-            }
-        }
-
-        # Binary decay (step function)
-        # Score is 1.0 until age >= scale, then drops to decay_to
-        # Parameters:
-        #   age: effective age in seconds
-        #   scale: threshold in seconds
-        #   decay_to: score after threshold
-        function recency_score_binary(age, scale, decay_to) {
-            expression: if(age < scale, 1.0, decay_to)
-        }
-
-        function recency_score_router() {
-            expression {
-                if (query(marqo__recency_decay_function_type) == 0,
-                    recency_score_exponential(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                    if (query(marqo__recency_decay_function_type) == 1,
-                        recency_score_linear(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                        if (query(marqo__recency_decay_function_type) == 2,
-                            recency_score_gaussian(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)),
-                            recency_score_binary(effective_age(), query(marqo__recency_scale_seconds), query(marqo__recency_decay_to)))))
-            }
-        }
-
-        # Grow functions for future timestamps (mirror of decay functions)
-        # These apply when timestamp > now(), with score increasing toward 1.0 as timestamp approaches now()
-
-        # Exponential grow
-        function recency_grow_score_exponential(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * exp(log(1.0 - grow_from) * age / scale)))
-            }
-        }
-
-        # Linear grow
-        function recency_grow_score_linear(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * age / scale))
-            }
-        }
-
-        # Gaussian grow
-        function recency_grow_score_gaussian(age, scale, grow_from) {
-            expression {
-                if (age == 0,
-                    1.0,
-                    max(grow_from, 1.0 - (1.0 - grow_from) * (1.0 - exp(pow(age, 2) * log(grow_from) / pow(scale, 2)))))
-            }
-        }
-
-        # Binary grow (step function)
-        function recency_grow_score_binary(age, scale, grow_from) {
-            expression: if(age < scale, 1.0, grow_from)
-        }
-
-        function recency_grow_score_router() {
-            expression {
-                if (query(marqo__recency_grow_function_type) == 0,
-                    recency_grow_score_exponential(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                    if (query(marqo__recency_grow_function_type) == 1,
-                        recency_grow_score_linear(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                        if (query(marqo__recency_grow_function_type) == 2,
-                            recency_grow_score_gaussian(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
-                            recency_grow_score_binary(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)))))
-            }
-        }
-
-        # Grow score: applies to future timestamps when grow is enabled
-        function grow_score() {
-            expression: if(query(marqo__recency_grow_enabled) != 0, recency_grow_score_router(), 1.0)
-        }
-
-        # Combined recency score: routes between decay (past) and grow (future)
         function recency_score() {
             expression {
-                if (query(marqo__recency_should_calculate_score) != 0,
-                    if (get_timestamp() <= now(),
-                        recency_score_router(),
-                        grow_score()),
-                    1.0)
+                if (query(marqo__recency_should_calculate_score) == 0,
+                    1.0,
+                    if (get_timestamp() == 0,
+                        query(marqo__recency_decay_to),
+                        if (age_in_seconds() >= query(marqo__recency_scale_seconds) + query(marqo__recency_offset_seconds),
+                            query(marqo__recency_decay_to),
+                            if (age_in_seconds() >= query(marqo__recency_offset_seconds),
+                                compute_score(
+                                    age_in_seconds() - query(marqo__recency_offset_seconds),
+                                    query(marqo__recency_scale_seconds),
+                                    query(marqo__recency_decay_to),
+                                    query(marqo__recency_decay_function_type)),
+                                if (query(marqo__recency_grow_enabled) == 0,
+                                    1.0,
+                                    if (age_in_seconds() >= -query(marqo__recency_grow_offset_seconds),
+                                        1.0,
+                                        if (age_in_seconds() >= -query(marqo__recency_grow_offset_seconds) - query(marqo__recency_grow_scale_seconds),
+                                            compute_score(
+                                                -age_in_seconds() - query(marqo__recency_grow_offset_seconds),
+                                                query(marqo__recency_grow_scale_seconds),
+                                                query(marqo__recency_grow_from),
+                                                query(marqo__recency_grow_function_type)),
+                                            query(marqo__recency_grow_from))))))))
             }
         }
 

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_tensor_field.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_tensor_field.sd
@@ -111,6 +111,13 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
             query(marqo__recency_add_to_score_weight) double: 0.0
+
+            # Grow parameters for future timestamp scoring
+            query(marqo__recency_grow_enabled): 0
+            query(marqo__recency_grow_from) double: 1.0
+            query(marqo__recency_grow_function_type): 0
+            query(marqo__recency_grow_scale_seconds) double: 604800.0
+            query(marqo__recency_grow_offset_seconds) double: 0.0
         }
 
         # Recency scoring functions
@@ -130,6 +137,17 @@ schema marqo__test_00semi_00structured_00schema {
         # Documents within offset period get 0 effective age (perfect score)
         function effective_age() {
             expression: max(0, age_in_seconds() - query(marqo__recency_offset_seconds))
+        }
+
+        # Future offset: how far timestamp is beyond now() (for grow functions)
+        function future_offset_in_seconds() {
+            expression: max(0, get_timestamp() - now())
+        }
+
+        # Future age after subtracting growOffset (for growth function calculation)
+        # Returns 0 if within the plateau zone (timestamp between now() and now() + growOffset)
+        function future_age_in_seconds() {
+            expression: max(0, future_offset_in_seconds() - query(marqo__recency_grow_offset_seconds))
         }
 
         # Exponential decay (Elasticsearch-compatible)
@@ -205,8 +223,67 @@ schema marqo__test_00semi_00structured_00schema {
             }
         }
 
+        # Grow functions for future timestamps (mirror of decay functions)
+        # These apply when timestamp > now(), with score increasing toward 1.0 as timestamp approaches now()
+
+        # Exponential grow
+        function recency_grow_score_exponential(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * exp(log(1.0 - grow_from) * age / scale)))
+            }
+        }
+
+        # Linear grow
+        function recency_grow_score_linear(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * age / scale))
+            }
+        }
+
+        # Gaussian grow
+        function recency_grow_score_gaussian(age, scale, grow_from) {
+            expression {
+                if (age == 0,
+                    1.0,
+                    max(grow_from, 1.0 - (1.0 - grow_from) * (1.0 - exp(pow(age, 2) * log(grow_from) / pow(scale, 2)))))
+            }
+        }
+
+        # Binary grow (step function)
+        function recency_grow_score_binary(age, scale, grow_from) {
+            expression: if(age < scale, 1.0, grow_from)
+        }
+
+        function recency_grow_score_router() {
+            expression {
+                if (query(marqo__recency_grow_function_type) == 0,
+                    recency_grow_score_exponential(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                    if (query(marqo__recency_grow_function_type) == 1,
+                        recency_grow_score_linear(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                        if (query(marqo__recency_grow_function_type) == 2,
+                            recency_grow_score_gaussian(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)),
+                            recency_grow_score_binary(future_age_in_seconds(), query(marqo__recency_grow_scale_seconds), query(marqo__recency_grow_from)))))
+            }
+        }
+
+        # Grow score: applies to future timestamps when grow is enabled
+        function grow_score() {
+            expression: if(query(marqo__recency_grow_enabled) != 0, recency_grow_score_router(), 1.0)
+        }
+
+        # Combined recency score: routes between decay (past) and grow (future)
         function recency_score() {
-            expression: if(query(marqo__recency_should_calculate_score) != 0, recency_score_router(), 1.0)
+            expression {
+                if (query(marqo__recency_should_calculate_score) != 0,
+                    if (get_timestamp() <= now(),
+                        recency_score_router(),
+                        grow_score()),
+                    1.0)
+            }
         }
 
         function mult_modifier(mult_weights) {

--- a/tests/integ_tests/inference/native_inference/media_download_and_preprocess/test_streaming_media_preprcessor.py
+++ b/tests/integ_tests/inference/native_inference/media_download_and_preprocess/test_streaming_media_preprcessor.py
@@ -254,7 +254,7 @@ class TestStreamingMediaProcessor(unittest.TestCase):
         an error is raised as StreamingMediaProcessor is not designed to handle images."""
         for url in [
             TestImageUrls.IMAGE1.value, TestImageUrls.IMAGE2.value, TestImageUrls.IMAGE3.value,
-            TestImageUrls.COCO.value
+            TestImageUrls.IMAGE4.value
         ]:
             with self.subTest(url=url):
                 with self.assertRaises(MediaMismatchError) as e:

--- a/tests/integ_tests/s2_inference/test_generic_clip_model.py
+++ b/tests/integ_tests/s2_inference/test_generic_clip_model.py
@@ -321,7 +321,7 @@ class TestGenericModelSupport(MarqoTestCase):
                 "_id": "123",
                 "title 1": "content 1",
                 "desc 2": "content 2. blah blah blah",
-                "image" : TestImageUrls.COCO.value
+                "image" : TestImageUrls.IMAGE1.value
             }]
 
         self.add_documents(config=config, add_docs_params=AddDocsParams(
@@ -369,7 +369,7 @@ class TestGenericModelSupport(MarqoTestCase):
 
         epsilon = 1e-7
 
-        image = TestImageUrls.COCO.value
+        image = TestImageUrls.IMAGE1.value
 
         model_name = "test-model"
         model_properties = {
@@ -408,7 +408,7 @@ class TestGenericModelSupport(MarqoTestCase):
 
         epsilon = 1e-7
 
-        image = TestImageUrls.COCO.value
+        image = TestImageUrls.IMAGE1.value
 
         model_name = "test-model"
         model_properties = {

--- a/tests/integ_tests/tensor_search/integ_tests/test_base64_image_search.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_base64_image_search.py
@@ -97,8 +97,8 @@ class TestBase64ImageSearch(MarqoTestCase):
                     },
                     {
                         "_id": "coco_doc",
-                        "image": TestImageUrls.COCO.value,
-                        "title": "COCO dataset image"
+                        "image": TestImageUrls.IMAGE0.value,
+                        "title": "Image search guide image"
                     }
                 ]
 
@@ -183,8 +183,8 @@ class TestBase64ImageSearch(MarqoTestCase):
                     },
                     {
                         "_id": "coco_doc",
-                        "image": TestImageUrls.COCO.value,
-                        "title": "COCO dataset image with various objects"
+                        "image": TestImageUrls.IMAGE0.value,
+                        "title": "Image search guide image with various objects"
                     },
                     {
                         "_id": "text_only_hippo",
@@ -304,8 +304,8 @@ class TestBase64ImageSearch(MarqoTestCase):
                     },
                     {
                         "_id": "coco_doc",
-                        "image": TestImageUrls.COCO.value,
-                        "title": "COCO dataset image with various objects"
+                        "image": TestImageUrls.IMAGE0.value,
+                        "title": "Image search guide image with various objects"
                     },
                     {
                         "_id": "text_only_hippo",

--- a/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
@@ -617,6 +617,7 @@ class TestRecencyScoring(MarqoTestCase):
         add_weight: Optional[float],
         multiply_weights: Optional[Dict[str, float]] = None,
         add_weights: Optional[Dict[str, float]] = None,
+        rerank_depth: Optional[int] = None,
     ):
         """Verify scores changed according to apply_in_ranking_phase setting.
 
@@ -635,6 +636,9 @@ class TestRecencyScoring(MarqoTestCase):
         - mult_modifier = product of (weight * field_value) for each field in multiply_weights
         - add_modifier = sum of (weight * field_value) for each field in add_weights
         - base_score = rrf * mult_modifier + add_modifier
+
+        rerank_depth: If provided, only the top N documents (by RRF score) get global
+        phase processing (modifiers + recency). Documents beyond this depth keep raw RRF.
         """
         common_docs = set(baseline.keys()) & set(recency.keys())
         self.assertGreater(len(common_docs), 0, "Should have common docs")
@@ -654,6 +658,14 @@ class TestRecencyScoring(MarqoTestCase):
             else:
                 return original * recency_score
 
+        # Calculate RRF scores and ranks (needed for rerank_depth logic)
+        rrf_scores = self._calculate_rrf_score(recency)
+
+        # Create a ranking of documents by RRF score (for rerank_depth check)
+        # Rank is 1-indexed (top doc has rank 1)
+        rrf_ranked = sorted(rrf_scores.items(), key=lambda x: x[1], reverse=True)
+        doc_rrf_rank = {doc_id: rank + 1 for rank, (doc_id, _) in enumerate(rrf_ranked)}
+
         for doc_id in affected_docs:
             b = baseline[doc_id]
             r = recency[doc_id]
@@ -662,6 +674,10 @@ class TestRecencyScoring(MarqoTestCase):
             # Skip if missing score data
             if b['lexical'] is None or b['tensor'] is None or b['score'] is None:
                 continue
+
+            # Check if this doc is within rerank_depth (gets global phase processing)
+            doc_rank = doc_rrf_rank.get(doc_id, float('inf'))
+            within_rerank_depth = rerank_depth is None or doc_rank <= rerank_depth
 
             if phase == "all":
                 # Lexical and tensor scores should be modified by recency
@@ -680,23 +696,27 @@ class TestRecencyScoring(MarqoTestCase):
                 )
 
                 # Calculate expected RRF from modified lexical/tensor scores
-                rrf_scores = self._calculate_rrf_score(recency)
                 expected_rrf = rrf_scores.get(doc_id, 0)
 
-                # Apply global score modifiers if present
-                if multiply_weights or add_weights:
-                    mult_mod, add_mod = self._calculate_global_modifiers(
-                        r, multiply_weights or {}, add_weights or {}
-                    )
-                    base_score = expected_rrf * mult_mod + add_mod
-                else:
-                    base_score = expected_rrf
+                if within_rerank_depth:
+                    # Apply global score modifiers if present
+                    if multiply_weights or add_weights:
+                        mult_mod, add_mod = self._calculate_global_modifiers(
+                            r, multiply_weights or {}, add_weights or {}
+                        )
+                        base_score = expected_rrf * mult_mod + add_mod
+                    else:
+                        base_score = expected_rrf
 
-                # Apply recency to final score (global phase)
-                expected_final = calculate_expected_recency(base_score, recency_score)
+                    # Apply recency to final score (global phase)
+                    expected_final = calculate_expected_recency(base_score, recency_score)
+                else:
+                    # Beyond rerank_depth: no global modifiers or recency applied to RRF
+                    expected_final = expected_rrf
+
                 self.assertAlmostEqual(
                     expected_final, r['score'], places=3,
-                    msg=f"Doc {doc_id}: RRF score mismatch. "
+                    msg=f"Doc {doc_id} (rank {doc_rank}): RRF score mismatch. "
                     f"Expected {expected_final:.6f}, got {r['score']:.6f}"
                 )
 
@@ -718,21 +738,24 @@ class TestRecencyScoring(MarqoTestCase):
 
                 # Calculate expected RRF from modified lexical/tensor scores
                 # NO recency applied to RRF in global phase
-                rrf_scores = self._calculate_rrf_score(recency)
                 expected_rrf = rrf_scores.get(doc_id, 0)
 
-                # Apply global score modifiers if present (but no recency)
-                if multiply_weights or add_weights:
-                    mult_mod, add_mod = self._calculate_global_modifiers(
-                        r, multiply_weights or {}, add_weights or {}
-                    )
-                    expected_final = expected_rrf * mult_mod + add_mod
+                if within_rerank_depth:
+                    # Apply global score modifiers if present (but no recency)
+                    if multiply_weights or add_weights:
+                        mult_mod, add_mod = self._calculate_global_modifiers(
+                            r, multiply_weights or {}, add_weights or {}
+                        )
+                        expected_final = expected_rrf * mult_mod + add_mod
+                    else:
+                        expected_final = expected_rrf
                 else:
+                    # Beyond rerank_depth: no global modifiers applied
                     expected_final = expected_rrf
 
                 self.assertAlmostEqual(
                     expected_final, r['score'], places=3,
-                    msg=f"Doc {doc_id}: RRF score mismatch. "
+                    msg=f"Doc {doc_id} (rank {doc_rank}): RRF score mismatch. "
                     f"Expected {expected_final:.6f}, got {r['score']:.6f}"
                 )
 
@@ -748,12 +771,18 @@ class TestRecencyScoring(MarqoTestCase):
                     msg=f"Doc {doc_id}: tensor should be unchanged. "
                     f"Baseline {b['tensor']:.6f}, got {r['tensor']:.6f}"
                 )
-                # RRF score should be modified by recency
-                # (baseline already has modifiers applied, so we just apply recency)
-                expected_score = calculate_expected_recency(b['score'], recency_score)
+
+                if within_rerank_depth:
+                    # RRF score should be modified by recency
+                    # (baseline already has modifiers applied, so we just apply recency)
+                    expected_score = calculate_expected_recency(b['score'], recency_score)
+                else:
+                    # Beyond rerank_depth: no recency applied, score equals baseline
+                    expected_score = b['score']
+
                 self.assertAlmostEqual(
                     expected_score, r['score'], places=3,
-                    msg=f"Doc {doc_id}: RRF score mismatch. "
+                    msg=f"Doc {doc_id} (rank {doc_rank}): RRF score mismatch. "
                         f"Expected {expected_score:.6f}, got {r['score']:.6f}"
                 )
 
@@ -901,23 +930,29 @@ class TestRecencyScoring(MarqoTestCase):
         self._add_shared_documents()
 
         # Test configurations
+        # (apply_in_ranking_phase, add_to_score_weight, use_score_modifiers, rerank_depth)
         test_cases = [
-            # (apply_in_ranking_phase, add_to_score_weight, use_score_modifiers)
-            ("all", None, True),           # Multiplicative, with score mods
-            ("all", None, False),          # Multiplicative, without score mods
-            ("all", 10.0, True),           # Additive, with score mods
-            ("exclude-global", None, True),
-            ("exclude-global", None, False),
-            ("exclude-global", 10.0, True),
-            ("only-global", None, True),
-            ("only-global", None, False),
-            ("only-global", 10.0, True),
+            # Standard cases without rerank_depth limit
+            ("all", None, True, None),           # Multiplicative, with score mods
+            ("all", None, False, None),          # Multiplicative, without score mods
+            ("all", 10.0, True, None),           # Additive, with score mods
+            ("exclude-global", None, True, None),
+            ("exclude-global", None, False, None),
+            ("exclude-global", 10.0, True, None),
+            ("only-global", None, True, None),
+            ("only-global", None, False, None),
+            ("only-global", 10.0, True, None),
+
+            # These verify that docs beyond rerank_depth don't get global processing, only top 5 get modifiers+recency in global
+            ("all", None, True, 5),
+            ("exclude-global", None, True, 5),
+            ("only-global", None, True, 5),
         ]
 
         from marqo.tensor_search.models.score_modifiers_object import ScoreModifierLists
 
-        for phase, add_weight, use_score_mods in test_cases:
-            with self.subTest(phase=phase, add_to_score_weight=add_weight, score_mods=use_score_mods):
+        for phase, add_weight, use_score_mods, rerank_depth in test_cases:
+            with self.subTest(phase=phase, add_to_score_weight=add_weight, score_mods=use_score_mods, rerank_depth=rerank_depth):
                 # 1. Build score modifiers (if enabled)
                 score_mods = None
                 multiply_weights = None
@@ -942,7 +977,8 @@ class TestRecencyScoring(MarqoTestCase):
                         scoreModifiersLexical=score_mods,
                     ),
                     score_modifiers=score_mods,
-                    result_count=20
+                    result_count=20,
+                    rerank_depth=rerank_depth,  # Controls global phase processing (score modifiers + recency)
                 )
                 baseline_scores = self._extract_scores(baseline_result['hits'])
 
@@ -971,7 +1007,8 @@ class TestRecencyScoring(MarqoTestCase):
                     ),
                     recency_parameters=recency_params,
                     score_modifiers=score_mods,
-                    result_count=20
+                    result_count=20,
+                    rerank_depth=rerank_depth,  # Controls global phase processing (score modifiers + recency)
                 )
                 recency_scores = self._extract_scores(recency_result['hits'])
 
@@ -979,7 +1016,8 @@ class TestRecencyScoring(MarqoTestCase):
                 self._verify_phase_score_changes(
                     baseline_scores, recency_scores, phase, add_weight,
                     multiply_weights=multiply_weights,
-                    add_weights=add_weights
+                    add_weights=add_weights,
+                    rerank_depth=rerank_depth
                 )
 
     # ============== Retrieval/Ranking Method Combinations ==============

--- a/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
@@ -1204,6 +1204,8 @@ class TestRecencyScoring(MarqoTestCase):
         # 2. Verify recency scores are calculated correctly for each doc
         self._verify_recency_behavior(hits, recency_params)
 
+    @pytest.mark.skip_for_multinode(
+        "Multi-nodes will return different lexical results so we can not assert on the results.")
     def test_with_collapsing_field(self):
         """Test recency + collapsing field picks highest scoring variant per parent.
 

--- a/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
@@ -88,18 +88,24 @@ class TestRecencyScoring(MarqoTestCase):
 
     # ============== Helper Methods ==============
     def _generate_shared_documents(self) -> List[Dict[str, Any]]:
-        """Generate shared documents with various ages and attributes.
+        """Generate shared documents with various ages (past and future) and attributes.
 
-        Price groupings for sortBy tie-breaker testing:
+        Price groupings for sortBy tie-breaker testing (past docs):
         - Price 100: doc-0d, doc-3d, doc-7d (newer docs should rank first within group)
         - Price 80: doc-1d, doc-5d, doc-14d
         - Price 60: doc-10d, doc-30d
         - Price 40: doc-60d, doc-90d
+
+        Future docs (for grow testing):
+        - Price 120: doc+1d, doc+3d, doc+7d, doc+14d, doc+30d
         """
         now = datetime.now()
 
-        # Document ages: 0, 1, 3, 5, 7, 10, 14, 30, 60, 90 days
-        ages_in_days = [0, 1, 3, 5, 7, 10, 14, 30, 60, 90]
+        # Past document ages: 0, 1, 3, 5, 7, 10, 14, 30, 60, 90 days ago
+        past_ages_in_days = [0, 1, 3, 5, 7, 10, 14, 30, 60, 90]
+
+        # Future document offsets: 1, 3, 7, 14, 30 days from now
+        future_offsets_in_days = [1, 3, 7, 14, 30]
 
         # Price groups - documents with same price will test tie-breaking by recency
         price_map = {
@@ -110,7 +116,9 @@ class TestRecencyScoring(MarqoTestCase):
         }
 
         documents = []
-        for i, age_days in enumerate(ages_in_days):
+
+        # Add past documents
+        for i, age_days in enumerate(past_ages_in_days):
             timestamp = (now - timedelta(days=age_days)).timestamp()
             documents.append({
                 "_id": f"doc-{age_days}d",
@@ -119,6 +127,19 @@ class TestRecencyScoring(MarqoTestCase):
                 "timestamp": timestamp,
                 "price": price_map[age_days],  # Deliberate duplicates for tie-breaker testing
                 "parent_id": f"group-{chr(65 + i % 5)}",  # A-E rotation
+                "mult": 1.0 + (i % 3) * 0.5,  # 1.0, 1.5, 2.0
+            })
+
+        # Add future documents (for grow parameter testing)
+        for i, offset_days in enumerate(future_offsets_in_days):
+            timestamp = (now + timedelta(days=offset_days)).timestamp()
+            documents.append({
+                "_id": f"doc+{offset_days}d",
+                "title": "product item",
+                "description": f"test product scheduled for {offset_days} days from now",
+                "timestamp": timestamp,
+                "price": 120,  # All future docs have same price (higher than past)
+                "parent_id": f"group-{chr(71 + i % 3)}",  # G-I rotation for future docs
                 "mult": 1.0 + (i % 3) * 0.5,  # 1.0, 1.5, 2.0
             })
 
@@ -304,42 +325,115 @@ class TestRecencyScoring(MarqoTestCase):
         scale: str,
         offset: str,
         decay_function: str,
-        decay_to: float
+        decay_to: float,
+        grow_enabled: bool = False,
+        grow_from: float = 0.5,
+        grow_function: str = None,  # Defaults to decay_function
+        grow_scale: str = None,  # Defaults to scale
+        grow_offset: str = None,  # Defaults to "0d"
     ) -> float:
-        """Calculate expected recency score using ES-compatible formulas."""
+        """Calculate expected recency score matching the rank profile logic.
+
+        Unified logic handles both decay (past) and grow (future) timestamps:
+        - age_seconds > 0: past document, use decay logic
+        - age_seconds < 0: future document, use grow logic (if enabled) or return 1.0
+        - age_seconds == 0: current document, score = 1.0
+        """
         scale_seconds = self._parse_duration_to_seconds(scale)
         offset_seconds = self._parse_duration_to_seconds(offset)
 
-        effective_age = max(0.0, age_seconds - offset_seconds)
+        # Handle grow parameter defaults
+        if grow_function is None:
+            grow_function = decay_function
+        if grow_scale is None:
+            grow_scale = scale
+        if grow_offset is None:
+            grow_offset = "0d"
 
+        grow_scale_seconds = self._parse_duration_to_seconds(grow_scale)
+        grow_offset_seconds = self._parse_duration_to_seconds(grow_offset)
+
+        # Past document (age >= 0): use decay logic
+        if age_seconds >= 0:
+            # Check if beyond decay range (very old)
+            if age_seconds >= scale_seconds + offset_seconds:
+                return decay_to
+
+            # Check if within offset grace period
+            if age_seconds < offset_seconds:
+                return 1.0
+
+            # Calculate decay score
+            effective_age = age_seconds - offset_seconds
+            return self._calculate_function_score(
+                effective_age, scale_seconds, decay_to, decay_function
+            )
+
+        # Future document (age < 0): use grow logic if enabled
+        if not grow_enabled:
+            return 1.0
+
+        future_age = -age_seconds  # Convert to positive
+
+        # Check if within grow offset plateau zone
+        if future_age <= grow_offset_seconds:
+            return 1.0
+
+        # Check if beyond grow range (far future)
+        if future_age >= grow_offset_seconds + grow_scale_seconds:
+            return grow_from
+
+        # Calculate grow score
+        effective_future_age = future_age - grow_offset_seconds
+        return self._calculate_function_score(
+            effective_future_age, grow_scale_seconds, grow_from, grow_function
+        )
+
+    def _calculate_function_score(
+        self,
+        effective_age: float,
+        scale_seconds: float,
+        floor_value: float,
+        function_type: str
+    ) -> float:
+        """Calculate score using specified decay/grow function.
+
+        Both decay and grow use the same mathematical functions:
+        - At effective_age=0: score = 1.0
+        - At effective_age=scale: score = floor_value
+        - Beyond scale: score = floor_value (clamped)
+        """
         if effective_age == 0:
             return 1.0
 
-        if decay_function == "exponential":
-            # λ = ln(decay_to) / scale
-            # score = max(decay_to, exp(λ × effective_age))
-            lambda_val = math.log(decay_to) / scale_seconds
-            score = math.exp(lambda_val * effective_age)
-        elif decay_function == "linear":
-            # score = max(decay_to, (scale - effective_age × (1 - decay_to)) / scale)
-            score = (scale_seconds - effective_age * (1.0 - decay_to)) / scale_seconds
-        elif decay_function == "gaussian":
-            # σ² = -scale² / (2 × ln(decay_to))
-            # score = max(decay_to, exp(-effective_age² / (2σ²)))
-            # Simplified: score = max(decay_to, exp(effective_age² × ln(decay_to) / scale²))
+        if function_type == "exponential":
+            # λ = ln(floor_value) / scale
+            # score = exp(λ × effective_age)
+            score = math.exp(math.log(floor_value) * effective_age / scale_seconds)
+        elif function_type == "linear":
+            # score = (scale - effective_age × (1 - floor_value)) / scale
+            score = (scale_seconds - effective_age * (1.0 - floor_value)) / scale_seconds
+        elif function_type == "gaussian":
+            # score = exp(effective_age² × ln(floor_value) / scale²)
             score = math.exp(
-                pow(effective_age, 2) * math.log(decay_to) / pow(scale_seconds, 2)
+                pow(effective_age, 2) * math.log(floor_value) / pow(scale_seconds, 2)
             )
-        elif decay_function == "binary":
-            # score = 1.0 if effective_age < scale else decay_to
-            score = 1.0 if effective_age < scale_seconds else decay_to
+        elif function_type == "binary":
+            # score = 1.0 if effective_age < scale else floor_value
+            score = 1.0 if effective_age < scale_seconds else floor_value
         else:
-            raise ValueError(f"Unknown decay function: {decay_function}")
+            raise ValueError(f"Unknown function type: {function_type}")
 
-        return max(decay_to, score)
+        return max(floor_value, score)
 
     def _get_doc_age_seconds(self, hit: Dict) -> Optional[float]:
-        """Get the age in seconds for a document based on its timestamp field."""
+        """Get the age in seconds for a document based on its timestamp field.
+
+        Returns:
+            - Positive value: past document (timestamp < now)
+            - Negative value: future document (timestamp > now)
+            - None: document has no timestamp field
+        """
         doc_id = hit.get('_id')
         if doc_id == "doc-no-ts":
             return None  # No timestamp
@@ -348,7 +442,7 @@ class TestRecencyScoring(MarqoTestCase):
         timestamp = hit.get('timestamp')
         if timestamp is not None:
             current_time = datetime.now().timestamp()
-            return max(0, current_time - timestamp)
+            return current_time - timestamp  # Can be negative for future docs
         return None
 
     # ============== Verification Helpers ==============
@@ -687,6 +781,7 @@ class TestRecencyScoring(MarqoTestCase):
         """Test recency + sortBy with recency as tie-breaker for equal prices.
 
         Documents have deliberate price duplicates:
+        - Price 120: doc+1d, doc+3d, doc+7d, doc+14d, doc+30d (future docs)
         - Price 100: doc-0d, doc-3d, doc-7d
         - Price 80: doc-1d, doc-5d, doc-14d
         - Price 60: doc-10d, doc-30d
@@ -695,8 +790,10 @@ class TestRecencyScoring(MarqoTestCase):
 
         When sorted by price desc, documents with same price should be
         ordered by recency (newer docs first) as a tie-breaker.
+        Future docs all have score 1.0 (grow disabled), so their relative
+        order within price=120 group is non-deterministic.
 
-        Uses scale=120d to ensure all docs (up to 90 days old) have
+        Uses scale=120d to ensure all past docs (up to 90 days old) have
         distinct recency scores for proper tie-breaking.
         """
         self._add_shared_documents()
@@ -722,28 +819,46 @@ class TestRecencyScoring(MarqoTestCase):
             recency_parameters=recency_params,
             sort_by=sort_by,
             hybrid_parameters=HybridParameters(rerankDepthTensor=20),
-            result_count=15
+            result_count=20
         )
 
         hits = search_result['hits']
-
-        # 1. Verify exact order of hits
-        # Sorted by price desc, with recency as tie-breaker (newer docs first)
-        expected_order = [
-            "doc-0d", "doc-3d", "doc-7d",      # Price 100: newest to oldest
-            "doc-1d", "doc-5d", "doc-14d",     # Price 80: newest to oldest
-            "doc-10d", "doc-30d",              # Price 60: newest to oldest
-            "doc-60d", "doc-90d",              # Price 40: newest to oldest
-            "doc-no-ts",                       # Price 20: no timestamp
-        ]
         actual_order = [hit['_id'] for hit in hits]
-        self.assertListEqual(
-            expected_order,
-            actual_order,
-            "Results should be sorted by price desc, with recency as tie-breaker"
-        )
 
-        # 2. Verify recency scores are calculated correctly for each doc
+        # 1. Verify price ordering (groups should be in correct order)
+        # Future docs (price 120) should come first - order within group is non-deterministic
+        future_docs = {"doc+1d", "doc+3d", "doc+7d", "doc+14d", "doc+30d"}
+        price_100_docs = {"doc-0d", "doc-3d", "doc-7d"}
+        price_80_docs = {"doc-1d", "doc-5d", "doc-14d"}
+        price_60_docs = {"doc-10d", "doc-30d"}
+        price_40_docs = {"doc-60d", "doc-90d"}
+
+        # Verify docs are grouped by price (first 5 should be future, etc.)
+        self.assertEqual(set(actual_order[:5]), future_docs, "First 5 docs should be price 120 (future)")
+        self.assertEqual(set(actual_order[5:8]), price_100_docs, "Next 3 docs should be price 100")
+        self.assertEqual(set(actual_order[8:11]), price_80_docs, "Next 3 docs should be price 80")
+        self.assertEqual(set(actual_order[11:13]), price_60_docs, "Next 2 docs should be price 60")
+        self.assertEqual(set(actual_order[13:15]), price_40_docs, "Next 2 docs should be price 40")
+        self.assertEqual(actual_order[15], "doc-no-ts", "Last doc should be price 20")
+
+        # 2. Verify recency-based ordering within past doc groups (distinct scores)
+        # Price 100 group: doc-0d should be first, then doc-3d, then doc-7d
+        price_100_order = actual_order[5:8]
+        self.assertEqual(price_100_order, ["doc-0d", "doc-3d", "doc-7d"], "Price 100 group should be ordered by recency")
+
+        # Price 80 group: doc-1d should be first, then doc-5d, then doc-14d
+        price_80_order = actual_order[8:11]
+        self.assertEqual(price_80_order, ["doc-1d", "doc-5d", "doc-14d"], "Price 80 group should be ordered by recency")
+
+        # Price 60 group: doc-10d should be first, then doc-30d
+        price_60_order = actual_order[11:13]
+        self.assertEqual(price_60_order, ["doc-10d", "doc-30d"], "Price 60 group should be ordered by recency")
+
+        # Price 40 group: doc-60d should be first, then doc-90d
+        price_40_order = actual_order[13:15]
+        self.assertEqual(price_40_order, ["doc-60d", "doc-90d"], "Price 40 group should be ordered by recency")
+
+        # 3. Verify recency scores are calculated correctly for each doc
         self._verify_basic_recency_behavior(
             hits,
             decay_to=0.3,
@@ -755,18 +870,25 @@ class TestRecencyScoring(MarqoTestCase):
     def test_with_collapsing_field(self):
         """Test recency + collapsing field picks most recent variant per parent.
 
-        Document structure (parent_id uses A-E rotation):
-        - group-A: doc-0d (newest), doc-10d
-        - group-B: doc-1d (newest), doc-14d
-        - group-C: doc-3d (newest), doc-30d
-        - group-D: doc-5d (newest), doc-60d
-        - group-E: doc-7d (newest), doc-90d
-        - group-F: doc-no-ts (only variant)
+        Document structure:
+        Past docs (parent_id uses A-E rotation):
+        - group-A: doc-0d (newest, score<1), doc-10d
+        - group-B: doc-1d (newest, score<1), doc-14d
+        - group-C: doc-3d (newest, score<1), doc-30d
+        - group-D: doc-5d (newest, score<1), doc-60d
+        - group-E: doc-7d (newest, score<1), doc-90d
+        - group-F: doc-no-ts (only variant, score=0.3)
+
+        Future docs (parent_id uses G-I rotation, all have score=1.0 with grow disabled):
+        - group-G: doc+1d, doc+14d (both score=1.0)
+        - group-H: doc+3d, doc+30d (both score=1.0)
+        - group-I: doc+7d (only variant, score=1.0)
 
         With recency boosting, the most recent variant should be selected
-        for each parent group when collapsing.
+        for each parent group when collapsing. Future docs all have score=1.0
+        when grow is disabled, so they score higher than past docs.
 
-        Uses scale=120d to ensure all documents (up to 90 days old) have
+        Uses scale=120d to ensure all past docs (up to 90 days old) have
         distinct recency scores for proper variant selection.
         """
         # Add documents to collapse index
@@ -787,7 +909,7 @@ class TestRecencyScoring(MarqoTestCase):
             search_method=SearchMethod.HYBRID,
             recency_parameters=recency_params,
             collapse_field_name="parent_id",
-            result_count=10
+            result_count=15  # Increased to cover all groups
         )
 
         hits = search_result['hits']
@@ -809,8 +931,8 @@ class TestRecencyScoring(MarqoTestCase):
             )
 
         # 3. Verify the most recent variant is selected for each parent group
-        # Expected: newest variant should be picked for each group
-        expected_newest_variant = {
+        # For past doc groups: newest variant should be picked (distinct scores)
+        expected_newest_variant_past = {
             "group-A": "doc-0d",   # 0d is newer than 10d
             "group-B": "doc-1d",   # 1d is newer than 14d
             "group-C": "doc-3d",   # 3d is newer than 30d
@@ -819,14 +941,28 @@ class TestRecencyScoring(MarqoTestCase):
             "group-F": "doc-no-ts",  # Only variant
         }
 
+        # For future doc groups: all have score=1.0, closest to now wins
+        expected_newest_variant_future = {
+            "group-G": "doc+1d",   # 1d is closer than 14d
+            "group-H": "doc+3d",   # 3d is closer than 30d
+            "group-I": "doc+7d",   # Only variant
+        }
+
         for hit in hits:
             parent_id = hit.get('parent_id')
             doc_id = hit.get('_id')
-            if parent_id in expected_newest_variant:
-                expected_doc = expected_newest_variant[parent_id]
+
+            if parent_id in expected_newest_variant_past:
+                expected_doc = expected_newest_variant_past[parent_id]
                 self.assertEqual(
                     doc_id, expected_doc,
                     f"For {parent_id}, expected newest variant {expected_doc} but got {doc_id}"
+                )
+            elif parent_id in expected_newest_variant_future:
+                expected_doc = expected_newest_variant_future[parent_id]
+                self.assertEqual(
+                    doc_id, expected_doc,
+                    f"For {parent_id}, expected closest variant {expected_doc} but got {doc_id}"
                 )
 
     # ============== Negative Case Tests ==============
@@ -910,143 +1046,9 @@ class TestRecencyScoring(MarqoTestCase):
                     str(ctx.exception)
                 )
 
-    # ============== Additive Recency Scoring Tests ==============
-
-    def test_additive_recency_scoring(self):
-        """Test additive recency scoring with addToScoreWeight parameter.
-
-        When addToScoreWeight is provided, recency is applied additively:
-        final_score = modified_score + (recency_score * addToScoreWeight)
-
-        Instead of multiplicatively:
-        final_score = modified_score * recency_score
-        """
-        self._add_shared_documents()
-
-        # Test with different addToScoreWeight values
-        weight_values = [0.1, 0.5, 1.0, 2.0]
-
-        for weight in weight_values:
-            with self.subTest(addToScoreWeight=weight):
-                params = RecencyParameters(
-                    recency_field="timestamp",
-                    scale="7d",
-                    offset="0d",
-                    decay_function="exponential",
-                    decay_to=0.5,
-                    add_to_score_weight=weight
-                )
-                hits = self._search_with_recency("product", params)
-
-                self.assertGreater(len(hits), 0, "Should have results")
-
-                # Verify recency scores are calculated correctly
-                for hit in hits:
-                    actual_recency = hit.get('_recency_score')
-                    doc_id = hit.get('_id')
-
-                    self.assertIsNotNone(actual_recency, f"Recency score should be present for {doc_id}")
-
-                    # Verify recency score is within valid range [decay_to, 1.0]
-                    self.assertGreaterEqual(actual_recency, 0.5, f"Recency score for {doc_id} should be >= decay_to")
-                    self.assertLessEqual(actual_recency, 1.0, f"Recency score for {doc_id} should be <= 1.0")
-
-                # Verify newer docs score higher than older docs
-                doc_0d = self._get_doc_by_id(hits, "doc-0d")
-                doc_30d = self._get_doc_by_id(hits, "doc-30d")
-                if doc_0d and doc_30d:
-                    self.assertGreater(
-                        doc_0d['_recency_score'],
-                        doc_30d['_recency_score'],
-                        "Newer doc should have higher recency score"
-                    )
-
-    def test_additive_recency_vs_multiplicative(self):
-        """Test that additive and multiplicative recency produce different final scores.
-
-        With additive mode (addToScoreWeight > 0), very old documents get boosted more
-        relative to their base score compared to multiplicative mode where they get
-        penalized more heavily.
-        """
-        self._add_shared_documents()
-
-        base_params = {
-            "recency_field": "timestamp",
-            "scale": "7d",
-            "offset": "0d",
-            "decay_function": "exponential",
-            "decay_to": 0.3
-        }
-
-        # Get results without additive (multiplicative mode - default)
-        multiplicative_params = RecencyParameters(**base_params)
-        multiplicative_hits = self._search_with_recency("product", multiplicative_params)
-
-        # Get results with additive mode
-        additive_params = RecencyParameters(
-            **base_params,
-            add_to_score_weight=0.5
-        )
-        additive_hits = self._search_with_recency("product", additive_params)
-
-        # Both should return results
-        self.assertGreater(len(multiplicative_hits), 0, "Multiplicative should have results")
-        self.assertGreater(len(additive_hits), 0, "Additive should have results")
-
-        # Both should have the same recency scores (recency calculation is the same)
-        for mult_hit, add_hit in zip(multiplicative_hits, additive_hits):
-            if mult_hit['_id'] == add_hit['_id']:
-                self.assertAlmostEqual(
-                    mult_hit.get('_recency_score', 0),
-                    add_hit.get('_recency_score', 0),
-                    places=3,
-                    msg=f"Recency scores should be the same for {mult_hit['_id']}"
-                )
-
-    def test_additive_recency_with_hybrid_search_methods(self):
-        """Test additive recency works with different hybrid search configurations."""
-        self._add_shared_documents()
-
-        test_cases = [
-            (RetrievalMethod.Disjunction, RankingMethod.RRF),
-            (RetrievalMethod.Tensor, RankingMethod.Tensor),
-            (RetrievalMethod.Lexical, RankingMethod.Lexical),
-        ]
-
-        params = RecencyParameters(
-            recency_field="timestamp",
-            scale="7d",
-            offset="0d",
-            decay_function="exponential",
-            decay_to=0.5,
-            add_to_score_weight=0.5
-        )
-
-        for retrieval, ranking in test_cases:
-            with self.subTest(retrieval=retrieval.value, ranking=ranking.value):
-                hybrid_params = HybridParameters(
-                    retrievalMethod=retrieval,
-                    rankingMethod=ranking
-                )
-                search_result = tensor_search.search(
-                    config=self.config,
-                    index_name=self.main_index.name,
-                    text="product",
-                    search_method=SearchMethod.HYBRID,
-                    recency_parameters=params,
-                    hybrid_parameters=hybrid_params,
-                    result_count=10
-                )
-
-                hits = search_result['hits']
-                self.assertGreater(len(hits), 0, "Should have results")
-
-                # Verify recency scores are present
-                for hit in hits:
-                    self.assertIsNotNone(
-                        hit.get('_recency_score'),
-                        f"Recency score should be present for {hit['_id']}"
-                    )
+    # NOTE: Version check tests for grow and addToScoreWeight are in unit tests
+    # (test_hybrid_search.py::TestRecencyValidation) because integration tests
+    # cannot create indexes with old schema versions.
 
     # ============== Validation Tests ==============
 
@@ -1102,357 +1104,12 @@ class TestRecencyScoring(MarqoTestCase):
                         decay_to=0.5
                     )
 
+    def test_grow_from_validation(self):
+        """Test grow_from must be in (0.0, 1.0]."""
+        valid_values = [0.01, 0.5, 1.0]
+        invalid_values = [0.0, -0.1, 1.1]
 
-    # ============== Grow Parameter Tests ==============
-
-    def _generate_future_documents(self) -> List[Dict[str, Any]]:
-        """Generate documents with future timestamps for grow parameter testing.
-
-        Document ages (relative to now):
-        - Past documents: -7d, -3d, -1d (negative = in the past)
-        - Current: 0d
-        - Future documents: +1d, +3d, +7d, +14d, +30d (positive = in the future)
-        """
-        now = datetime.now()
-
-        # Mix of past, present, and future documents
-        time_offsets_days = [-7, -3, -1, 0, 1, 3, 7, 14, 30]
-
-        documents = []
-        for offset_days in time_offsets_days:
-            timestamp = (now + timedelta(days=offset_days)).timestamp()
-            if offset_days < 0:
-                doc_id = f"doc-past-{abs(offset_days)}d"
-            elif offset_days == 0:
-                doc_id = "doc-now"
-            else:
-                doc_id = f"doc-future-{offset_days}d"
-
-            documents.append({
-                "_id": doc_id,
-                "title": "event announcement",
-                "description": f"event scheduled for {offset_days} days from now",
-                "timestamp": timestamp,
-            })
-
-        return documents
-
-    def _add_future_documents(self, index=None):
-        """Add future timestamp documents to the specified or main index."""
-        if index is None:
-            index = self.main_index
-        documents = self._generate_future_documents()
-        add_docs_params = AddDocsParams(
-            index_name=index.name,
-            docs=documents,
-            tensor_fields=["title", "description"]
-        )
-        self.add_documents(self.config, add_docs_params)
-
-    def _calculate_expected_grow_score(
-        self,
-        future_age_seconds: float,
-        grow_scale: str,
-        grow_offset: str,
-        grow_function: str,
-        grow_from: float
-    ) -> float:
-        """Calculate expected grow score using the same formulas as decay (mirrored)."""
-        scale_seconds = self._parse_duration_to_seconds(grow_scale)
-        offset_seconds = self._parse_duration_to_seconds(grow_offset)
-
-        # Future age after subtracting offset (plateau zone)
-        effective_future_age = max(0.0, future_age_seconds - offset_seconds)
-
-        if effective_future_age == 0:
-            return 1.0
-
-        if grow_function == "exponential":
-            # Mirror of decay: score approaches grow_from at scale
-            score = 1.0 - (1.0 - grow_from) * math.exp(
-                math.log(1.0 - grow_from) * effective_future_age / scale_seconds
-            )
-        elif grow_function == "linear":
-            score = 1.0 - (1.0 - grow_from) * effective_future_age / scale_seconds
-        elif grow_function == "gaussian":
-            score = 1.0 - (1.0 - grow_from) * (
-                1.0 - math.exp(pow(effective_future_age, 2) * math.log(grow_from) / pow(scale_seconds, 2))
-            )
-        elif grow_function == "binary":
-            score = 1.0 if effective_future_age < scale_seconds else grow_from
-        else:
-            raise ValueError(f"Unknown grow function: {grow_function}")
-
-        return max(grow_from, score)
-
-    def test_grow_disabled_by_default(self):
-        """Test future timestamps get score 1.0 when growFrom is not specified."""
-        self._add_future_documents()
-
-        # Without grow_from, future timestamps should get score 1.0
-        params = RecencyParameters(
-            recency_field="timestamp",
-            scale="7d",
-            offset="0d",
-            decay_function="exponential",
-            decay_to=0.5
-            # No grow_from specified
-        )
-        hits = self._search_with_recency("event", params)
-
-        self.assertGreater(len(hits), 0, "Should have results")
-
-        # Future documents should have score 1.0 when grow is disabled
-        for hit in hits:
-            doc_id = hit.get('_id')
-            recency_score = hit.get('_recency_score')
-            self.assertIsNotNone(recency_score, f"Recency score should be present for {doc_id}")
-
-            if doc_id.startswith("doc-future"):
-                self.assertAlmostEqual(
-                    recency_score, 1.0, places=2,
-                    msg=f"Future doc {doc_id} should have score 1.0 when grow disabled"
-                )
-
-    def test_grow_functions(self):
-        """Test all grow functions work correctly for future timestamps."""
-        self._add_future_documents()
-
-        for grow_func in ["exponential", "linear", "gaussian", "binary"]:
-            with self.subTest(function=grow_func):
-                params = RecencyParameters(
-                    recency_field="timestamp",
-                    scale="7d",
-                    offset="0d",
-                    decay_function="exponential",
-                    decay_to=0.5,
-                    grow_from=0.3,
-                    grow_function=grow_func,
-                    grow_scale="14d",
-                    grow_offset="0d"
-                )
-                hits = self._search_with_recency("event", params)
-
-                self.assertGreater(len(hits), 0, "Should have results")
-
-                # Verify future documents have grow scores applied
-                for hit in hits:
-                    doc_id = hit.get('_id')
-                    recency_score = hit.get('_recency_score')
-                    self.assertIsNotNone(recency_score, f"Recency score should be present for {doc_id}")
-
-                    if doc_id.startswith("doc-future"):
-                        # Score should be between grow_from and 1.0
-                        self.assertGreaterEqual(
-                            recency_score, 0.3,
-                            f"Future doc {doc_id} score should be >= grow_from"
-                        )
-                        self.assertLessEqual(
-                            recency_score, 1.0,
-                            f"Future doc {doc_id} score should be <= 1.0"
-                        )
-
-    def test_grow_with_decay(self):
-        """Test combined grow (future) and decay (past) behavior."""
-        self._add_future_documents()
-
-        params = RecencyParameters(
-            recency_field="timestamp",
-            scale="7d",
-            offset="0d",
-            decay_function="exponential",
-            decay_to=0.5,
-            grow_from=0.3,
-            grow_function="exponential",
-            grow_scale="14d",
-            grow_offset="0d"
-        )
-        hits = self._search_with_recency("event", params)
-
-        self.assertGreater(len(hits), 0, "Should have results")
-
-        # Categorize documents
-        past_docs = [h for h in hits if h['_id'].startswith("doc-past")]
-        future_docs = [h for h in hits if h['_id'].startswith("doc-future")]
-        now_doc = self._get_doc_by_id(hits, "doc-now")
-
-        # Verify now doc has score ~1.0
-        if now_doc:
-            self.assertAlmostEqual(
-                now_doc.get('_recency_score'), 1.0, places=1,
-                msg="Current timestamp should have score ~1.0"
-            )
-
-        # Verify past docs use decay (score between decay_to and 1.0)
-        for hit in past_docs:
-            recency_score = hit.get('_recency_score')
-            self.assertGreaterEqual(recency_score, 0.5, f"Past doc {hit['_id']} should use decay_to as floor")
-            self.assertLessEqual(recency_score, 1.0, f"Past doc {hit['_id']} should be <= 1.0")
-
-        # Verify future docs use grow (score between grow_from and 1.0)
-        for hit in future_docs:
-            recency_score = hit.get('_recency_score')
-            self.assertGreaterEqual(recency_score, 0.3, f"Future doc {hit['_id']} should use grow_from as floor")
-            self.assertLessEqual(recency_score, 1.0, f"Future doc {hit['_id']} should be <= 1.0")
-
-    def test_grow_defaults_to_decay_function(self):
-        """Test growFunction defaults to decayFunction when not specified."""
-        self._add_future_documents()
-
-        # When grow_function is not specified, it should default to decay_function
-        params = RecencyParameters(
-            recency_field="timestamp",
-            scale="7d",
-            offset="0d",
-            decay_function="linear",  # Using linear decay
-            decay_to=0.5,
-            grow_from=0.3,
-            # grow_function not specified - should default to "linear"
-            grow_scale="14d",
-            grow_offset="0d"
-        )
-        hits = self._search_with_recency("event", params)
-
-        self.assertGreater(len(hits), 0, "Should have results")
-
-        # Verify future documents have grow scores applied
-        for hit in hits:
-            doc_id = hit.get('_id')
-            recency_score = hit.get('_recency_score')
-
-            if doc_id.startswith("doc-future"):
-                # Score should be between grow_from and 1.0
-                self.assertGreaterEqual(
-                    recency_score, 0.3,
-                    f"Future doc {doc_id} score should be >= grow_from"
-                )
-
-    def test_grow_defaults_to_scale(self):
-        """Test growScale defaults to scale when not specified."""
-        self._add_future_documents()
-
-        # When grow_scale is not specified, it should default to scale
-        params = RecencyParameters(
-            recency_field="timestamp",
-            scale="14d",  # Using 14d scale
-            offset="0d",
-            decay_function="exponential",
-            decay_to=0.5,
-            grow_from=0.3,
-            grow_function="exponential",
-            # grow_scale not specified - should default to "14d"
-            grow_offset="0d"
-        )
-        hits = self._search_with_recency("event", params)
-
-        self.assertGreater(len(hits), 0, "Should have results")
-
-        # Verify future documents have grow scores applied
-        future_14d = self._get_doc_by_id(hits, "doc-future-14d")
-        if future_14d:
-            # At future_age = scale, exponential score equals grow_from (floor)
-            # Formula: exp(log(floor) * age / scale) = exp(log(floor)) = floor at age=scale
-            recency_score = future_14d.get('_recency_score')
-            # Score should be significantly less than 1.0, showing grow is applied
-            self.assertLess(
-                recency_score, 0.7,
-                f"Future doc at scale should have score significantly below 1.0"
-            )
-            # Score should be at or above grow_from floor (equals floor at exactly scale)
-            self.assertGreaterEqual(
-                recency_score, 0.3,
-                f"Future doc at scale should have score at or above grow_from"
-            )
-
-    def test_grow_offset_creates_plateau(self):
-        """Test growOffset creates plateau zone where score = 1.0."""
-        self._add_future_documents()
-
-        # With grow_offset=7d, documents with timestamps between now() and now()+7d
-        # should have score 1.0 (plateau zone)
-        params = RecencyParameters(
-            recency_field="timestamp",
-            scale="7d",
-            offset="0d",
-            decay_function="exponential",
-            decay_to=0.5,
-            grow_from=0.3,
-            grow_function="exponential",
-            grow_scale="14d",
-            grow_offset="7d"  # Plateau zone: now() to now()+7d
-        )
-        hits = self._search_with_recency("event", params)
-
-        self.assertGreater(len(hits), 0, "Should have results")
-
-        # Documents in plateau zone (1d, 3d, 7d) should have score ~1.0
-        plateau_docs = ["doc-future-1d", "doc-future-3d", "doc-future-7d"]
-        for doc_id in plateau_docs:
-            hit = self._get_doc_by_id(hits, doc_id)
-            if hit:
-                recency_score = hit.get('_recency_score')
-                self.assertAlmostEqual(
-                    recency_score, 1.0, places=1,
-                    msg=f"Doc {doc_id} within plateau should have score ~1.0"
-                )
-
-        # Documents beyond plateau (14d, 30d) should have score < 1.0
-        beyond_plateau_docs = ["doc-future-14d", "doc-future-30d"]
-        for doc_id in beyond_plateau_docs:
-            hit = self._get_doc_by_id(hits, doc_id)
-            if hit:
-                recency_score = hit.get('_recency_score')
-                self.assertLess(
-                    recency_score, 1.0,
-                    msg=f"Doc {doc_id} beyond plateau should have score < 1.0"
-                )
-
-    def test_grow_binary_function(self):
-        """Test binary grow function creates step function at scale."""
-        self._add_future_documents()
-
-        params = RecencyParameters(
-            recency_field="timestamp",
-            scale="7d",
-            offset="0d",
-            decay_function="exponential",
-            decay_to=0.5,
-            grow_from=0.2,
-            grow_function="binary",
-            grow_scale="10d",  # Step at 10 days
-            grow_offset="0d"
-        )
-        hits = self._search_with_recency("event", params)
-
-        self.assertGreater(len(hits), 0, "Should have results")
-
-        # Documents within scale (1d, 3d, 7d) should have score 1.0
-        within_scale_docs = ["doc-future-1d", "doc-future-3d", "doc-future-7d"]
-        for doc_id in within_scale_docs:
-            hit = self._get_doc_by_id(hits, doc_id)
-            if hit:
-                recency_score = hit.get('_recency_score')
-                self.assertAlmostEqual(
-                    recency_score, 1.0, places=1,
-                    msg=f"Doc {doc_id} within binary scale should have score 1.0"
-                )
-
-        # Documents beyond scale (14d, 30d) should have score = grow_from
-        beyond_scale_docs = ["doc-future-14d", "doc-future-30d"]
-        for doc_id in beyond_scale_docs:
-            hit = self._get_doc_by_id(hits, doc_id)
-            if hit:
-                recency_score = hit.get('_recency_score')
-                self.assertAlmostEqual(
-                    recency_score, 0.2, places=1,
-                    msg=f"Doc {doc_id} beyond binary scale should have score ~grow_from"
-                )
-
-    def test_grow_parameters_validation(self):
-        """Test grow parameter validation."""
-        # Valid grow_from values
-        valid_grow_from = [0.01, 0.5, 1.0]
-        for val in valid_grow_from:
+        for val in valid_values:
             with self.subTest(grow_from=val, valid=True):
                 params = RecencyParameters(
                     recency_field="timestamp",
@@ -1463,9 +1120,7 @@ class TestRecencyScoring(MarqoTestCase):
                 )
                 self.assertEqual(params.grow_from, val)
 
-        # Invalid grow_from values
-        invalid_grow_from = [0.0, -0.1, 1.1]
-        for val in invalid_grow_from:
+        for val in invalid_values:
             with self.subTest(grow_from=val, valid=False):
                 with self.assertRaises(Exception):
                     RecencyParameters(
@@ -1474,6 +1129,551 @@ class TestRecencyScoring(MarqoTestCase):
                         decay_function="exponential",
                         decay_to=0.5,
                         grow_from=val
+                    )
+
+    def test_grow_function_validation(self):
+        """Test grow_function must be a valid function type."""
+        valid_functions = ["exponential", "linear", "gaussian", "binary"]
+        invalid_functions = ["invalid", "exp", "lin"]
+
+        for func in valid_functions:
+            with self.subTest(grow_function=func, valid=True):
+                params = RecencyParameters(
+                    recency_field="timestamp",
+                    scale="7d",
+                    decay_function="exponential",
+                    decay_to=0.5,
+                    grow_from=0.3,
+                    grow_function=func
+                )
+                self.assertEqual(params.grow_function, func)
+
+        for func in invalid_functions:
+            with self.subTest(grow_function=func, valid=False):
+                with self.assertRaises(Exception):
+                    RecencyParameters(
+                        recency_field="timestamp",
+                        scale="7d",
+                        decay_function="exponential",
+                        decay_to=0.5,
+                        grow_from=0.3,
+                        grow_function=func
+                    )
+
+    def test_grow_scale_validation(self):
+        """Test grow_scale must be a valid duration format."""
+        valid_formats = ["1d", "7d", "24h", "168h"]
+        invalid_formats = ["-1d", "abc", "0d"]
+
+        for fmt in valid_formats:
+            with self.subTest(grow_scale=fmt, valid=True):
+                params = RecencyParameters(
+                    recency_field="timestamp",
+                    scale="7d",
+                    decay_function="exponential",
+                    decay_to=0.5,
+                    grow_from=0.3,
+                    grow_scale=fmt
+                )
+                self.assertEqual(params.grow_scale, fmt)
+
+        for fmt in invalid_formats:
+            with self.subTest(grow_scale=fmt, valid=False):
+                with self.assertRaises(Exception):
+                    RecencyParameters(
+                        recency_field="timestamp",
+                        scale="7d",
+                        decay_function="exponential",
+                        decay_to=0.5,
+                        grow_from=0.3,
+                        grow_scale=fmt
+                    )
+
+    def test_grow_offset_validation(self):
+        """Test grow_offset must be a valid duration format."""
+        valid_formats = ["0d", "1d", "7d", "24h"]
+        invalid_formats = ["-1d", "abc"]
+
+        for fmt in valid_formats:
+            with self.subTest(grow_offset=fmt, valid=True):
+                params = RecencyParameters(
+                    recency_field="timestamp",
+                    scale="7d",
+                    decay_function="exponential",
+                    decay_to=0.5,
+                    grow_from=0.3,
+                    grow_offset=fmt
+                )
+                self.assertEqual(params.grow_offset, fmt)
+
+        for fmt in invalid_formats:
+            with self.subTest(grow_offset=fmt, valid=False):
+                with self.assertRaises(Exception):
+                    RecencyParameters(
+                        recency_field="timestamp",
+                        scale="7d",
+                        decay_function="exponential",
+                        decay_to=0.5,
+                        grow_from=0.3,
+                        grow_offset=fmt
+                    )
+
+    # ============== Grow Parameter Tests ==============
+
+    def _verify_grow_behavior(
+        self,
+        hits: List[Dict],
+        decay_to: float,
+        grow_from: float,
+        scale: str = "7d",
+        offset: str = "0d",
+        decay_function: str = "exponential",
+        grow_function: str = None,
+        grow_scale: str = None,
+        grow_offset: str = None,
+    ):
+        """Verify recency scores match expected values for both decay and grow.
+
+        Uses _calculate_expected_score which handles both past (decay) and future (grow).
+        """
+        if grow_function is None:
+            grow_function = decay_function
+        if grow_scale is None:
+            grow_scale = scale
+
+        for hit in hits:
+            actual_score = hit.get('_recency_score')
+            doc_id = hit.get('_id')
+
+            self.assertIsNotNone(actual_score, f"Recency score should be present for {doc_id}")
+
+            age_seconds = self._get_doc_age_seconds(hit)
+            if age_seconds is not None:
+                expected_score = self._calculate_expected_score(
+                    age_seconds=age_seconds,
+                    scale=scale,
+                    offset=offset,
+                    decay_function=decay_function,
+                    decay_to=decay_to,
+                    grow_enabled=True,
+                    grow_from=grow_from,
+                    grow_function=grow_function,
+                    grow_scale=grow_scale,
+                    grow_offset=grow_offset,
+                )
+                self.assertAlmostEqual(
+                    actual_score,
+                    expected_score,
+                    places=3,
+                    msg=f"Score mismatch for {doc_id}: expected {expected_score:.4f}, got {actual_score:.4f}"
+                )
+            elif doc_id == "doc-no-ts":
+                # Document without timestamp should get decay_to
+                self.assertAlmostEqual(
+                    actual_score,
+                    decay_to,
+                    places=3,
+                    msg=f"Doc without timestamp should have decay_to score"
+                )
+
+    def test_grow_disabled_by_default(self):
+        """Test future timestamps get score 1.0 when growFrom is not specified.
+
+        Shared documents include:
+        - Past docs: doc-0d, doc-1d, doc-3d, ... doc-90d (use decay)
+        - Future docs: doc+1d, doc+3d, doc+7d, doc+14d, doc+30d (all score 1.0)
+        """
+        self._add_shared_documents()
+
+        # Without grow_from, future timestamps should get score 1.0
+        params = RecencyParameters(
+            recency_field="timestamp",
+            scale="7d",
+            offset="0d",
+            decay_function="exponential",
+            decay_to=0.5
+            # No grow_from specified - grow disabled
+        )
+        hits = self._search_with_recency("product", params)
+
+        self.assertGreater(len(hits), 0, "Should have results")
+
+        # Verify all future documents have score exactly 1.0
+        for hit in hits:
+            doc_id = hit.get('_id')
+            recency_score = hit.get('_recency_score')
+            self.assertIsNotNone(recency_score, f"Recency score should be present for {doc_id}")
+
+            if doc_id.startswith("doc+"):
+                self.assertAlmostEqual(
+                    recency_score, 1.0, places=3,
+                    msg=f"Future doc {doc_id} should have score 1.0 when grow disabled"
+                )
+
+        # Verify past docs still use decay correctly
+        self._verify_basic_recency_behavior(
+            [h for h in hits if not h['_id'].startswith("doc+")],
+            decay_to=0.5,
+            scale="7d",
+            offset="0d",
+            decay_function="exponential"
+        )
+
+    def test_grow_functions(self):
+        """Test all grow functions work correctly with precise score verification.
+
+        Fixed decay params: scale=120d, decay_to=0.3, offset=0d, exponential
+        Tests each grow function: exponential, linear, gaussian, binary
+        """
+        self._add_shared_documents()
+
+        for grow_func in ["exponential", "linear", "gaussian", "binary"]:
+            with self.subTest(function=grow_func):
+                params = RecencyParameters(
+                    recency_field="timestamp",
+                    scale="120d",  # Large decay scale so past docs are distinct
+                    offset="0d",
+                    decay_function="exponential",
+                    decay_to=0.3,
+                    grow_from=0.2,
+                    grow_function=grow_func,
+                    grow_scale="60d",  # Grow scale covers future docs
+                    grow_offset="0d"
+                )
+                hits = self._search_with_recency("product", params)
+
+                self.assertGreater(len(hits), 0, "Should have results")
+
+                # Verify exact scores for all documents
+                self._verify_grow_behavior(
+                    hits,
+                    decay_to=0.3,
+                    grow_from=0.2,
+                    scale="120d",
+                    offset="0d",
+                    decay_function="exponential",
+                    grow_function=grow_func,
+                    grow_scale="60d",
+                    grow_offset="0d"
+                )
+
+    def test_grow_with_decay(self):
+        """Test combined grow (future) and decay (past) with precise score verification.
+
+        Verifies:
+        - doc-0d has score ~1.0 (current)
+        - Past docs have decay scores in [decay_to, 1.0]
+        - Future docs have grow scores in [grow_from, 1.0]
+        """
+        self._add_shared_documents()
+
+        params = RecencyParameters(
+            recency_field="timestamp",
+            scale="120d",
+            offset="0d",
+            decay_function="exponential",
+            decay_to=0.5,
+            grow_from=0.3,
+            grow_function="exponential",
+            grow_scale="60d",
+            grow_offset="0d"
+        )
+        hits = self._search_with_recency("product", params)
+
+        self.assertGreater(len(hits), 0, "Should have results")
+
+        # Verify all scores precisely
+        self._verify_grow_behavior(
+            hits,
+            decay_to=0.5,
+            grow_from=0.3,
+            scale="120d",
+            offset="0d",
+            decay_function="exponential",
+            grow_function="exponential",
+            grow_scale="60d",
+            grow_offset="0d"
+        )
+
+        # Additional category checks
+        doc_0d = self._get_doc_by_id(hits, "doc-0d")
+        if doc_0d:
+            self.assertAlmostEqual(
+                doc_0d.get('_recency_score'), 1.0, places=2,
+                msg="doc-0d should have score ~1.0"
+            )
+
+        # Verify decay/grow floor bounds
+        for hit in hits:
+            doc_id = hit.get('_id')
+            score = hit.get('_recency_score')
+
+            if doc_id.startswith("doc-") and doc_id != "doc-0d" and doc_id != "doc-no-ts":
+                self.assertGreaterEqual(score, 0.5, f"Past doc {doc_id} should be >= decay_to")
+                self.assertLessEqual(score, 1.0, f"Past doc {doc_id} should be <= 1.0")
+            elif doc_id.startswith("doc+"):
+                self.assertGreaterEqual(score, 0.3, f"Future doc {doc_id} should be >= grow_from")
+                self.assertLessEqual(score, 1.0, f"Future doc {doc_id} should be <= 1.0")
+
+    def test_grow_defaults_to_decay_function(self):
+        """Test growFunction defaults to decayFunction when not specified.
+
+        Use linear decay and verify future docs also use linear grow.
+        """
+        self._add_shared_documents()
+
+        # grow_function not specified - should default to decay_function (linear)
+        params = RecencyParameters(
+            recency_field="timestamp",
+            scale="120d",
+            offset="0d",
+            decay_function="linear",
+            decay_to=0.5,
+            grow_from=0.3,
+            # grow_function not specified
+            grow_scale="60d",
+            grow_offset="0d"
+        )
+        hits = self._search_with_recency("product", params)
+
+        self.assertGreater(len(hits), 0, "Should have results")
+
+        # Verify scores with linear grow function (defaults from decay)
+        self._verify_grow_behavior(
+            hits,
+            decay_to=0.5,
+            grow_from=0.3,
+            scale="120d",
+            offset="0d",
+            decay_function="linear",
+            grow_function="linear",  # Defaults to decay_function
+            grow_scale="60d",
+            grow_offset="0d"
+        )
+
+    def test_grow_defaults_to_scale(self):
+        """Test growScale defaults to scale when not specified.
+
+        Use scale=30d and verify grow also uses 30d scale.
+        """
+        self._add_shared_documents()
+
+        # grow_scale not specified - should default to scale
+        params = RecencyParameters(
+            recency_field="timestamp",
+            scale="30d",
+            offset="0d",
+            decay_function="exponential",
+            decay_to=0.5,
+            grow_from=0.3,
+            grow_function="exponential",
+            # grow_scale not specified - defaults to scale
+            grow_offset="0d"
+        )
+        hits = self._search_with_recency("product", params)
+
+        self.assertGreater(len(hits), 0, "Should have results")
+
+        # Verify scores with grow_scale=30d (defaults from scale)
+        self._verify_grow_behavior(
+            hits,
+            decay_to=0.5,
+            grow_from=0.3,
+            scale="30d",
+            offset="0d",
+            decay_function="exponential",
+            grow_function="exponential",
+            grow_scale="30d",  # Defaults to scale
+            grow_offset="0d"
+        )
+
+        # Specifically check doc+30d - at exactly scale, score should be at grow_from
+        doc_30d_future = self._get_doc_by_id(hits, "doc+30d")
+        if doc_30d_future:
+            recency_score = doc_30d_future.get('_recency_score')
+            self.assertAlmostEqual(
+                recency_score, 0.3, places=2,
+                msg="Future doc at exactly scale should have score ~grow_from"
+            )
+
+    def test_grow_offset_creates_plateau(self):
+        """Test growOffset creates plateau zone where score = 1.0.
+
+        With grow_offset=10d:
+        - doc+1d, doc+3d, doc+7d should be in plateau (score = 1.0)
+        - doc+14d, doc+30d should be beyond plateau (score < 1.0)
+        """
+        self._add_shared_documents()
+
+        params = RecencyParameters(
+            recency_field="timestamp",
+            scale="120d",
+            offset="0d",
+            decay_function="exponential",
+            decay_to=0.5,
+            grow_from=0.3,
+            grow_function="exponential",
+            grow_scale="60d",
+            grow_offset="10d"  # Plateau zone: now() to now()+10d
+        )
+        hits = self._search_with_recency("product", params)
+
+        self.assertGreater(len(hits), 0, "Should have results")
+
+        # Verify scores with grow_offset plateau
+        self._verify_grow_behavior(
+            hits,
+            decay_to=0.5,
+            grow_from=0.3,
+            scale="120d",
+            offset="0d",
+            decay_function="exponential",
+            grow_function="exponential",
+            grow_scale="60d",
+            grow_offset="10d"
+        )
+
+        # Documents in plateau zone (1d, 3d, 7d < 10d) should have score 1.0
+        plateau_docs = ["doc+1d", "doc+3d", "doc+7d"]
+        for doc_id in plateau_docs:
+            hit = self._get_doc_by_id(hits, doc_id)
+            if hit:
+                recency_score = hit.get('_recency_score')
+                self.assertAlmostEqual(
+                    recency_score, 1.0, places=2,
+                    msg=f"Doc {doc_id} within plateau should have score 1.0"
+                )
+
+        # Documents beyond plateau (14d, 30d > 10d) should have score < 1.0
+        beyond_plateau_docs = ["doc+14d", "doc+30d"]
+        for doc_id in beyond_plateau_docs:
+            hit = self._get_doc_by_id(hits, doc_id)
+            if hit:
+                recency_score = hit.get('_recency_score')
+                self.assertLess(
+                    recency_score, 1.0,
+                    msg=f"Doc {doc_id} beyond plateau should have score < 1.0"
+                )
+
+    def test_grow_binary_function(self):
+        """Test binary grow function creates step function at scale.
+
+        With grow_scale=10d:
+        - doc+1d, doc+3d, doc+7d (< 10d) should have score 1.0
+        - doc+14d, doc+30d (>= 10d) should have score = grow_from
+        """
+        self._add_shared_documents()
+
+        params = RecencyParameters(
+            recency_field="timestamp",
+            scale="120d",
+            offset="0d",
+            decay_function="exponential",
+            decay_to=0.5,
+            grow_from=0.2,
+            grow_function="binary",
+            grow_scale="10d",  # Step at 10 days
+            grow_offset="0d"
+        )
+        hits = self._search_with_recency("product", params)
+
+        self.assertGreater(len(hits), 0, "Should have results")
+
+        # Verify exact scores with binary grow
+        self._verify_grow_behavior(
+            hits,
+            decay_to=0.5,
+            grow_from=0.2,
+            scale="120d",
+            offset="0d",
+            decay_function="exponential",
+            grow_function="binary",
+            grow_scale="10d",
+            grow_offset="0d"
+        )
+
+        # Documents within scale (< 10d) should have score 1.0
+        within_scale_docs = ["doc+1d", "doc+3d", "doc+7d"]
+        for doc_id in within_scale_docs:
+            hit = self._get_doc_by_id(hits, doc_id)
+            if hit:
+                recency_score = hit.get('_recency_score')
+                self.assertAlmostEqual(
+                    recency_score, 1.0, places=2,
+                    msg=f"Doc {doc_id} within binary scale should have score 1.0"
+                )
+
+        # Documents beyond scale (>= 10d) should have score = grow_from
+        beyond_scale_docs = ["doc+14d", "doc+30d"]
+        for doc_id in beyond_scale_docs:
+            hit = self._get_doc_by_id(hits, doc_id)
+            if hit:
+                recency_score = hit.get('_recency_score')
+                self.assertAlmostEqual(
+                    recency_score, 0.2, places=2,
+                    msg=f"Doc {doc_id} beyond binary scale should have score ~grow_from"
+                )
+
+    # ============== Add To Score Weight Tests ==============
+
+    def test_add_to_score_weight_values(self):
+        """Test addToScoreWeight with various weight values.
+
+        Fixed params: scale=7d, decay_to=0.5, grow_from=0.3, exponential
+        Tests weights: [0.1, 1.0, 10.0, 100.0] (must be > 0.0)
+
+        Verifies:
+        - Recency scores are calculated identically regardless of weight
+        - Different weights only affect final _score, not _recency_score
+        """
+        self._add_shared_documents()
+
+        weight_values = [0.1, 1.0, 10.0, 100.0]  # All must be > 0.0
+        results_by_weight = {}
+
+        for weight in weight_values:
+            with self.subTest(addToScoreWeight=weight):
+                params = RecencyParameters(
+                    recency_field="timestamp",
+                    scale="7d",
+                    offset="0d",
+                    decay_function="exponential",
+                    decay_to=0.5,
+                    grow_from=0.3,
+                    grow_function="exponential",
+                    grow_scale="7d",
+                    grow_offset="0d",
+                    add_to_score_weight=weight
+                )
+                hits = self._search_with_recency("product", params)
+
+                self.assertGreater(len(hits), 0, "Should have results")
+                results_by_weight[weight] = {h['_id']: h for h in hits}
+
+                # Verify recency scores match expected values
+                self._verify_grow_behavior(
+                    hits,
+                    decay_to=0.5,
+                    grow_from=0.3,
+                    scale="7d",
+                    offset="0d",
+                    decay_function="exponential",
+                    grow_function="exponential",
+                    grow_scale="7d",
+                    grow_offset="0d"
+                )
+
+        # Verify recency scores are identical across all weight values
+        base_results = results_by_weight[0.1]
+        for weight in [1.0, 10.0, 100.0]:
+            for doc_id, base_hit in base_results.items():
+                if doc_id in results_by_weight[weight]:
+                    other_hit = results_by_weight[weight][doc_id]
+                    self.assertAlmostEqual(
+                        base_hit.get('_recency_score', 0),
+                        other_hit.get('_recency_score', 0),
+                        places=3,
+                        msg=f"Recency scores should be identical for {doc_id} across weights"
                     )
 
 

--- a/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
@@ -1350,18 +1350,18 @@ class TestRecencyScoring(MarqoTestCase):
         # Verify future documents have grow scores applied
         future_14d = self._get_doc_by_id(hits, "doc-future-14d")
         if future_14d:
-            # At future_age = scale, exponential score is ~0.51 for grow_from=0.3
-            # (score = 1.0 - 0.7 * exp(ln(0.7)) = 1.0 - 0.7 * 0.7 = 0.51)
+            # At future_age = scale, exponential score equals grow_from (floor)
+            # Formula: exp(log(floor) * age / scale) = exp(log(floor)) = floor at age=scale
             recency_score = future_14d.get('_recency_score')
             # Score should be significantly less than 1.0, showing grow is applied
             self.assertLess(
                 recency_score, 0.7,
                 f"Future doc at scale should have score significantly below 1.0"
             )
-            # Score should be above grow_from floor
-            self.assertGreater(
+            # Score should be at or above grow_from floor (equals floor at exactly scale)
+            self.assertGreaterEqual(
                 recency_score, 0.3,
-                f"Future doc at scale should have score above grow_from"
+                f"Future doc at scale should have score at or above grow_from"
             )
 
     def test_grow_offset_creates_plateau(self):

--- a/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
@@ -494,6 +494,131 @@ class TestRecencyScoring(MarqoTestCase):
         """Find document by ID in search results."""
         return next((h for h in hits if h.get('_id') == doc_id), None)
 
+    def _extract_scores(self, hits: List[Dict]) -> Dict[str, Dict[str, float]]:
+        """Extract score map: {doc_id: {lexical, tensor, score, recency}}"""
+        result = {}
+        for hit in hits:
+            doc_id = hit['_id']
+            result[doc_id] = {
+                'lexical': hit.get('_lexical_score'),
+                'tensor': hit.get('_tensor_score'),
+                'score': hit.get('_score'),
+                'recency': hit.get('_recency_score'),
+            }
+        return result
+
+    def _verify_phase_score_changes(
+        self,
+        baseline: Dict[str, Dict],
+        recency: Dict[str, Dict],
+        phase: str,
+        add_weight: Optional[float]
+    ):
+        """Verify scores changed according to apply_in_ranking_phase setting.
+
+        Verifies both:
+        1. Which scores changed based on phase setting
+        2. The actual score values match expected calculation:
+           - Multiplicative (add_weight=None): expected = original * recency
+           - Additive (add_weight provided): expected = original + recency * add_weight
+
+        Phase behavior:
+        - 'all': recency applied to lexical, tensor, AND global RRF score
+        - 'exclude-global': recency applied to lexical and tensor only
+        - 'only-global': recency applied to global RRF score only
+        """
+        common_docs = set(baseline.keys()) & set(recency.keys())
+        self.assertGreater(len(common_docs), 0, "Should have common docs")
+
+        # Find docs where recency was actually applied (score != 1.0)
+        affected_docs = [
+            doc_id for doc_id in common_docs
+            if recency[doc_id]['recency'] is not None
+            and abs(recency[doc_id]['recency'] - 1.0) > 0.01
+        ]
+        self.assertGreater(len(affected_docs), 0, "Should have docs affected by recency")
+
+        def calculate_expected(original: float, recency_score: float) -> float:
+            """Calculate expected score based on recency mode."""
+            if add_weight is not None:
+                return original + recency_score * add_weight
+            else:
+                return original * recency_score
+
+        for doc_id in affected_docs:
+            b = baseline[doc_id]
+            r = recency[doc_id]
+            recency_score = r['recency']
+
+            # Skip if missing score data
+            if b['lexical'] is None or b['tensor'] is None or b['score'] is None:
+                continue
+
+            if phase == "all":
+                # Lexical and tensor scores should be modified by recency
+                expected_lexical = calculate_expected(b['lexical'], recency_score)
+                expected_tensor = calculate_expected(b['tensor'], recency_score)
+
+                self.assertAlmostEqual(
+                    expected_lexical, r['lexical'], places=3,
+                    msg=f"Doc {doc_id}: lexical score mismatch. "
+                    f"Expected {expected_lexical:.6f}, got {r['lexical']:.6f}"
+                )
+                self.assertAlmostEqual(
+                    expected_tensor, r['tensor'], places=3,
+                    msg=f"Doc {doc_id}: tensor score mismatch. "
+                    f"Expected {expected_tensor:.6f}, got {r['tensor']:.6f}"
+                )
+                # RRF score: We can't verify exact value because RRF depends on ranks,
+                # and ranks may shift when recency modifies lexical/tensor scores.
+                # Just verify it changed from baseline (using relative difference > 1%).
+                # TODO calculate RRF based on the lexical/tensor ranking
+                # self.assertFalse(
+                #     math.isclose(b['score'], r['score'], rel_tol=0.01),
+                #     msg=f"Doc {doc_id}: RRF score should have changed. "
+                #     f"Baseline {b['score']:.6f}, got {r['score']:.6f}"
+                # )
+
+            elif phase == "exclude-global":
+                # Lexical and tensor modified by recency, but NOT the global RRF score
+                expected_lexical = calculate_expected(b['lexical'], recency_score)
+                expected_tensor = calculate_expected(b['tensor'], recency_score)
+
+                self.assertAlmostEqual(
+                    expected_lexical, r['lexical'], places=3,
+                    msg=f"Doc {doc_id}: lexical score mismatch. "
+                    f"Expected {expected_lexical:.6f}, got {r['lexical']:.6f}"
+                )
+                self.assertAlmostEqual(
+                    expected_tensor, r['tensor'], places=3,
+                    msg=f"Doc {doc_id}: tensor score mismatch. "
+                    f"Expected {expected_tensor:.6f}, got {r['tensor']:.6f}"
+                )
+                # Note: RRF score will change because inputs changed, but recency
+                # is NOT applied to RRF in global phase. We don't verify exact RRF
+                # value since it depends on ranking which may shift.
+                # TODO calculate RRF based on the lexical/tensor ranking
+
+            elif phase == "only-global":
+                # Lexical and tensor should remain unchanged
+                self.assertAlmostEqual(
+                    b['lexical'], r['lexical'], places=5,
+                    msg=f"Doc {doc_id}: lexical should be unchanged. "
+                    f"Baseline {b['lexical']:.6f}, got {r['lexical']:.6f}"
+                )
+                self.assertAlmostEqual(
+                    b['tensor'], r['tensor'], places=5,
+                    msg=f"Doc {doc_id}: tensor should be unchanged. "
+                    f"Baseline {b['tensor']:.6f}, got {r['tensor']:.6f}"
+                )
+                # RRF score should be modified by recency
+                expected_score = calculate_expected(b['score'], recency_score)
+                self.assertAlmostEqual(
+                    expected_score, r['score'], places=3,
+                    msg=f"Doc {doc_id}: RRF score mismatch. "
+                        f"Expected {expected_score:.6f}, got {r['score']:.6f}"
+                )
+
     # ============== Core Decay Function Tests ==============
 
     def test_decay_and_grow_functions(self):
@@ -621,74 +746,96 @@ class TestRecencyScoring(MarqoTestCase):
         # Verify past docs still use decay correctly
         self._verify_recency_behavior([h for h in hits if not h['_id'].startswith("doc+")], params)
 
-    # ============== Apply in Ranking Phase Tests ==============
+    # ============== Apply in Ranking Phase and Add To Score Weight Tests ==============
 
-    # TODO change this two verify if it's applied in different phases (with score mods)
-    def test_apply_in_ranking_phase_options(self):
-        """Test all apply_in_ranking_phase options."""
-        self._add_shared_documents()
+    def test_apply_in_ranking_phase_with_score_modifiers(self):
+        """Comprehensive test for apply_in_ranking_phase and add_to_score_weight.
 
-        for phase in ["all", "only-global", "exclude-global"]:
-            with self.subTest(phase=phase):
-                params = RecencyParameters(
-                    recency_field="timestamp",
-                    scale="7d",
-                    offset="0d",
-                    decay_function="exponential",
-                    decay_to=0.5,
-                    apply_in_ranking_phase=phase
-                )
-                hits = self._search_with_recency("product", params)
-                self._verify_recency_behavior(hits, params)
+        Verifies that recency scoring is applied correctly in different ranking phases:
+        - 'all': Recency modifies lexical_score, tensor_score, AND rrf_score
+        - 'exclude-global': Recency modifies lexical_score and tensor_score only
+        - 'only-global': Recency modifies rrf_score only
 
-    # ============== Add To Score Weight Tests ==============
-    # TODO verify this works
-    def test_add_to_score_weight_values(self):
-        """Test addToScoreWeight with various weight values.
-
-        Fixed params: scale=7d, decay_to=0.5, grow_from=0.3, exponential
-        Tests weights: [0.1, 1.0, 10.0, 100.0] (must be > 0.0)
-
-        Verifies:
-        - Recency scores are calculated identically regardless of weight
-        - Different weights only affect final _score, not _recency_score
+        Also tests:
+        - With and without score modifiers
+        - Different add_to_score_weight values (multiplicative vs additive)
         """
         self._add_shared_documents()
 
-        weight_values = [0.1, 1.0, 10.0, 100.0]  # All must be > 0.0
-        results_by_weight = {}
+        # Test configurations
+        test_cases = [
+            # (apply_in_ranking_phase, add_to_score_weight, use_score_modifiers)
+            ("all", None, True),           # Multiplicative, with score mods
+            ("all", None, False),          # Multiplicative, without score mods
+            ("all", 10.0, True),           # Additive, with score mods
+            ("exclude-global", None, True),
+            ("exclude-global", None, False),
+            ("exclude-global", 10.0, True),
+            ("only-global", None, True),
+            ("only-global", None, False),
+            ("only-global", 10.0, True),
+        ]
 
-        for weight in weight_values:
-            with self.subTest(addToScoreWeight=weight):
-                params = RecencyParameters(
+        from marqo.tensor_search.models.score_modifiers_object import ScoreModifierLists
+
+        for phase, add_weight, use_score_mods in test_cases:
+            with self.subTest(phase=phase, add_to_score_weight=add_weight, score_mods=use_score_mods):
+                # 1. Build score modifiers (if enabled)
+                score_mods = None
+                if use_score_mods:
+                    score_mods = ScoreModifierLists(
+                        multiply_score_by=[{"field_name": "mult", "weight": 5.0}],
+                        add_to_score=[{"field_name": "timestamp", "weight": 1e-8}]
+                    )
+
+                # 2. Baseline search: WITH score mods, WITHOUT recency
+                baseline_result = tensor_search.search(
+                    config=self.config,
+                    index_name=self.main_index.name,
+                    text="product",
+                    search_method=SearchMethod.HYBRID,
+                    hybrid_parameters=HybridParameters(
+                        scoreModifiersTensor=score_mods,
+                        scoreModifiersLexical=score_mods,
+                    ),
+                    score_modifiers=score_mods,
+                    result_count=20
+                )
+                baseline_scores = self._extract_scores(baseline_result['hits'])
+
+                # 3. Recency search: WITH score mods AND recency
+                recency_params = RecencyParameters(
                     recency_field="timestamp",
-                    scale="7d",
+                    scale="60d",  # Moderate scale for varied scores
                     offset="0d",
                     decay_function="exponential",
-                    decay_to=0.5,
-                    grow_from=0.3,
-                    grow_function="exponential",
-                    grow_scale="7d",
-                    grow_offset="0d",
-                    add_to_score_weight=weight
+                    decay_to=0.3,
+                    grow_from=0.2,
+                    grow_function="linear",
+                    grow_scale="45d",
+                    grow_offset="1d",
+                    apply_in_ranking_phase=phase,
+                    add_to_score_weight=add_weight
                 )
-                hits = self._search_with_recency("product", params)
+                recency_result = tensor_search.search(
+                    config=self.config,
+                    index_name=self.main_index.name,
+                    text="product",
+                    search_method=SearchMethod.HYBRID,
+                    hybrid_parameters=HybridParameters(
+                        scoreModifiersTensor=score_mods,
+                        scoreModifiersLexical=score_mods,
+                    ),
+                    recency_parameters=recency_params,
+                    score_modifiers=score_mods,
+                    result_count=20
+                )
+                recency_scores = self._extract_scores(recency_result['hits'])
 
-                self.assertGreater(len(hits), 0, "Should have results")
-                results_by_weight[weight] = {h['_id']: h for h in hits}
-
-        # Verify recency scores are identical across all weight values
-        base_results = results_by_weight[0.1]
-        for weight in [1.0, 10.0, 100.0]:
-            for doc_id, base_hit in base_results.items():
-                if doc_id in results_by_weight[weight]:
-                    other_hit = results_by_weight[weight][doc_id]
-                    self.assertAlmostEqual(
-                        base_hit.get('_recency_score', 0),
-                        other_hit.get('_recency_score', 0),
-                        places=3,
-                        msg=f"Recency scores should be identical for {doc_id} across weights"
-                    )
+                # 4. Verify scores changed according to phase setting
+                self._verify_phase_score_changes(
+                    baseline_scores, recency_scores, phase, add_weight
+                )
 
     # ============== Retrieval/Ranking Method Combinations ==============
 

--- a/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
@@ -914,7 +914,8 @@ class TestRecencyScoring(MarqoTestCase):
         self._verify_recency_behavior([h for h in hits if not h['_id'].startswith("doc+")], params)
 
     # ============== Apply in Ranking Phase and Add To Score Weight Tests ==============
-
+    @pytest.mark.skip_for_multinode(
+        "Multi-nodes will return different lexical results so we can not assert on the results.")
     def test_apply_in_ranking_phase_with_score_modifiers(self):
         """Comprehensive test for apply_in_ranking_phase and add_to_score_weight.
 

--- a/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
@@ -74,17 +74,35 @@ class TestRecencyScoring(MarqoTestCase):
             model=Model(name='hf/all-MiniLM-L6-v2')
         )
 
+        # 5. 2.24.7 does not support recency feature
+        cls.old_index_2247_request = cls.unstructured_marqo_index_request(
+            marqo_version="2.24.7",
+            schema_template_version="2.24.7",
+            model=Model(name='hf/all-MiniLM-L6-v2')
+        )
+
+        # 5. 2.24.8 does not support grow params and add_to_score_weight
+        cls.old_index_2248_request = cls.unstructured_marqo_index_request(
+            marqo_version="2.24.8",
+            schema_template_version="2.24.8",
+            model=Model(name='hf/all-MiniLM-L6-v2')
+        )
+
         cls.indexes = cls.create_indexes([
             cls.main_index_request,
             cls.collapse_index_request,
             cls.structured_index_request,
-            cls.relevance_cutoff_index_request
+            cls.relevance_cutoff_index_request,
+            cls.old_index_2247_request,
+            cls.old_index_2248_request
         ])
 
         cls.main_index = cls.indexes[0]
         cls.collapse_index = cls.indexes[1]
         cls.structured_index = cls.indexes[2]
         cls.relevance_cutoff_index = cls.indexes[3]
+        cls.old_index_2247 = cls.indexes[4]
+        cls.old_index_2248 = cls.indexes[5]
 
     # ============== Helper Methods ==============
     def _generate_shared_documents(self) -> List[Dict[str, Any]]:
@@ -93,35 +111,19 @@ class TestRecencyScoring(MarqoTestCase):
         Naming convention:
         - Past docs: doc-Xd where X is days ago (e.g., doc-0d = today, doc-7d = 7 days ago)
         - Future docs: doc+Xd where X is days in future (e.g., doc+1d = 1 day from now)
-
-        Price groupings for sortBy tie-breaker testing:
-        - Price 120: doc+1d, doc+3d, doc+7d, doc+14d, doc+30d (future docs)
-        - Price 100: doc-0d, doc-3d, doc-7d (past docs - newer)
-        - Price 80: doc-1d, doc-5d, doc-14d
-        - Price 60: doc-10d, doc-30d
-        - Price 40: doc-60d, doc-90d
-        - Price 20: doc-no-ts
-
-        Parent groupings for collapsing test (future and past docs mixed):
-        - group-A: doc-0d, doc-10d, doc+1d
-        - group-B: doc-1d, doc-14d, doc+3d
-        - group-C: doc-3d, doc-30d, doc+7d
-        - group-D: doc-5d, doc-60d, doc+14d
-        - group-E: doc-7d, doc-90d, doc+30d
-        - group-F: doc-no-ts
         """
         now = datetime.now()
 
         # Explicit config for each document: (price, parent_id, mult)
         # age > 0 means days in past, age < 0 means days in future
         doc_configs = {
-            # Future docs (negative ages = future timestamps) - Price 120
+            # Future docs (negative ages = future timestamps)
             # Mixed into same groups as past docs
-            -30: (120, "group-E", 1.0),   # doc+30d - with doc-7d, doc-90d
-            -14: (120, "group-D", 1.5),   # doc+14d - with doc-5d, doc-60d
-            -7:  (120, "group-C", 2.0),   # doc+7d - with doc-3d, doc-30d
-            -3:  (120, "group-B", 1.0),   # doc+3d - with doc-1d, doc-14d
-            -1:  (120, "group-A", 1.5),   # doc+1d - with doc-0d, doc-10d
+            -30: (80, "group-C", 1.0),   # doc+30d - with doc-3d, doc-30d: C
+            -14: (40, "group-D", 1.5),   # doc+14d - with doc-5d, doc-60d: D
+            -7:  (60, "group-E", 2.0),   # doc+7d - with doc-7d, doc-90d: E
+            -3:  (100, "group-A", 1.0),   # doc+3d - with doc-0d, doc-10d: A
+            -1:  (80, "group-B", 1.5),   # doc+1d - with doc-1d, doc-14d: B
 
             # Past docs (positive ages = past timestamps)
             0:   (100, "group-A", 2.0),   # doc-0d (today)
@@ -341,11 +343,10 @@ class TestRecencyScoring(MarqoTestCase):
         offset: str,
         decay_function: str,
         decay_to: float,
-        grow_enabled: bool = False,
-        grow_from: float = 0.5,
-        grow_function: str = None,  # Defaults to decay_function
-        grow_scale: str = None,  # Defaults to scale
-        grow_offset: str = None,  # Defaults to "0d"
+        grow_from: float = None,
+        grow_function: str = None,
+        grow_scale: str = None,
+        grow_offset: str = None,
     ) -> float:
         """Calculate expected recency score matching the rank profile logic.
 
@@ -356,17 +357,6 @@ class TestRecencyScoring(MarqoTestCase):
         """
         scale_seconds = self._parse_duration_to_seconds(scale)
         offset_seconds = self._parse_duration_to_seconds(offset)
-
-        # Handle grow parameter defaults
-        if grow_function is None:
-            grow_function = decay_function
-        if grow_scale is None:
-            grow_scale = scale
-        if grow_offset is None:
-            grow_offset = "0d"
-
-        grow_scale_seconds = self._parse_duration_to_seconds(grow_scale)
-        grow_offset_seconds = self._parse_duration_to_seconds(grow_offset)
 
         # Past document (age >= 0): use decay logic
         if age_seconds >= 0:
@@ -384,11 +374,13 @@ class TestRecencyScoring(MarqoTestCase):
                 effective_age, scale_seconds, decay_to, decay_function
             )
 
-        # Future document (age < 0): use grow logic if enabled
-        if not grow_enabled:
+        # Future document (age < 0): use grow logic if enabled, return 1.0 if not
+        if grow_from is None: # if not enabled
             return 1.0
 
         future_age = -age_seconds  # Convert to positive
+        grow_scale_seconds = self._parse_duration_to_seconds(grow_scale)
+        grow_offset_seconds = self._parse_duration_to_seconds(grow_offset)
 
         # Check if within grow offset plateau zone
         if future_age <= grow_offset_seconds:
@@ -462,13 +454,10 @@ class TestRecencyScoring(MarqoTestCase):
 
     # ============== Verification Helpers ==============
 
-    def _verify_basic_recency_behavior(
+    def _verify_recency_behavior(
         self,
         hits: List[Dict],
-        decay_to: float,
-        scale: str = "7d",
-        offset: str = "0d",
-        decay_function: str = "exponential"
+        recency_params: RecencyParameters
     ):
         """Verify recency scores match expected values within 3 decimal places."""
         self.assertGreater(len(hits), 0, "Should have results")
@@ -483,79 +472,23 @@ class TestRecencyScoring(MarqoTestCase):
             age_seconds = self._get_doc_age_seconds(hit)
             if age_seconds is not None:
                 expected_score = self._calculate_expected_score(
-                    age_seconds, scale, offset, decay_function, decay_to
+                    age_seconds, recency_params.scale, recency_params.offset, recency_params.decay_function, recency_params.decay_to,
+                    recency_params.grow_from, recency_params.grow_function, recency_params.grow_scale, recency_params.grow_offset
                 )
                 self.assertAlmostEqual(
-                    actual_score,
                     expected_score,
+                    actual_score,
                     places=3,
                     msg=f"Score mismatch for {doc_id}: expected {expected_score:.4f}, got {actual_score:.4f}"
                 )
             elif doc_id == "doc-no-ts":
                 # Document without timestamp should get decay_to
                 self.assertAlmostEqual(
+                    recency_params.decay_to,
                     actual_score,
-                    decay_to,
                     places=3,
                     msg=f"Doc without timestamp should have decay_to score"
                 )
-
-        # Verify newer docs score higher than older docs
-        doc_0d = self._get_doc_by_id(hits, "doc-0d")
-        doc_30d = self._get_doc_by_id(hits, "doc-30d")
-        if doc_0d and doc_30d:
-            self.assertGreater(
-                doc_0d['_recency_score'],
-                doc_30d['_recency_score'],
-                "Newer doc should have higher recency score"
-            )
-
-    def _verify_decay_to_floor(self, hits: List[Dict], decay_to: float):
-        """Verify that old documents floor at decay_to value."""
-        doc_90d = self._get_doc_by_id(hits, "doc-90d")
-        if doc_90d:
-            self.assertAlmostEqual(
-                doc_90d['_recency_score'],
-                decay_to,
-                places=3,
-                msg=f"Very old doc should be at decay_to floor ({decay_to})"
-            )
-
-    def _verify_offset_behavior(
-        self,
-        hits: List[Dict],
-        offset: str,
-        scale: str = "7d",
-        decay_function: str = "exponential",
-        decay_to: float = 0.5
-    ):
-        """Verify documents within offset have score ~1.0 and verify exact scores."""
-        offset_seconds = self._parse_duration_to_seconds(offset)
-
-        for hit in hits:
-            doc_id = hit.get('_id')
-            actual_score = hit.get('_recency_score')
-            age_seconds = self._get_doc_age_seconds(hit)
-
-            if age_seconds is not None:
-                expected_score = self._calculate_expected_score(
-                    age_seconds, scale, offset, decay_function, decay_to
-                )
-                self.assertAlmostEqual(
-                    actual_score,
-                    expected_score,
-                    places=3,
-                    msg=f"Score mismatch for {doc_id} with offset={offset}"
-                )
-
-                # Additional check: docs within offset should have score 1.0
-                if age_seconds < offset_seconds:
-                    self.assertAlmostEqual(
-                        actual_score,
-                        1.0,
-                        places=3,
-                        msg=f"Doc {doc_id} within offset should have score 1.0"
-                    )
 
     def _get_doc_by_id(self, hits: List[Dict], doc_id: str) -> Optional[Dict]:
         """Find document by ID in search results."""
@@ -563,23 +496,25 @@ class TestRecencyScoring(MarqoTestCase):
 
     # ============== Core Decay Function Tests ==============
 
-    def test_decay_functions(self):
+    def test_decay_and_grow_functions(self):
         """Test all decay functions work correctly."""
         self._add_shared_documents()
 
-        for decay_func in ["exponential", "linear", "gaussian", "binary"]:
-            with self.subTest(function=decay_func):
+        for decay_and_grow_func in ["exponential", "linear", "gaussian", "binary"]:
+            with self.subTest(function=decay_and_grow_func):
                 params = RecencyParameters(
                     recency_field="timestamp",
                     scale="8d",
                     offset="0d",
-                    decay_function=decay_func,
-                    decay_to=0.5
+                    decay_function=decay_and_grow_func,
+                    decay_to=0.5,
+                    grow_function=decay_and_grow_func,
+                    grow_from=0.2,
+                    grow_scale="3d",
+                    grow_offset="1d",
                 )
                 hits = self._search_with_recency("product", params)
-                self._verify_basic_recency_behavior(
-                    hits, decay_to=0.5, scale="8d", offset="0d", decay_function=decay_func
-                )
+                self._verify_recency_behavior(hits, params)
 
     def test_scale_offset_combinations(self):
         """Test representative scale/offset combinations."""
@@ -587,9 +522,8 @@ class TestRecencyScoring(MarqoTestCase):
 
         test_cases = [
             ("7d", "0d"),   # No offset
-            ("7d", "3d"),   # Offset < scale
+            ("3d", "0d"),  # Short scale
             ("14d", "7d"),  # Large scale with offset
-            ("3d", "0d"),   # Short scale
         ]
 
         for scale, offset in test_cases:
@@ -599,30 +533,34 @@ class TestRecencyScoring(MarqoTestCase):
                     scale=scale,
                     offset=offset,
                     decay_function="exponential",
-                    decay_to=0.5
+                    decay_to=0.5,
+                    grow_from=0.2,
+                    grow_function="linear",
+                    grow_scale=scale,
+                    grow_offset=offset,
                 )
                 hits = self._search_with_recency("product", params)
-                self._verify_basic_recency_behavior(
-                    hits, decay_to=0.5, scale=scale, offset=offset, decay_function="exponential"
-                )
-                self._verify_offset_behavior(hits, offset, scale=scale)
+                self._verify_recency_behavior(hits, params)
 
-    def test_decay_to_values(self):
+    def test_decay_to_grow_from_values(self):
         """Test various decay_to floor values."""
         self._add_shared_documents()
 
-        for decay_to in [0.1, 0.3, 0.5, 0.8]:
-            with self.subTest(decay_to=decay_to):
+        for decay_to_grow_from in [0.1, 0.3, 0.5, 0.8]:
+            with self.subTest(decay_to_grow_from=decay_to_grow_from):
                 params = RecencyParameters(
                     recency_field="timestamp",
                     scale="7d",
                     offset="0d",
                     decay_function="exponential",
-                    decay_to=decay_to
+                    decay_to=decay_to_grow_from,
+                    grow_from=decay_to_grow_from,
+                    grow_function="linear",
+                    grow_scale="3d",
+                    grow_offset="1d",
                 )
                 hits = self._search_with_recency("product", params)
-                self._verify_basic_recency_behavior(hits, decay_to=decay_to)
-                self._verify_decay_to_floor(hits, decay_to)
+                self._verify_recency_behavior(hits, params)
 
     def test_missing_field_uses_decay_to(self):
         """Documents without timestamp field get decay_to score."""
@@ -648,8 +586,44 @@ class TestRecencyScoring(MarqoTestCase):
                     msg="Doc without timestamp should have decay_to as recency score"
                 )
 
+    def test_grow_disabled_by_default(self):
+        """Test future timestamps get score 1.0 when growFrom is not specified.
+
+        Shared documents include:
+        - Past docs: doc-0d, doc-1d, doc-3d, ... doc-90d (use decay)
+        - Future docs: doc+1d, doc+3d, doc+7d, doc+14d, doc+30d (all score 1.0)
+        """
+        self._add_shared_documents()
+
+        # Without grow_from, future timestamps should get score 1.0
+        params = RecencyParameters(
+            recency_field="timestamp",
+            scale="7d",
+            offset="0d",
+            decay_function="exponential",
+            decay_to=0.5
+            # No grow_from specified - grow disabled
+        )
+        hits = self._search_with_recency("product", params)
+
+        # Verify all future documents have score exactly 1.0
+        for hit in hits:
+            doc_id = hit.get('_id')
+            recency_score = hit.get('_recency_score')
+            self.assertIsNotNone(recency_score, f"Recency score should be present for {doc_id}")
+
+            if doc_id.startswith("doc+"):
+                self.assertAlmostEqual(
+                    recency_score, 1.0, places=3,
+                    msg=f"Future doc {doc_id} should have score 1.0 when grow disabled"
+                )
+
+        # Verify past docs still use decay correctly
+        self._verify_recency_behavior([h for h in hits if not h['_id'].startswith("doc+")], params)
+
     # ============== Apply in Ranking Phase Tests ==============
 
+    # TODO change this two verify if it's applied in different phases (with score mods)
     def test_apply_in_ranking_phase_options(self):
         """Test all apply_in_ranking_phase options."""
         self._add_shared_documents()
@@ -665,7 +639,56 @@ class TestRecencyScoring(MarqoTestCase):
                     apply_in_ranking_phase=phase
                 )
                 hits = self._search_with_recency("product", params)
-                self._verify_basic_recency_behavior(hits, decay_to=0.5)
+                self._verify_recency_behavior(hits, params)
+
+    # ============== Add To Score Weight Tests ==============
+    # TODO verify this works
+    def test_add_to_score_weight_values(self):
+        """Test addToScoreWeight with various weight values.
+
+        Fixed params: scale=7d, decay_to=0.5, grow_from=0.3, exponential
+        Tests weights: [0.1, 1.0, 10.0, 100.0] (must be > 0.0)
+
+        Verifies:
+        - Recency scores are calculated identically regardless of weight
+        - Different weights only affect final _score, not _recency_score
+        """
+        self._add_shared_documents()
+
+        weight_values = [0.1, 1.0, 10.0, 100.0]  # All must be > 0.0
+        results_by_weight = {}
+
+        for weight in weight_values:
+            with self.subTest(addToScoreWeight=weight):
+                params = RecencyParameters(
+                    recency_field="timestamp",
+                    scale="7d",
+                    offset="0d",
+                    decay_function="exponential",
+                    decay_to=0.5,
+                    grow_from=0.3,
+                    grow_function="exponential",
+                    grow_scale="7d",
+                    grow_offset="0d",
+                    add_to_score_weight=weight
+                )
+                hits = self._search_with_recency("product", params)
+
+                self.assertGreater(len(hits), 0, "Should have results")
+                results_by_weight[weight] = {h['_id']: h for h in hits}
+
+        # Verify recency scores are identical across all weight values
+        base_results = results_by_weight[0.1]
+        for weight in [1.0, 10.0, 100.0]:
+            for doc_id, base_hit in base_results.items():
+                if doc_id in results_by_weight[weight]:
+                    other_hit = results_by_weight[weight][doc_id]
+                    self.assertAlmostEqual(
+                        base_hit.get('_recency_score', 0),
+                        other_hit.get('_recency_score', 0),
+                        places=3,
+                        msg=f"Recency scores should be identical for {doc_id} across weights"
+                    )
 
     # ============== Retrieval/Ranking Method Combinations ==============
 
@@ -686,7 +709,11 @@ class TestRecencyScoring(MarqoTestCase):
             scale="7d",
             offset="0d",
             decay_function="exponential",
-            decay_to=0.5
+            decay_to=0.5,
+            grow_from=0.2,
+            grow_function="linear",
+            grow_scale="3d",
+            grow_offset="1d"
         )
 
         for retrieval, ranking in test_cases:
@@ -704,7 +731,7 @@ class TestRecencyScoring(MarqoTestCase):
                     hybrid_parameters=hybrid_params,
                     result_count=10
                 )
-                self._verify_basic_recency_behavior(search_result['hits'], decay_to=0.5)
+                self._verify_recency_behavior(search_result['hits'], params)
 
     # ============== Feature Combination Tests ==============
     @pytest.mark.skip_for_multinode(
@@ -795,21 +822,8 @@ class TestRecencyScoring(MarqoTestCase):
     def test_with_sort_by_exclude_global(self):
         """Test recency + sortBy with recency as tie-breaker for equal prices.
 
-        Documents have deliberate price duplicates:
-        - Price 120: doc+1d, doc+3d, doc+7d, doc+14d, doc+30d (future docs)
-        - Price 100: doc-0d, doc-3d, doc-7d
-        - Price 80: doc-1d, doc-5d, doc-14d
-        - Price 60: doc-10d, doc-30d
-        - Price 40: doc-60d, doc-90d
-        - Price 20: doc-no-ts
-
         When sorted by price desc, documents with same price should be
         ordered by recency (newer docs first) as a tie-breaker.
-        Future docs all have score 1.0 (grow disabled), so their relative
-        order within price=120 group is non-deterministic.
-
-        Uses scale=120d to ensure all past docs (up to 90 days old) have
-        distinct recency scores for proper tie-breaking.
         """
         self._add_shared_documents()
 
@@ -819,6 +833,11 @@ class TestRecencyScoring(MarqoTestCase):
             offset="0d",
             decay_function="exponential",
             decay_to=0.3,
+            # faster grow
+            grow_from=0.3,
+            grow_function="exponential",
+            grow_scale="90d",
+            grow_offset="0d",
             apply_in_ranking_phase="exclude-global"
         )
         sort_by = SortByModel(
@@ -841,56 +860,28 @@ class TestRecencyScoring(MarqoTestCase):
         actual_order = [hit['_id'] for hit in hits]
 
         # 1. Verify price ordering (groups should be in correct order)
-        # Future docs (price 120) should come first - order within group is non-deterministic
-        future_docs = {"doc+1d", "doc+3d", "doc+7d", "doc+14d", "doc+30d"}
-        price_100_docs = {"doc-0d", "doc-3d", "doc-7d"}
-        price_80_docs = {"doc-1d", "doc-5d", "doc-14d"}
-        price_60_docs = {"doc-10d", "doc-30d"}
-        price_40_docs = {"doc-60d", "doc-90d"}
+        expected_order = [
+            "doc-0d", "doc-3d", "doc+3d", "doc-7d",  # price=100
+            "doc-1d", "doc+1d", "doc-5d", "doc-14d", "doc+30d",  # price=80
+            "doc+7d", "doc-10d", "doc-30d",  # price=60
+            "doc+14d", "doc-60d", "doc-90d",  # price=40
+            "doc-no-ts",  # price=20
+        ]
 
-        # Verify docs are grouped by price (first 5 should be future, etc.)
-        self.assertEqual(set(actual_order[:5]), future_docs, "First 5 docs should be price 120 (future)")
-        self.assertEqual(set(actual_order[5:8]), price_100_docs, "Next 3 docs should be price 100")
-        self.assertEqual(set(actual_order[8:11]), price_80_docs, "Next 3 docs should be price 80")
-        self.assertEqual(set(actual_order[11:13]), price_60_docs, "Next 2 docs should be price 60")
-        self.assertEqual(set(actual_order[13:15]), price_40_docs, "Next 2 docs should be price 40")
-        self.assertEqual(actual_order[15], "doc-no-ts", "Last doc should be price 20")
+        self.assertListEqual(expected_order, actual_order)
 
-        # 2. Verify recency-based ordering within past doc groups (distinct scores)
-        # Price 100 group: doc-0d should be first, then doc-3d, then doc-7d
-        price_100_order = actual_order[5:8]
-        self.assertEqual(price_100_order, ["doc-0d", "doc-3d", "doc-7d"], "Price 100 group should be ordered by recency")
-
-        # Price 80 group: doc-1d should be first, then doc-5d, then doc-14d
-        price_80_order = actual_order[8:11]
-        self.assertEqual(price_80_order, ["doc-1d", "doc-5d", "doc-14d"], "Price 80 group should be ordered by recency")
-
-        # Price 60 group: doc-10d should be first, then doc-30d
-        price_60_order = actual_order[11:13]
-        self.assertEqual(price_60_order, ["doc-10d", "doc-30d"], "Price 60 group should be ordered by recency")
-
-        # Price 40 group: doc-60d should be first, then doc-90d
-        price_40_order = actual_order[13:15]
-        self.assertEqual(price_40_order, ["doc-60d", "doc-90d"], "Price 40 group should be ordered by recency")
-
-        # 3. Verify recency scores are calculated correctly for each doc
-        self._verify_basic_recency_behavior(
-            hits,
-            decay_to=0.3,
-            scale="120d",
-            offset="0d",
-            decay_function="exponential"
-        )
+        # 2. Verify recency scores are calculated correctly for each doc
+        self._verify_recency_behavior(hits, recency_params)
 
     def test_with_collapsing_field(self):
         """Test recency + collapsing field picks highest scoring variant per parent.
 
         Document structure (future and past docs mixed in same groups):
-        - group-A: doc-0d (today, score=1.0), doc-10d, doc+1d
-        - group-B: doc-1d (closest to now), doc-14d, doc+3d
-        - group-C: doc-3d (closest to now), doc-30d, doc+7d
-        - group-D: doc-5d (closest to now), doc-60d, doc+14d
-        - group-E: doc-7d (closest to now), doc-90d, doc+30d
+        - group-A: doc-0d (today, score=1.0), doc-10d, doc+3d (offset-2d)
+        - group-B: doc+1d (closest to now, with offset-2), doc-1d, doc-14d
+        - group-C: doc-3d (closest to now), doc-30d, doc+30d (offset-2d)
+        - group-D: doc-5d (closest to now), doc-60d, doc+14d (offset-2d)
+        - group-E: doc+7d (closest to now, with offset-2), doc-7d, doc-90d, doc+7d
         - group-F: doc-no-ts (only variant, score=0.3)
 
         With recency boosting and grow enabled, the variant closest to now
@@ -912,10 +903,10 @@ class TestRecencyScoring(MarqoTestCase):
             decay_function="exponential",
             decay_to=0.3,
             # Enable grow so future docs have distinct scores (closer = higher)
-            grow_from=0.2,
+            grow_from=0.3,
             grow_function="exponential",
             grow_scale="60d",  # Faster decay for future docs
-            grow_offset="0d"
+            grow_offset="2d",  # Two days plateau before release date
         )
 
         search_result = tensor_search.search(
@@ -925,7 +916,10 @@ class TestRecencyScoring(MarqoTestCase):
             search_method=SearchMethod.HYBRID,
             recency_parameters=recency_params,
             collapse_field_name="parent_id",
-            result_count=10
+            result_count=10,
+            hybrid_parameters=HybridParameters(
+                rerankDepthTensor=20
+            )
         )
 
         hits = search_result['hits']
@@ -949,11 +943,11 @@ class TestRecencyScoring(MarqoTestCase):
         # 3. Verify the highest scoring variant is selected for each parent group
         # Past docs closest to now win because decay is slower than grow
         expected_winner = {
-            "group-A": "doc-0d",   # 0d (score=1.0) beats doc-10d and doc+1d
-            "group-B": "doc-1d",   # 1d ago beats doc-14d and doc+3d
-            "group-C": "doc-3d",   # 3d ago beats doc-30d and doc+7d
+            "group-A": "doc-0d",   # 0d (score=1.0) beats doc-10d and doc+3d
+            "group-B": "doc+1d",   # 1d away (with growOffset=2, score=1.0) beats doc-14d and doc-1d
+            "group-C": "doc-3d",   # 3d ago beats doc-30d and doc+30d
             "group-D": "doc-5d",   # 5d ago beats doc-60d and doc+14d
-            "group-E": "doc-7d",   # 7d ago beats doc-90d and doc+30d
+            "group-E": "doc-7d",   # 7d ago beats doc-90d and doc+7d (with growOffset=2, but with quicker decay)
             "group-F": "doc-no-ts",  # Only variant
         }
 
@@ -964,7 +958,7 @@ class TestRecencyScoring(MarqoTestCase):
             if parent_id in expected_winner:
                 expected_doc = expected_winner[parent_id]
                 self.assertEqual(
-                    doc_id, expected_doc,
+                    expected_doc, doc_id,
                     f"For {parent_id}, expected winner {expected_doc} but got {doc_id}"
                 )
 
@@ -1048,687 +1042,6 @@ class TestRecencyScoring(MarqoTestCase):
                     "'sortBy' cannot be used with 'recencyParameters' with global-phase reranking in hybrid search",
                     str(ctx.exception)
                 )
-
-    # NOTE: Version check tests for grow and addToScoreWeight are in unit tests
-    # (test_hybrid_search.py::TestRecencyValidation) because integration tests
-    # cannot create indexes with old schema versions.
-
-    # ============== Validation Tests ==============
-
-    def test_decay_to_validation(self):
-        """Test decay_to must be in (0.0, 1.0]."""
-        valid_values = [0.1, 0.5, 1.0]
-        invalid_values = [0.0, -0.1, 1.1]
-
-        for val in valid_values:
-            with self.subTest(decay_to=val, valid=True):
-                params = RecencyParameters(
-                    recency_field="timestamp",
-                    scale="7d",
-                    decay_function="exponential",
-                    decay_to=val
-                )
-                self.assertEqual(params.decay_to, val)
-
-        for val in invalid_values:
-            with self.subTest(decay_to=val, valid=False):
-                with self.assertRaises(Exception):
-                    RecencyParameters(
-                        recency_field="timestamp",
-                        scale="7d",
-                        decay_function="exponential",
-                        decay_to=val
-                    )
-
-    def test_duration_format_validation(self):
-        """Test scale/offset duration string formats."""
-        valid_formats = ["1d", "7d", "24h", "168h"]
-        invalid_formats = ["-1d", "abc"]
-
-        for fmt in valid_formats:
-            with self.subTest(format=fmt, valid=True):
-                params = RecencyParameters(
-                    recency_field="timestamp",
-                    scale=fmt,
-                    offset="0d",
-                    decay_function="exponential",
-                    decay_to=0.5
-                )
-                self.assertIsNotNone(params)
-
-        for fmt in invalid_formats:
-            with self.subTest(format=fmt, valid=False):
-                with self.assertRaises(Exception):
-                    RecencyParameters(
-                        recency_field="timestamp",
-                        scale=fmt,
-                        offset="0d",
-                        decay_function="exponential",
-                        decay_to=0.5
-                    )
-
-    def test_grow_params_all_or_nothing_validation(self):
-        """Test that grow parameters must be either all provided or all omitted."""
-        # Partial combinations should fail
-        partial_cases = [
-            ("only_grow_from", {"grow_from": 0.5}),
-            ("missing_grow_offset", {"grow_from": 0.5, "grow_function": "exponential", "grow_scale": "7d"}),
-            ("missing_grow_scale", {"grow_from": 0.5, "grow_function": "exponential", "grow_offset": "0d"}),
-        ]
-
-        for test_name, grow_params in partial_cases:
-            with self.subTest(test_name):
-                with self.assertRaises(Exception) as ctx:
-                    RecencyParameters(
-                        recency_field="timestamp",
-                        scale="7d",
-                        decay_function="exponential",
-                        decay_to=0.5,
-                        **grow_params
-                    )
-                self.assertIn("all provided or all omitted", str(ctx.exception).lower())
-
-        # All provided should work
-        with self.subTest("all_provided"):
-            params = RecencyParameters(
-                recency_field="timestamp",
-                scale="7d",
-                decay_function="exponential",
-                decay_to=0.5,
-                grow_from=0.5,
-                grow_function="exponential",
-                grow_scale="7d",
-                grow_offset="0d"
-            )
-            self.assertEqual(params.grow_from, 0.5)
-
-    def test_grow_from_validation(self):
-        """Test grow_from must be in (0.0, 1.0]."""
-        valid_values = [0.01, 0.5, 1.0]
-        invalid_values = [0.0, -0.1, 1.1]
-
-        for val in valid_values:
-            with self.subTest(grow_from=val, valid=True):
-                params = RecencyParameters(
-                    recency_field="timestamp",
-                    scale="7d",
-                    decay_function="exponential",
-                    decay_to=0.5,
-                    grow_from=val,
-                    grow_function="exponential",
-                    grow_scale="7d",
-                    grow_offset="0d"
-                )
-                self.assertEqual(params.grow_from, val)
-
-        for val in invalid_values:
-            with self.subTest(grow_from=val, valid=False):
-                with self.assertRaises(Exception):
-                    RecencyParameters(
-                        recency_field="timestamp",
-                        scale="7d",
-                        decay_function="exponential",
-                        decay_to=0.5,
-                        grow_from=val,
-                        grow_function="exponential",
-                        grow_scale="7d",
-                        grow_offset="0d"
-                    )
-
-    def test_grow_function_validation(self):
-        """Test grow_function must be a valid function type."""
-        valid_functions = ["exponential", "linear", "gaussian", "binary"]
-        invalid_functions = ["invalid", "exp", "lin"]
-
-        for func in valid_functions:
-            with self.subTest(grow_function=func, valid=True):
-                params = RecencyParameters(
-                    recency_field="timestamp",
-                    scale="7d",
-                    decay_function="exponential",
-                    decay_to=0.5,
-                    grow_from=0.3,
-                    grow_function=func,
-                    grow_scale="7d",
-                    grow_offset="0d"
-                )
-                self.assertEqual(params.grow_function, func)
-
-        for func in invalid_functions:
-            with self.subTest(grow_function=func, valid=False):
-                with self.assertRaises(Exception):
-                    RecencyParameters(
-                        recency_field="timestamp",
-                        scale="7d",
-                        decay_function="exponential",
-                        decay_to=0.5,
-                        grow_from=0.3,
-                        grow_function=func,
-                        grow_scale="7d",
-                        grow_offset="0d"
-                    )
-
-    def test_grow_scale_validation(self):
-        """Test grow_scale must be a valid duration format."""
-        valid_formats = ["1d", "7d", "24h", "168h"]
-        invalid_formats = ["-1d", "abc", "0d"]
-
-        for fmt in valid_formats:
-            with self.subTest(grow_scale=fmt, valid=True):
-                params = RecencyParameters(
-                    recency_field="timestamp",
-                    scale="7d",
-                    decay_function="exponential",
-                    decay_to=0.5,
-                    grow_from=0.3,
-                    grow_function="exponential",
-                    grow_scale=fmt,
-                    grow_offset="0d"
-                )
-                self.assertEqual(params.grow_scale, fmt)
-
-        for fmt in invalid_formats:
-            with self.subTest(grow_scale=fmt, valid=False):
-                with self.assertRaises(Exception):
-                    RecencyParameters(
-                        recency_field="timestamp",
-                        scale="7d",
-                        decay_function="exponential",
-                        decay_to=0.5,
-                        grow_from=0.3,
-                        grow_function="exponential",
-                        grow_scale=fmt,
-                        grow_offset="0d"
-                    )
-
-    def test_grow_offset_validation(self):
-        """Test grow_offset must be a valid duration format."""
-        valid_formats = ["0d", "1d", "7d", "24h"]
-        invalid_formats = ["-1d", "abc"]
-
-        for fmt in valid_formats:
-            with self.subTest(grow_offset=fmt, valid=True):
-                params = RecencyParameters(
-                    recency_field="timestamp",
-                    scale="7d",
-                    decay_function="exponential",
-                    decay_to=0.5,
-                    grow_from=0.3,
-                    grow_function="exponential",
-                    grow_scale="7d",
-                    grow_offset=fmt
-                )
-                self.assertEqual(params.grow_offset, fmt)
-
-        for fmt in invalid_formats:
-            with self.subTest(grow_offset=fmt, valid=False):
-                with self.assertRaises(Exception):
-                    RecencyParameters(
-                        recency_field="timestamp",
-                        scale="7d",
-                        decay_function="exponential",
-                        decay_to=0.5,
-                        grow_from=0.3,
-                        grow_function="exponential",
-                        grow_scale="7d",
-                        grow_offset=fmt
-                    )
-
-    # ============== Grow Parameter Tests ==============
-
-    def _verify_grow_behavior(
-        self,
-        hits: List[Dict],
-        decay_to: float,
-        grow_from: float,
-        scale: str = "7d",
-        offset: str = "0d",
-        decay_function: str = "exponential",
-        grow_function: str = None,
-        grow_scale: str = None,
-        grow_offset: str = None,
-    ):
-        """Verify recency scores match expected values for both decay and grow.
-
-        Uses _calculate_expected_score which handles both past (decay) and future (grow).
-        """
-        if grow_function is None:
-            grow_function = decay_function
-        if grow_scale is None:
-            grow_scale = scale
-
-        for hit in hits:
-            actual_score = hit.get('_recency_score')
-            doc_id = hit.get('_id')
-
-            self.assertIsNotNone(actual_score, f"Recency score should be present for {doc_id}")
-
-            age_seconds = self._get_doc_age_seconds(hit)
-            if age_seconds is not None:
-                expected_score = self._calculate_expected_score(
-                    age_seconds=age_seconds,
-                    scale=scale,
-                    offset=offset,
-                    decay_function=decay_function,
-                    decay_to=decay_to,
-                    grow_enabled=True,
-                    grow_from=grow_from,
-                    grow_function=grow_function,
-                    grow_scale=grow_scale,
-                    grow_offset=grow_offset,
-                )
-                self.assertAlmostEqual(
-                    actual_score,
-                    expected_score,
-                    places=3,
-                    msg=f"Score mismatch for {doc_id}: expected {expected_score:.4f}, got {actual_score:.4f}"
-                )
-            elif doc_id == "doc-no-ts":
-                # Document without timestamp should get decay_to
-                self.assertAlmostEqual(
-                    actual_score,
-                    decay_to,
-                    places=3,
-                    msg=f"Doc without timestamp should have decay_to score"
-                )
-
-    def test_grow_disabled_by_default(self):
-        """Test future timestamps get score 1.0 when growFrom is not specified.
-
-        Shared documents include:
-        - Past docs: doc-0d, doc-1d, doc-3d, ... doc-90d (use decay)
-        - Future docs: doc+1d, doc+3d, doc+7d, doc+14d, doc+30d (all score 1.0)
-        """
-        self._add_shared_documents()
-
-        # Without grow_from, future timestamps should get score 1.0
-        params = RecencyParameters(
-            recency_field="timestamp",
-            scale="7d",
-            offset="0d",
-            decay_function="exponential",
-            decay_to=0.5
-            # No grow_from specified - grow disabled
-        )
-        hits = self._search_with_recency("product", params)
-
-        self.assertGreater(len(hits), 0, "Should have results")
-
-        # Verify all future documents have score exactly 1.0
-        for hit in hits:
-            doc_id = hit.get('_id')
-            recency_score = hit.get('_recency_score')
-            self.assertIsNotNone(recency_score, f"Recency score should be present for {doc_id}")
-
-            if doc_id.startswith("doc+"):
-                self.assertAlmostEqual(
-                    recency_score, 1.0, places=3,
-                    msg=f"Future doc {doc_id} should have score 1.0 when grow disabled"
-                )
-
-        # Verify past docs still use decay correctly
-        self._verify_basic_recency_behavior(
-            [h for h in hits if not h['_id'].startswith("doc+")],
-            decay_to=0.5,
-            scale="7d",
-            offset="0d",
-            decay_function="exponential"
-        )
-
-    def test_grow_functions(self):
-        """Test all grow functions work correctly with precise score verification.
-
-        Fixed decay params: scale=120d, decay_to=0.3, offset=0d, exponential
-        Tests each grow function: exponential, linear, gaussian, binary
-        """
-        self._add_shared_documents()
-
-        for grow_func in ["exponential", "linear", "gaussian", "binary"]:
-            with self.subTest(function=grow_func):
-                params = RecencyParameters(
-                    recency_field="timestamp",
-                    scale="120d",  # Large decay scale so past docs are distinct
-                    offset="0d",
-                    decay_function="exponential",
-                    decay_to=0.3,
-                    grow_from=0.2,
-                    grow_function=grow_func,
-                    grow_scale="60d",  # Grow scale covers future docs
-                    grow_offset="0d"
-                )
-                hits = self._search_with_recency("product", params)
-
-                self.assertGreater(len(hits), 0, "Should have results")
-
-                # Verify exact scores for all documents
-                self._verify_grow_behavior(
-                    hits,
-                    decay_to=0.3,
-                    grow_from=0.2,
-                    scale="120d",
-                    offset="0d",
-                    decay_function="exponential",
-                    grow_function=grow_func,
-                    grow_scale="60d",
-                    grow_offset="0d"
-                )
-
-    def test_grow_with_decay(self):
-        """Test combined grow (future) and decay (past) with precise score verification.
-
-        Verifies:
-        - doc-0d has score ~1.0 (current)
-        - Past docs have decay scores in [decay_to, 1.0]
-        - Future docs have grow scores in [grow_from, 1.0]
-        """
-        self._add_shared_documents()
-
-        params = RecencyParameters(
-            recency_field="timestamp",
-            scale="120d",
-            offset="0d",
-            decay_function="exponential",
-            decay_to=0.5,
-            grow_from=0.3,
-            grow_function="exponential",
-            grow_scale="60d",
-            grow_offset="0d"
-        )
-        hits = self._search_with_recency("product", params)
-
-        self.assertGreater(len(hits), 0, "Should have results")
-
-        # Verify all scores precisely
-        self._verify_grow_behavior(
-            hits,
-            decay_to=0.5,
-            grow_from=0.3,
-            scale="120d",
-            offset="0d",
-            decay_function="exponential",
-            grow_function="exponential",
-            grow_scale="60d",
-            grow_offset="0d"
-        )
-
-        # Additional category checks
-        doc_0d = self._get_doc_by_id(hits, "doc-0d")
-        if doc_0d:
-            self.assertAlmostEqual(
-                doc_0d.get('_recency_score'), 1.0, places=2,
-                msg="doc-0d should have score ~1.0"
-            )
-
-        # Verify decay/grow floor bounds
-        for hit in hits:
-            doc_id = hit.get('_id')
-            score = hit.get('_recency_score')
-
-            if doc_id.startswith("doc-") and doc_id != "doc-0d" and doc_id != "doc-no-ts":
-                self.assertGreaterEqual(score, 0.5, f"Past doc {doc_id} should be >= decay_to")
-                self.assertLessEqual(score, 1.0, f"Past doc {doc_id} should be <= 1.0")
-            elif doc_id.startswith("doc+"):
-                self.assertGreaterEqual(score, 0.3, f"Future doc {doc_id} should be >= grow_from")
-                self.assertLessEqual(score, 1.0, f"Future doc {doc_id} should be <= 1.0")
-
-    def test_grow_with_linear_function(self):
-        """Test grow with linear function produces correct scores.
-
-        Use linear grow function and verify future docs have expected scores.
-        """
-        self._add_shared_documents()
-
-        params = RecencyParameters(
-            recency_field="timestamp",
-            scale="120d",
-            offset="0d",
-            decay_function="linear",
-            decay_to=0.5,
-            grow_from=0.3,
-            grow_function="linear",
-            grow_scale="60d",
-            grow_offset="0d"
-        )
-        hits = self._search_with_recency("product", params)
-
-        self.assertGreater(len(hits), 0, "Should have results")
-
-        # Verify scores with linear grow function
-        self._verify_grow_behavior(
-            hits,
-            decay_to=0.5,
-            grow_from=0.3,
-            scale="120d",
-            offset="0d",
-            decay_function="linear",
-            grow_function="linear",
-            grow_scale="60d",
-            grow_offset="0d"
-        )
-
-    def test_grow_scale_at_boundary(self):
-        """Test grow_scale boundary - doc at exactly scale gets grow_from score.
-
-        Use grow_scale=30d and verify doc+30d has score ~grow_from.
-        """
-        self._add_shared_documents()
-
-        params = RecencyParameters(
-            recency_field="timestamp",
-            scale="120d",
-            offset="0d",
-            decay_function="exponential",
-            decay_to=0.5,
-            grow_from=0.3,
-            grow_function="exponential",
-            grow_scale="30d",
-            grow_offset="0d"
-        )
-        hits = self._search_with_recency("product", params)
-
-        self.assertGreater(len(hits), 0, "Should have results")
-
-        # Verify scores
-        self._verify_grow_behavior(
-            hits,
-            decay_to=0.5,
-            grow_from=0.3,
-            scale="120d",
-            offset="0d",
-            decay_function="exponential",
-            grow_function="exponential",
-            grow_scale="30d",
-            grow_offset="0d"
-        )
-
-        # Specifically check doc+30d - at exactly scale, score should be at grow_from
-        doc_30d_future = self._get_doc_by_id(hits, "doc+30d")
-        if doc_30d_future:
-            recency_score = doc_30d_future.get('_recency_score')
-            self.assertAlmostEqual(
-                recency_score, 0.3, places=2,
-                msg="Future doc at exactly scale should have score ~grow_from"
-            )
-
-    def test_grow_offset_creates_plateau(self):
-        """Test growOffset creates plateau zone where score = 1.0.
-
-        With grow_offset=10d:
-        - doc+1d, doc+3d, doc+7d should be in plateau (score = 1.0)
-        - doc+14d, doc+30d should be beyond plateau (score < 1.0)
-        """
-        self._add_shared_documents()
-
-        params = RecencyParameters(
-            recency_field="timestamp",
-            scale="120d",
-            offset="0d",
-            decay_function="exponential",
-            decay_to=0.5,
-            grow_from=0.3,
-            grow_function="exponential",
-            grow_scale="60d",
-            grow_offset="10d"  # Plateau zone: now() to now()+10d
-        )
-        hits = self._search_with_recency("product", params)
-
-        self.assertGreater(len(hits), 0, "Should have results")
-
-        # Verify scores with grow_offset plateau
-        self._verify_grow_behavior(
-            hits,
-            decay_to=0.5,
-            grow_from=0.3,
-            scale="120d",
-            offset="0d",
-            decay_function="exponential",
-            grow_function="exponential",
-            grow_scale="60d",
-            grow_offset="10d"
-        )
-
-        # Documents in plateau zone (1d, 3d, 7d < 10d) should have score 1.0
-        plateau_docs = ["doc+1d", "doc+3d", "doc+7d"]
-        for doc_id in plateau_docs:
-            hit = self._get_doc_by_id(hits, doc_id)
-            if hit:
-                recency_score = hit.get('_recency_score')
-                self.assertAlmostEqual(
-                    recency_score, 1.0, places=2,
-                    msg=f"Doc {doc_id} within plateau should have score 1.0"
-                )
-
-        # Documents beyond plateau (14d, 30d > 10d) should have score < 1.0
-        beyond_plateau_docs = ["doc+14d", "doc+30d"]
-        for doc_id in beyond_plateau_docs:
-            hit = self._get_doc_by_id(hits, doc_id)
-            if hit:
-                recency_score = hit.get('_recency_score')
-                self.assertLess(
-                    recency_score, 1.0,
-                    msg=f"Doc {doc_id} beyond plateau should have score < 1.0"
-                )
-
-    def test_grow_binary_function(self):
-        """Test binary grow function creates step function at scale.
-
-        With grow_scale=10d:
-        - doc+1d, doc+3d, doc+7d (< 10d) should have score 1.0
-        - doc+14d, doc+30d (>= 10d) should have score = grow_from
-        """
-        self._add_shared_documents()
-
-        params = RecencyParameters(
-            recency_field="timestamp",
-            scale="120d",
-            offset="0d",
-            decay_function="exponential",
-            decay_to=0.5,
-            grow_from=0.2,
-            grow_function="binary",
-            grow_scale="10d",  # Step at 10 days
-            grow_offset="0d"
-        )
-        hits = self._search_with_recency("product", params)
-
-        self.assertGreater(len(hits), 0, "Should have results")
-
-        # Verify exact scores with binary grow
-        self._verify_grow_behavior(
-            hits,
-            decay_to=0.5,
-            grow_from=0.2,
-            scale="120d",
-            offset="0d",
-            decay_function="exponential",
-            grow_function="binary",
-            grow_scale="10d",
-            grow_offset="0d"
-        )
-
-        # Documents within scale (< 10d) should have score 1.0
-        within_scale_docs = ["doc+1d", "doc+3d", "doc+7d"]
-        for doc_id in within_scale_docs:
-            hit = self._get_doc_by_id(hits, doc_id)
-            if hit:
-                recency_score = hit.get('_recency_score')
-                self.assertAlmostEqual(
-                    recency_score, 1.0, places=2,
-                    msg=f"Doc {doc_id} within binary scale should have score 1.0"
-                )
-
-        # Documents beyond scale (>= 10d) should have score = grow_from
-        beyond_scale_docs = ["doc+14d", "doc+30d"]
-        for doc_id in beyond_scale_docs:
-            hit = self._get_doc_by_id(hits, doc_id)
-            if hit:
-                recency_score = hit.get('_recency_score')
-                self.assertAlmostEqual(
-                    recency_score, 0.2, places=2,
-                    msg=f"Doc {doc_id} beyond binary scale should have score ~grow_from"
-                )
-
-    # ============== Add To Score Weight Tests ==============
-
-    def test_add_to_score_weight_values(self):
-        """Test addToScoreWeight with various weight values.
-
-        Fixed params: scale=7d, decay_to=0.5, grow_from=0.3, exponential
-        Tests weights: [0.1, 1.0, 10.0, 100.0] (must be > 0.0)
-
-        Verifies:
-        - Recency scores are calculated identically regardless of weight
-        - Different weights only affect final _score, not _recency_score
-        """
-        self._add_shared_documents()
-
-        weight_values = [0.1, 1.0, 10.0, 100.0]  # All must be > 0.0
-        results_by_weight = {}
-
-        for weight in weight_values:
-            with self.subTest(addToScoreWeight=weight):
-                params = RecencyParameters(
-                    recency_field="timestamp",
-                    scale="7d",
-                    offset="0d",
-                    decay_function="exponential",
-                    decay_to=0.5,
-                    grow_from=0.3,
-                    grow_function="exponential",
-                    grow_scale="7d",
-                    grow_offset="0d",
-                    add_to_score_weight=weight
-                )
-                hits = self._search_with_recency("product", params)
-
-                self.assertGreater(len(hits), 0, "Should have results")
-                results_by_weight[weight] = {h['_id']: h for h in hits}
-
-                # Verify recency scores match expected values
-                self._verify_grow_behavior(
-                    hits,
-                    decay_to=0.5,
-                    grow_from=0.3,
-                    scale="7d",
-                    offset="0d",
-                    decay_function="exponential",
-                    grow_function="exponential",
-                    grow_scale="7d",
-                    grow_offset="0d"
-                )
-
-        # Verify recency scores are identical across all weight values
-        base_results = results_by_weight[0.1]
-        for weight in [1.0, 10.0, 100.0]:
-            for doc_id, base_hit in base_results.items():
-                if doc_id in results_by_weight[weight]:
-                    other_hit = results_by_weight[weight][doc_id]
-                    self.assertAlmostEqual(
-                        base_hit.get('_recency_score', 0),
-                        other_hit.get('_recency_score', 0),
-                        places=3,
-                        msg=f"Recency scores should be identical for {doc_id} across weights"
-                    )
 
 
 if __name__ == '__main__':

--- a/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
@@ -190,6 +190,7 @@ class TestRecencyScoring(MarqoTestCase):
 
         # HIGH RELEVANCE (10 docs) - Contains ALL 5 query words
         # Ages distributed: 0, 1, 3, 5, 7, 10, 14, 21, 28, 30 days
+        # TODO add future documents
         high_relevance = [
             {"_id": "h1",
              "content": "Machine learning algorithms in artificial intelligence enable systems to adapt.",
@@ -495,7 +496,11 @@ class TestRecencyScoring(MarqoTestCase):
         return next((h for h in hits if h.get('_id') == doc_id), None)
 
     def _extract_scores(self, hits: List[Dict]) -> Dict[str, Dict[str, float]]:
-        """Extract score map: {doc_id: {lexical, tensor, score, recency}}"""
+        """Extract score map including field values for modifier calculation.
+
+        Returns:
+            Dict mapping doc_id -> {lexical, tensor, score, recency, mult, timestamp}
+        """
         result = {}
         for hit in hits:
             doc_id = hit['_id']
@@ -504,15 +509,114 @@ class TestRecencyScoring(MarqoTestCase):
                 'tensor': hit.get('_tensor_score'),
                 'score': hit.get('_score'),
                 'recency': hit.get('_recency_score'),
+                # Field values for global score modifier calculation
+                'mult': hit.get('mult'),
+                'timestamp': hit.get('timestamp'),
             }
         return result
+
+    def _calculate_rrf_score(
+        self,
+        scores: Dict[str, Dict[str, float]],
+        alpha: float = 0.5,
+        k: int = 60
+    ) -> Dict[str, float]:
+        """Calculate RRF scores from lexical and tensor scores.
+
+        RRF (Reciprocal Rank Fusion) formula:
+        - tensor_rrf = alpha * (1.0 / (tensor_rank + k))
+        - lexical_rrf = (1 - alpha) * (1.0 / (lexical_rank + k))
+        - combined = tensor_rrf + lexical_rrf (if doc in both)
+
+        Args:
+            scores: Dict mapping doc_id -> {lexical, tensor, recency}
+            alpha: Weight for tensor vs lexical (default 0.5)
+            k: RRF constant (default 60)
+
+        Returns:
+            Dict mapping doc_id -> calculated RRF score
+        """
+        # Extract and rank by lexical scores (descending)
+        lexical_scores = [
+            (doc_id, s['lexical'])
+            for doc_id, s in scores.items()
+            if s['lexical'] is not None
+        ]
+        lexical_scores.sort(key=lambda x: x[1], reverse=True)
+        lexical_ranks = {doc_id: rank + 1 for rank, (doc_id, _) in enumerate(lexical_scores)}
+
+        # Extract and rank by tensor scores (descending)
+        tensor_scores = [
+            (doc_id, s['tensor'])
+            for doc_id, s in scores.items()
+            if s['tensor'] is not None
+        ]
+        tensor_scores.sort(key=lambda x: x[1], reverse=True)
+        tensor_ranks = {doc_id: rank + 1 for rank, (doc_id, _) in enumerate(tensor_scores)}
+
+        # Calculate RRF for each document
+        rrf_scores = {}
+        all_doc_ids = set(lexical_ranks.keys()) | set(tensor_ranks.keys())
+
+        for doc_id in all_doc_ids:
+            rrf = 0.0
+
+            # Tensor contribution
+            if doc_id in tensor_ranks and alpha > 0:
+                rrf += alpha * (1.0 / (tensor_ranks[doc_id] + k))
+
+            # Lexical contribution
+            if doc_id in lexical_ranks and alpha < 1.0:
+                rrf += (1.0 - alpha) * (1.0 / (lexical_ranks[doc_id] + k))
+
+            rrf_scores[doc_id] = rrf
+
+        return rrf_scores
+
+    def _calculate_global_modifiers(
+        self,
+        doc_scores: Dict[str, float],
+        multiply_weights: Dict[str, float],
+        add_weights: Dict[str, float]
+    ) -> tuple:
+        """Calculate global score modifiers from document field values.
+
+        Formula from Vespa schema template:
+        - mult_modifier = product of (weight * field_value) for each field
+        - add_modifier = sum of (weight * field_value) for each field
+
+        Args:
+            doc_scores: Dict with document field values (e.g., {'mult': 2.0, 'timestamp': 1.7e9})
+            multiply_weights: Dict of {field_name: weight} for multiply_score_by
+            add_weights: Dict of {field_name: weight} for add_to_score
+
+        Returns:
+            (mult_modifier, add_modifier) tuple
+        """
+        # Multiplicative: product of (weight * field_value)
+        mult_modifier = 1.0
+        for field_name, weight in multiply_weights.items():
+            field_value = doc_scores.get(field_name)
+            if field_value is not None:
+                mult_modifier *= (weight * field_value)
+
+        # Additive: sum of (weight * field_value)
+        add_modifier = 0.0
+        for field_name, weight in add_weights.items():
+            field_value = doc_scores.get(field_name)
+            if field_value is not None:
+                add_modifier += (weight * field_value)
+
+        return mult_modifier, add_modifier
 
     def _verify_phase_score_changes(
         self,
         baseline: Dict[str, Dict],
         recency: Dict[str, Dict],
         phase: str,
-        add_weight: Optional[float]
+        add_weight: Optional[float],
+        multiply_weights: Optional[Dict[str, float]] = None,
+        add_weights: Optional[Dict[str, float]] = None,
     ):
         """Verify scores changed according to apply_in_ranking_phase setting.
 
@@ -526,6 +630,11 @@ class TestRecencyScoring(MarqoTestCase):
         - 'all': recency applied to lexical, tensor, AND global RRF score
         - 'exclude-global': recency applied to lexical and tensor only
         - 'only-global': recency applied to global RRF score only
+
+        Global score modifiers are calculated from document field values:
+        - mult_modifier = product of (weight * field_value) for each field in multiply_weights
+        - add_modifier = sum of (weight * field_value) for each field in add_weights
+        - base_score = rrf * mult_modifier + add_modifier
         """
         common_docs = set(baseline.keys()) & set(recency.keys())
         self.assertGreater(len(common_docs), 0, "Should have common docs")
@@ -538,8 +647,8 @@ class TestRecencyScoring(MarqoTestCase):
         ]
         self.assertGreater(len(affected_docs), 0, "Should have docs affected by recency")
 
-        def calculate_expected(original: float, recency_score: float) -> float:
-            """Calculate expected score based on recency mode."""
+        def calculate_expected_recency(original: float, recency_score: float) -> float:
+            """Calculate expected score after recency is applied."""
             if add_weight is not None:
                 return original + recency_score * add_weight
             else:
@@ -556,8 +665,8 @@ class TestRecencyScoring(MarqoTestCase):
 
             if phase == "all":
                 # Lexical and tensor scores should be modified by recency
-                expected_lexical = calculate_expected(b['lexical'], recency_score)
-                expected_tensor = calculate_expected(b['tensor'], recency_score)
+                expected_lexical = calculate_expected_recency(b['lexical'], recency_score)
+                expected_tensor = calculate_expected_recency(b['tensor'], recency_score)
 
                 self.assertAlmostEqual(
                     expected_lexical, r['lexical'], places=3,
@@ -569,20 +678,32 @@ class TestRecencyScoring(MarqoTestCase):
                     msg=f"Doc {doc_id}: tensor score mismatch. "
                     f"Expected {expected_tensor:.6f}, got {r['tensor']:.6f}"
                 )
-                # RRF score: We can't verify exact value because RRF depends on ranks,
-                # and ranks may shift when recency modifies lexical/tensor scores.
-                # Just verify it changed from baseline (using relative difference > 1%).
-                # TODO calculate RRF based on the lexical/tensor ranking
-                # self.assertFalse(
-                #     math.isclose(b['score'], r['score'], rel_tol=0.01),
-                #     msg=f"Doc {doc_id}: RRF score should have changed. "
-                #     f"Baseline {b['score']:.6f}, got {r['score']:.6f}"
-                # )
+
+                # Calculate expected RRF from modified lexical/tensor scores
+                rrf_scores = self._calculate_rrf_score(recency)
+                expected_rrf = rrf_scores.get(doc_id, 0)
+
+                # Apply global score modifiers if present
+                if multiply_weights or add_weights:
+                    mult_mod, add_mod = self._calculate_global_modifiers(
+                        r, multiply_weights or {}, add_weights or {}
+                    )
+                    base_score = expected_rrf * mult_mod + add_mod
+                else:
+                    base_score = expected_rrf
+
+                # Apply recency to final score (global phase)
+                expected_final = calculate_expected_recency(base_score, recency_score)
+                self.assertAlmostEqual(
+                    expected_final, r['score'], places=3,
+                    msg=f"Doc {doc_id}: RRF score mismatch. "
+                    f"Expected {expected_final:.6f}, got {r['score']:.6f}"
+                )
 
             elif phase == "exclude-global":
                 # Lexical and tensor modified by recency, but NOT the global RRF score
-                expected_lexical = calculate_expected(b['lexical'], recency_score)
-                expected_tensor = calculate_expected(b['tensor'], recency_score)
+                expected_lexical = calculate_expected_recency(b['lexical'], recency_score)
+                expected_tensor = calculate_expected_recency(b['tensor'], recency_score)
 
                 self.assertAlmostEqual(
                     expected_lexical, r['lexical'], places=3,
@@ -594,10 +715,26 @@ class TestRecencyScoring(MarqoTestCase):
                     msg=f"Doc {doc_id}: tensor score mismatch. "
                     f"Expected {expected_tensor:.6f}, got {r['tensor']:.6f}"
                 )
-                # Note: RRF score will change because inputs changed, but recency
-                # is NOT applied to RRF in global phase. We don't verify exact RRF
-                # value since it depends on ranking which may shift.
-                # TODO calculate RRF based on the lexical/tensor ranking
+
+                # Calculate expected RRF from modified lexical/tensor scores
+                # NO recency applied to RRF in global phase
+                rrf_scores = self._calculate_rrf_score(recency)
+                expected_rrf = rrf_scores.get(doc_id, 0)
+
+                # Apply global score modifiers if present (but no recency)
+                if multiply_weights or add_weights:
+                    mult_mod, add_mod = self._calculate_global_modifiers(
+                        r, multiply_weights or {}, add_weights or {}
+                    )
+                    expected_final = expected_rrf * mult_mod + add_mod
+                else:
+                    expected_final = expected_rrf
+
+                self.assertAlmostEqual(
+                    expected_final, r['score'], places=3,
+                    msg=f"Doc {doc_id}: RRF score mismatch. "
+                    f"Expected {expected_final:.6f}, got {r['score']:.6f}"
+                )
 
             elif phase == "only-global":
                 # Lexical and tensor should remain unchanged
@@ -612,7 +749,8 @@ class TestRecencyScoring(MarqoTestCase):
                     f"Baseline {b['tensor']:.6f}, got {r['tensor']:.6f}"
                 )
                 # RRF score should be modified by recency
-                expected_score = calculate_expected(b['score'], recency_score)
+                # (baseline already has modifiers applied, so we just apply recency)
+                expected_score = calculate_expected_recency(b['score'], recency_score)
                 self.assertAlmostEqual(
                     expected_score, r['score'], places=3,
                     msg=f"Doc {doc_id}: RRF score mismatch. "
@@ -782,11 +920,16 @@ class TestRecencyScoring(MarqoTestCase):
             with self.subTest(phase=phase, add_to_score_weight=add_weight, score_mods=use_score_mods):
                 # 1. Build score modifiers (if enabled)
                 score_mods = None
+                multiply_weights = None
+                add_weights = None
                 if use_score_mods:
                     score_mods = ScoreModifierLists(
                         multiply_score_by=[{"field_name": "mult", "weight": 5.0}],
                         add_to_score=[{"field_name": "timestamp", "weight": 1e-8}]
                     )
+                    # Extract weights for verification
+                    multiply_weights = {"mult": 5.0}
+                    add_weights = {"timestamp": 1e-8}
 
                 # 2. Baseline search: WITH score mods, WITHOUT recency
                 baseline_result = tensor_search.search(
@@ -834,7 +977,9 @@ class TestRecencyScoring(MarqoTestCase):
 
                 # 4. Verify scores changed according to phase setting
                 self._verify_phase_score_changes(
-                    baseline_scores, recency_scores, phase, add_weight
+                    baseline_scores, recency_scores, phase, add_weight,
+                    multiply_weights=multiply_weights,
+                    add_weights=add_weights
                 )
 
     # ============== Retrieval/Ranking Method Combinations ==============

--- a/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
@@ -90,57 +90,72 @@ class TestRecencyScoring(MarqoTestCase):
     def _generate_shared_documents(self) -> List[Dict[str, Any]]:
         """Generate shared documents with various ages (past and future) and attributes.
 
-        Price groupings for sortBy tie-breaker testing (past docs):
-        - Price 100: doc-0d, doc-3d, doc-7d (newer docs should rank first within group)
+        Naming convention:
+        - Past docs: doc-Xd where X is days ago (e.g., doc-0d = today, doc-7d = 7 days ago)
+        - Future docs: doc+Xd where X is days in future (e.g., doc+1d = 1 day from now)
+
+        Price groupings for sortBy tie-breaker testing:
+        - Price 120: doc+1d, doc+3d, doc+7d, doc+14d, doc+30d (future docs)
+        - Price 100: doc-0d, doc-3d, doc-7d (past docs - newer)
         - Price 80: doc-1d, doc-5d, doc-14d
         - Price 60: doc-10d, doc-30d
         - Price 40: doc-60d, doc-90d
+        - Price 20: doc-no-ts
 
-        Future docs (for grow testing):
-        - Price 120: doc+1d, doc+3d, doc+7d, doc+14d, doc+30d
+        Parent groupings for collapsing test (future and past docs mixed):
+        - group-A: doc-0d, doc-10d, doc+1d
+        - group-B: doc-1d, doc-14d, doc+3d
+        - group-C: doc-3d, doc-30d, doc+7d
+        - group-D: doc-5d, doc-60d, doc+14d
+        - group-E: doc-7d, doc-90d, doc+30d
+        - group-F: doc-no-ts
         """
         now = datetime.now()
 
-        # Past document ages: 0, 1, 3, 5, 7, 10, 14, 30, 60, 90 days ago
-        past_ages_in_days = [0, 1, 3, 5, 7, 10, 14, 30, 60, 90]
+        # Explicit config for each document: (price, parent_id, mult)
+        # age > 0 means days in past, age < 0 means days in future
+        doc_configs = {
+            # Future docs (negative ages = future timestamps) - Price 120
+            # Mixed into same groups as past docs
+            -30: (120, "group-E", 1.0),   # doc+30d - with doc-7d, doc-90d
+            -14: (120, "group-D", 1.5),   # doc+14d - with doc-5d, doc-60d
+            -7:  (120, "group-C", 2.0),   # doc+7d - with doc-3d, doc-30d
+            -3:  (120, "group-B", 1.0),   # doc+3d - with doc-1d, doc-14d
+            -1:  (120, "group-A", 1.5),   # doc+1d - with doc-0d, doc-10d
 
-        # Future document offsets: 1, 3, 7, 14, 30 days from now
-        future_offsets_in_days = [1, 3, 7, 14, 30]
-
-        # Price groups - documents with same price will test tie-breaking by recency
-        price_map = {
-            0: 100, 3: 100, 7: 100,      # Group 1: same price, different ages
-            1: 80, 5: 80, 14: 80,        # Group 2: same price, different ages
-            10: 60, 30: 60,              # Group 3: same price, different ages
-            60: 40, 90: 40,              # Group 4: same price, different ages
+            # Past docs (positive ages = past timestamps)
+            0:   (100, "group-A", 2.0),   # doc-0d (today)
+            1:   (80,  "group-B", 1.0),   # doc-1d
+            3:   (100, "group-C", 1.5),   # doc-3d
+            5:   (80,  "group-D", 2.0),   # doc-5d
+            7:   (100, "group-E", 1.0),   # doc-7d
+            10:  (60,  "group-A", 1.5),   # doc-10d
+            14:  (80,  "group-B", 2.0),   # doc-14d
+            30:  (60,  "group-C", 1.0),   # doc-30d
+            60:  (40,  "group-D", 1.5),   # doc-60d
+            90:  (40,  "group-E", 2.0),   # doc-90d
         }
 
         documents = []
 
-        # Add past documents
-        for i, age_days in enumerate(past_ages_in_days):
+        for age_days, (price, parent_id, mult) in doc_configs.items():
+            # timestamp = now - age_days (negative age = future timestamp)
             timestamp = (now - timedelta(days=age_days)).timestamp()
+
+            # Doc ID format: doc+Xd for future, doc-Xd for past
+            if age_days < 0:
+                doc_id = f"doc+{abs(age_days)}d"
+            else:
+                doc_id = f"doc-{age_days}d"
+
             documents.append({
-                "_id": f"doc-{age_days}d",
+                "_id": doc_id,
                 "title": "product item",
                 "description": f"test product {age_days} days old",
                 "timestamp": timestamp,
-                "price": price_map[age_days],  # Deliberate duplicates for tie-breaker testing
-                "parent_id": f"group-{chr(65 + i % 5)}",  # A-E rotation
-                "mult": 1.0 + (i % 3) * 0.5,  # 1.0, 1.5, 2.0
-            })
-
-        # Add future documents (for grow parameter testing)
-        for i, offset_days in enumerate(future_offsets_in_days):
-            timestamp = (now + timedelta(days=offset_days)).timestamp()
-            documents.append({
-                "_id": f"doc+{offset_days}d",
-                "title": "product item",
-                "description": f"test product scheduled for {offset_days} days from now",
-                "timestamp": timestamp,
-                "price": 120,  # All future docs have same price (higher than past)
-                "parent_id": f"group-{chr(71 + i % 3)}",  # G-I rotation for future docs
-                "mult": 1.0 + (i % 3) * 0.5,  # 1.0, 1.5, 2.0
+                "price": price,
+                "parent_id": parent_id,
+                "mult": mult,
             })
 
         # Special: Document without timestamp field
@@ -148,7 +163,7 @@ class TestRecencyScoring(MarqoTestCase):
             "_id": "doc-no-ts",
             "title": "product item",
             "description": "product without timestamp",
-            "price": 20,  # Unique price for this doc
+            "price": 20,
             "parent_id": "group-F",
             "mult": 1.0,
         })
@@ -868,38 +883,39 @@ class TestRecencyScoring(MarqoTestCase):
         )
 
     def test_with_collapsing_field(self):
-        """Test recency + collapsing field picks most recent variant per parent.
+        """Test recency + collapsing field picks highest scoring variant per parent.
 
-        Document structure:
-        Past docs (parent_id uses A-E rotation):
-        - group-A: doc-0d (newest, score<1), doc-10d
-        - group-B: doc-1d (newest, score<1), doc-14d
-        - group-C: doc-3d (newest, score<1), doc-30d
-        - group-D: doc-5d (newest, score<1), doc-60d
-        - group-E: doc-7d (newest, score<1), doc-90d
+        Document structure (future and past docs mixed in same groups):
+        - group-A: doc-0d (today, score=1.0), doc-10d, doc+1d
+        - group-B: doc-1d (closest to now), doc-14d, doc+3d
+        - group-C: doc-3d (closest to now), doc-30d, doc+7d
+        - group-D: doc-5d (closest to now), doc-60d, doc+14d
+        - group-E: doc-7d (closest to now), doc-90d, doc+30d
         - group-F: doc-no-ts (only variant, score=0.3)
 
-        Future docs (parent_id uses G-I rotation, all have score=1.0 with grow disabled):
-        - group-G: doc+1d, doc+14d (both score=1.0)
-        - group-H: doc+3d, doc+30d (both score=1.0)
-        - group-I: doc+7d (only variant, score=1.0)
+        With recency boosting and grow enabled, the variant closest to now
+        should be selected for each parent group when collapsing:
+        - Past docs closest to now have highest scores (~1.0)
+        - Future docs have lower scores due to grow function
+        - Old past docs have lowest scores due to decay
 
-        With recency boosting, the most recent variant should be selected
-        for each parent group when collapsing. Future docs all have score=1.0
-        when grow is disabled, so they score higher than past docs.
-
-        Uses scale=120d to ensure all past docs (up to 90 days old) have
-        distinct recency scores for proper variant selection.
+        Uses scale=120d for decay (slower) and grow_scale=60d for grow (faster)
+        to ensure past docs closest to now win over equidistant future docs.
         """
         # Add documents to collapse index
         self._add_shared_documents(index=self.collapse_index)
 
         recency_params = RecencyParameters(
             recency_field="timestamp",
-            scale="120d",  # Large scale so all docs have distinct recency scores
+            scale="120d",  # Large scale so past docs decay slowly
             offset="0d",
             decay_function="exponential",
-            decay_to=0.3
+            decay_to=0.3,
+            # Enable grow so future docs have distinct scores (closer = higher)
+            grow_from=0.2,
+            grow_function="exponential",
+            grow_scale="60d",  # Faster decay for future docs
+            grow_offset="0d"
         )
 
         search_result = tensor_search.search(
@@ -909,7 +925,7 @@ class TestRecencyScoring(MarqoTestCase):
             search_method=SearchMethod.HYBRID,
             recency_parameters=recency_params,
             collapse_field_name="parent_id",
-            result_count=15  # Increased to cover all groups
+            result_count=10
         )
 
         hits = search_result['hits']
@@ -930,39 +946,26 @@ class TestRecencyScoring(MarqoTestCase):
                 "Recency score should be present"
             )
 
-        # 3. Verify the most recent variant is selected for each parent group
-        # For past doc groups: newest variant should be picked (distinct scores)
-        expected_newest_variant_past = {
-            "group-A": "doc-0d",   # 0d is newer than 10d
-            "group-B": "doc-1d",   # 1d is newer than 14d
-            "group-C": "doc-3d",   # 3d is newer than 30d
-            "group-D": "doc-5d",   # 5d is newer than 60d
-            "group-E": "doc-7d",   # 7d is newer than 90d
+        # 3. Verify the highest scoring variant is selected for each parent group
+        # Past docs closest to now win because decay is slower than grow
+        expected_winner = {
+            "group-A": "doc-0d",   # 0d (score=1.0) beats doc-10d and doc+1d
+            "group-B": "doc-1d",   # 1d ago beats doc-14d and doc+3d
+            "group-C": "doc-3d",   # 3d ago beats doc-30d and doc+7d
+            "group-D": "doc-5d",   # 5d ago beats doc-60d and doc+14d
+            "group-E": "doc-7d",   # 7d ago beats doc-90d and doc+30d
             "group-F": "doc-no-ts",  # Only variant
-        }
-
-        # For future doc groups: all have score=1.0, closest to now wins
-        expected_newest_variant_future = {
-            "group-G": "doc+1d",   # 1d is closer than 14d
-            "group-H": "doc+3d",   # 3d is closer than 30d
-            "group-I": "doc+7d",   # Only variant
         }
 
         for hit in hits:
             parent_id = hit.get('parent_id')
             doc_id = hit.get('_id')
 
-            if parent_id in expected_newest_variant_past:
-                expected_doc = expected_newest_variant_past[parent_id]
+            if parent_id in expected_winner:
+                expected_doc = expected_winner[parent_id]
                 self.assertEqual(
                     doc_id, expected_doc,
-                    f"For {parent_id}, expected newest variant {expected_doc} but got {doc_id}"
-                )
-            elif parent_id in expected_newest_variant_future:
-                expected_doc = expected_newest_variant_future[parent_id]
-                self.assertEqual(
-                    doc_id, expected_doc,
-                    f"For {parent_id}, expected closest variant {expected_doc} but got {doc_id}"
+                    f"For {parent_id}, expected winner {expected_doc} but got {doc_id}"
                 )
 
     # ============== Negative Case Tests ==============

--- a/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
@@ -1350,12 +1350,18 @@ class TestRecencyScoring(MarqoTestCase):
         # Verify future documents have grow scores applied
         future_14d = self._get_doc_by_id(hits, "doc-future-14d")
         if future_14d:
-            # At future_age = scale, score should be close to grow_from
+            # At future_age = scale, exponential score is ~0.51 for grow_from=0.3
+            # (score = 1.0 - 0.7 * exp(ln(0.7)) = 1.0 - 0.7 * 0.7 = 0.51)
             recency_score = future_14d.get('_recency_score')
-            # Allow some tolerance since we're testing the score at scale
+            # Score should be significantly less than 1.0, showing grow is applied
             self.assertLess(
-                recency_score, 0.5,
-                f"Future doc at scale should have score closer to grow_from"
+                recency_score, 0.7,
+                f"Future doc at scale should have score significantly below 1.0"
+            )
+            # Score should be above grow_from floor
+            self.assertGreater(
+                recency_score, 0.3,
+                f"Future doc at scale should have score above grow_from"
             )
 
     def test_grow_offset_creates_plateau(self):

--- a/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
@@ -1103,5 +1103,373 @@ class TestRecencyScoring(MarqoTestCase):
                     )
 
 
+    # ============== Grow Parameter Tests ==============
+
+    def _generate_future_documents(self) -> List[Dict[str, Any]]:
+        """Generate documents with future timestamps for grow parameter testing.
+
+        Document ages (relative to now):
+        - Past documents: -7d, -3d, -1d (negative = in the past)
+        - Current: 0d
+        - Future documents: +1d, +3d, +7d, +14d, +30d (positive = in the future)
+        """
+        now = datetime.now()
+
+        # Mix of past, present, and future documents
+        time_offsets_days = [-7, -3, -1, 0, 1, 3, 7, 14, 30]
+
+        documents = []
+        for offset_days in time_offsets_days:
+            timestamp = (now + timedelta(days=offset_days)).timestamp()
+            if offset_days < 0:
+                doc_id = f"doc-past-{abs(offset_days)}d"
+            elif offset_days == 0:
+                doc_id = "doc-now"
+            else:
+                doc_id = f"doc-future-{offset_days}d"
+
+            documents.append({
+                "_id": doc_id,
+                "title": "event announcement",
+                "description": f"event scheduled for {offset_days} days from now",
+                "timestamp": timestamp,
+            })
+
+        return documents
+
+    def _add_future_documents(self, index=None):
+        """Add future timestamp documents to the specified or main index."""
+        if index is None:
+            index = self.main_index
+        documents = self._generate_future_documents()
+        add_docs_params = AddDocsParams(
+            index_name=index.name,
+            docs=documents,
+            tensor_fields=["title", "description"]
+        )
+        self.add_documents(self.config, add_docs_params)
+
+    def _calculate_expected_grow_score(
+        self,
+        future_age_seconds: float,
+        grow_scale: str,
+        grow_offset: str,
+        grow_function: str,
+        grow_from: float
+    ) -> float:
+        """Calculate expected grow score using the same formulas as decay (mirrored)."""
+        scale_seconds = self._parse_duration_to_seconds(grow_scale)
+        offset_seconds = self._parse_duration_to_seconds(grow_offset)
+
+        # Future age after subtracting offset (plateau zone)
+        effective_future_age = max(0.0, future_age_seconds - offset_seconds)
+
+        if effective_future_age == 0:
+            return 1.0
+
+        if grow_function == "exponential":
+            # Mirror of decay: score approaches grow_from at scale
+            score = 1.0 - (1.0 - grow_from) * math.exp(
+                math.log(1.0 - grow_from) * effective_future_age / scale_seconds
+            )
+        elif grow_function == "linear":
+            score = 1.0 - (1.0 - grow_from) * effective_future_age / scale_seconds
+        elif grow_function == "gaussian":
+            score = 1.0 - (1.0 - grow_from) * (
+                1.0 - math.exp(pow(effective_future_age, 2) * math.log(grow_from) / pow(scale_seconds, 2))
+            )
+        elif grow_function == "binary":
+            score = 1.0 if effective_future_age < scale_seconds else grow_from
+        else:
+            raise ValueError(f"Unknown grow function: {grow_function}")
+
+        return max(grow_from, score)
+
+    def test_grow_disabled_by_default(self):
+        """Test future timestamps get score 1.0 when growFrom is not specified."""
+        self._add_future_documents()
+
+        # Without grow_from, future timestamps should get score 1.0
+        params = RecencyParameters(
+            recency_field="timestamp",
+            scale="7d",
+            offset="0d",
+            decay_function="exponential",
+            decay_to=0.5
+            # No grow_from specified
+        )
+        hits = self._search_with_recency("event", params)
+
+        self.assertGreater(len(hits), 0, "Should have results")
+
+        # Future documents should have score 1.0 when grow is disabled
+        for hit in hits:
+            doc_id = hit.get('_id')
+            recency_score = hit.get('_recency_score')
+            self.assertIsNotNone(recency_score, f"Recency score should be present for {doc_id}")
+
+            if doc_id.startswith("doc-future"):
+                self.assertAlmostEqual(
+                    recency_score, 1.0, places=2,
+                    msg=f"Future doc {doc_id} should have score 1.0 when grow disabled"
+                )
+
+    def test_grow_functions(self):
+        """Test all grow functions work correctly for future timestamps."""
+        self._add_future_documents()
+
+        for grow_func in ["exponential", "linear", "gaussian", "binary"]:
+            with self.subTest(function=grow_func):
+                params = RecencyParameters(
+                    recency_field="timestamp",
+                    scale="7d",
+                    offset="0d",
+                    decay_function="exponential",
+                    decay_to=0.5,
+                    grow_from=0.3,
+                    grow_function=grow_func,
+                    grow_scale="14d",
+                    grow_offset="0d"
+                )
+                hits = self._search_with_recency("event", params)
+
+                self.assertGreater(len(hits), 0, "Should have results")
+
+                # Verify future documents have grow scores applied
+                for hit in hits:
+                    doc_id = hit.get('_id')
+                    recency_score = hit.get('_recency_score')
+                    self.assertIsNotNone(recency_score, f"Recency score should be present for {doc_id}")
+
+                    if doc_id.startswith("doc-future"):
+                        # Score should be between grow_from and 1.0
+                        self.assertGreaterEqual(
+                            recency_score, 0.3,
+                            f"Future doc {doc_id} score should be >= grow_from"
+                        )
+                        self.assertLessEqual(
+                            recency_score, 1.0,
+                            f"Future doc {doc_id} score should be <= 1.0"
+                        )
+
+    def test_grow_with_decay(self):
+        """Test combined grow (future) and decay (past) behavior."""
+        self._add_future_documents()
+
+        params = RecencyParameters(
+            recency_field="timestamp",
+            scale="7d",
+            offset="0d",
+            decay_function="exponential",
+            decay_to=0.5,
+            grow_from=0.3,
+            grow_function="exponential",
+            grow_scale="14d",
+            grow_offset="0d"
+        )
+        hits = self._search_with_recency("event", params)
+
+        self.assertGreater(len(hits), 0, "Should have results")
+
+        # Categorize documents
+        past_docs = [h for h in hits if h['_id'].startswith("doc-past")]
+        future_docs = [h for h in hits if h['_id'].startswith("doc-future")]
+        now_doc = self._get_doc_by_id(hits, "doc-now")
+
+        # Verify now doc has score ~1.0
+        if now_doc:
+            self.assertAlmostEqual(
+                now_doc.get('_recency_score'), 1.0, places=1,
+                msg="Current timestamp should have score ~1.0"
+            )
+
+        # Verify past docs use decay (score between decay_to and 1.0)
+        for hit in past_docs:
+            recency_score = hit.get('_recency_score')
+            self.assertGreaterEqual(recency_score, 0.5, f"Past doc {hit['_id']} should use decay_to as floor")
+            self.assertLessEqual(recency_score, 1.0, f"Past doc {hit['_id']} should be <= 1.0")
+
+        # Verify future docs use grow (score between grow_from and 1.0)
+        for hit in future_docs:
+            recency_score = hit.get('_recency_score')
+            self.assertGreaterEqual(recency_score, 0.3, f"Future doc {hit['_id']} should use grow_from as floor")
+            self.assertLessEqual(recency_score, 1.0, f"Future doc {hit['_id']} should be <= 1.0")
+
+    def test_grow_defaults_to_decay_function(self):
+        """Test growFunction defaults to decayFunction when not specified."""
+        self._add_future_documents()
+
+        # When grow_function is not specified, it should default to decay_function
+        params = RecencyParameters(
+            recency_field="timestamp",
+            scale="7d",
+            offset="0d",
+            decay_function="linear",  # Using linear decay
+            decay_to=0.5,
+            grow_from=0.3,
+            # grow_function not specified - should default to "linear"
+            grow_scale="14d",
+            grow_offset="0d"
+        )
+        hits = self._search_with_recency("event", params)
+
+        self.assertGreater(len(hits), 0, "Should have results")
+
+        # Verify future documents have grow scores applied
+        for hit in hits:
+            doc_id = hit.get('_id')
+            recency_score = hit.get('_recency_score')
+
+            if doc_id.startswith("doc-future"):
+                # Score should be between grow_from and 1.0
+                self.assertGreaterEqual(
+                    recency_score, 0.3,
+                    f"Future doc {doc_id} score should be >= grow_from"
+                )
+
+    def test_grow_defaults_to_scale(self):
+        """Test growScale defaults to scale when not specified."""
+        self._add_future_documents()
+
+        # When grow_scale is not specified, it should default to scale
+        params = RecencyParameters(
+            recency_field="timestamp",
+            scale="14d",  # Using 14d scale
+            offset="0d",
+            decay_function="exponential",
+            decay_to=0.5,
+            grow_from=0.3,
+            grow_function="exponential",
+            # grow_scale not specified - should default to "14d"
+            grow_offset="0d"
+        )
+        hits = self._search_with_recency("event", params)
+
+        self.assertGreater(len(hits), 0, "Should have results")
+
+        # Verify future documents have grow scores applied
+        future_14d = self._get_doc_by_id(hits, "doc-future-14d")
+        if future_14d:
+            # At future_age = scale, score should be close to grow_from
+            recency_score = future_14d.get('_recency_score')
+            # Allow some tolerance since we're testing the score at scale
+            self.assertLess(
+                recency_score, 0.5,
+                f"Future doc at scale should have score closer to grow_from"
+            )
+
+    def test_grow_offset_creates_plateau(self):
+        """Test growOffset creates plateau zone where score = 1.0."""
+        self._add_future_documents()
+
+        # With grow_offset=7d, documents with timestamps between now() and now()+7d
+        # should have score 1.0 (plateau zone)
+        params = RecencyParameters(
+            recency_field="timestamp",
+            scale="7d",
+            offset="0d",
+            decay_function="exponential",
+            decay_to=0.5,
+            grow_from=0.3,
+            grow_function="exponential",
+            grow_scale="14d",
+            grow_offset="7d"  # Plateau zone: now() to now()+7d
+        )
+        hits = self._search_with_recency("event", params)
+
+        self.assertGreater(len(hits), 0, "Should have results")
+
+        # Documents in plateau zone (1d, 3d, 7d) should have score ~1.0
+        plateau_docs = ["doc-future-1d", "doc-future-3d", "doc-future-7d"]
+        for doc_id in plateau_docs:
+            hit = self._get_doc_by_id(hits, doc_id)
+            if hit:
+                recency_score = hit.get('_recency_score')
+                self.assertAlmostEqual(
+                    recency_score, 1.0, places=1,
+                    msg=f"Doc {doc_id} within plateau should have score ~1.0"
+                )
+
+        # Documents beyond plateau (14d, 30d) should have score < 1.0
+        beyond_plateau_docs = ["doc-future-14d", "doc-future-30d"]
+        for doc_id in beyond_plateau_docs:
+            hit = self._get_doc_by_id(hits, doc_id)
+            if hit:
+                recency_score = hit.get('_recency_score')
+                self.assertLess(
+                    recency_score, 1.0,
+                    msg=f"Doc {doc_id} beyond plateau should have score < 1.0"
+                )
+
+    def test_grow_binary_function(self):
+        """Test binary grow function creates step function at scale."""
+        self._add_future_documents()
+
+        params = RecencyParameters(
+            recency_field="timestamp",
+            scale="7d",
+            offset="0d",
+            decay_function="exponential",
+            decay_to=0.5,
+            grow_from=0.2,
+            grow_function="binary",
+            grow_scale="10d",  # Step at 10 days
+            grow_offset="0d"
+        )
+        hits = self._search_with_recency("event", params)
+
+        self.assertGreater(len(hits), 0, "Should have results")
+
+        # Documents within scale (1d, 3d, 7d) should have score 1.0
+        within_scale_docs = ["doc-future-1d", "doc-future-3d", "doc-future-7d"]
+        for doc_id in within_scale_docs:
+            hit = self._get_doc_by_id(hits, doc_id)
+            if hit:
+                recency_score = hit.get('_recency_score')
+                self.assertAlmostEqual(
+                    recency_score, 1.0, places=1,
+                    msg=f"Doc {doc_id} within binary scale should have score 1.0"
+                )
+
+        # Documents beyond scale (14d, 30d) should have score = grow_from
+        beyond_scale_docs = ["doc-future-14d", "doc-future-30d"]
+        for doc_id in beyond_scale_docs:
+            hit = self._get_doc_by_id(hits, doc_id)
+            if hit:
+                recency_score = hit.get('_recency_score')
+                self.assertAlmostEqual(
+                    recency_score, 0.2, places=1,
+                    msg=f"Doc {doc_id} beyond binary scale should have score ~grow_from"
+                )
+
+    def test_grow_parameters_validation(self):
+        """Test grow parameter validation."""
+        # Valid grow_from values
+        valid_grow_from = [0.01, 0.5, 1.0]
+        for val in valid_grow_from:
+            with self.subTest(grow_from=val, valid=True):
+                params = RecencyParameters(
+                    recency_field="timestamp",
+                    scale="7d",
+                    decay_function="exponential",
+                    decay_to=0.5,
+                    grow_from=val
+                )
+                self.assertEqual(params.grow_from, val)
+
+        # Invalid grow_from values
+        invalid_grow_from = [0.0, -0.1, 1.1]
+        for val in invalid_grow_from:
+            with self.subTest(grow_from=val, valid=False):
+                with self.assertRaises(Exception):
+                    RecencyParameters(
+                        recency_field="timestamp",
+                        scale="7d",
+                        decay_function="exponential",
+                        decay_to=0.5,
+                        grow_from=val
+                    )
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
@@ -1043,6 +1043,83 @@ class TestRecencyScoring(MarqoTestCase):
                     str(ctx.exception)
                 )
 
+    def test_recency_on_old_index_2247_not_supported(self):
+        """Recency parameters should fail on index created with schema version 2.24.7."""
+        recency_params = RecencyParameters(
+            recency_field="timestamp",
+            scale="7d",
+            offset="0d",
+            decay_function="exponential",
+            decay_to=0.5
+        )
+
+        with self.assertRaises(UnsupportedFeatureError) as ctx:
+            tensor_search.search(
+                config=self.config,
+                index_name=self.old_index_2247.name,
+                text="product",
+                search_method=SearchMethod.HYBRID,
+                recency_parameters=recency_params,
+                result_count=10
+            )
+
+        # Verify error message mentions minimum version requirement
+        self.assertIn("2.24.8", str(ctx.exception), "Error should mention minimum version 2.24.8")
+
+    def test_grow_params_on_old_index_2248_not_supported(self):
+        """Grow parameters should fail on index created with schema version 2.24.8."""
+        recency_params = RecencyParameters(
+            recency_field="timestamp",
+            scale="7d",
+            offset="0d",
+            decay_function="exponential",
+            decay_to=0.5,
+            # Grow parameters - not supported on 2.24.8
+            grow_from=0.3,
+            grow_function="exponential",
+            grow_scale="7d",
+            grow_offset="0d"
+        )
+
+        with self.assertRaises(UnsupportedFeatureError) as ctx:
+            tensor_search.search(
+                config=self.config,
+                index_name=self.old_index_2248.name,
+                text="product",
+                search_method=SearchMethod.HYBRID,
+                recency_parameters=recency_params,
+                result_count=10
+            )
+
+        # Verify error message mentions growFrom and minimum version
+        error_message = str(ctx.exception)
+        self.assertIn("growFrom", error_message, "Error should mention growFrom parameter")
+
+    def test_add_to_score_weight_on_old_index_2248_not_supported(self):
+        """addToScoreWeight parameter should fail on index created with schema version 2.24.8."""
+        recency_params = RecencyParameters(
+            recency_field="timestamp",
+            scale="7d",
+            offset="0d",
+            decay_function="exponential",
+            decay_to=0.5,
+            add_to_score_weight=1.0  # Not supported on 2.24.8
+        )
+
+        with self.assertRaises(UnsupportedFeatureError) as ctx:
+            tensor_search.search(
+                config=self.config,
+                index_name=self.old_index_2248.name,
+                text="product",
+                search_method=SearchMethod.HYBRID,
+                recency_parameters=recency_params,
+                result_count=10
+            )
+
+        # Verify error message mentions addToScoreWeight and minimum version
+        error_message = str(ctx.exception)
+        self.assertIn("addToScoreWeight", error_message, "Error should mention addToScoreWeight parameter")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
@@ -910,6 +910,144 @@ class TestRecencyScoring(MarqoTestCase):
                     str(ctx.exception)
                 )
 
+    # ============== Additive Recency Scoring Tests ==============
+
+    def test_additive_recency_scoring(self):
+        """Test additive recency scoring with addToScoreWeight parameter.
+
+        When addToScoreWeight is provided, recency is applied additively:
+        final_score = modified_score + (recency_score * addToScoreWeight)
+
+        Instead of multiplicatively:
+        final_score = modified_score * recency_score
+        """
+        self._add_shared_documents()
+
+        # Test with different addToScoreWeight values
+        weight_values = [0.1, 0.5, 1.0, 2.0]
+
+        for weight in weight_values:
+            with self.subTest(addToScoreWeight=weight):
+                params = RecencyParameters(
+                    recency_field="timestamp",
+                    scale="7d",
+                    offset="0d",
+                    decay_function="exponential",
+                    decay_to=0.5,
+                    add_to_score_weight=weight
+                )
+                hits = self._search_with_recency("product", params)
+
+                self.assertGreater(len(hits), 0, "Should have results")
+
+                # Verify recency scores are calculated correctly
+                for hit in hits:
+                    actual_recency = hit.get('_recency_score')
+                    doc_id = hit.get('_id')
+
+                    self.assertIsNotNone(actual_recency, f"Recency score should be present for {doc_id}")
+
+                    # Verify recency score is within valid range [decay_to, 1.0]
+                    self.assertGreaterEqual(actual_recency, 0.5, f"Recency score for {doc_id} should be >= decay_to")
+                    self.assertLessEqual(actual_recency, 1.0, f"Recency score for {doc_id} should be <= 1.0")
+
+                # Verify newer docs score higher than older docs
+                doc_0d = self._get_doc_by_id(hits, "doc-0d")
+                doc_30d = self._get_doc_by_id(hits, "doc-30d")
+                if doc_0d and doc_30d:
+                    self.assertGreater(
+                        doc_0d['_recency_score'],
+                        doc_30d['_recency_score'],
+                        "Newer doc should have higher recency score"
+                    )
+
+    def test_additive_recency_vs_multiplicative(self):
+        """Test that additive and multiplicative recency produce different final scores.
+
+        With additive mode (addToScoreWeight > 0), very old documents get boosted more
+        relative to their base score compared to multiplicative mode where they get
+        penalized more heavily.
+        """
+        self._add_shared_documents()
+
+        base_params = {
+            "recency_field": "timestamp",
+            "scale": "7d",
+            "offset": "0d",
+            "decay_function": "exponential",
+            "decay_to": 0.3
+        }
+
+        # Get results without additive (multiplicative mode - default)
+        multiplicative_params = RecencyParameters(**base_params)
+        multiplicative_hits = self._search_with_recency("product", multiplicative_params)
+
+        # Get results with additive mode
+        additive_params = RecencyParameters(
+            **base_params,
+            add_to_score_weight=0.5
+        )
+        additive_hits = self._search_with_recency("product", additive_params)
+
+        # Both should return results
+        self.assertGreater(len(multiplicative_hits), 0, "Multiplicative should have results")
+        self.assertGreater(len(additive_hits), 0, "Additive should have results")
+
+        # Both should have the same recency scores (recency calculation is the same)
+        for mult_hit, add_hit in zip(multiplicative_hits, additive_hits):
+            if mult_hit['_id'] == add_hit['_id']:
+                self.assertAlmostEqual(
+                    mult_hit.get('_recency_score', 0),
+                    add_hit.get('_recency_score', 0),
+                    places=3,
+                    msg=f"Recency scores should be the same for {mult_hit['_id']}"
+                )
+
+    def test_additive_recency_with_hybrid_search_methods(self):
+        """Test additive recency works with different hybrid search configurations."""
+        self._add_shared_documents()
+
+        test_cases = [
+            (RetrievalMethod.Disjunction, RankingMethod.RRF),
+            (RetrievalMethod.Tensor, RankingMethod.Tensor),
+            (RetrievalMethod.Lexical, RankingMethod.Lexical),
+        ]
+
+        params = RecencyParameters(
+            recency_field="timestamp",
+            scale="7d",
+            offset="0d",
+            decay_function="exponential",
+            decay_to=0.5,
+            add_to_score_weight=0.5
+        )
+
+        for retrieval, ranking in test_cases:
+            with self.subTest(retrieval=retrieval.value, ranking=ranking.value):
+                hybrid_params = HybridParameters(
+                    retrievalMethod=retrieval,
+                    rankingMethod=ranking
+                )
+                search_result = tensor_search.search(
+                    config=self.config,
+                    index_name=self.main_index.name,
+                    text="product",
+                    search_method=SearchMethod.HYBRID,
+                    recency_parameters=params,
+                    hybrid_parameters=hybrid_params,
+                    result_count=10
+                )
+
+                hits = search_result['hits']
+                self.assertGreater(len(hits), 0, "Should have results")
+
+                # Verify recency scores are present
+                for hit in hits:
+                    self.assertIsNotNone(
+                        hit.get('_recency_score'),
+                        f"Recency score should be present for {hit['_id']}"
+                    )
+
     # ============== Validation Tests ==============
 
     def test_decay_to_validation(self):

--- a/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
@@ -1104,6 +1104,41 @@ class TestRecencyScoring(MarqoTestCase):
                         decay_to=0.5
                     )
 
+    def test_grow_params_all_or_nothing_validation(self):
+        """Test that grow parameters must be either all provided or all omitted."""
+        # Partial combinations should fail
+        partial_cases = [
+            ("only_grow_from", {"grow_from": 0.5}),
+            ("missing_grow_offset", {"grow_from": 0.5, "grow_function": "exponential", "grow_scale": "7d"}),
+            ("missing_grow_scale", {"grow_from": 0.5, "grow_function": "exponential", "grow_offset": "0d"}),
+        ]
+
+        for test_name, grow_params in partial_cases:
+            with self.subTest(test_name):
+                with self.assertRaises(Exception) as ctx:
+                    RecencyParameters(
+                        recency_field="timestamp",
+                        scale="7d",
+                        decay_function="exponential",
+                        decay_to=0.5,
+                        **grow_params
+                    )
+                self.assertIn("all provided or all omitted", str(ctx.exception).lower())
+
+        # All provided should work
+        with self.subTest("all_provided"):
+            params = RecencyParameters(
+                recency_field="timestamp",
+                scale="7d",
+                decay_function="exponential",
+                decay_to=0.5,
+                grow_from=0.5,
+                grow_function="exponential",
+                grow_scale="7d",
+                grow_offset="0d"
+            )
+            self.assertEqual(params.grow_from, 0.5)
+
     def test_grow_from_validation(self):
         """Test grow_from must be in (0.0, 1.0]."""
         valid_values = [0.01, 0.5, 1.0]
@@ -1116,7 +1151,10 @@ class TestRecencyScoring(MarqoTestCase):
                     scale="7d",
                     decay_function="exponential",
                     decay_to=0.5,
-                    grow_from=val
+                    grow_from=val,
+                    grow_function="exponential",
+                    grow_scale="7d",
+                    grow_offset="0d"
                 )
                 self.assertEqual(params.grow_from, val)
 
@@ -1128,7 +1166,10 @@ class TestRecencyScoring(MarqoTestCase):
                         scale="7d",
                         decay_function="exponential",
                         decay_to=0.5,
-                        grow_from=val
+                        grow_from=val,
+                        grow_function="exponential",
+                        grow_scale="7d",
+                        grow_offset="0d"
                     )
 
     def test_grow_function_validation(self):
@@ -1144,7 +1185,9 @@ class TestRecencyScoring(MarqoTestCase):
                     decay_function="exponential",
                     decay_to=0.5,
                     grow_from=0.3,
-                    grow_function=func
+                    grow_function=func,
+                    grow_scale="7d",
+                    grow_offset="0d"
                 )
                 self.assertEqual(params.grow_function, func)
 
@@ -1157,7 +1200,9 @@ class TestRecencyScoring(MarqoTestCase):
                         decay_function="exponential",
                         decay_to=0.5,
                         grow_from=0.3,
-                        grow_function=func
+                        grow_function=func,
+                        grow_scale="7d",
+                        grow_offset="0d"
                     )
 
     def test_grow_scale_validation(self):
@@ -1173,7 +1218,9 @@ class TestRecencyScoring(MarqoTestCase):
                     decay_function="exponential",
                     decay_to=0.5,
                     grow_from=0.3,
-                    grow_scale=fmt
+                    grow_function="exponential",
+                    grow_scale=fmt,
+                    grow_offset="0d"
                 )
                 self.assertEqual(params.grow_scale, fmt)
 
@@ -1186,7 +1233,9 @@ class TestRecencyScoring(MarqoTestCase):
                         decay_function="exponential",
                         decay_to=0.5,
                         grow_from=0.3,
-                        grow_scale=fmt
+                        grow_function="exponential",
+                        grow_scale=fmt,
+                        grow_offset="0d"
                     )
 
     def test_grow_offset_validation(self):
@@ -1202,6 +1251,8 @@ class TestRecencyScoring(MarqoTestCase):
                     decay_function="exponential",
                     decay_to=0.5,
                     grow_from=0.3,
+                    grow_function="exponential",
+                    grow_scale="7d",
                     grow_offset=fmt
                 )
                 self.assertEqual(params.grow_offset, fmt)
@@ -1215,6 +1266,8 @@ class TestRecencyScoring(MarqoTestCase):
                         decay_function="exponential",
                         decay_to=0.5,
                         grow_from=0.3,
+                        grow_function="exponential",
+                        grow_scale="7d",
                         grow_offset=fmt
                     )
 
@@ -1415,14 +1468,13 @@ class TestRecencyScoring(MarqoTestCase):
                 self.assertGreaterEqual(score, 0.3, f"Future doc {doc_id} should be >= grow_from")
                 self.assertLessEqual(score, 1.0, f"Future doc {doc_id} should be <= 1.0")
 
-    def test_grow_defaults_to_decay_function(self):
-        """Test growFunction defaults to decayFunction when not specified.
+    def test_grow_with_linear_function(self):
+        """Test grow with linear function produces correct scores.
 
-        Use linear decay and verify future docs also use linear grow.
+        Use linear grow function and verify future docs have expected scores.
         """
         self._add_shared_documents()
 
-        # grow_function not specified - should default to decay_function (linear)
         params = RecencyParameters(
             recency_field="timestamp",
             scale="120d",
@@ -1430,7 +1482,7 @@ class TestRecencyScoring(MarqoTestCase):
             decay_function="linear",
             decay_to=0.5,
             grow_from=0.3,
-            # grow_function not specified
+            grow_function="linear",
             grow_scale="60d",
             grow_offset="0d"
         )
@@ -1438,7 +1490,7 @@ class TestRecencyScoring(MarqoTestCase):
 
         self.assertGreater(len(hits), 0, "Should have results")
 
-        # Verify scores with linear grow function (defaults from decay)
+        # Verify scores with linear grow function
         self._verify_grow_behavior(
             hits,
             decay_to=0.5,
@@ -1446,44 +1498,43 @@ class TestRecencyScoring(MarqoTestCase):
             scale="120d",
             offset="0d",
             decay_function="linear",
-            grow_function="linear",  # Defaults to decay_function
+            grow_function="linear",
             grow_scale="60d",
             grow_offset="0d"
         )
 
-    def test_grow_defaults_to_scale(self):
-        """Test growScale defaults to scale when not specified.
+    def test_grow_scale_at_boundary(self):
+        """Test grow_scale boundary - doc at exactly scale gets grow_from score.
 
-        Use scale=30d and verify grow also uses 30d scale.
+        Use grow_scale=30d and verify doc+30d has score ~grow_from.
         """
         self._add_shared_documents()
 
-        # grow_scale not specified - should default to scale
         params = RecencyParameters(
             recency_field="timestamp",
-            scale="30d",
+            scale="120d",
             offset="0d",
             decay_function="exponential",
             decay_to=0.5,
             grow_from=0.3,
             grow_function="exponential",
-            # grow_scale not specified - defaults to scale
+            grow_scale="30d",
             grow_offset="0d"
         )
         hits = self._search_with_recency("product", params)
 
         self.assertGreater(len(hits), 0, "Should have results")
 
-        # Verify scores with grow_scale=30d (defaults from scale)
+        # Verify scores
         self._verify_grow_behavior(
             hits,
             decay_to=0.5,
             grow_from=0.3,
-            scale="30d",
+            scale="120d",
             offset="0d",
             decay_function="exponential",
             grow_function="exponential",
-            grow_scale="30d",  # Defaults to scale
+            grow_scale="30d",
             grow_offset="0d"
         )
 

--- a/tests/unit_tests/core/semi_structured_vespa_index/test_recency_query_input.py
+++ b/tests/unit_tests/core/semi_structured_vespa_index/test_recency_query_input.py
@@ -153,7 +153,7 @@ class TestRecencyQueryInput(unittest.TestCase):
         )
 
     def test_all_query_input_constants_present(self):
-        """Test that all 7 expected query input constants are present."""
+        """Test that all 8 expected query input constants are present."""
         params = RecencyParameters(recency_field="created_at")
         result = self.vespa_index._get_recency_query_input(params)
 
@@ -165,6 +165,7 @@ class TestRecencyQueryInput(unittest.TestCase):
             constants.QUERY_INPUT_RECENCY_DECAY_TO,
             constants.QUERY_INPUT_RECENCY_TIMESTAMP_KEY,
             constants.QUERY_INPUT_RECENCY_DECAY_FUNCTION_TYPE,
+            constants.QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT,
         ]
 
         for key in expected_keys:
@@ -192,6 +193,7 @@ class TestRecencyQueryInput(unittest.TestCase):
                     constants.QUERY_INPUT_RECENCY_DECAY_TO: 0.5,
                     constants.QUERY_INPUT_RECENCY_TIMESTAMP_KEY: {"created_at": 1.0},
                     constants.QUERY_INPUT_RECENCY_DECAY_FUNCTION_TYPE: 0,
+                    constants.QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT: 0.0,
                 }
             ),
             (
@@ -212,6 +214,7 @@ class TestRecencyQueryInput(unittest.TestCase):
                     constants.QUERY_INPUT_RECENCY_DECAY_TO: 0.3,
                     constants.QUERY_INPUT_RECENCY_TIMESTAMP_KEY: {"updated_at": 1.0},
                     constants.QUERY_INPUT_RECENCY_DECAY_FUNCTION_TYPE: 1,
+                    constants.QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT: 0.0,
                 }
             ),
             (
@@ -232,6 +235,7 @@ class TestRecencyQueryInput(unittest.TestCase):
                     constants.QUERY_INPUT_RECENCY_DECAY_TO: 0.75,
                     constants.QUERY_INPUT_RECENCY_TIMESTAMP_KEY: {"publish_date": 1.0},
                     constants.QUERY_INPUT_RECENCY_DECAY_FUNCTION_TYPE: 2,
+                    constants.QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT: 0.0,
                 }
             ),
             (
@@ -252,6 +256,29 @@ class TestRecencyQueryInput(unittest.TestCase):
                     constants.QUERY_INPUT_RECENCY_DECAY_TO: 0.01,
                     constants.QUERY_INPUT_RECENCY_TIMESTAMP_KEY: {"event_time": 1.0},
                     constants.QUERY_INPUT_RECENCY_DECAY_FUNCTION_TYPE: 3,
+                    constants.QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT: 0.0,
+                }
+            ),
+            (
+                "with_add_to_score_weight",
+                {
+                    "recency_field": "created_at",
+                    "decay_function": "exponential",
+                    "scale": "7d",
+                    "offset": "0d",
+                    "decay_to": 0.5,
+                    "apply_in_ranking_phase": "all",
+                    "add_to_score_weight": 0.5
+                },
+                {
+                    constants.QUERY_INPUT_RECENCY_SHOULD_CALCULATE_SCORE: 1,
+                    constants.QUERY_INPUT_RECENCY_SHOULD_APPLY_SCORE: 1,
+                    constants.QUERY_INPUT_RECENCY_SCALE_SECONDS: 604800,
+                    constants.QUERY_INPUT_RECENCY_OFFSET_SECONDS: 0,
+                    constants.QUERY_INPUT_RECENCY_DECAY_TO: 0.5,
+                    constants.QUERY_INPUT_RECENCY_TIMESTAMP_KEY: {"created_at": 1.0},
+                    constants.QUERY_INPUT_RECENCY_DECAY_FUNCTION_TYPE: 0,
+                    constants.QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT: 0.5,
                 }
             ),
         ]
@@ -262,6 +289,33 @@ class TestRecencyQueryInput(unittest.TestCase):
                 result = self.vespa_index._get_recency_query_input(params)
 
                 self.assertEqual(result, expected_output)
+
+    def test_add_to_score_weight_defaults_to_zero(self):
+        """Test add_to_score_weight defaults to 0.0 when not provided."""
+        params = RecencyParameters(recency_field="created_at")
+        result = self.vespa_index._get_recency_query_input(params)
+
+        self.assertEqual(
+            result[constants.QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT],
+            0.0
+        )
+
+    def test_add_to_score_weight_passed_correctly(self):
+        """Test add_to_score_weight is passed correctly when provided."""
+        weight_values = [0.1, 0.5, 1.0, 10.0]
+
+        for weight in weight_values:
+            with self.subTest(weight=weight):
+                params = RecencyParameters(
+                    recency_field="created_at",
+                    add_to_score_weight=weight
+                )
+                result = self.vespa_index._get_recency_query_input(params)
+
+                self.assertEqual(
+                    result[constants.QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT],
+                    weight
+                )
 
     def test_global_phase_parameter_for_all_apply_modes(self):
         """Test marqo__recency_apply_in_global_ranking_phase is set correctly for all modes.

--- a/tests/unit_tests/core/semi_structured_vespa_index/test_recency_query_input.py
+++ b/tests/unit_tests/core/semi_structured_vespa_index/test_recency_query_input.py
@@ -188,12 +188,18 @@ class TestRecencyQueryInput(unittest.TestCase):
                 {
                     constants.QUERY_INPUT_RECENCY_SHOULD_CALCULATE_SCORE: 1,
                     constants.QUERY_INPUT_RECENCY_SHOULD_APPLY_SCORE: 1,
-                    constants.QUERY_INPUT_RECENCY_SCALE_SECONDS: 604800,
-                    constants.QUERY_INPUT_RECENCY_OFFSET_SECONDS: 0,
+                    constants.QUERY_INPUT_RECENCY_SCALE_SECONDS: 604800.0,
+                    constants.QUERY_INPUT_RECENCY_OFFSET_SECONDS: 0.0,
                     constants.QUERY_INPUT_RECENCY_DECAY_TO: 0.5,
                     constants.QUERY_INPUT_RECENCY_TIMESTAMP_KEY: {"created_at": 1.0},
                     constants.QUERY_INPUT_RECENCY_DECAY_FUNCTION_TYPE: 0,
                     constants.QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT: 0.0,
+                    # Grow parameters (disabled by default)
+                    constants.QUERY_INPUT_RECENCY_GROW_ENABLED: 0,
+                    constants.QUERY_INPUT_RECENCY_GROW_FROM: 1.0,
+                    constants.QUERY_INPUT_RECENCY_GROW_FUNCTION_TYPE: 0,
+                    constants.QUERY_INPUT_RECENCY_GROW_SCALE_SECONDS: 604800.0,
+                    constants.QUERY_INPUT_RECENCY_GROW_OFFSET_SECONDS: 0,
                 }
             ),
             (
@@ -209,12 +215,18 @@ class TestRecencyQueryInput(unittest.TestCase):
                 {
                     constants.QUERY_INPUT_RECENCY_SHOULD_CALCULATE_SCORE: 1,
                     constants.QUERY_INPUT_RECENCY_SHOULD_APPLY_SCORE: 0,
-                    constants.QUERY_INPUT_RECENCY_SCALE_SECONDS: 1209600,
-                    constants.QUERY_INPUT_RECENCY_OFFSET_SECONDS: 86400,
+                    constants.QUERY_INPUT_RECENCY_SCALE_SECONDS: 1209600.0,
+                    constants.QUERY_INPUT_RECENCY_OFFSET_SECONDS: 86400.0,
                     constants.QUERY_INPUT_RECENCY_DECAY_TO: 0.3,
                     constants.QUERY_INPUT_RECENCY_TIMESTAMP_KEY: {"updated_at": 1.0},
                     constants.QUERY_INPUT_RECENCY_DECAY_FUNCTION_TYPE: 1,
                     constants.QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT: 0.0,
+                    # Grow parameters (disabled by default)
+                    constants.QUERY_INPUT_RECENCY_GROW_ENABLED: 0,
+                    constants.QUERY_INPUT_RECENCY_GROW_FROM: 1.0,
+                    constants.QUERY_INPUT_RECENCY_GROW_FUNCTION_TYPE: 0,
+                    constants.QUERY_INPUT_RECENCY_GROW_SCALE_SECONDS: 1209600.0,
+                    constants.QUERY_INPUT_RECENCY_GROW_OFFSET_SECONDS: 0,
                 }
             ),
             (
@@ -230,12 +242,18 @@ class TestRecencyQueryInput(unittest.TestCase):
                 {
                     constants.QUERY_INPUT_RECENCY_SHOULD_CALCULATE_SCORE: 1,
                     constants.QUERY_INPUT_RECENCY_SHOULD_APPLY_SCORE: 1,
-                    constants.QUERY_INPUT_RECENCY_SCALE_SECONDS: 86400,
-                    constants.QUERY_INPUT_RECENCY_OFFSET_SECONDS: 43200,
+                    constants.QUERY_INPUT_RECENCY_SCALE_SECONDS: 86400.0,
+                    constants.QUERY_INPUT_RECENCY_OFFSET_SECONDS: 43200.0,
                     constants.QUERY_INPUT_RECENCY_DECAY_TO: 0.75,
                     constants.QUERY_INPUT_RECENCY_TIMESTAMP_KEY: {"publish_date": 1.0},
                     constants.QUERY_INPUT_RECENCY_DECAY_FUNCTION_TYPE: 2,
                     constants.QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT: 0.0,
+                    # Grow parameters (disabled by default)
+                    constants.QUERY_INPUT_RECENCY_GROW_ENABLED: 0,
+                    constants.QUERY_INPUT_RECENCY_GROW_FROM: 1.0,
+                    constants.QUERY_INPUT_RECENCY_GROW_FUNCTION_TYPE: 0,
+                    constants.QUERY_INPUT_RECENCY_GROW_SCALE_SECONDS: 86400.0,
+                    constants.QUERY_INPUT_RECENCY_GROW_OFFSET_SECONDS: 0,
                 }
             ),
             (
@@ -251,12 +269,18 @@ class TestRecencyQueryInput(unittest.TestCase):
                 {
                     constants.QUERY_INPUT_RECENCY_SHOULD_CALCULATE_SCORE: 1,
                     constants.QUERY_INPUT_RECENCY_SHOULD_APPLY_SCORE: 1,
-                    constants.QUERY_INPUT_RECENCY_SCALE_SECONDS: 86400,
-                    constants.QUERY_INPUT_RECENCY_OFFSET_SECONDS: 0,
+                    constants.QUERY_INPUT_RECENCY_SCALE_SECONDS: 86400.0,
+                    constants.QUERY_INPUT_RECENCY_OFFSET_SECONDS: 0.0,
                     constants.QUERY_INPUT_RECENCY_DECAY_TO: 0.01,
                     constants.QUERY_INPUT_RECENCY_TIMESTAMP_KEY: {"event_time": 1.0},
                     constants.QUERY_INPUT_RECENCY_DECAY_FUNCTION_TYPE: 3,
                     constants.QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT: 0.0,
+                    # Grow parameters (disabled by default)
+                    constants.QUERY_INPUT_RECENCY_GROW_ENABLED: 0,
+                    constants.QUERY_INPUT_RECENCY_GROW_FROM: 1.0,
+                    constants.QUERY_INPUT_RECENCY_GROW_FUNCTION_TYPE: 0,
+                    constants.QUERY_INPUT_RECENCY_GROW_SCALE_SECONDS: 86400.0,
+                    constants.QUERY_INPUT_RECENCY_GROW_OFFSET_SECONDS: 0,
                 }
             ),
             (
@@ -273,12 +297,18 @@ class TestRecencyQueryInput(unittest.TestCase):
                 {
                     constants.QUERY_INPUT_RECENCY_SHOULD_CALCULATE_SCORE: 1,
                     constants.QUERY_INPUT_RECENCY_SHOULD_APPLY_SCORE: 1,
-                    constants.QUERY_INPUT_RECENCY_SCALE_SECONDS: 604800,
-                    constants.QUERY_INPUT_RECENCY_OFFSET_SECONDS: 0,
+                    constants.QUERY_INPUT_RECENCY_SCALE_SECONDS: 604800.0,
+                    constants.QUERY_INPUT_RECENCY_OFFSET_SECONDS: 0.0,
                     constants.QUERY_INPUT_RECENCY_DECAY_TO: 0.5,
                     constants.QUERY_INPUT_RECENCY_TIMESTAMP_KEY: {"created_at": 1.0},
                     constants.QUERY_INPUT_RECENCY_DECAY_FUNCTION_TYPE: 0,
                     constants.QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT: 0.5,
+                    # Grow parameters (disabled by default)
+                    constants.QUERY_INPUT_RECENCY_GROW_ENABLED: 0,
+                    constants.QUERY_INPUT_RECENCY_GROW_FROM: 1.0,
+                    constants.QUERY_INPUT_RECENCY_GROW_FUNCTION_TYPE: 0,
+                    constants.QUERY_INPUT_RECENCY_GROW_SCALE_SECONDS: 604800.0,
+                    constants.QUERY_INPUT_RECENCY_GROW_OFFSET_SECONDS: 0,
                 }
             ),
         ]
@@ -376,6 +406,280 @@ class TestRecencyQueryInput(unittest.TestCase):
             recency_parameters=recency_params
         )
         return query
+
+    # ============= Grow Parameters Tests =============
+
+    def test_grow_parameters_disabled_by_default(self):
+        """Test grow parameters are disabled when grow_from is not specified."""
+        params = RecencyParameters(recency_field="created_at")
+        result = self.vespa_index._get_recency_query_input(params)
+
+        self.assertEqual(
+            result[constants.QUERY_INPUT_RECENCY_GROW_ENABLED],
+            0
+        )
+
+    def test_grow_parameters_enabled_when_grow_from_specified(self):
+        """Test grow parameters are enabled when grow_from is specified."""
+        params = RecencyParameters(
+            recency_field="created_at",
+            grow_from=0.5
+        )
+        result = self.vespa_index._get_recency_query_input(params)
+
+        self.assertEqual(
+            result[constants.QUERY_INPUT_RECENCY_GROW_ENABLED],
+            1
+        )
+        self.assertEqual(
+            result[constants.QUERY_INPUT_RECENCY_GROW_FROM],
+            0.5
+        )
+
+    def test_grow_from_values(self):
+        """Test grow_from values are passed correctly."""
+        grow_from_values = [0.01, 0.3, 0.5, 0.75, 0.99, 1.0]
+
+        for grow_from in grow_from_values:
+            with self.subTest(grow_from=grow_from):
+                params = RecencyParameters(
+                    recency_field="created_at",
+                    grow_from=grow_from
+                )
+                result = self.vespa_index._get_recency_query_input(params)
+
+                self.assertEqual(
+                    result[constants.QUERY_INPUT_RECENCY_GROW_FROM],
+                    grow_from
+                )
+
+    def test_grow_function_defaults_to_decay_function(self):
+        """Test grow_function defaults to decay_function when not specified."""
+        decay_functions = [
+            ("exponential", 0),
+            ("linear", 1),
+            ("gaussian", 2),
+            ("binary", 3),
+        ]
+
+        for decay_func, expected_code in decay_functions:
+            with self.subTest(decay_func):
+                params = RecencyParameters(
+                    recency_field="created_at",
+                    decay_function=decay_func,
+                    grow_from=0.5
+                    # grow_function not specified, should default to decay_function
+                )
+                result = self.vespa_index._get_recency_query_input(params)
+
+                self.assertEqual(
+                    result[constants.QUERY_INPUT_RECENCY_GROW_FUNCTION_TYPE],
+                    expected_code
+                )
+
+    def test_grow_function_mapping(self):
+        """Test grow_function to numeric mapping when specified."""
+        grow_functions = [
+            ("exponential", 0),
+            ("linear", 1),
+            ("gaussian", 2),
+            ("binary", 3),
+        ]
+
+        for function_name, expected_code in grow_functions:
+            with self.subTest(function_name):
+                params = RecencyParameters(
+                    recency_field="created_at",
+                    decay_function="exponential",  # Different from grow_function
+                    grow_from=0.5,
+                    grow_function=function_name
+                )
+                result = self.vespa_index._get_recency_query_input(params)
+
+                self.assertEqual(
+                    result[constants.QUERY_INPUT_RECENCY_GROW_FUNCTION_TYPE],
+                    expected_code
+                )
+
+    def test_grow_scale_defaults_to_scale(self):
+        """Test grow_scale defaults to scale when not specified."""
+        duration_cases = [
+            ("7d", 604800),
+            ("1d", 86400),
+            ("24h", 86400),
+            ("14d", 1209600),
+        ]
+
+        for scale, expected_seconds in duration_cases:
+            with self.subTest(scale=scale):
+                params = RecencyParameters(
+                    recency_field="created_at",
+                    scale=scale,
+                    grow_from=0.5
+                    # grow_scale not specified, should default to scale
+                )
+                result = self.vespa_index._get_recency_query_input(params)
+
+                self.assertEqual(
+                    result[constants.QUERY_INPUT_RECENCY_GROW_SCALE_SECONDS],
+                    expected_seconds
+                )
+
+    def test_grow_scale_to_seconds_conversion(self):
+        """Test grow_scale conversion to seconds when specified."""
+        duration_cases = [
+            ("7d", 604800),
+            ("1d", 86400),
+            ("24h", 86400),
+            ("14d", 1209600),
+            ("1.5d", 129600),
+            ("0.5h", 1800),
+        ]
+
+        for grow_scale, expected_seconds in duration_cases:
+            with self.subTest(grow_scale=grow_scale):
+                params = RecencyParameters(
+                    recency_field="created_at",
+                    scale="7d",  # Different from grow_scale
+                    grow_from=0.5,
+                    grow_scale=grow_scale
+                )
+                result = self.vespa_index._get_recency_query_input(params)
+
+                self.assertEqual(
+                    result[constants.QUERY_INPUT_RECENCY_GROW_SCALE_SECONDS],
+                    expected_seconds
+                )
+
+    def test_grow_offset_defaults_to_zero(self):
+        """Test grow_offset defaults to 0 when not specified."""
+        params = RecencyParameters(
+            recency_field="created_at",
+            grow_from=0.5
+            # grow_offset not specified, should default to 0
+        )
+        result = self.vespa_index._get_recency_query_input(params)
+
+        self.assertEqual(
+            result[constants.QUERY_INPUT_RECENCY_GROW_OFFSET_SECONDS],
+            0
+        )
+
+    def test_grow_offset_to_seconds_conversion(self):
+        """Test grow_offset conversion to seconds when specified."""
+        duration_cases = [
+            ("0d", 0),
+            ("1d", 86400),
+            ("12h", 43200),
+            ("2d", 172800),
+            ("0.5d", 43200),
+        ]
+
+        for grow_offset, expected_seconds in duration_cases:
+            with self.subTest(grow_offset=grow_offset):
+                params = RecencyParameters(
+                    recency_field="created_at",
+                    grow_from=0.5,
+                    grow_offset=grow_offset
+                )
+                result = self.vespa_index._get_recency_query_input(params)
+
+                self.assertEqual(
+                    result[constants.QUERY_INPUT_RECENCY_GROW_OFFSET_SECONDS],
+                    expected_seconds
+                )
+
+    def test_all_grow_query_input_constants_present(self):
+        """Test that all grow query input constants are present when grow is enabled."""
+        params = RecencyParameters(
+            recency_field="created_at",
+            grow_from=0.5
+        )
+        result = self.vespa_index._get_recency_query_input(params)
+
+        expected_grow_keys = [
+            constants.QUERY_INPUT_RECENCY_GROW_ENABLED,
+            constants.QUERY_INPUT_RECENCY_GROW_FROM,
+            constants.QUERY_INPUT_RECENCY_GROW_FUNCTION_TYPE,
+            constants.QUERY_INPUT_RECENCY_GROW_SCALE_SECONDS,
+            constants.QUERY_INPUT_RECENCY_GROW_OFFSET_SECONDS,
+        ]
+
+        for key in expected_grow_keys:
+            with self.subTest(key=key):
+                self.assertIn(key, result)
+
+    def test_complete_grow_parameter_combination(self):
+        """Test complete grow parameter combination produces expected output."""
+        test_cases = [
+            (
+                "grow_with_all_params",
+                {
+                    "recency_field": "created_at",
+                    "decay_function": "exponential",
+                    "scale": "7d",
+                    "offset": "0d",
+                    "decay_to": 0.5,
+                    "grow_from": 0.3,
+                    "grow_function": "linear",
+                    "grow_scale": "14d",
+                    "grow_offset": "1d"
+                },
+                {
+                    constants.QUERY_INPUT_RECENCY_GROW_ENABLED: 1,
+                    constants.QUERY_INPUT_RECENCY_GROW_FROM: 0.3,
+                    constants.QUERY_INPUT_RECENCY_GROW_FUNCTION_TYPE: 1,  # linear
+                    constants.QUERY_INPUT_RECENCY_GROW_SCALE_SECONDS: 1209600,  # 14d
+                    constants.QUERY_INPUT_RECENCY_GROW_OFFSET_SECONDS: 86400,  # 1d
+                }
+            ),
+            (
+                "grow_with_defaults",
+                {
+                    "recency_field": "created_at",
+                    "decay_function": "gaussian",
+                    "scale": "24h",
+                    "grow_from": 0.5
+                    # grow_function, grow_scale, grow_offset should use defaults
+                },
+                {
+                    constants.QUERY_INPUT_RECENCY_GROW_ENABLED: 1,
+                    constants.QUERY_INPUT_RECENCY_GROW_FROM: 0.5,
+                    constants.QUERY_INPUT_RECENCY_GROW_FUNCTION_TYPE: 2,  # gaussian (default to decay)
+                    constants.QUERY_INPUT_RECENCY_GROW_SCALE_SECONDS: 86400,  # 24h (default to scale)
+                    constants.QUERY_INPUT_RECENCY_GROW_OFFSET_SECONDS: 0,  # default to 0
+                }
+            ),
+            (
+                "grow_disabled",
+                {
+                    "recency_field": "created_at",
+                    "decay_function": "exponential",
+                    "scale": "7d",
+                    # grow_from not specified
+                },
+                {
+                    constants.QUERY_INPUT_RECENCY_GROW_ENABLED: 0,
+                    constants.QUERY_INPUT_RECENCY_GROW_FROM: 1.0,
+                    constants.QUERY_INPUT_RECENCY_GROW_FUNCTION_TYPE: 0,
+                    constants.QUERY_INPUT_RECENCY_GROW_SCALE_SECONDS: 604800,
+                    constants.QUERY_INPUT_RECENCY_GROW_OFFSET_SECONDS: 0,
+                }
+            ),
+        ]
+
+        for test_name, input_params, expected_grow_output in test_cases:
+            with self.subTest(test_name):
+                params = RecencyParameters(**input_params)
+                result = self.vespa_index._get_recency_query_input(params)
+
+                for key, expected_value in expected_grow_output.items():
+                    self.assertEqual(
+                        result[key],
+                        expected_value,
+                        f"Key {key}: expected {expected_value}, got {result.get(key)}"
+                    )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit_tests/core/semi_structured_vespa_index/test_recency_query_input.py
+++ b/tests/unit_tests/core/semi_structured_vespa_index/test_recency_query_input.py
@@ -420,10 +420,13 @@ class TestRecencyQueryInput(unittest.TestCase):
         )
 
     def test_grow_parameters_enabled_when_grow_from_specified(self):
-        """Test grow parameters are enabled when grow_from is specified."""
+        """Test grow parameters are enabled when all grow params are specified."""
         params = RecencyParameters(
             recency_field="created_at",
-            grow_from=0.5
+            grow_from=0.5,
+            grow_function="exponential",
+            grow_scale="7d",
+            grow_offset="0d"
         )
         result = self.vespa_index._get_recency_query_input(params)
 
@@ -444,7 +447,10 @@ class TestRecencyQueryInput(unittest.TestCase):
             with self.subTest(grow_from=grow_from):
                 params = RecencyParameters(
                     recency_field="created_at",
-                    grow_from=grow_from
+                    grow_from=grow_from,
+                    grow_function="exponential",
+                    grow_scale="7d",
+                    grow_offset="0d"
                 )
                 result = self.vespa_index._get_recency_query_input(params)
 
@@ -453,32 +459,9 @@ class TestRecencyQueryInput(unittest.TestCase):
                     grow_from
                 )
 
-    def test_grow_function_defaults_to_decay_function(self):
-        """Test grow_function defaults to decay_function when not specified."""
-        decay_functions = [
-            ("exponential", 0),
-            ("linear", 1),
-            ("gaussian", 2),
-            ("binary", 3),
-        ]
-
-        for decay_func, expected_code in decay_functions:
-            with self.subTest(decay_func):
-                params = RecencyParameters(
-                    recency_field="created_at",
-                    decay_function=decay_func,
-                    grow_from=0.5
-                    # grow_function not specified, should default to decay_function
-                )
-                result = self.vespa_index._get_recency_query_input(params)
-
-                self.assertEqual(
-                    result[constants.QUERY_INPUT_RECENCY_GROW_FUNCTION_TYPE],
-                    expected_code
-                )
-
-    def test_grow_function_mapping(self):
-        """Test grow_function to numeric mapping when specified."""
+    def test_grow_function_explicit_mapping(self):
+        """Test grow_function to numeric mapping when explicitly specified."""
+        # All grow params must be provided together
         grow_functions = [
             ("exponential", 0),
             ("linear", 1),
@@ -486,43 +469,21 @@ class TestRecencyQueryInput(unittest.TestCase):
             ("binary", 3),
         ]
 
-        for function_name, expected_code in grow_functions:
-            with self.subTest(function_name):
+        for func_name, expected_code in grow_functions:
+            with self.subTest(func_name):
                 params = RecencyParameters(
                     recency_field="created_at",
-                    decay_function="exponential",  # Different from grow_function
+                    decay_function="exponential",
                     grow_from=0.5,
-                    grow_function=function_name
+                    grow_function=func_name,
+                    grow_scale="7d",
+                    grow_offset="0d"
                 )
                 result = self.vespa_index._get_recency_query_input(params)
 
                 self.assertEqual(
                     result[constants.QUERY_INPUT_RECENCY_GROW_FUNCTION_TYPE],
                     expected_code
-                )
-
-    def test_grow_scale_defaults_to_scale(self):
-        """Test grow_scale defaults to scale when not specified."""
-        duration_cases = [
-            ("7d", 604800),
-            ("1d", 86400),
-            ("24h", 86400),
-            ("14d", 1209600),
-        ]
-
-        for scale, expected_seconds in duration_cases:
-            with self.subTest(scale=scale):
-                params = RecencyParameters(
-                    recency_field="created_at",
-                    scale=scale,
-                    grow_from=0.5
-                    # grow_scale not specified, should default to scale
-                )
-                result = self.vespa_index._get_recency_query_input(params)
-
-                self.assertEqual(
-                    result[constants.QUERY_INPUT_RECENCY_GROW_SCALE_SECONDS],
-                    expected_seconds
                 )
 
     def test_grow_scale_to_seconds_conversion(self):
@@ -540,9 +501,11 @@ class TestRecencyQueryInput(unittest.TestCase):
             with self.subTest(grow_scale=grow_scale):
                 params = RecencyParameters(
                     recency_field="created_at",
-                    scale="7d",  # Different from grow_scale
+                    scale="7d",
                     grow_from=0.5,
-                    grow_scale=grow_scale
+                    grow_function="exponential",
+                    grow_scale=grow_scale,
+                    grow_offset="0d"
                 )
                 result = self.vespa_index._get_recency_query_input(params)
 
@@ -550,20 +513,6 @@ class TestRecencyQueryInput(unittest.TestCase):
                     result[constants.QUERY_INPUT_RECENCY_GROW_SCALE_SECONDS],
                     expected_seconds
                 )
-
-    def test_grow_offset_defaults_to_zero(self):
-        """Test grow_offset defaults to 0 when not specified."""
-        params = RecencyParameters(
-            recency_field="created_at",
-            grow_from=0.5
-            # grow_offset not specified, should default to 0
-        )
-        result = self.vespa_index._get_recency_query_input(params)
-
-        self.assertEqual(
-            result[constants.QUERY_INPUT_RECENCY_GROW_OFFSET_SECONDS],
-            0
-        )
 
     def test_grow_offset_to_seconds_conversion(self):
         """Test grow_offset conversion to seconds when specified."""
@@ -580,6 +529,8 @@ class TestRecencyQueryInput(unittest.TestCase):
                 params = RecencyParameters(
                     recency_field="created_at",
                     grow_from=0.5,
+                    grow_function="exponential",
+                    grow_scale="7d",
                     grow_offset=grow_offset
                 )
                 result = self.vespa_index._get_recency_query_input(params)
@@ -593,7 +544,10 @@ class TestRecencyQueryInput(unittest.TestCase):
         """Test that all grow query input constants are present when grow is enabled."""
         params = RecencyParameters(
             recency_field="created_at",
-            grow_from=0.5
+            grow_from=0.5,
+            grow_function="exponential",
+            grow_scale="7d",
+            grow_offset="0d"
         )
         result = self.vespa_index._get_recency_query_input(params)
 
@@ -634,20 +588,22 @@ class TestRecencyQueryInput(unittest.TestCase):
                 }
             ),
             (
-                "grow_with_defaults",
+                "grow_with_gaussian",
                 {
                     "recency_field": "created_at",
                     "decay_function": "gaussian",
                     "scale": "24h",
-                    "grow_from": 0.5
-                    # grow_function, grow_scale, grow_offset should use defaults
+                    "grow_from": 0.5,
+                    "grow_function": "gaussian",
+                    "grow_scale": "24h",
+                    "grow_offset": "0d"
                 },
                 {
                     constants.QUERY_INPUT_RECENCY_GROW_ENABLED: 1,
                     constants.QUERY_INPUT_RECENCY_GROW_FROM: 0.5,
-                    constants.QUERY_INPUT_RECENCY_GROW_FUNCTION_TYPE: 2,  # gaussian (default to decay)
-                    constants.QUERY_INPUT_RECENCY_GROW_SCALE_SECONDS: 86400,  # 24h (default to scale)
-                    constants.QUERY_INPUT_RECENCY_GROW_OFFSET_SECONDS: 0,  # default to 0
+                    constants.QUERY_INPUT_RECENCY_GROW_FUNCTION_TYPE: 2,  # gaussian
+                    constants.QUERY_INPUT_RECENCY_GROW_SCALE_SECONDS: 86400,  # 24h
+                    constants.QUERY_INPUT_RECENCY_GROW_OFFSET_SECONDS: 0,
                 }
             ),
             (
@@ -656,7 +612,7 @@ class TestRecencyQueryInput(unittest.TestCase):
                     "recency_field": "created_at",
                     "decay_function": "exponential",
                     "scale": "7d",
-                    # grow_from not specified
+                    # No grow params specified - grow disabled
                 },
                 {
                     constants.QUERY_INPUT_RECENCY_GROW_ENABLED: 0,

--- a/tests/unit_tests/marqo/core/models/test_marqo_index.py
+++ b/tests/unit_tests/marqo/core/models/test_marqo_index.py
@@ -718,3 +718,40 @@ class TestMarqoIndexSchemaVersion(MarqoTestCase):
                     **index_kwargs
                 )
                 self.assertEqual(index.index_supports_collapse_minimal_summary, expected_result)
+
+    def test_index_supports_recency_scoring(self):
+        """Test index_supports_recency_scoring with different schema_template_version and marqo_version values."""
+        test_cases = [
+            ("schema_template_version >= 2.24.8", {"schema_template_version": "2.24.8"}, True),
+            ("schema_template_version > 2.24.8", {"schema_template_version": "2.24.9"}, True),
+            ("schema_template_version < 2.24.8", {"schema_template_version": "2.24.7"}, False),
+            ("schema_template_version None, marqo_version >= 2.24.8", {"marqo_version": "2.24.8", "schema_template_version": None}, True),
+            ("schema_template_version None, marqo_version < 2.24.8", {"marqo_version": "2.24.7", "schema_template_version": None}, False),
+        ]
+
+        for case_name, index_kwargs, expected_result in test_cases:
+            with self.subTest(case=case_name):
+                index = self.semi_structured_marqo_index(
+                    name="test_index",
+                    **index_kwargs
+                )
+                self.assertEqual(index.index_supports_recency_scoring, expected_result)
+
+    def test_index_supports_recency_additive(self):
+        """Test index_supports_recency_additive with different schema_template_version and marqo_version values."""
+        test_cases = [
+            ("schema_template_version >= 2.24.9", {"schema_template_version": "2.24.9"}, True),
+            ("schema_template_version > 2.24.9", {"schema_template_version": "2.24.10"}, True),
+            ("schema_template_version == 2.24.8 (not additive)", {"schema_template_version": "2.24.8"}, False),
+            ("schema_template_version < 2.24.8", {"schema_template_version": "2.24.7"}, False),
+            ("schema_template_version None, marqo_version >= 2.24.9", {"marqo_version": "2.24.9", "schema_template_version": None}, True),
+            ("schema_template_version None, marqo_version < 2.24.9", {"marqo_version": "2.24.8", "schema_template_version": None}, False),
+        ]
+
+        for case_name, index_kwargs, expected_result in test_cases:
+            with self.subTest(case=case_name):
+                index = self.semi_structured_marqo_index(
+                    name="test_index",
+                    **index_kwargs
+                )
+                self.assertEqual(index.index_supports_recency_additive, expected_result)

--- a/tests/unit_tests/marqo/core/models/test_marqo_index.py
+++ b/tests/unit_tests/marqo/core/models/test_marqo_index.py
@@ -755,3 +755,22 @@ class TestMarqoIndexSchemaVersion(MarqoTestCase):
                     **index_kwargs
                 )
                 self.assertEqual(index.index_supports_recency_additive, expected_result)
+
+    def test_index_supports_recency_grow(self):
+        """Test index_supports_recency_grow with different schema_template_version and marqo_version values."""
+        test_cases = [
+            ("schema_template_version >= 2.24.9", {"schema_template_version": "2.24.9"}, True),
+            ("schema_template_version > 2.24.9", {"schema_template_version": "2.24.10"}, True),
+            ("schema_template_version == 2.24.8 (not grow)", {"schema_template_version": "2.24.8"}, False),
+            ("schema_template_version < 2.24.8", {"schema_template_version": "2.24.7"}, False),
+            ("schema_template_version None, marqo_version >= 2.24.9", {"marqo_version": "2.24.9", "schema_template_version": None}, True),
+            ("schema_template_version None, marqo_version < 2.24.9", {"marqo_version": "2.24.8", "schema_template_version": None}, False),
+        ]
+
+        for case_name, index_kwargs, expected_result in test_cases:
+            with self.subTest(case=case_name):
+                index = self.semi_structured_marqo_index(
+                    name="test_index",
+                    **index_kwargs
+                )
+                self.assertEqual(index.index_supports_recency_grow, expected_result)

--- a/tests/unit_tests/marqo/core/search/test_hybrid_search.py
+++ b/tests/unit_tests/marqo/core/search/test_hybrid_search.py
@@ -1,8 +1,10 @@
 from unittest import TestCase
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, PropertyMock
 from pydantic.v1 import ValidationError
 import semver
 
+from marqo.core import constants
+from marqo.core.exceptions import UnsupportedFeatureError
 from marqo.core.models.marqo_query import MarqoHybridQuery
 from marqo.core.models.score_modifier import ScoreModifier, ScoreModifierType
 from marqo.core.models.hybrid_parameters import (
@@ -12,9 +14,10 @@ from marqo.core.models.facets_parameters import (
     FacetsParameters, FieldFacetsConfiguration
 )
 from marqo.core.search.hybrid_search import HybridSearch
-from marqo.core.models.marqo_index import SemiStructuredMarqoIndex
+from marqo.core.models.marqo_index import SemiStructuredMarqoIndex, StructuredMarqoIndex
 from marqo.core.semi_structured_vespa_index.semi_structured_vespa_index import SemiStructuredVespaIndex
 from marqo.tensor_search.models.api_models import ScoreModifierLists, CustomVectorQuery
+from marqo.tensor_search.models.recency_parameters import RecencyParameters
 from marqo.tensor_search.models.search import SearchContext, SearchContextDocuments, SearchContextTensor
 from marqo.config import Config
 
@@ -333,4 +336,240 @@ class TestHybridSearch(TestCase):
         self.assertEqual(context.tensor[0].vector, [0.1, 0.2, 0.3])  # Original tensor
         self.assertEqual(context.tensor[0].weight, 0.5)
         self.assertEqual(context.tensor[1].vector, [0.5, 0.6, 0.7])  # Appended tensor
-        self.assertEqual(context.tensor[1].weight, 1) 
+        self.assertEqual(context.tensor[1].weight, 1)
+
+
+class TestRecencyValidation(TestCase):
+    """Tests for recency scoring validation in HybridSearch."""
+
+    def _setup_metrics_mock(self, mock_metrics):
+        """Helper to set up the metrics store mock."""
+        mock_metrics_instance = Mock()
+        mock_metrics.for_request.return_value = mock_metrics_instance
+        mock_metrics_instance.start.return_value = None
+        mock_metrics_instance.stop.return_value = 100.0
+        mock_context_manager = Mock()
+        mock_context_manager.__enter__ = Mock(return_value=None)
+        mock_context_manager.__exit__ = Mock(return_value=None)
+        mock_metrics_instance.time.return_value = mock_context_manager
+        return mock_metrics_instance
+
+    @patch('marqo.core.search.hybrid_search.RequestMetricsStore')
+    def test_recency_on_structured_index_raises_error(self, mock_metrics):
+        """Test that recency scoring on structured index raises UnsupportedFeatureError."""
+        self._setup_metrics_mock(mock_metrics)
+
+        # Create a mock structured index
+        marqo_index = Mock(spec=StructuredMarqoIndex)
+        marqo_index.name = "test_structured_index"
+        marqo_index.model = Mock()
+        marqo_index.model.get_text_query_prefix.return_value = ""
+        marqo_index.parsed_marqo_version.return_value = semver.VersionInfo.parse("2.24.9")
+
+        config = Mock(spec=Config)
+
+        recency_params = RecencyParameters(
+            recency_field="timestamp",
+            scale="7d",
+            decay_function="exponential",
+            decay_to=0.5
+        )
+
+        hybrid_search = HybridSearch()
+        with self.assertRaises(UnsupportedFeatureError) as ctx:
+            hybrid_search.search(
+                config=config,
+                marqo_index=marqo_index,
+                query="test",
+                hybrid_parameters=HybridParameters(),
+                recency_parameters=recency_params
+            )
+
+        self.assertIn("unstructured", str(ctx.exception).lower())
+        self.assertIn("Structured indexes do not support", str(ctx.exception))
+
+    @patch('marqo.core.search.hybrid_search.RequestMetricsStore')
+    def test_recency_on_old_schema_version_raises_error(self, mock_metrics):
+        """Test that recency scoring on old schema version raises UnsupportedFeatureError."""
+        self._setup_metrics_mock(mock_metrics)
+
+        # Create a mock semi-structured index with old schema version
+        marqo_index = Mock(spec=SemiStructuredMarqoIndex)
+        marqo_index.name = "test_index"
+        marqo_index.schema_template_version = "2.24.7"  # Old version
+        marqo_index.marqo_version = "2.24.7"
+        marqo_index.model = Mock()
+        marqo_index.model.get_text_query_prefix.return_value = ""
+        marqo_index.parsed_marqo_version.return_value = semver.VersionInfo.parse("2.24.7")
+        # Set up property mock - returns False because schema is too old
+        type(marqo_index).index_supports_recency_scoring = PropertyMock(return_value=False)
+
+        config = Mock(spec=Config)
+
+        recency_params = RecencyParameters(
+            recency_field="timestamp",
+            scale="7d",
+            decay_function="exponential",
+            decay_to=0.5
+        )
+
+        hybrid_search = HybridSearch()
+        with self.assertRaises(UnsupportedFeatureError) as ctx:
+            hybrid_search.search(
+                config=config,
+                marqo_index=marqo_index,
+                query="test",
+                hybrid_parameters=HybridParameters(),
+                recency_parameters=recency_params
+            )
+
+        self.assertIn(str(constants.MARQO_RECENCY_SCORING_MINIMUM_VERSION), str(ctx.exception))
+
+    @patch('marqo.core.search.hybrid_search.RequestMetricsStore')
+    def test_additive_recency_on_old_schema_version_raises_error(self, mock_metrics):
+        """Test that additive recency (addToScoreWeight) on old schema version raises UnsupportedFeatureError."""
+        self._setup_metrics_mock(mock_metrics)
+
+        # Create a mock semi-structured index that supports basic recency but NOT additive
+        marqo_index = Mock(spec=SemiStructuredMarqoIndex)
+        marqo_index.name = "test_index"
+        marqo_index.schema_template_version = "2.24.8"  # Supports recency but not additive
+        marqo_index.marqo_version = "2.24.8"
+        marqo_index.model = Mock()
+        marqo_index.model.get_text_query_prefix.return_value = ""
+        marqo_index.parsed_marqo_version.return_value = semver.VersionInfo.parse("2.24.8")
+        # Supports basic recency
+        type(marqo_index).index_supports_recency_scoring = PropertyMock(return_value=True)
+        # Does NOT support additive recency
+        type(marqo_index).index_supports_recency_additive = PropertyMock(return_value=False)
+
+        config = Mock(spec=Config)
+
+        recency_params = RecencyParameters(
+            recency_field="timestamp",
+            scale="7d",
+            decay_function="exponential",
+            decay_to=0.5,
+            add_to_score_weight=0.5  # This should trigger the error
+        )
+
+        hybrid_search = HybridSearch()
+        with self.assertRaises(UnsupportedFeatureError) as ctx:
+            hybrid_search.search(
+                config=config,
+                marqo_index=marqo_index,
+                query="test",
+                hybrid_parameters=HybridParameters(),
+                recency_parameters=recency_params
+            )
+
+        self.assertIn("addToScoreWeight", str(ctx.exception))
+        self.assertIn(str(constants.MARQO_RECENCY_ADDITIVE_MINIMUM_VERSION), str(ctx.exception))
+
+    @patch('marqo.core.search.hybrid_search.vespa_index_factory')
+    @patch('marqo.core.search.hybrid_search.run_vectorise_pipeline')
+    @patch('marqo.core.search.hybrid_search.utils.parse_lexical_query')
+    @patch('marqo.core.search.hybrid_search.gather_documents_from_response')
+    @patch('marqo.core.search.hybrid_search.RequestMetricsStore')
+    def test_additive_recency_on_new_schema_version_succeeds(
+        self, mock_metrics, mock_gather_docs, mock_parse_lexical,
+        mock_vectorise, mock_vespa_factory
+    ):
+        """Test that additive recency succeeds on index that supports it."""
+        # Setup mocks
+        config = Mock(spec=Config)
+        config.vespa_client = Mock()
+        mock_response = Mock()
+        mock_response.root.coverage.coverage = 100
+        mock_response.root.coverage.degraded = None
+        config.vespa_client.query.return_value = mock_response
+
+        # Mock marqo_index with new schema version
+        marqo_index = Mock(spec=SemiStructuredMarqoIndex)
+        marqo_index.name = "test_index"
+        marqo_index.schema_template_version = "2.24.9"  # New version
+        marqo_index.marqo_version = "2.24.9"
+        marqo_index.model = Mock()
+        marqo_index.model.get_text_query_prefix.return_value = ""
+        marqo_index.parsed_marqo_version.return_value = semver.VersionInfo.parse("2.24.9")
+        # Supports both basic recency and additive recency
+        type(marqo_index).index_supports_recency_scoring = PropertyMock(return_value=True)
+        type(marqo_index).index_supports_recency_additive = PropertyMock(return_value=True)
+
+        # Mock vespa_index
+        mock_vespa_index = Mock(spec=SemiStructuredVespaIndex)
+        mock_vespa_query = {"query": "test"}
+        mock_vespa_index.to_vespa_query.return_value = mock_vespa_query
+        mock_vespa_factory.return_value = mock_vespa_index
+
+        # Mock vectorisation pipeline
+        mock_vectorise.return_value = {0: [0.1, 0.2, 0.3]}
+
+        # Mock lexical query parsing
+        mock_parse_lexical.return_value = (["required"], ["optional"])
+
+        # Mock metrics store
+        mock_metrics_instance = Mock()
+        mock_metrics.for_request.return_value = mock_metrics_instance
+        mock_metrics_instance.start.return_value = None
+        mock_metrics_instance.stop.return_value = 100.0
+        mock_context_manager = Mock()
+        mock_context_manager.__enter__ = Mock(return_value=None)
+        mock_context_manager.__exit__ = Mock(return_value=None)
+        mock_metrics_instance.time.return_value = mock_context_manager
+
+        # Mock gather_documents_from_response
+        mock_gather_docs.return_value = {
+            "hits": [{"_id": "1", "doc": {"field": "value"}}]
+        }
+
+        recency_params = RecencyParameters(
+            recency_field="timestamp",
+            scale="7d",
+            decay_function="exponential",
+            decay_to=0.5,
+            add_to_score_weight=0.5  # Additive mode
+        )
+
+        # Execute the search - should not raise
+        hybrid_search = HybridSearch()
+        result = hybrid_search.search(
+            config=config,
+            marqo_index=marqo_index,
+            query="test query",
+            hybrid_parameters=HybridParameters(),
+            recency_parameters=recency_params
+        )
+
+        # Verify the search executed successfully
+        self.assertIsNotNone(result)
+
+    def test_basic_recency_without_additive_succeeds_on_old_additive_schema(self):
+        """Test that basic recency (without addToScoreWeight) succeeds on schema 2.24.8."""
+        # Create a mock semi-structured index that supports basic recency but NOT additive
+        marqo_index = Mock(spec=SemiStructuredMarqoIndex)
+        marqo_index.name = "test_index"
+        marqo_index.schema_template_version = "2.24.8"
+        marqo_index.model = Mock()
+        marqo_index.model.get_text_query_prefix.return_value = ""
+        # Supports basic recency
+        type(marqo_index).index_supports_recency_scoring = PropertyMock(return_value=True)
+        # Does NOT support additive recency - but this shouldn't matter if we don't use additive
+        type(marqo_index).index_supports_recency_additive = PropertyMock(return_value=False)
+
+        # Recency params WITHOUT add_to_score_weight (basic/multiplicative mode)
+        recency_params = RecencyParameters(
+            recency_field="timestamp",
+            scale="7d",
+            decay_function="exponential",
+            decay_to=0.5
+            # No add_to_score_weight - should pass validation
+        )
+
+        # The validation should pass (no error raised)
+        # This test verifies that the validation ONLY fails when add_to_score_weight is provided
+        # The actual search would require more setup, but we're testing the validation logic
+
+        # Since we can't easily test the full search flow without extensive mocking,
+        # let's just verify the RecencyParameters accepts the parameters
+        self.assertIsNone(recency_params.add_to_score_weight)

--- a/tests/unit_tests/marqo/core/search/test_hybrid_search.py
+++ b/tests/unit_tests/marqo/core/search/test_hybrid_search.py
@@ -491,7 +491,11 @@ class TestRecencyValidation(TestCase):
             scale="7d",
             decay_function="exponential",
             decay_to=0.5,
-            grow_from=0.3  # This should trigger the error
+            # All grow params required together - this should trigger the schema version error
+            grow_from=0.3,
+            grow_function="exponential",
+            grow_scale="7d",
+            grow_offset="0d"
         )
 
         hybrid_search = HybridSearch()

--- a/tests/unit_tests/marqo/core/search/test_hybrid_search.py
+++ b/tests/unit_tests/marqo/core/search/test_hybrid_search.py
@@ -466,6 +466,47 @@ class TestRecencyValidation(TestCase):
         self.assertIn("addToScoreWeight", str(ctx.exception))
         self.assertIn(str(constants.MARQO_RECENCY_ADDITIVE_MINIMUM_VERSION), str(ctx.exception))
 
+    @patch('marqo.core.search.hybrid_search.RequestMetricsStore')
+    def test_grow_recency_on_old_schema_version_raises_error(self, mock_metrics):
+        """Test that recency grow parameters (growFrom) on old schema version raises UnsupportedFeatureError."""
+        self._setup_metrics_mock(mock_metrics)
+
+        # Create a mock semi-structured index that supports basic recency but NOT grow
+        marqo_index = Mock(spec=SemiStructuredMarqoIndex)
+        marqo_index.name = "test_index"
+        marqo_index.schema_template_version = "2.24.8"  # Supports recency but not grow
+        marqo_index.marqo_version = "2.24.8"
+        marqo_index.model = Mock()
+        marqo_index.model.get_text_query_prefix.return_value = ""
+        marqo_index.parsed_marqo_version.return_value = semver.VersionInfo.parse("2.24.8")
+        # Supports basic recency
+        type(marqo_index).index_supports_recency_scoring = PropertyMock(return_value=True)
+        # Does NOT support grow recency
+        type(marqo_index).index_supports_recency_grow = PropertyMock(return_value=False)
+
+        config = Mock(spec=Config)
+
+        recency_params = RecencyParameters(
+            recency_field="timestamp",
+            scale="7d",
+            decay_function="exponential",
+            decay_to=0.5,
+            grow_from=0.3  # This should trigger the error
+        )
+
+        hybrid_search = HybridSearch()
+        with self.assertRaises(UnsupportedFeatureError) as ctx:
+            hybrid_search.search(
+                config=config,
+                marqo_index=marqo_index,
+                query="test",
+                hybrid_parameters=HybridParameters(),
+                recency_parameters=recency_params
+            )
+
+        self.assertIn("growFrom", str(ctx.exception))
+        self.assertIn(str(constants.MARQO_RECENCY_GROW_MINIMUM_VERSION), str(ctx.exception))
+
     @patch('marqo.core.search.hybrid_search.vespa_index_factory')
     @patch('marqo.core.search.hybrid_search.run_vectorise_pipeline')
     @patch('marqo.core.search.hybrid_search.utils.parse_lexical_query')
@@ -544,6 +585,87 @@ class TestRecencyValidation(TestCase):
         # Verify the search executed successfully
         self.assertIsNotNone(result)
 
+    @patch('marqo.core.search.hybrid_search.vespa_index_factory')
+    @patch('marqo.core.search.hybrid_search.run_vectorise_pipeline')
+    @patch('marqo.core.search.hybrid_search.utils.parse_lexical_query')
+    @patch('marqo.core.search.hybrid_search.gather_documents_from_response')
+    @patch('marqo.core.search.hybrid_search.RequestMetricsStore')
+    def test_grow_recency_on_new_schema_version_succeeds(
+        self, mock_metrics, mock_gather_docs, mock_parse_lexical,
+        mock_vectorise, mock_vespa_factory
+    ):
+        """Test that grow recency (growFrom) succeeds on index that supports it."""
+        # Setup mocks
+        config = Mock(spec=Config)
+        config.vespa_client = Mock()
+        mock_response = Mock()
+        mock_response.root.coverage.coverage = 100
+        mock_response.root.coverage.degraded = None
+        config.vespa_client.query.return_value = mock_response
+
+        # Mock marqo_index with new schema version
+        marqo_index = Mock(spec=SemiStructuredMarqoIndex)
+        marqo_index.name = "test_index"
+        marqo_index.schema_template_version = "2.24.9"  # New version
+        marqo_index.marqo_version = "2.24.9"
+        marqo_index.model = Mock()
+        marqo_index.model.get_text_query_prefix.return_value = ""
+        marqo_index.parsed_marqo_version.return_value = semver.VersionInfo.parse("2.24.9")
+        # Supports both basic recency and grow recency
+        type(marqo_index).index_supports_recency_scoring = PropertyMock(return_value=True)
+        type(marqo_index).index_supports_recency_grow = PropertyMock(return_value=True)
+
+        # Mock vespa_index
+        mock_vespa_index = Mock(spec=SemiStructuredVespaIndex)
+        mock_vespa_query = {"query": "test"}
+        mock_vespa_index.to_vespa_query.return_value = mock_vespa_query
+        mock_vespa_factory.return_value = mock_vespa_index
+
+        # Mock vectorisation pipeline
+        mock_vectorise.return_value = {0: [0.1, 0.2, 0.3]}
+
+        # Mock lexical query parsing
+        mock_parse_lexical.return_value = (["required"], ["optional"])
+
+        # Mock metrics store
+        mock_metrics_instance = Mock()
+        mock_metrics.for_request.return_value = mock_metrics_instance
+        mock_metrics_instance.start.return_value = None
+        mock_metrics_instance.stop.return_value = 100.0
+        mock_context_manager = Mock()
+        mock_context_manager.__enter__ = Mock(return_value=None)
+        mock_context_manager.__exit__ = Mock(return_value=None)
+        mock_metrics_instance.time.return_value = mock_context_manager
+
+        # Mock gather_documents_from_response
+        mock_gather_docs.return_value = {
+            "hits": [{"_id": "1", "doc": {"field": "value"}}]
+        }
+
+        recency_params = RecencyParameters(
+            recency_field="timestamp",
+            scale="7d",
+            decay_function="exponential",
+            decay_to=0.5,
+            grow_from=0.3,  # Grow mode
+            grow_function="exponential",
+            grow_scale="7d",
+            grow_offset="0d"
+        )
+
+        # Execute the search - should not raise
+        hybrid_search = HybridSearch()
+        result = hybrid_search.search(
+            config=config,
+            marqo_index=marqo_index,
+            query="test query",
+            hybrid_parameters=HybridParameters(),
+            recency_parameters=recency_params
+        )
+
+        # Verify the search executed successfully
+        self.assertIsNotNone(result)
+
     def test_basic_recency_without_additive_succeeds_on_old_additive_schema(self):
         """Test that basic recency (without addToScoreWeight) succeeds on schema 2.24.8."""
         # Create a mock semi-structured index that supports basic recency but NOT additive
@@ -573,3 +695,29 @@ class TestRecencyValidation(TestCase):
         # Since we can't easily test the full search flow without extensive mocking,
         # let's just verify the RecencyParameters accepts the parameters
         self.assertIsNone(recency_params.add_to_score_weight)
+
+    def test_basic_recency_without_grow_succeeds_on_old_grow_schema(self):
+        """Test that basic recency (without growFrom) succeeds on schema 2.24.8."""
+        # Create a mock semi-structured index that supports basic recency but NOT grow
+        marqo_index = Mock(spec=SemiStructuredMarqoIndex)
+        marqo_index.name = "test_index"
+        marqo_index.schema_template_version = "2.24.8"
+        marqo_index.model = Mock()
+        marqo_index.model.get_text_query_prefix.return_value = ""
+        # Supports basic recency
+        type(marqo_index).index_supports_recency_scoring = PropertyMock(return_value=True)
+        # Does NOT support grow recency - but this shouldn't matter if we don't use grow
+        type(marqo_index).index_supports_recency_grow = PropertyMock(return_value=False)
+
+        # Recency params WITHOUT grow_from (basic mode)
+        recency_params = RecencyParameters(
+            recency_field="timestamp",
+            scale="7d",
+            decay_function="exponential",
+            decay_to=0.5
+            # No grow_from - should pass validation
+        )
+
+        # The validation should pass (no error raised)
+        # This test verifies that the validation ONLY fails when grow_from is provided
+        self.assertIsNone(recency_params.grow_from)

--- a/tests/unit_tests/marqo/tensor_search/models/test_recency_parameters.py
+++ b/tests/unit_tests/marqo/tensor_search/models/test_recency_parameters.py
@@ -394,3 +394,247 @@ class TestRecencyParameters(unittest.TestCase):
         result = params.dict(by_alias=True)
         self.assertIn('addToScoreWeight', result)
         self.assertEqual(result['addToScoreWeight'], 0.5)
+
+    # ============= Grow Parameters Tests =============
+
+    def test_grow_from_validation(self):
+        """Test grow_from field validation."""
+        # Valid grow_from values
+        valid_values = [
+            ("min", 0.01, 0.01),
+            ("mid", 0.5, 0.5),
+            ("max", 1.0, 1.0),
+            ("near_min", 0.001, 0.001),
+        ]
+
+        for test_name, grow_from, expected in valid_values:
+            with self.subTest(test_name):
+                params = RecencyParameters(recency_field="created_at", grow_from=grow_from)
+                self.assertEqual(params.grow_from, expected)
+
+        # Invalid grow_from values
+        invalid_values = [
+            ("zero", 0.0),
+            ("negative", -0.5),
+            ("greater_than_one", 1.5),
+        ]
+
+        for test_name, grow_from in invalid_values:
+            with self.subTest(test_name):
+                with self.assertRaises(ValidationError) as exc_info:
+                    RecencyParameters(recency_field="created_at", grow_from=grow_from)
+                errors = exc_info.exception.errors()
+                self.assertTrue(
+                    any('grow_from' in str(e['loc']) or 'growFrom' in str(e['loc']) for e in errors),
+                    f"Expected 'grow_from' or 'growFrom' in error locations: {errors}"
+                )
+
+    def test_grow_from_default_none(self):
+        """Test grow_from defaults to None."""
+        params = RecencyParameters(recency_field="created_at")
+        self.assertIsNone(params.grow_from)
+
+    def test_grow_from_alias(self):
+        """Test grow_from alias (growFrom)."""
+        params = RecencyParameters(
+            recency_field="created_at",
+            growFrom=0.3
+        )
+        self.assertEqual(params.grow_from, 0.3)
+
+        # Test dict serialization with alias
+        result = params.dict(by_alias=True)
+        self.assertIn('growFrom', result)
+        self.assertEqual(result['growFrom'], 0.3)
+
+    def test_grow_function_validation(self):
+        """Test grow_function field validation."""
+        # Valid grow functions (same as decay functions)
+        valid_functions = ["exponential", "linear", "gaussian", "binary"]
+
+        for func in valid_functions:
+            with self.subTest(func):
+                params = RecencyParameters(
+                    recency_field="created_at",
+                    grow_from=0.5,
+                    grow_function=func
+                )
+                self.assertEqual(params.grow_function, func)
+
+        # Invalid grow functions
+        invalid_functions = [
+            ("invalid", "invalid"),
+            ("case_sensitive", "EXPONENTIAL"),
+        ]
+
+        for test_name, func in invalid_functions:
+            with self.subTest(test_name):
+                with self.assertRaises(ValidationError):
+                    RecencyParameters(
+                        recency_field="created_at",
+                        grow_from=0.5,
+                        grow_function=func
+                    )
+
+    def test_grow_function_default_none(self):
+        """Test grow_function defaults to None (will use decay_function at query time)."""
+        params = RecencyParameters(recency_field="created_at", grow_from=0.5)
+        self.assertIsNone(params.grow_function)
+
+    def test_grow_function_alias(self):
+        """Test grow_function alias (growFunction)."""
+        params = RecencyParameters(
+            recency_field="created_at",
+            grow_from=0.5,
+            growFunction="linear"
+        )
+        self.assertEqual(params.grow_function, "linear")
+
+        # Test dict serialization with alias
+        result = params.dict(by_alias=True)
+        self.assertIn('growFunction', result)
+        self.assertEqual(result['growFunction'], 'linear')
+
+    def test_grow_scale_validation(self):
+        """Test grow_scale field validation."""
+        # Valid scales (same format as scale)
+        valid_scales = [
+            ("days", "7d", "7d"),
+            ("hours", "24h", "24h"),
+            ("decimal_days", "1.5d", "1.5d"),
+            ("decimal_hours", "0.5h", "0.5h"),
+        ]
+
+        for test_name, grow_scale, expected in valid_scales:
+            with self.subTest(test_name):
+                params = RecencyParameters(
+                    recency_field="created_at",
+                    grow_from=0.5,
+                    grow_scale=grow_scale
+                )
+                self.assertEqual(params.grow_scale, expected)
+
+        # Invalid scales
+        invalid_scales = [
+            ("zero", "0d"),
+            ("negative", "-1d"),
+            ("invalid_format", "7"),
+            ("invalid_unit", "7w"),
+        ]
+
+        for test_name, grow_scale in invalid_scales:
+            with self.subTest(test_name):
+                with self.assertRaises(ValidationError):
+                    RecencyParameters(
+                        recency_field="created_at",
+                        grow_from=0.5,
+                        grow_scale=grow_scale
+                    )
+
+    def test_grow_scale_default_none(self):
+        """Test grow_scale defaults to None (will use scale at query time)."""
+        params = RecencyParameters(recency_field="created_at", grow_from=0.5)
+        self.assertIsNone(params.grow_scale)
+
+    def test_grow_scale_alias(self):
+        """Test grow_scale alias (growScale)."""
+        params = RecencyParameters(
+            recency_field="created_at",
+            grow_from=0.5,
+            growScale="14d"
+        )
+        self.assertEqual(params.grow_scale, "14d")
+
+        # Test dict serialization with alias
+        result = params.dict(by_alias=True)
+        self.assertIn('growScale', result)
+        self.assertEqual(result['growScale'], '14d')
+
+    def test_grow_offset_validation(self):
+        """Test grow_offset field validation."""
+        # Valid offsets (same format as offset)
+        valid_offsets = [
+            ("zero_days", "0d", "0d"),
+            ("days", "1d", "1d"),
+            ("hours", "12h", "12h"),
+            ("decimal_days", "0.5d", "0.5d"),
+        ]
+
+        for test_name, grow_offset, expected in valid_offsets:
+            with self.subTest(test_name):
+                params = RecencyParameters(
+                    recency_field="created_at",
+                    grow_from=0.5,
+                    grow_offset=grow_offset
+                )
+                self.assertEqual(params.grow_offset, expected)
+
+        # Invalid offsets
+        invalid_offsets = [
+            ("negative", "-1d"),
+            ("invalid_format", "1"),
+            ("invalid_unit", "1m"),
+        ]
+
+        for test_name, grow_offset in invalid_offsets:
+            with self.subTest(test_name):
+                with self.assertRaises(ValidationError):
+                    RecencyParameters(
+                        recency_field="created_at",
+                        grow_from=0.5,
+                        grow_offset=grow_offset
+                    )
+
+    def test_grow_offset_default_none(self):
+        """Test grow_offset defaults to None (will use '0d' at query time)."""
+        params = RecencyParameters(recency_field="created_at", grow_from=0.5)
+        self.assertIsNone(params.grow_offset)
+
+    def test_grow_offset_alias(self):
+        """Test grow_offset alias (growOffset)."""
+        params = RecencyParameters(
+            recency_field="created_at",
+            grow_from=0.5,
+            growOffset="2d"
+        )
+        self.assertEqual(params.grow_offset, "2d")
+
+        # Test dict serialization with alias
+        result = params.dict(by_alias=True)
+        self.assertIn('growOffset', result)
+        self.assertEqual(result['growOffset'], '2d')
+
+    def test_grow_parameters_complete(self):
+        """Test all grow parameters together."""
+        params = RecencyParameters(
+            recency_field="created_at",
+            decay_function="exponential",
+            scale="7d",
+            offset="0d",
+            decay_to=0.5,
+            grow_from=0.3,
+            grow_function="linear",
+            grow_scale="14d",
+            grow_offset="1d"
+        )
+
+        self.assertEqual(params.grow_from, 0.3)
+        self.assertEqual(params.grow_function, "linear")
+        self.assertEqual(params.grow_scale, "14d")
+        self.assertEqual(params.grow_offset, "1d")
+
+    def test_grow_parameters_with_camel_case_aliases(self):
+        """Test grow parameters using camelCase aliases."""
+        params = RecencyParameters(
+            recencyField="created_at",
+            growFrom=0.4,
+            growFunction="gaussian",
+            growScale="21d",
+            growOffset="3d"
+        )
+
+        self.assertEqual(params.recency_field, "created_at")
+        self.assertEqual(params.grow_from, 0.4)
+        self.assertEqual(params.grow_function, "gaussian")
+        self.assertEqual(params.grow_scale, "21d")
+        self.assertEqual(params.grow_offset, "3d")

--- a/tests/unit_tests/marqo/tensor_search/models/test_recency_parameters.py
+++ b/tests/unit_tests/marqo/tensor_search/models/test_recency_parameters.py
@@ -396,21 +396,80 @@ class TestRecencyParameters(unittest.TestCase):
         self.assertEqual(result['addToScoreWeight'], 0.5)
 
     # ============= Grow Parameters Tests =============
+    # Note: Grow parameters follow "all or nothing" rule - either all 4 must be
+    # provided (growFrom, growFunction, growScale, growOffset) or none.
 
-    def test_grow_from_validation(self):
-        """Test grow_from field validation."""
-        # Valid grow_from values
-        valid_values = [
-            ("min", 0.01, 0.01),
-            ("mid", 0.5, 0.5),
-            ("max", 1.0, 1.0),
-            ("near_min", 0.001, 0.001),
+    def test_grow_params_all_or_nothing_validation(self):
+        """Test that grow parameters must be either all provided or all omitted."""
+        # Test partial combinations - all should fail
+        partial_combinations = [
+            # Only one param
+            ("only_grow_from", {"grow_from": 0.5}),
+            ("only_grow_function", {"grow_function": "exponential"}),
+            ("only_grow_scale", {"grow_scale": "7d"}),
+            ("only_grow_offset", {"grow_offset": "1d"}),
+            # Two params
+            ("grow_from_and_function", {"grow_from": 0.5, "grow_function": "exponential"}),
+            ("grow_from_and_scale", {"grow_from": 0.5, "grow_scale": "7d"}),
+            ("grow_from_and_offset", {"grow_from": 0.5, "grow_offset": "1d"}),
+            ("grow_function_and_scale", {"grow_function": "exponential", "grow_scale": "7d"}),
+            # Three params
+            ("missing_grow_from", {"grow_function": "exponential", "grow_scale": "7d", "grow_offset": "1d"}),
+            ("missing_grow_function", {"grow_from": 0.5, "grow_scale": "7d", "grow_offset": "1d"}),
+            ("missing_grow_scale", {"grow_from": 0.5, "grow_function": "exponential", "grow_offset": "1d"}),
+            ("missing_grow_offset", {"grow_from": 0.5, "grow_function": "exponential", "grow_scale": "7d"}),
         ]
 
-        for test_name, grow_from, expected in valid_values:
+        for test_name, grow_params in partial_combinations:
             with self.subTest(test_name):
-                params = RecencyParameters(recency_field="created_at", grow_from=grow_from)
-                self.assertEqual(params.grow_from, expected)
+                with self.assertRaises(ValidationError) as exc_info:
+                    RecencyParameters(recency_field="created_at", **grow_params)
+                error_str = str(exc_info.exception)
+                self.assertIn("all provided or all omitted", error_str.lower(),
+                    f"Expected 'all provided or all omitted' in error: {error_str}")
+
+        # All params provided - should pass
+        with self.subTest("all_provided"):
+            params = RecencyParameters(
+                recency_field="created_at",
+                grow_from=0.5,
+                grow_function="exponential",
+                grow_scale="7d",
+                grow_offset="1d"
+            )
+            self.assertEqual(params.grow_from, 0.5)
+            self.assertEqual(params.grow_function, "exponential")
+            self.assertEqual(params.grow_scale, "7d")
+            self.assertEqual(params.grow_offset, "1d")
+
+        # No grow params - should pass
+        with self.subTest("none_provided"):
+            params = RecencyParameters(recency_field="created_at")
+            self.assertIsNone(params.grow_from)
+            self.assertIsNone(params.grow_function)
+            self.assertIsNone(params.grow_scale)
+            self.assertIsNone(params.grow_offset)
+
+    def test_grow_from_validation(self):
+        """Test grow_from field value validation."""
+        # Valid grow_from values (must provide all grow params)
+        valid_values = [
+            ("min", 0.01),
+            ("mid", 0.5),
+            ("max", 1.0),
+            ("near_min", 0.001),
+        ]
+
+        for test_name, grow_from in valid_values:
+            with self.subTest(test_name):
+                params = RecencyParameters(
+                    recency_field="created_at",
+                    grow_from=grow_from,
+                    grow_function="exponential",
+                    grow_scale="7d",
+                    grow_offset="0d"
+                )
+                self.assertEqual(params.grow_from, grow_from)
 
         # Invalid grow_from values
         invalid_values = [
@@ -422,7 +481,13 @@ class TestRecencyParameters(unittest.TestCase):
         for test_name, grow_from in invalid_values:
             with self.subTest(test_name):
                 with self.assertRaises(ValidationError) as exc_info:
-                    RecencyParameters(recency_field="created_at", grow_from=grow_from)
+                    RecencyParameters(
+                        recency_field="created_at",
+                        grow_from=grow_from,
+                        grow_function="exponential",
+                        grow_scale="7d",
+                        grow_offset="0d"
+                    )
                 errors = exc_info.exception.errors()
                 self.assertTrue(
                     any('grow_from' in str(e['loc']) or 'growFrom' in str(e['loc']) for e in errors),
@@ -430,7 +495,7 @@ class TestRecencyParameters(unittest.TestCase):
                 )
 
     def test_grow_from_default_none(self):
-        """Test grow_from defaults to None."""
+        """Test grow_from defaults to None when no grow params provided."""
         params = RecencyParameters(recency_field="created_at")
         self.assertIsNone(params.grow_from)
 
@@ -438,7 +503,10 @@ class TestRecencyParameters(unittest.TestCase):
         """Test grow_from alias (growFrom)."""
         params = RecencyParameters(
             recency_field="created_at",
-            growFrom=0.3
+            growFrom=0.3,
+            growFunction="exponential",
+            growScale="7d",
+            growOffset="0d"
         )
         self.assertEqual(params.grow_from, 0.3)
 
@@ -457,7 +525,9 @@ class TestRecencyParameters(unittest.TestCase):
                 params = RecencyParameters(
                     recency_field="created_at",
                     grow_from=0.5,
-                    grow_function=func
+                    grow_function=func,
+                    grow_scale="7d",
+                    grow_offset="0d"
                 )
                 self.assertEqual(params.grow_function, func)
 
@@ -473,20 +543,19 @@ class TestRecencyParameters(unittest.TestCase):
                     RecencyParameters(
                         recency_field="created_at",
                         grow_from=0.5,
-                        grow_function=func
+                        grow_function=func,
+                        grow_scale="7d",
+                        grow_offset="0d"
                     )
-
-    def test_grow_function_default_none(self):
-        """Test grow_function defaults to None (will use decay_function at query time)."""
-        params = RecencyParameters(recency_field="created_at", grow_from=0.5)
-        self.assertIsNone(params.grow_function)
 
     def test_grow_function_alias(self):
         """Test grow_function alias (growFunction)."""
         params = RecencyParameters(
             recency_field="created_at",
             grow_from=0.5,
-            growFunction="linear"
+            growFunction="linear",
+            grow_scale="7d",
+            grow_offset="0d"
         )
         self.assertEqual(params.grow_function, "linear")
 
@@ -499,20 +568,22 @@ class TestRecencyParameters(unittest.TestCase):
         """Test grow_scale field validation."""
         # Valid scales (same format as scale)
         valid_scales = [
-            ("days", "7d", "7d"),
-            ("hours", "24h", "24h"),
-            ("decimal_days", "1.5d", "1.5d"),
-            ("decimal_hours", "0.5h", "0.5h"),
+            ("days", "7d"),
+            ("hours", "24h"),
+            ("decimal_days", "1.5d"),
+            ("decimal_hours", "0.5h"),
         ]
 
-        for test_name, grow_scale, expected in valid_scales:
+        for test_name, grow_scale in valid_scales:
             with self.subTest(test_name):
                 params = RecencyParameters(
                     recency_field="created_at",
                     grow_from=0.5,
-                    grow_scale=grow_scale
+                    grow_function="exponential",
+                    grow_scale=grow_scale,
+                    grow_offset="0d"
                 )
-                self.assertEqual(params.grow_scale, expected)
+                self.assertEqual(params.grow_scale, grow_scale)
 
         # Invalid scales
         invalid_scales = [
@@ -528,20 +599,19 @@ class TestRecencyParameters(unittest.TestCase):
                     RecencyParameters(
                         recency_field="created_at",
                         grow_from=0.5,
-                        grow_scale=grow_scale
+                        grow_function="exponential",
+                        grow_scale=grow_scale,
+                        grow_offset="0d"
                     )
-
-    def test_grow_scale_default_none(self):
-        """Test grow_scale defaults to None (will use scale at query time)."""
-        params = RecencyParameters(recency_field="created_at", grow_from=0.5)
-        self.assertIsNone(params.grow_scale)
 
     def test_grow_scale_alias(self):
         """Test grow_scale alias (growScale)."""
         params = RecencyParameters(
             recency_field="created_at",
             grow_from=0.5,
-            growScale="14d"
+            grow_function="exponential",
+            growScale="14d",
+            grow_offset="0d"
         )
         self.assertEqual(params.grow_scale, "14d")
 
@@ -554,20 +624,22 @@ class TestRecencyParameters(unittest.TestCase):
         """Test grow_offset field validation."""
         # Valid offsets (same format as offset)
         valid_offsets = [
-            ("zero_days", "0d", "0d"),
-            ("days", "1d", "1d"),
-            ("hours", "12h", "12h"),
-            ("decimal_days", "0.5d", "0.5d"),
+            ("zero_days", "0d"),
+            ("days", "1d"),
+            ("hours", "12h"),
+            ("decimal_days", "0.5d"),
         ]
 
-        for test_name, grow_offset, expected in valid_offsets:
+        for test_name, grow_offset in valid_offsets:
             with self.subTest(test_name):
                 params = RecencyParameters(
                     recency_field="created_at",
                     grow_from=0.5,
+                    grow_function="exponential",
+                    grow_scale="7d",
                     grow_offset=grow_offset
                 )
-                self.assertEqual(params.grow_offset, expected)
+                self.assertEqual(params.grow_offset, grow_offset)
 
         # Invalid offsets
         invalid_offsets = [
@@ -582,19 +654,18 @@ class TestRecencyParameters(unittest.TestCase):
                     RecencyParameters(
                         recency_field="created_at",
                         grow_from=0.5,
+                        grow_function="exponential",
+                        grow_scale="7d",
                         grow_offset=grow_offset
                     )
-
-    def test_grow_offset_default_none(self):
-        """Test grow_offset defaults to None (will use '0d' at query time)."""
-        params = RecencyParameters(recency_field="created_at", grow_from=0.5)
-        self.assertIsNone(params.grow_offset)
 
     def test_grow_offset_alias(self):
         """Test grow_offset alias (growOffset)."""
         params = RecencyParameters(
             recency_field="created_at",
             grow_from=0.5,
+            grow_function="exponential",
+            grow_scale="7d",
             growOffset="2d"
         )
         self.assertEqual(params.grow_offset, "2d")

--- a/tests/unit_tests/marqo/tensor_search/models/test_recency_parameters.py
+++ b/tests/unit_tests/marqo/tensor_search/models/test_recency_parameters.py
@@ -338,3 +338,59 @@ class TestRecencyParameters(unittest.TestCase):
             self.assertIsInstance(json_str, str)
             self.assertIn("created_at", json_str)
             self.assertIn("gaussian", json_str)
+
+    def test_add_to_score_weight_validation(self):
+        """Test add_to_score_weight field validation."""
+        # Valid add_to_score_weight values
+        valid_values = [
+            ("positive_small", 0.1, 0.1),
+            ("positive_large", 10.0, 10.0),
+            ("positive_one", 1.0, 1.0),
+            ("positive_decimal", 0.01, 0.01),
+        ]
+
+        for test_name, add_to_score_weight, expected in valid_values:
+            with self.subTest(test_name):
+                params = RecencyParameters(
+                    recency_field="created_at",
+                    add_to_score_weight=add_to_score_weight
+                )
+                self.assertEqual(params.add_to_score_weight, expected)
+
+        # Invalid add_to_score_weight values
+        invalid_values = [
+            ("zero", 0.0),
+            ("negative", -0.5),
+            ("negative_large", -10.0),
+        ]
+
+        for test_name, add_to_score_weight in invalid_values:
+            with self.subTest(test_name):
+                with self.assertRaises(ValidationError) as exc_info:
+                    RecencyParameters(
+                        recency_field="created_at",
+                        add_to_score_weight=add_to_score_weight
+                    )
+                errors = exc_info.exception.errors()
+                self.assertTrue(
+                    any('add_to_score_weight' in str(e['loc']) or 'addToScoreWeight' in str(e['loc']) for e in errors),
+                    f"Expected 'add_to_score_weight' or 'addToScoreWeight' in error locations: {errors}"
+                )
+
+    def test_add_to_score_weight_default_none(self):
+        """Test add_to_score_weight defaults to None."""
+        params = RecencyParameters(recency_field="created_at")
+        self.assertIsNone(params.add_to_score_weight)
+
+    def test_add_to_score_weight_alias(self):
+        """Test add_to_score_weight alias (addToScoreWeight)."""
+        params = RecencyParameters(
+            recency_field="created_at",
+            addToScoreWeight=0.5
+        )
+        self.assertEqual(params.add_to_score_weight, 0.5)
+
+        # Test dict serialization with alias
+        result = params.dict(by_alias=True)
+        self.assertIn('addToScoreWeight', result)
+        self.assertEqual(result['addToScoreWeight'], 0.5)

--- a/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
+++ b/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
@@ -995,18 +995,30 @@ public class HybridSearcher extends Searcher {
             logIfVerbose("Applying global score modifiers and reranking.", verbose);
             resultToRerank = applyGlobalScoreModifiers(resultToRerank, query, verbose);
         } else if (query.properties().getBoolean("marqo__recency_apply_in_global_ranking_phase")) {
-            // apply recency score
+            // Apply recency score without global score modifiers
+            double addToScoreWeight =
+                    query.properties().getDouble("marqo__recency_add_to_score_weight", 0.0);
+
             for (Hit hit : resultToRerank.asList()) {
                 FeatureData matchFeatures = (FeatureData) hit.getField("matchfeatures");
                 if (matchFeatures == null) continue;
 
                 double recencyScore = matchFeatures.getDouble("recency_score");
                 double originalScore = hit.getRelevance().getScore();
-                double modifiedScore = originalScore * recencyScore;
+                double modifiedScore;
+
+                if (addToScoreWeight > 0) {
+                    // Additive mode
+                    modifiedScore = originalScore + (recencyScore * addToScoreWeight);
+                } else {
+                    // Multiplicative mode (default)
+                    modifiedScore = originalScore * recencyScore;
+                }
+
                 hit.setRelevance(modifiedScore);
                 logIfVerbose(
                         String.format(
-                                "Applied recency score %.4f to score %.4f -> %.4f" + " for hit %s",
+                                "Applied recency score %.4f to score %.4f -> %.4f for hit %s",
                                 recencyScore, originalScore, modifiedScore, hit.getId()),
                         verbose);
             }
@@ -1437,6 +1449,9 @@ public class HybridSearcher extends Searcher {
         boolean applyRecency =
                 query.properties().getBoolean("marqo__recency_apply_in_global_ranking_phase");
 
+        double addToScoreWeight =
+                query.properties().getDouble("marqo__recency_add_to_score_weight", 0.0);
+
         for (Hit hit : hits) {
             logIfVerbose("Applying score modifiers to hit: " + hit.getId(), verbose);
             // Extract the mult and add modifiers from match-features
@@ -1449,15 +1464,26 @@ public class HybridSearcher extends Searcher {
                 if (mult_modifier != null && add_modifier != null) {
                     // Apply the modifiers to the hit's relevance
                     original_score = hit.getRelevance().getScore();
-                    modified_score = (original_score * mult_modifier + add_modifier) * recencyScore;
+                    double baseScore = original_score * mult_modifier + add_modifier;
+
+                    if (applyRecency && addToScoreWeight > 0) {
+                        // Additive mode: base + (recency * weight)
+                        modified_score = baseScore + (recencyScore * addToScoreWeight);
+                    } else {
+                        // Multiplicative mode (default): base * recency
+                        modified_score = baseScore * recencyScore;
+                    }
+
                     logIfVerbose(
                             String.format(
                                     "Original score: %.7f, mult modifier: %.5f, add modifier: %.5f,"
-                                            + " recency score: %.5f, Modified score: %.7f",
+                                        + " recency score: %.5f, addToScoreWeight: %.5f, Modified"
+                                        + " score: %.7f",
                                     original_score,
                                     mult_modifier,
                                     add_modifier,
                                     recencyScore,
+                                    addToScoreWeight,
                                     modified_score),
                             verbose);
                     hit.setRelevance(modified_score);

--- a/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
+++ b/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
@@ -997,7 +997,10 @@ public class HybridSearcher extends Searcher {
         } else if (query.properties().getBoolean("marqo__recency_apply_in_global_ranking_phase")) {
             // Apply recency score without global score modifiers
             double addToScoreWeight =
-                    query.properties().getDouble("marqo__recency_add_to_score_weight", 0.0);
+                    query.getRanking()
+                            .getFeatures()
+                            .getDouble(addQueryWrapper("marqo__recency_add_to_score_weight"))
+                            .orElse(0.0);
 
             for (Hit hit : resultToRerank.asList()) {
                 FeatureData matchFeatures = (FeatureData) hit.getField("matchfeatures");
@@ -1450,7 +1453,10 @@ public class HybridSearcher extends Searcher {
                 query.properties().getBoolean("marqo__recency_apply_in_global_ranking_phase");
 
         double addToScoreWeight =
-                query.properties().getDouble("marqo__recency_add_to_score_weight", 0.0);
+                query.getRanking()
+                        .getFeatures()
+                        .getDouble(addQueryWrapper("marqo__recency_add_to_score_weight"))
+                        .orElse(0.0);
 
         for (Hit hit : hits) {
             logIfVerbose("Applying score modifiers to hit: " + hit.getId(), verbose);
@@ -1466,7 +1472,9 @@ public class HybridSearcher extends Searcher {
                     original_score = hit.getRelevance().getScore();
                     double baseScore = original_score * mult_modifier + add_modifier;
 
-                    if (applyRecency && addToScoreWeight > 0) {
+                    if (!applyRecency) {
+                        modified_score = baseScore;
+                    } else if (addToScoreWeight > 0) {
                         // Additive mode: base + (recency * weight)
                         modified_score = baseScore + (recencyScore * addToScoreWeight);
                     } else {

--- a/vespa/src/test/java/ai/marqo/search/HybridSearcherRecencyTest.java
+++ b/vespa/src/test/java/ai/marqo/search/HybridSearcherRecencyTest.java
@@ -83,7 +83,11 @@ class HybridSearcherRecencyTest {
     private Query createQueryWithAdditiveRecency(
             boolean enabled, boolean applyInGlobalPhase, double addToScoreWeight) {
         Query query = createQueryWithRecency(enabled, applyInGlobalPhase);
-        query.properties().set("marqo__recency_add_to_score_weight", addToScoreWeight);
+        // Set addToScoreWeight in rank features (not properties) - this is where HybridSearcher
+        // reads it from
+        query.getRanking()
+                .getFeatures()
+                .put("query(marqo__recency_add_to_score_weight)", addToScoreWeight);
         return query;
     }
 

--- a/vespa/src/test/java/ai/marqo/search/HybridSearcherRecencyTest.java
+++ b/vespa/src/test/java/ai/marqo/search/HybridSearcherRecencyTest.java
@@ -77,6 +77,16 @@ class HybridSearcherRecencyTest {
         return query;
     }
 
+    /**
+     * Helper method to create a query with additive recency enabled
+     */
+    private Query createQueryWithAdditiveRecency(
+            boolean enabled, boolean applyInGlobalPhase, double addToScoreWeight) {
+        Query query = createQueryWithRecency(enabled, applyInGlobalPhase);
+        query.properties().set("marqo__recency_add_to_score_weight", addToScoreWeight);
+        return query;
+    }
+
     @Nested
     class ExtractRecencyScoreTests {
         @Test
@@ -234,6 +244,73 @@ class HybridSearcherRecencyTest {
             // Expected: (0.75 * 3.0 + 1.0) * 0.6 = (2.25 + 1.0) * 0.6 = 3.25 * 0.6 = 1.95
             assertThat(result.get(0).getRelevance().getScore()).isCloseTo(1.95, within(0.0001));
         }
+
+        @Test
+        void shouldApplyAdditiveRecencyInGlobalRankingPhase() {
+            Query query = createQueryWithAdditiveRecency(true, true, 0.5);
+            HitGroup hits = new HitGroup();
+            hits.add(createHitWithScoreModifiers("index:test/0/doc1", 1.0, 2.0, 0.5, 0.8));
+
+            HitGroup result = hybridSearcher.applyGlobalScoreModifiers(hits, query, false);
+
+            // Expected: (1.0 * 2.0 + 0.5) + (0.8 * 0.5) = 2.5 + 0.4 = 2.9
+            assertThat(result.get(0).getRelevance().getScore()).isCloseTo(2.9, within(0.0001));
+        }
+
+        @Test
+        void shouldUseDefaultMultiplicativeModeWhenAddToScoreWeightIsZero() {
+            Query query = createQueryWithAdditiveRecency(true, true, 0.0);
+            HitGroup hits = new HitGroup();
+            hits.add(createHitWithScoreModifiers("index:test/0/doc1", 1.0, 2.0, 0.5, 0.8));
+
+            HitGroup result = hybridSearcher.applyGlobalScoreModifiers(hits, query, false);
+
+            // Expected: (1.0 * 2.0 + 0.5) * 0.8 = 2.5 * 0.8 = 2.0 (multiplicative mode)
+            assertThat(result.get(0).getRelevance().getScore()).isCloseTo(2.0, within(0.0001));
+        }
+
+        @Test
+        void shouldHandleVariousAdditiveRecencyWeights() {
+            // Test different addToScoreWeight values
+            double[] weights = {0.1, 0.5, 1.0, 10.0};
+            double baseScore = 1.0;
+            double multModifier = 1.0;
+            double addModifier = 0.0;
+            double recencyScore = 0.8;
+
+            for (double weight : weights) {
+                Query query = createQueryWithAdditiveRecency(true, true, weight);
+                HitGroup hits = new HitGroup();
+                hits.add(
+                        createHitWithScoreModifiers(
+                                "index:test/0/doc1",
+                                baseScore,
+                                multModifier,
+                                addModifier,
+                                recencyScore));
+
+                HitGroup result = hybridSearcher.applyGlobalScoreModifiers(hits, query, false);
+
+                // Expected: (baseScore * multModifier + addModifier) + (recencyScore * weight)
+                double expected =
+                        (baseScore * multModifier + addModifier) + (recencyScore * weight);
+                assertThat(result.get(0).getRelevance().getScore())
+                        .as("Failed for weight=" + weight)
+                        .isCloseTo(expected, within(0.0001));
+            }
+        }
+
+        @Test
+        void shouldHandleAdditiveRecencyWithComplexScoreModifiers() {
+            Query query = createQueryWithAdditiveRecency(true, true, 2.0);
+            HitGroup hits = new HitGroup();
+            hits.add(createHitWithScoreModifiers("index:test/0/doc1", 0.75, 3.0, 1.0, 0.6));
+
+            HitGroup result = hybridSearcher.applyGlobalScoreModifiers(hits, query, false);
+
+            // Expected: (0.75 * 3.0 + 1.0) + (0.6 * 2.0) = 3.25 + 1.2 = 4.45
+            assertThat(result.get(0).getRelevance().getScore()).isCloseTo(4.45, within(0.0001));
+        }
     }
 
     @Nested
@@ -345,6 +422,71 @@ class HybridSearcherRecencyTest {
             HitGroup result = hybridSearcher.postProcessResults(hits, query, null, 5, 0, false);
 
             assertThat(result.size()).isEqualTo(5);
+        }
+
+        @Test
+        void shouldApplyAdditiveRecencyWithoutGlobalWeights() {
+            Query query = createQueryWithAdditiveRecency(true, true, 0.5);
+            // Set empty global weights to trigger standalone recency path
+            RankFeatures rankFeatures = query.getRanking().getFeatures();
+            TensorType tensorType = new TensorType.Builder().mapped("p").build();
+            Tensor emptyTensor = Tensor.Builder.of(tensorType).build();
+            rankFeatures.put("query(marqo__mult_weights_global)", emptyTensor);
+            rankFeatures.put("query(marqo__add_weights_global)", emptyTensor);
+
+            HitGroup hits = new HitGroup();
+            hits.add(createHitWithRecencyScore("index:test/0/doc1", 1.0, 0.8));
+            hits.add(createHitWithRecencyScore("index:test/0/doc2", 0.9, 0.6));
+
+            HitGroup result = hybridSearcher.postProcessResults(hits, query, null, 10, 0, false);
+
+            // Additive mode: score + (recencyScore * weight)
+            // doc1: 1.0 + (0.8 * 0.5) = 1.0 + 0.4 = 1.4
+            // doc2: 0.9 + (0.6 * 0.5) = 0.9 + 0.3 = 1.2
+            assertThat(result.get(0).getRelevance().getScore()).isCloseTo(1.4, within(0.0001));
+            assertThat(result.get(1).getRelevance().getScore()).isCloseTo(1.2, within(0.0001));
+        }
+
+        @Test
+        void shouldUseMultiplicativeModeWhenAddToScoreWeightIsZeroStandalone() {
+            Query query = createQueryWithAdditiveRecency(true, true, 0.0);
+            RankFeatures rankFeatures = query.getRanking().getFeatures();
+            TensorType tensorType = new TensorType.Builder().mapped("p").build();
+            Tensor emptyTensor = Tensor.Builder.of(tensorType).build();
+            rankFeatures.put("query(marqo__mult_weights_global)", emptyTensor);
+            rankFeatures.put("query(marqo__add_weights_global)", emptyTensor);
+
+            HitGroup hits = new HitGroup();
+            hits.add(createHitWithRecencyScore("index:test/0/doc1", 1.0, 0.8));
+
+            HitGroup result = hybridSearcher.postProcessResults(hits, query, null, 10, 0, false);
+
+            // Multiplicative mode (default): score * recencyScore
+            // doc1: 1.0 * 0.8 = 0.8
+            assertThat(result.get(0).getRelevance().getScore()).isCloseTo(0.8, within(0.0001));
+        }
+
+        @Test
+        void shouldRerankCorrectlyAfterAdditiveRecency() {
+            Query query = createQueryWithAdditiveRecency(true, true, 1.0);
+            RankFeatures rankFeatures = query.getRanking().getFeatures();
+            TensorType tensorType = new TensorType.Builder().mapped("p").build();
+            Tensor emptyTensor = Tensor.Builder.of(tensorType).build();
+            rankFeatures.put("query(marqo__mult_weights_global)", emptyTensor);
+            rankFeatures.put("query(marqo__add_weights_global)", emptyTensor);
+
+            HitGroup hits = new HitGroup();
+            // Add hits that will change order after additive recency
+            hits.add(createHitWithRecencyScore("index:test/0/doc1", 0.5, 1.0)); // 0.5 + 1.0 = 1.5
+            hits.add(createHitWithRecencyScore("index:test/0/doc2", 1.0, 0.3)); // 1.0 + 0.3 = 1.3
+            hits.add(createHitWithRecencyScore("index:test/0/doc3", 0.6, 0.8)); // 0.6 + 0.8 = 1.4
+
+            HitGroup result = hybridSearcher.postProcessResults(hits, query, null, 10, 0, false);
+
+            // After sorting: doc1 (1.5), doc3 (1.4), doc2 (1.3)
+            assertThat(result.get(0).getId().toString()).contains("doc1");
+            assertThat(result.get(1).getId().toString()).contains("doc3");
+            assertThat(result.get(2).getId().toString()).contains("doc2");
         }
     }
 


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds additive recency scoring and grow parameters for future timestamps, updates Vespa rank profiles and validation, and bumps version to 2.24.9 with comprehensive tests.
> 
> - **Recency Scoring (core/model)**:
>   - Add `addToScoreWeight` (additive mode) and grow params (`growFrom`, `growFunction`, `growScale`, `growOffset`) to `RecencyParameters`, with validation (all-or-nothing grow, duration parsing, bounds).
>   - Gate features by schema version on semi-structured indexes: `index_supports_recency_scoring`, `index_supports_recency_additive`, `index_supports_recency_grow`.
>   - Enforce in `HybridSearch`: reject on structured indexes; check min versions for base, additive, and grow.
>   - Extend constants with new query inputs and minimum versions.
> - **Vespa Integration**:
>   - Update semi-structured schema templates to compute unified `recency_score` (past decay + future grow), include `add_to_score_weight`, and apply in `modify()`.
>   - Populate recency query features in `SemiStructuredVespaIndex` (including defaults when grow disabled).
>   - Vespa Java `HybridSearcher`: support additive or multiplicative application in global phase and when only recency is applied; expose `_recency_score`.
> - **Version**:
>   - Bump to `2.24.9`.
> - **Tests**:
>   - Add extensive unit/integration tests for additive mode, grow behavior, version gating, ranking-phase application, interactions with sort/collapse/relevanceCutoff.
>   - Minor test asset URL updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit def49f88970eae051c89bc5d6a64bce0801b6b26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->