### PR TITLE
Add marqo deployment workflows

### DIFF
--- a/.github/scripts/create_ecrs.sh
+++ b/.github/scripts/create_ecrs.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+REPO_PREFIX=$1
+SUFFIXES=("api" "inference-orchestrator" "model-management")
+
+create_repo_if_not_exists() {
+    local repo_name=$1
+    output=$(aws ecr describe-repositories --repository-names ${repo_name} 2>&1)
+    if [ $? -ne 0 ]; then
+        if echo ${output} | grep -q RepositoryNotFoundException; then
+            echo "Creating ${repo_name} ECR Repository"
+            aws ecr create-repository --repository-name ${repo_name}
+        else
+            >&2 echo ${output}
+            return 1
+        fi
+    else
+        echo "${repo_name} ECR Repository already exists"
+    fi
+}
+
+# Validate input
+if [ -z "$REPO_PREFIX" ]; then
+    echo "Usage: $0 <repo_prefix>"
+    echo "Example: $0 marqoai"
+    exit 1
+fi
+
+# Strip trailing slashes
+REPO_PREFIX="${REPO_PREFIX%/}"
+
+# Create all three repos
+for suffix in "${SUFFIXES[@]}"; do
+    repo_name="${REPO_PREFIX}/${suffix}"
+    create_repo_if_not_exists "${repo_name}"
+done

--- a/.github/workflows/deploy-marqo-images.yml
+++ b/.github/workflows/deploy-marqo-images.yml
@@ -1,0 +1,117 @@
+name: Deploy Marqo Images to All ECRs (os, staging, preprod, prod)
+
+on:
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: 'Tags to apply to the image, comma separated. E.g: latest,stable. If not provided, defaults to commit SHA.'
+        type: string
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build-and-deploy:
+    name: Build and Deploy Marqo Images to ECR for all AWS Environments
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        environment: [staging, preprod, os]
+    environment: ${{ matrix.environment }}
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@master
+        with:
+          role-to-assume: ${{ vars.AWS_OIDC_ROLE_ARN }}
+          role-session-name: deploy-marqo-images
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Prepare image tags
+        id: prepare
+        run: |
+          REGISTRY=${{ steps.login-ecr.outputs.registry }}
+          echo "registry=${REGISTRY}" >> $GITHUB_OUTPUT
+          
+          # Use provided tags or default to commit SHA
+          if [ -z "${{ inputs.tags }}" ]; then
+            IMAGE_TAGS="${{ github.sha }}"
+          else
+            IMAGE_TAGS="${{ inputs.tags }}"
+          fi
+          echo "image_tags=${IMAGE_TAGS}" >> $GITHUB_OUTPUT
+          
+          # Build full tag strings for each image (handle comma-separated tags)
+          API_TAGS=""
+          INFERENCE_TAGS=""
+          MODEL_TAGS=""
+          
+          IFS=',' read -ra TAG_ARRAY <<< "$IMAGE_TAGS"
+          for tag in "${TAG_ARRAY[@]}"; do
+            tag=$(echo "$tag" | xargs)  # trim whitespace
+            API_TAGS="${API_TAGS}${REGISTRY}/marqoai/api:${tag},"
+            INFERENCE_TAGS="${INFERENCE_TAGS}${REGISTRY}/marqoai/inference-orchestrator:${tag},"
+            MODEL_TAGS="${MODEL_TAGS}${REGISTRY}/marqoai/model-management:${tag},"
+          done
+          
+          # Remove trailing comma
+          API_TAGS="${API_TAGS%,}"
+          INFERENCE_TAGS="${INFERENCE_TAGS%,}"
+          MODEL_TAGS="${MODEL_TAGS%,}"
+          
+          echo "api_tags=${API_TAGS}" >> $GITHUB_OUTPUT
+          echo "inference_tags=${INFERENCE_TAGS}" >> $GITHUB_OUTPUT
+          echo "model_tags=${MODEL_TAGS}" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Create ECR Repository if not found
+        run: ./github/scripts/create_ecr_repo_if_not_exists.sh marqoai
+
+      - name: Build and push api image
+        id: build-and-push-api
+        uses: docker/build-push-action@v6
+        with:
+          context: ./components
+          file: ./components/marqo/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.prepare.outputs.api_tags }}
+
+      - name: Build and push inference orchestrator image
+        id: build-and-push-inference-orchestrator
+        uses: docker/build-push-action@v6
+        with:
+          context: ./components
+          file: ./components/inference_orchestrator/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.prepare.outputs.inference_tags }}
+
+      - name: Build and push model management image
+        id: build-and-push-model-management
+        uses: docker/build-push-action@v6
+        with:
+          context: ./components/model_management
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.prepare.outputs.model_tags }}


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new AWS/ECR deployment workflow and repository-creation script, which can affect release pipeline behavior and AWS resources. There’s also a likely path mismatch (`create_ecrs.sh` added but workflow calls `create_ecr_repo_if_not_exists.sh`) that could break deployments.
> 
> **Overview**
> Adds a new manual GitHub Actions workflow (`deploy-marqo-images.yml`) that OIDC-authenticates to AWS, builds multi-arch Docker images for `api`, `inference-orchestrator`, and `model-management`, and pushes them to ECR across an environment matrix, with optional comma-separated tagging (defaulting to commit SHA).
> 
> Introduces `.github/scripts/create_ecrs.sh` to create the three expected ECR repositories if they don’t exist; the workflow also includes an ECR-create step but currently references a differently named script (`create_ecr_repo_if_not_exists.sh`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d64248d965467893b6fcd4d9ba45206b718726cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->