### PR TITLE
Fix model download auth handling to support public buckets; make bind host configurable

### DIFF
--- a/components/model_management/Dockerfile
+++ b/components/model_management/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 # System deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
- && rm -rf /var/mlib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/*
 
 # Install uv
 RUN pip install --no-cache-dir uv
@@ -24,7 +24,8 @@ COPY src ./src
 # Set Python path
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/.venv/bin:$PATH"
+ENV MARQO_HOST=0.0.0.0
 RUN echo $COMMITHASH > build_info.txt
 
-# Run with gunicorn and uvicorn worker
-CMD ["uvicorn", "model_management.main:app", "--host", "0.0.0.0", "--port", "8883"]
+# Run the FastAPI app with uvicorn
+CMD ["sh", "-c", "exec uvicorn model_management.main:app --host ${MARQO_HOST} --port 8883"]

--- a/components/model_management/src/model_management/services/model_manager/triton_model_downloader.py
+++ b/components/model_management/src/model_management/services/model_manager/triton_model_downloader.py
@@ -99,7 +99,7 @@ class TritonModelDownloader:
                 out_paths.append(dest)
                 continue
 
-            fs, path = fsspec.core.url_to_fs(uri, anon=True)
+            fs, path = fsspec.core.url_to_fs(uri)
             dest.parent.mkdir(parents=True, exist_ok=True)
             self._download_with_progress(fs, path, dest)
             out_paths.append(dest)

--- a/components/model_management/src/model_management/services/model_manager/triton_model_downloader.py
+++ b/components/model_management/src/model_management/services/model_manager/triton_model_downloader.py
@@ -99,7 +99,7 @@ class TritonModelDownloader:
                 out_paths.append(dest)
                 continue
 
-            fs, path = fsspec.core.url_to_fs(uri)
+            fs, path = fsspec.core.url_to_fs(uri, anon=True)
             dest.parent.mkdir(parents=True, exist_ok=True)
             self._download_with_progress(fs, path, dest)
             out_paths.append(dest)


### PR DESCRIPTION
## Change Summary

This pull request makes several improvements to the `model_management` component, focusing on Dockerfile configuration and model downloading. The changes fix a cleanup path in the Dockerfile, enhance environment variable handling for the server host, and ensure anonymous access when downloading models via `fsspec`.

**Dockerfile improvements:**

* Fixed a typo in the Dockerfile cleanup command by changing `/var/mlib/apt/lists/*` to `/var/lib/apt/lists/*`, ensuring apt cache is properly removed after installing dependencies.
* Added the `MARQO_HOST` environment variable to the Dockerfile and updated the `CMD` to use it, allowing for more flexible host configuration when starting the FastAPI app.

**Model downloading:**

* Updated the `fsspec.core.url_to_fs` call in `triton_model_downloader.py` to use `anon=True`, enabling anonymous access when downloading models from remote storage.

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Dockerfile-only change affecting image size cleanup and container startup command/host binding behavior.
> 
> **Overview**
> Fixes the Dockerfile apt cache cleanup path (`/var/lib/apt/lists/*`) so the image properly removes package lists after install.
> 
> Makes the uvicorn bind host configurable by introducing `MARQO_HOST` (default `0.0.0.0`) and updating `CMD` to use it when starting `model_management.main:app`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21b844210ab2722c43e9d56c3c8e9063277c1757. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->