### PR TITLE
support ipv6 sockets and default to ipv4

### DIFF
--- a/src/marqo/core/monitoring/statsd_client.py
+++ b/src/marqo/core/monitoring/statsd_client.py
@@ -1,6 +1,6 @@
 import logging
 import socket
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
 import marqo.logging
 from marqo.tensor_search.enums import EnvVars
@@ -24,16 +24,46 @@ class StatsDClient:
         port: Optional[int] = None,
         prefix: str = "",
     ) -> None:
-        self.addr = (
-            host or read_env_vars_and_defaults(EnvVars.STATSD_HOST),
-            int(port or read_env_vars_and_defaults_ints(EnvVars.STATSD_PORT)),
-        )
+        host = host or read_env_vars_and_defaults(EnvVars.STATSD_HOST)
+        port = int(port or read_env_vars_and_defaults_ints(EnvVars.STATSD_PORT))
+
         self.prefix = prefix
-        self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        self._sock.setblocking(False)
+        self._sock, self.addr = self._create_socket(host, port)
 
         # Parse once; reused for every metric
         self._common_tags = self._parse_common_tags(read_env_vars_and_defaults(EnvVars.STATSD_COMMON_TAGS))
+
+    @staticmethod
+    def _create_socket(host: str, port: int) -> Tuple[socket.socket, Tuple]:
+        """
+        Create a UDP socket that supports both IPv4 and IPv6 (dual-stack).
+
+        Args:
+            host: The hostname or IP address to connect to.
+            port: The port number.
+
+        Returns:
+            A tuple of (socket, address) where address is suitable for sendto().
+        """
+        # getaddrinfo returns a list of 5-tuples: (family, type, proto, canonname, sockaddr)
+        try:
+            addr_info = socket.getaddrinfo(host, port, socket.AF_UNSPEC, socket.SOCK_DGRAM)
+        except socket.gaierror:
+            addr_info = None
+
+        if addr_info:
+            # Use the first resolved address - socket family matches the host address type
+            # (IPv4 addresses get AF_INET, IPv6 addresses get AF_INET6)
+            family, socktype, proto, canonname, addr = addr_info[0]
+        else:
+            # Fall back to IPv4 if address resolution fails
+            family, socktype, proto = socket.AF_INET, socket.SOCK_DGRAM, 0
+            addr = (host, port)
+
+        sock = socket.socket(family, socktype, proto)
+        sock.setblocking(False)
+
+        return sock, addr
 
     def increment(
         self,

--- a/src/marqo/core/monitoring/statsd_client.py
+++ b/src/marqo/core/monitoring/statsd_client.py
@@ -46,22 +46,28 @@ class StatsDClient:
             A tuple of (socket, address) where address is suitable for sendto().
         """
         # getaddrinfo returns a list of 5-tuples: (family, type, proto, canonname, sockaddr)
+        logger.debug(f"Resolving address for StatsD: host={host}, port={port}")
         try:
             addr_info = socket.getaddrinfo(host, port, socket.AF_UNSPEC, socket.SOCK_DGRAM)
-        except socket.gaierror:
+        except socket.gaierror as e:
+            logger.debug(f"Address resolution failed for {host}:{port}: {e}")
             addr_info = None
 
         if addr_info:
             # Use the first resolved address - socket family matches the host address type
             # (IPv4 addresses get AF_INET, IPv6 addresses get AF_INET6)
             family, socktype, proto, canonname, addr = addr_info[0]
+            family_name = "IPv6" if family == socket.AF_INET6 else "IPv4"
+            logger.debug(f"Address resolved: family={family_name}, addr={addr}")
         else:
             # Fall back to IPv4 if address resolution fails
             family, socktype, proto = socket.AF_INET, socket.SOCK_DGRAM, 0
             addr = (host, port)
+            logger.debug(f"Falling back to IPv4 socket: addr={addr}")
 
         sock = socket.socket(family, socktype, proto)
         sock.setblocking(False)
+        logger.debug(f"StatsD socket created: family={sock.family}, blocking=False")
 
         return sock, addr
 

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.24.9"
+__version__ = "2.24.10"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/tests/integ_tests/core/monitoring/test_metrics_udp.py
+++ b/tests/integ_tests/core/monitoring/test_metrics_udp.py
@@ -5,6 +5,7 @@ import time
 import unittest
 from contextlib import contextmanager
 from typing import List
+from unittest.mock import patch
 
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
@@ -365,3 +366,12 @@ class TestStatsDClientDualStack(unittest.TestCase):
                 _has(pkt, r"test\.ipv6\.latency:250\|ms"),
                 msg=f"IPv6 timing metric not received\nSeen:\n{pkt}",
             )
+
+    def test_statsd_client_fallback_to_ipv4_when_resolution_fails(self):
+        """If getaddrinfo raises, we fall back to IPv4 and do not raise on send."""
+        with patch("socket.getaddrinfo", side_effect=socket.gaierror("mock resolution failure")):
+            client = sc.StatsDClient(host="does-not-resolve.invalid", port=8125)
+            # Fallback path should create an IPv4 socket
+            self.assertEqual(client._sock.family, socket.AF_INET)
+            # Sending should not raise (errors are swallowed and logged at debug)
+            client.increment("test.fallback.counter", 1)

--- a/tests/integ_tests/core/monitoring/test_metrics_udp.py
+++ b/tests/integ_tests/core/monitoring/test_metrics_udp.py
@@ -16,11 +16,12 @@ import marqo.core.monitoring.statsd_middleware as sm
 
 class _UDPSink:
     """A UDP sink that captures packets sent to it, thread-safe via _lock."""
-    def __init__(self, host: str = "127.0.0.1", port: int = 0):
-        self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        # ensure recvfrom() wakes up regularly so stop()/join() can’t hang
+    def __init__(self, host: str = "127.0.0.1", port: int = 0, family: int = socket.AF_INET):
+        self._sock = socket.socket(family, socket.SOCK_DGRAM)
+        # ensure recvfrom() wakes up regularly so stop()/join() can't hang
         self._sock.settimeout(0.2)
         self._sock.bind((host, port))
+        self.host = self._sock.getsockname()[0]
         self.port = self._sock.getsockname()[1]
 
         self._lock = threading.Lock()
@@ -47,7 +48,7 @@ class _UDPSink:
         self._running = False
         # poke the socket so recvfrom() unblocks on stubborn kernels
         try:
-            self._sock.sendto(b"", ("127.0.0.1", self.port))
+            self._sock.sendto(b"", (self.host, self.port))
         except OSError:
             pass
         self._sock.close()
@@ -69,9 +70,9 @@ class _UDPSink:
 
 
 @contextmanager
-def udp_sink():
+def udp_sink(host: str = "127.0.0.1", family: int = socket.AF_INET):
     """Context manager to create a UDP sink for capturing metrics."""
-    sink = _UDPSink()
+    sink = _UDPSink(host=host, family=family)
     try:
         yield sink
     finally:
@@ -298,3 +299,69 @@ class TestStatsDMiddlewareUDP(unittest.TestCase):
             _has(pkt, r"#path:/indexes/foo/documents/<document_id>,method:GET,status_code:200"),
             msg=f"Missing redacted packet\nSeen:\n{pkt}",
         )
+
+
+class TestStatsDClientDualStack(unittest.TestCase):
+    """Integration tests for StatsDClient dual-stack (IPv4/IPv6) socket support."""
+
+    def test_statsd_client_ipv4_sends_metrics(self):
+        """Test that StatsDClient can send metrics over IPv4."""
+        with udp_sink(host="127.0.0.1", family=socket.AF_INET) as sink:
+            client = sc.StatsDClient(host="127.0.0.1", port=sink.port)
+
+            # Verify socket is IPv4
+            self.assertEqual(client._sock.family, socket.AF_INET)
+
+            # Send a metric and verify it arrives
+            client.increment("test.ipv4.counter", 1)
+            sink.wait(n=1)
+
+            pkt = sink.decoded()
+            self.assertTrue(
+                _has(pkt, r"test\.ipv4\.counter:1\|c"),
+                msg=f"IPv4 metric not received\nSeen:\n{pkt}",
+            )
+
+    def test_statsd_client_ipv6_sends_metrics(self):
+        """Test that StatsDClient can send metrics over IPv6."""
+        with udp_sink(host="::1", family=socket.AF_INET6) as sink:
+            client = sc.StatsDClient(host="::1", port=sink.port)
+
+            # Verify socket is IPv6
+            self.assertEqual(client._sock.family, socket.AF_INET6)
+
+            # Send a metric and verify it arrives
+            client.increment("test.ipv6.counter", 1)
+            sink.wait(n=1)
+
+            pkt = sink.decoded()
+            self.assertTrue(
+                _has(pkt, r"test\.ipv6\.counter:1\|c"),
+                msg=f"IPv6 metric not received\nSeen:\n{pkt}",
+            )
+
+    def test_statsd_client_ipv4_timing_metric(self):
+        """Test that timing metrics work over IPv4."""
+        with udp_sink(host="127.0.0.1", family=socket.AF_INET) as sink:
+            client = sc.StatsDClient(host="127.0.0.1", port=sink.port)
+            client.timing("test.ipv4.latency", 150)
+            sink.wait(n=1)
+
+            pkt = sink.decoded()
+            self.assertTrue(
+                _has(pkt, r"test\.ipv4\.latency:150\|ms"),
+                msg=f"IPv4 timing metric not received\nSeen:\n{pkt}",
+            )
+
+    def test_statsd_client_ipv6_timing_metric(self):
+        """Test that timing metrics work over IPv6."""
+        with udp_sink(host="::1", family=socket.AF_INET6) as sink:
+            client = sc.StatsDClient(host="::1", port=sink.port)
+            client.timing("test.ipv6.latency", 250)
+            sink.wait(n=1)
+
+            pkt = sink.decoded()
+            self.assertTrue(
+                _has(pkt, r"test\.ipv6\.latency:250\|ms"),
+                msg=f"IPv6 timing metric not received\nSeen:\n{pkt}",
+            )

--- a/tests/unit_tests/marqo/core/monitoring/test_statsd_client.py
+++ b/tests/unit_tests/marqo/core/monitoring/test_statsd_client.py
@@ -1,4 +1,6 @@
+import socket
 from typing import List
+from unittest.mock import patch
 
 import pytest
 
@@ -60,3 +62,53 @@ class TestStatsDClient:
         """Test that _parse_common_tags handles empty and malformed strings."""
         assert sc.StatsDClient._parse_common_tags("") == {}
         assert sc.StatsDClient._parse_common_tags("foo:bar,,baz:") == {"foo": "bar"}
+
+
+class TestCreateSocket:
+    """Tests for the _create_socket method and dual-stack support."""
+
+    def test_create_socket_ipv4_address(self):
+        """Test that an IPv4 address creates an IPv4 socket."""
+        sock, addr = sc.StatsDClient._create_socket("127.0.0.1", 8125)
+        try:
+            assert sock.family == socket.AF_INET
+            assert addr == ("127.0.0.1", 8125)
+        finally:
+            sock.close()
+
+    def test_create_socket_ipv6_address(self):
+        """Test that an IPv6 address creates an IPv6 socket."""
+        sock, addr = sc.StatsDClient._create_socket("::1", 8125)
+        try:
+            assert sock.family == socket.AF_INET6
+            # IPv6 sockaddr is (host, port, flowinfo, scope_id)
+            assert addr[0] == "::1"
+            assert addr[1] == 8125
+        finally:
+            sock.close()
+
+    def test_create_socket_fallback_to_ipv4_on_resolution_failure(self):
+        """Test that socket falls back to IPv4 when address resolution fails."""
+        with patch("socket.getaddrinfo", side_effect=socket.gaierror("mock failure")):
+            sock, addr = sc.StatsDClient._create_socket("unresolvable.invalid", 8125)
+            try:
+                assert sock.family == socket.AF_INET
+                assert addr == ("unresolvable.invalid", 8125)
+            finally:
+                sock.close()
+
+    def test_create_socket_is_non_blocking(self):
+        """Test that created sockets are non-blocking."""
+        sock, _ = sc.StatsDClient._create_socket("127.0.0.1", 8125)
+        try:
+            assert sock.getblocking() is False
+        finally:
+            sock.close()
+
+    def test_create_socket_is_udp(self):
+        """Test that created sockets are UDP (SOCK_DGRAM)."""
+        sock, _ = sc.StatsDClient._create_socket("127.0.0.1", 8125)
+        try:
+            assert sock.type == socket.SOCK_DGRAM
+        finally:
+            sock.close()


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable dual-stack (IPv4/IPv6) UDP in `StatsDClient` with IPv4 fallback, update UDP sink, add IPv4/IPv6 integration and unit tests, and bump version.
> 
> - **Monitoring**:
>   - `src/marqo/core/monitoring/statsd_client.py`: Add dual-stack UDP support via `_create_socket()` using `getaddrinfo`, non-blocking sockets, and fallback to IPv4 on resolution failure. Constructor now uses this socket/address.
> - **Tests**:
>   - `tests/integ_tests/core/monitoring/test_metrics_udp.py`: Update `_UDPSink` and `udp_sink` to support IPv4/IPv6; add integration tests for IPv4/IPv6 counters/timings and fallback behavior.
>   - `tests/unit_tests/marqo/core/monitoring/test_statsd_client.py`: Add unit tests for `_create_socket` (IPv4, IPv6, fallback, non-blocking, UDP type) and existing serialization/tag parsing.
> - **Version**:
>   - `src/marqo/version.py`: Bump to `2.24.10`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6d2784070fc36377f7a60bad29f9eb9f7021ceb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->