### PR TITLE
Collapse sortby tie breaker

### DIFF
--- a/src/marqo/core/search/collapse_search.py
+++ b/src/marqo/core/search/collapse_search.py
@@ -170,6 +170,10 @@ class CollapseSearch:
 
         return merged_results
 
+    @staticmethod
+    def _value_is_valid_number(value: Any) -> bool:
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
     def collect_parent_ids(self, search_results: Dict) -> List[str]:
         """
         Collect parent IDs from the collapse field in search results. Only include those where the sort_by field value is a valid number
@@ -179,13 +183,10 @@ class CollapseSearch:
         Returns:
             A list of document IDs (parent IDs) that meet the criteria.
         """
-        def value_is_valid_number(value: Any) -> bool:
-            return isinstance(value, (int, float)) and not isinstance(value, bool)
-
         document_ids = []
         for hit in search_results.get("hits", []):
             value = hit.get(self.internal_params.collapse.sort_by.fields[0].field_name)
-            if self.internal_params.collapse.sort_by.always_fetch_variants or value_is_valid_number(value):
+            if self.internal_params.collapse.sort_by.always_fetch_variants or self._value_is_valid_number(value):
                 parent_id = hit.get(self.internal_params.collapse.name)
                 # Ideally all documents should have the collapse field with a parent id, however, we do a
                 # check here to be safe.
@@ -265,11 +266,11 @@ class CollapseSearch:
         # If the sorted value is not a valid value, we fall back to the original behaviour
         # Note this shouldn't happen as we already check the validity of the sort value when
         # collecting parent ids for the sorted search, but we add this check here to be safe.
-        if not isinstance(sorted_value, (int, float)) or isinstance(sorted_value, bool):
+        if not self._value_is_valid_number(sorted_value):
             return False
 
         # This could happen if always_fetch_variants is True
-        if not isinstance(relevance_value, (int, float)) or isinstance(relevance_value, bool):
+        if not self._value_is_valid_number(relevance_value):
             return True
 
         if sort_field.order == SortOrder.Asc:
@@ -330,7 +331,7 @@ class CollapseSearch:
         for relevance_hit in relevance_collapse_results.get("hits", []):
             parent_id = relevance_hit.get(collapse_field_name)
             if parent_id in sorted_hits_by_parent:
-                sorted_hit = sorted_hits_by_parent.get(parent_id, dict())
+                sorted_hit = sorted_hits_by_parent[parent_id]
                 if self._sorted_variant_is_strictly_better(sorted_hit, relevance_hit):
                     # Replace with the sorted variant (e.g., lower price)
                     merged_hits.append(merge_hit(sorted_hit, relevance_hit))

--- a/src/marqo/core/search/collapse_search.py
+++ b/src/marqo/core/search/collapse_search.py
@@ -330,7 +330,7 @@ class CollapseSearch:
         for relevance_hit in relevance_collapse_results.get("hits", []):
             parent_id = relevance_hit.get(collapse_field_name)
             if parent_id in sorted_hits_by_parent:
-                sorted_hit = sorted_hits_by_parent[parent_id]
+                sorted_hit = sorted_hits_by_parent.get(parent_id, dict())
                 if self._sorted_variant_is_strictly_better(sorted_hit, relevance_hit):
                     # Replace with the sorted variant (e.g., lower price)
                     merged_hits.append(merge_hit(sorted_hit, relevance_hit))

--- a/src/marqo/core/search/collapse_search.py
+++ b/src/marqo/core/search/collapse_search.py
@@ -330,10 +330,10 @@ class CollapseSearch:
         for relevance_hit in relevance_collapse_results.get("hits", []):
             parent_id = relevance_hit.get(collapse_field_name)
             if parent_id in sorted_hits_by_parent:
-                sorted_relevance_hit = sorted_hits_by_parent[parent_id]
-                if self._sorted_variant_is_strictly_better(sorted_relevance_hit, relevance_hit):
+                sorted_hit = sorted_hits_by_parent[parent_id]
+                if self._sorted_variant_is_strictly_better(sorted_hit, relevance_hit):
                     # Replace with the sorted variant (e.g., lower price)
-                    merged_hits.append(merge_hit(sorted_relevance_hit, relevance_hit))
+                    merged_hits.append(merge_hit(sorted_hit, relevance_hit))
                 else:
                     # Sorted variant is not strictly better (tie), keep the relevance relevance_hit
                     merged_hits.append(relevance_hit)

--- a/src/marqo/core/search/collapse_search.py
+++ b/src/marqo/core/search/collapse_search.py
@@ -248,8 +248,7 @@ class CollapseSearch:
         """Check if the sorted variant is strictly better than the relevance hit based on the sort field value.
 
         Returns True if the sorted variant's sort value is strictly lower (for asc) or strictly higher (for desc)
-        than the relevance hit's sort value. Returns True if the values cannot be compared (e.g., missing field),
-        to preserve the original replacement behavior for non-tie cases.
+        than the relevance hit's sort value.
 
         Consider the special case that always_fetch_variants is True,
         in which we will fetch the sort_by variants even if the sort_by field value in relevance

--- a/src/marqo/core/search/collapse_search.py
+++ b/src/marqo/core/search/collapse_search.py
@@ -14,7 +14,7 @@ from marqo.tensor_search.models.private_models import ModelAuth
 from marqo.tensor_search.models.recency_parameters import RecencyParameters
 from marqo.tensor_search.models.relevance_cutoff_model import RelevanceCutoffModel
 from marqo.tensor_search.models.search import SearchContext
-from marqo.tensor_search.models.sort_by_model import SortByModel
+from marqo.tensor_search.models.sort_by_model import SortByModel, SortOrder
 from marqo.tensor_search.telemetry import RequestMetricsStore
 from marqo.core.vespa_index.vespa_index import VespaIndex
 from copy import deepcopy
@@ -165,7 +165,7 @@ class CollapseSearch:
 
         with RequestMetricsStore.for_request().time("search.hybrid.collapse_search.merge_results"):
             merged_results = self.merge_two_collapse_results(
-                relevance_collapse_results, sorted_collapse_results, collected_parent_ids
+                relevance_collapse_results, sorted_collapse_results
             )
 
         return merged_results
@@ -243,7 +243,41 @@ class CollapseSearch:
         collapse_sort_by_hybrid_parameters.collapse.sort_by.set_collapse_sort_by_filter_string(collapse_filter_string)
         return collapse_sort_by_hybrid_parameters
 
-    def merge_two_collapse_results(self, relevance_collapse_results, sorted_collapse_results, parent_ids: List[str]):
+    def _sorted_variant_is_strictly_better(self, sorted_hit: Dict, relevance_hit: Dict) -> bool:
+        """Check if the sorted variant is strictly better than the relevance hit based on the sort field value.
+
+        Returns True if the sorted variant's sort value is strictly lower (for asc) or strictly higher (for desc)
+        than the relevance hit's sort value. Returns True if the values cannot be compared (e.g., missing field),
+        to preserve the original replacement behavior for non-tie cases.
+
+        Consider the special case that always_fetch_variants is True,
+        in which we will fetch the sort_by variants even if the sort_by field value in relevance
+        hits is not a valid number. In this sense, we do the comparison with the following logic by
+        prioritising the relevance hit in more cases to avoid hurting relevance:
+        1. If sorted_hits has an invalid sort_value -> return False;
+        2. If relevance_hit has an invalid sort_value -> return True;
+        3. If both have valid sort_value, compare them as normal.
+        """
+        sort_field = self.internal_params.collapse.sort_by.fields[0]
+        sorted_value = sorted_hit.get(sort_field.field_name)
+        relevance_value = relevance_hit.get(sort_field.field_name)
+
+        # If the sorted value is not a valid value, we fall back to the original behaviour
+        # Note this shouldn't happen as we already check the validity of the sort value when
+        # collecting parent ids for the sorted search, but we add this check here to be safe.
+        if not isinstance(sorted_value, (int, float)) or isinstance(sorted_value, bool):
+            return False
+
+        # This could happen if always_fetch_variants is True
+        if not isinstance(relevance_value, (int, float)) or isinstance(relevance_value, bool):
+            return True
+
+        if sort_field.order == SortOrder.Asc:
+            return sorted_value < relevance_value
+        else:
+            return sorted_value > relevance_value
+
+    def merge_two_collapse_results(self, relevance_collapse_results, sorted_collapse_results):
         """
         Merge two collapse results by keeping the structure from relevance_collapse_results
         but replacing hits with lower-priced variants from sorted_collapse_results.
@@ -256,10 +290,12 @@ class CollapseSearch:
         For fields exist in relevance results but not in sorted results, we remove them.
         And extra meta field '_originalId' is added to keep track of the original relevance hit ID.
 
+        If the sorted variant's sort value is not strictly better than the relevance hit's (i.e., a tie),
+        the relevance hit is kept as the representative, since it was chosen for higher relevance.
+
         Args:
             relevance_collapse_results: Results from relevance-based collapse search
             sorted_collapse_results: Results from sort-based collapse search (e.g., lowest price)
-            parent_ids: List of collapse field values that were used in the sorted search
 
         Returns:
             Merged results with structure from relevance_collapse_results but variants from sorted_collapse_results
@@ -291,14 +327,19 @@ class CollapseSearch:
 
         # Replace hits in relevance results with sorted variants where available
         merged_hits = []
-        for hit in relevance_collapse_results.get("hits", []):
-            parent_id = hit.get(collapse_field_name)
+        for relevance_hit in relevance_collapse_results.get("hits", []):
+            parent_id = relevance_hit.get(collapse_field_name)
             if parent_id in sorted_hits_by_parent:
-                # Replace with the sorted variant (e.g., lower price)
-                merged_hits.append(merge_hit(sorted_hits_by_parent[parent_id], hit))
+                sorted_relevance_hit = sorted_hits_by_parent[parent_id]
+                if self._sorted_variant_is_strictly_better(sorted_relevance_hit, relevance_hit):
+                    # Replace with the sorted variant (e.g., lower price)
+                    merged_hits.append(merge_hit(sorted_relevance_hit, relevance_hit))
+                else:
+                    # Sorted variant is not strictly better (tie), keep the relevance relevance_hit
+                    merged_hits.append(relevance_hit)
             else:
-                # Keep the original hit (either no sort field or not in sorted results)
-                merged_hits.append(hit)
+                # Keep the original relevance_hit (either no sort field or not in sorted results)
+                merged_hits.append(relevance_hit)
 
             if self.original_attributes_to_retrieve is not None:
                 # Remove collapse field and sort_by field if they were not in the original attributes to retrieve,

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2
@@ -412,6 +412,13 @@ schema {{ index.schema_name }} {
         first-phase {
             expression: collapse_sort_value()
         }
+
+        function tie_breaker() {
+            expression: random(1024).match * 1e-9
+        }
+        function collapse_final_score() {
+            expression: collapse_sort_value() + tie_breaker()
+        }
         diversity {
             attribute: {{ collapse_field.name }}
             min-groups: {{ collapse_field.min_groups }}

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2
@@ -410,7 +410,7 @@ schema {{ index.schema_name }} {
     }
     rank-profile collapse_to_sort_value inherits base_rank_profile{
         first-phase {
-            expression: collapse_sort_value()
+            expression: collapse_final_score()
         }
 
         function tie_breaker() {

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2
@@ -414,7 +414,8 @@ schema {{ index.schema_name }} {
         }
 
         function tie_breaker() {
-            expression: random(1024).match * 1e-9
+            # Map to [1e-7, 1e-6] to ensure it is smaller than any meaningful score difference but provides deterministic tie-breaking based on global sequence
+            expression: 1e-7 + (globalSequence / 281474976710656.0) * 9e-7
         }
         function collapse_final_score() {
             expression: collapse_sort_value() + tie_breaker()

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.24.13"
+__version__ = "2.24.14"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_fields_with_collapse_fields.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_fields_with_collapse_fields.sd
@@ -369,7 +369,8 @@ schema marqo__test_00semi_00structured_00schema {
             expression: collapse_final_score()
         }
         function tie_breaker() {
-            expression: random(1024).match * 1e-9
+            # Map to [1e-7, 1e-6] to ensure it is smaller than any meaningful score difference but provides deterministic tie-breaking based on global sequence
+            expression: 1e-7 + (globalSequence / 281474976710656.0) * 9e-7
         }
         function collapse_final_score() {
             expression: collapse_sort_value() + tie_breaker()

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_fields_with_collapse_fields.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_fields_with_collapse_fields.sd
@@ -366,7 +366,7 @@ schema marqo__test_00semi_00structured_00schema {
     }
     rank-profile collapse_to_sort_value inherits base_rank_profile{
         first-phase {
-            expression: collapse_sort_final_score()
+            expression: collapse_final_score()
         }
         function tie_breaker() {
             expression: random(1024).match * 1e-9

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_fields_with_collapse_fields.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_fields_with_collapse_fields.sd
@@ -368,6 +368,12 @@ schema marqo__test_00semi_00structured_00schema {
         first-phase {
             expression: collapse_sort_value()
         }
+        function tie_breaker() {
+            expression: random(1024).match * 1e-9
+        }
+        function collapse_final_score() {
+            expression: collapse_sort_value() + tie_breaker()
+        }
         diversity {
             attribute: parent_id
             min-groups: 100

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_fields_with_collapse_fields.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_fields_with_collapse_fields.sd
@@ -366,7 +366,7 @@ schema marqo__test_00semi_00structured_00schema {
     }
     rank-profile collapse_to_sort_value inherits base_rank_profile{
         first-phase {
-            expression: collapse_sort_value()
+            expression: collapse_sort_final_score()
         }
         function tie_breaker() {
             expression: random(1024).match * 1e-9

--- a/tests/integ_tests/tensor_search/integ_tests/test_collapse_fields.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_collapse_fields.py
@@ -1595,7 +1595,6 @@ class TestCollapseSortByTieBreaker(MarqoTestCase):
                 f"Collapse sort by with ties should consistently select the same representative "
                 f"document based on relevance as a tie-breaker, however got different results across runs. "
                 f"Expected result: {first_result}, Returned result: {result}"
-
             )
 
     def test_collapse_sort_by_keeps_relevance_hit_on_tie_asc(self):

--- a/tests/integ_tests/tensor_search/integ_tests/test_collapse_fields.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_collapse_fields.py
@@ -381,8 +381,6 @@ class TestCollapseFields(MarqoTestCase):
                 self.assertEqual(4, len(page_2_res["hits"]))
                 page_2_res_groups = set([hit['parent_id'] for hit in page_2_res["hits"]])
                 self.assertEqual(4, len(page_2_res_groups))
-
-                print(retrieval_method, ranking_method, page_1_res_groups, page_2_res_groups)
                 self.assertEqual(10, len(page_1_res_groups.union(page_2_res_groups)))
 
     def test_sort_by(self):
@@ -724,11 +722,12 @@ class TestCollapseWithSortByFeature(MarqoTestCase):
         res = tensor_search.search(
             config=self.config,
             index_name=self.default_text_index.name,
-            text="shoe",
+            text="shoe Delta",
             search_method="HYBRID",
             hybrid_parameters=HybridParameters(
                 retrievalMethod=RetrievalMethod.Disjunction,
                 rankingMethod=RankingMethod.RRF,
+                alpha=0
             ),
             collapse=CollapseModel(
                 name="category",
@@ -738,11 +737,8 @@ class TestCollapseWithSortByFeature(MarqoTestCase):
         )
 
         self.assertEqual(["shoe_a4", "shoe_b5"], [hit["_id"] for hit in res["hits"]])
-        # _originalId should be set to the relevance-phase representative's _id
-        for hit in res["hits"]:
-            self.assertIn("_originalId", hit)
-            # The original relevance hit was different from the sorted variant
-            self.assertIsInstance(hit["_originalId"], str)
+        # _originalId is None for shoe_a4 because it's the cheapest in its category, not replacement
+        self.assertEqual([None, "shoe_b4"], [hit.get("_originalId") for hit in res["hits"]])
 
     def test_collapse_sort_by_price_desc(self):
         """Scenario 1b: Collapse with sortBy desc returns the most expensive variant per category."""
@@ -1131,37 +1127,6 @@ class TestCollapseWithSortByFeature(MarqoTestCase):
             )
             # Now group_a enters sort-by phase and picks a3 (cheapest at 30.0), group_b still picks b2
             self.assertEqual(["a3", "b2"], [hit["_id"] for hit in res_with["hits"]])
-
-    # ---- Scenario 5c: _originalId meta field ----
-
-    def test_collapse_sort_by_sets_original_id(self):
-        """Scenario 5c: Merged hits should have _originalId set to the relevance-phase representative's _id.
-        Hits not replaced by sort-by should NOT have _originalId."""
-        self._add_shoe_documents()
-
-        res = tensor_search.search(
-            config=self.config,
-            index_name=self.default_text_index.name,
-            text="shoe",
-            search_method="HYBRID",
-            hybrid_parameters=HybridParameters(
-                retrievalMethod=RetrievalMethod.Disjunction,
-                rankingMethod=RankingMethod.RRF,
-            ),
-            collapse=CollapseModel(
-                name="category",
-                sort_by=CollapseSortBy(fields=[CollapseSortByField(fieldName="price", order="asc")])
-            ),
-            result_count=10
-        )
-
-        # Both groups have price fields, so sort-by runs and replaces representatives
-        self.assertEqual(2, len(res["hits"]))
-        for hit in res["hits"]:
-            self.assertIn("_originalId", hit)
-            # The cheapest variants (shoe_a4, shoe_b5) replaced the relevance-based representatives
-            # _originalId should differ from _id since a different variant was selected
-            self.assertIsInstance(hit["_originalId"], str)
 
     def test_collapse_without_sort_by_has_no_original_id(self):
         """When collapse is used without sortBy, hits should NOT have _originalId
@@ -1632,3 +1597,89 @@ class TestCollapseSortByTieBreaker(MarqoTestCase):
                 f"Expected result: {first_result}, Returned result: {result}"
 
             )
+
+    def test_collapse_sort_by_keeps_relevance_hit_on_tie_asc(self):
+        """When all documents in a group share the same sort value with order=asc,
+        the sorted variant is not strictly cheaper, so the relevance representative is kept"""
+        docs = [
+            # shoes_a: all same price -> tie
+            {"_id": "shoe_a1", "title": "Running Shoe Alpha", "category": "shoes_a", "price": 100.0},
+            {"_id": "shoe_a2", "title": "variants", "category": "shoes_a", "price": 100.0},
+            {"_id": "shoe_a3", "title": "variants", "category": "shoes_a", "price": 100.0},
+            {"_id": "shoe_a4", "title": "variants", "category": "shoes_a", "price": 100.0},
+            {"_id": "shoe_a5", "title": "variants", "category": "shoes_a", "price": 100.0},
+            # shoes_b: all same price -> tie
+            {"_id": "shoe_b1", "title": "Hiking Boot Alpha", "category": "shoes_b", "price": 100.0},
+            {"_id": "shoe_b2", "title": "variants", "category": "shoes_b", "price": 100.0},
+            {"_id": "shoe_b3", "title": "variants", "category": "shoes_b", "price": 100.0},
+        ]
+        res = self.add_documents(
+            config=self.config,
+            add_docs_params=AddDocsParams(
+                index_name=self.default_text_index.name,
+                docs=docs,
+                tensor_fields=["title"]
+            )
+        )
+
+        res = tensor_search.search(
+            config=self.config,
+            index_name=self.default_text_index.name,
+            text="running alpha shoe boot",
+            search_method="HYBRID",
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                rankingMethod=RankingMethod.RRF,
+                alpha=0,
+            ),
+            collapse=CollapseModel(
+                name="category",
+                sort_by=CollapseSortBy(fields=[CollapseSortByField(fieldName="price", order="asc")])
+            ),
+            result_count=10
+        )
+        self.assertEqual(["shoe_a1", "shoe_b1"], [hit["_id"] for hit in res["hits"]])
+        for hits in res["hits"]:
+            self.assertNotIn("_originalId", hits)
+
+    def test_collapse_sort_by_keeps_relevance_hit_on_tie_desc(self):
+        """When all documents in a group share the same sort value with order=desc,
+        the sorted variant is not strictly higher, so the relevance representative is kept."""
+        docs = [
+            {"_id": "shoe_a1", "title": "Running Shoe Alpha", "category": "shoes_a", "price": 100.0},
+            {"_id": "shoe_a2", "title": "variants", "category": "shoes_a", "price": 100.0},
+            {"_id": "shoe_a3", "title": "variants", "category": "shoes_a", "price": 100.0},
+            {"_id": "shoe_a4", "title": "variants", "category": "shoes_a", "price": 100.0},
+            {"_id": "shoe_a5", "title": "variants", "category": "shoes_a", "price": 100.0},
+            {"_id": "shoe_b1", "title": "Hiking Boot Alpha", "category": "shoes_b", "price": 100.0},
+            {"_id": "shoe_b2", "title": "variants", "category": "shoes_b", "price": 100.0},
+            {"_id": "shoe_b3", "title": "variants", "category": "shoes_b", "price": 100.0},
+        ]
+        self.add_documents(
+            config=self.config,
+            add_docs_params=AddDocsParams(
+                index_name=self.default_text_index.name,
+                docs=docs,
+                tensor_fields=["title"]
+            )
+        )
+
+        res = tensor_search.search(
+            config=self.config,
+            index_name=self.default_text_index.name,
+            text="running alpha shoe boot",
+            search_method="HYBRID",
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                rankingMethod=RankingMethod.RRF,
+                alpha=0,
+            ),
+            collapse=CollapseModel(
+                name="category",
+                sort_by=CollapseSortBy(fields=[CollapseSortByField(fieldName="price", order="desc")])
+            ),
+            result_count=10
+        )
+        self.assertEqual(["shoe_a1", "shoe_b1"], [hit["_id"] for hit in res["hits"]])
+        for hits in res["hits"]:
+            self.assertNotIn("_originalId", hits)

--- a/tests/integ_tests/tensor_search/integ_tests/test_collapse_fields.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_collapse_fields.py
@@ -1533,3 +1533,102 @@ class TestCollapseWithSortByFeature(MarqoTestCase):
             collapse_search_results_without_sort_by["facets"],
             collapse_search_results_with_sort_by["facets"]
         )
+
+class TestCollapseSortByTieBreaker(MarqoTestCase):
+    """Integration tests for collapse fields with sort by functionality in tie-breaking scenarios.
+
+    This test class must pass on the multi-shard environment to ensure that the collapse sort by logic correctly
+    handles tie-breaking when multiple documents have the same sort field value. The tests cover scenarios where
+    multiple documents within a group have the same price, and we verify that the collapse sort by consistently
+    selects the same representative document based on relevance as a tie-breaker.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+
+        default_text_index = cls.unstructured_marqo_index_request(
+            collapse_fields=[CollapseField(name="category", minGroups=2)]
+        )
+
+        cls.indexes = cls.create_indexes([
+            default_text_index,
+        ])
+
+        cls.default_text_index = cls.indexes[0]
+
+    def setUp(self) -> None:
+        self.clear_indexes(self.indexes)
+
+    def _add_shoe_documents(self):
+        """Add sample shoe documents across two category groups with varying prices."""
+        basic_docs = [
+            # Two basic shoes
+            {"_id": "shoe_a1", "title": "Running Shoe Alpha", "category": "shoes_a", "price": 120.0, "cost": 95.0, "brand": "nike"},
+            {"_id": "shoe_b1", "title": "Walking boot Alpha", "category": "shoes_b", "price": 89.99, "cost": 70.0, "brand": "adidas"},
+        ]
+
+        shoe_a_variants = [
+            {
+                "_id": f"shoe_a{i}", "title": f"variants",
+             "category": "shoes_a", "price": 120.0, "cost": 15.0,
+            }
+            for i in range(2, 10)
+        ]
+
+        shoe_b_variants = [
+            {
+                "_id": f"shoe_b{i}", "title": f"variants",
+                "category": "shoes_b", "price": 120.0, "cost": 1.0,
+            }
+            for i in range(2, 6)
+        ]
+
+        docs = basic_docs + shoe_a_variants + shoe_b_variants
+
+
+        self.add_documents(
+            config=self.config,
+            add_docs_params=AddDocsParams(
+                index_name=self.default_text_index.name,
+                docs=docs,
+                tensor_fields=["title"]
+            )
+        )
+
+    def test_collapse_sort_by_with_ties(self):
+        """When multiple documents within a group have the same sort field value (price),
+        the collapse sort by should consistently select the same representative based on a tie-breaker."""
+        self._add_shoe_documents()
+
+        def get_results():
+            res = tensor_search.search(
+                config=self.config,
+                index_name=self.default_text_index.name,
+                text="running shoe boot alpha",
+                search_method="HYBRID",
+                hybrid_parameters=HybridParameters(
+                    retrievalMethod=RetrievalMethod.Disjunction,
+                    rankingMethod=RankingMethod.RRF,
+                    alpha=0,
+                ),
+                collapse=CollapseModel(
+                    name="category",
+                    sort_by=CollapseSortBy(fields=[CollapseSortByField(fieldName="price", order="asc")])
+                ),
+                result_count=10
+            )
+            return [hit["_id"] for hit in res["hits"]] + [hit.get("_originalId") for hit in res["hits"]]
+
+        first_result = get_results()
+
+        for _ in range(10):
+            # Run the same search multiple times to verify that the same representative is consistently selected
+            result = get_results()
+            self.assertEqual(
+                first_result, result,
+                f"Collapse sort by with ties should consistently select the same representative "
+                f"document based on relevance as a tie-breaker, however got different results across runs. "
+                f"Expected result: {first_result}, Returned result: {result}"
+
+            )

--- a/tests/integ_tests/tensor_search/integ_tests/test_collapse_fields.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_collapse_fields.py
@@ -1587,14 +1587,14 @@ class TestCollapseSortByTieBreaker(MarqoTestCase):
 
         first_result = get_results()
 
-        for _ in range(10):
+        for i in range(10):
             # Run the same search multiple times to verify that the same representative is consistently selected
             result = get_results()
             self.assertEqual(
                 first_result, result,
                 f"Collapse sort by with ties should consistently select the same representative "
                 f"document based on relevance as a tie-breaker, however got different results across runs. "
-                f"Expected result: {first_result}, Returned result: {result}"
+                f"Expected result: {first_result}, Returned result: {result}, in the run {i+1}/10"
             )
 
     def test_collapse_sort_by_keeps_relevance_hit_on_tie_asc(self):

--- a/tests/integ_tests/tensor_search/integ_tests/test_collapse_fields.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_collapse_fields.py
@@ -1614,7 +1614,7 @@ class TestCollapseSortByTieBreaker(MarqoTestCase):
                 ),
                 collapse=CollapseModel(
                     name="category",
-                    sort_by=CollapseSortBy(fields=[CollapseSortByField(fieldName="price", order="asc")])
+                    sort_by=CollapseSortBy(fields=[CollapseSortByField(fieldName="cost", order="asc")])
                 ),
                 result_count=10
             )

--- a/tests/integ_tests/tensor_search/integ_tests/test_collapse_fields.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_collapse_fields.py
@@ -1568,6 +1568,7 @@ class TestCollapseSortByTieBreaker(MarqoTestCase):
             {"_id": "shoe_b1", "title": "Walking boot Alpha", "category": "shoes_b", "price": 89.99, "cost": 70.0, "brand": "adidas"},
         ]
 
+        # A lot of identical variants with the same low cost to force ties in collapse sort by
         shoe_a_variants = [
             {
                 "_id": f"shoe_a{i}", "title": f"variants",
@@ -1576,6 +1577,7 @@ class TestCollapseSortByTieBreaker(MarqoTestCase):
             for i in range(2, 10)
         ]
 
+        # A lot of identical variants with the same low cost to force ties in collapse sort by
         shoe_b_variants = [
             {
                 "_id": f"shoe_b{i}", "title": f"variants",
@@ -1585,8 +1587,6 @@ class TestCollapseSortByTieBreaker(MarqoTestCase):
         ]
 
         docs = basic_docs + shoe_a_variants + shoe_b_variants
-
-
         self.add_documents(
             config=self.config,
             add_docs_params=AddDocsParams(

--- a/tests/integ_tests/tensor_search/test_weakand_and_second_phase_lexical_modifiers.py
+++ b/tests/integ_tests/tensor_search/test_weakand_and_second_phase_lexical_modifiers.py
@@ -475,6 +475,7 @@ class TestRerankDepthLexicalAndWeakAndParameters(MarqoTestCase):
         self.assertEqual([], results_with_stop_word_limit_and_drop_all['hits'])
 
 
+@pytest.mark.skip_for_multinode
 class TestSecondPhaseLexicalModifiersAndCollapseField(MarqoTestCase):
     """
     A test class to verify that using second phase lexical modifiers with collapse field raises an error.

--- a/tests/unit_tests/core/search/test_collapse_search.py
+++ b/tests/unit_tests/core/search/test_collapse_search.py
@@ -345,7 +345,7 @@ class TestMergeTwoCollapseResults(unittest.TestCase):
             },
         ]}
 
-        result = cs.merge_two_collapse_results(relevance, sorted_res, ["g1"])
+        result = cs.merge_two_collapse_results(relevance, sorted_res)
 
         expected = {
             # _id from sorted variant
@@ -371,8 +371,8 @@ class TestMergeTwoCollapseResults(unittest.TestCase):
 
         self.assertEqual(expected, result["hits"][0])
 
-    def test_merge_original_id_equals_id_when_same_variant_selected(self):
-        """When sorted picks the same doc as relevance, _originalId still equals relevance _id."""
+    def test_merge_keeps_relevance_hit_when_sort_value_is_tied(self):
+        """When sorted variant has the same sort value as relevance hit (tie), keep the relevance hit."""
         cs = _make_collapse_search()
 
         relevance = {"hits": [
@@ -382,15 +382,13 @@ class TestMergeTwoCollapseResults(unittest.TestCase):
             {"_id": "same1", "category": "g1", "price": 10},
         ]}
 
-        result = cs.merge_two_collapse_results(relevance, sorted_res, ["g1"])
+        result = cs.merge_two_collapse_results(relevance, sorted_res)
 
         expected = {
             "_id": "same1",
             "category": "g1",
             "price": 10,
             "_score": 0.9,
-            "_highlights": [{}],
-            "_originalId": "same1",
         }
         self.assertEqual(expected, result["hits"][0])
 
@@ -406,7 +404,7 @@ class TestMergeTwoCollapseResults(unittest.TestCase):
             {"_id": "h3", "category": "g1", "price": 10},
         ]}
 
-        result = cs.merge_two_collapse_results(relevance, sorted_res, ["g1"])
+        result = cs.merge_two_collapse_results(relevance, sorted_res)
 
         expected_merged = {
             "_id": "h3",
@@ -436,7 +434,7 @@ class TestMergeTwoCollapseResults(unittest.TestCase):
             ]}
             sorted_res = {"hits": []}
 
-            result = cs.merge_two_collapse_results(relevance, sorted_res, [])
+            result = cs.merge_two_collapse_results(relevance, sorted_res)
             expected = {"hits": [
                 {"_id": "h1", "category": "g1", "price": 100, "_score": 0.9},
                 {"_id": "h2", "category": "g2", "price": 200, "_score": 0.8},
@@ -451,7 +449,7 @@ class TestMergeTwoCollapseResults(unittest.TestCase):
                 {"_id": "h3", "category": None, "price": 10},
             ]}
 
-            result = cs.merge_two_collapse_results(relevance, sorted_res, ["g1"])
+            result = cs.merge_two_collapse_results(relevance, sorted_res)
             expected = {"hits": [
                 {"_id": "h1", "category": "g1", "price": 100, "_score": 0.9},
             ]}
@@ -465,7 +463,7 @@ class TestMergeTwoCollapseResults(unittest.TestCase):
             }
             sorted_res = {"hits": [{"_id": "h3", "category": "g1", "price": 10}]}
 
-            result = cs.merge_two_collapse_results(relevance, sorted_res, ["g1"])
+            result = cs.merge_two_collapse_results(relevance, sorted_res)
             expected = {
                 "hits": [{
                     "_id": "h3",
@@ -499,7 +497,7 @@ class TestMergeAttributesToRetrieve(unittest.TestCase):
             {"_id": "h3", "category": "g1", "price": 10, "title": "Shoe B"},
         ]}
 
-        result = cs.merge_two_collapse_results(relevance, sorted_res, ["g1"])
+        result = cs.merge_two_collapse_results(relevance, sorted_res)
 
         # 'category' and 'price' should be removed since not in original_attributes_to_retrieve
         expected = {
@@ -526,7 +524,7 @@ class TestMergeAttributesToRetrieve(unittest.TestCase):
             {"_id": "h3", "category": "g1", "price": 10, "title": "Shoe B"},
         ]}
 
-        result = cs.merge_two_collapse_results(relevance, sorted_res, ["g1"])
+        result = cs.merge_two_collapse_results(relevance, sorted_res)
 
         # 'category' and 'price' should be kept since in original_attributes_to_retrieve
         expected = {
@@ -555,7 +553,7 @@ class TestMergeAttributesToRetrieve(unittest.TestCase):
             {"_id": "h3", "category": "g1", "price": 10, "title": "Shoe B"},
         ]}
 
-        result = cs.merge_two_collapse_results(relevance, sorted_res, ["g1"])
+        result = cs.merge_two_collapse_results(relevance, sorted_res)
 
         # All fields should be kept since original_attributes_to_retrieve is None
         expected = {


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches both Vespa ranking expressions and collapse result merging, which can subtly change representative selection and stability across shards; covered by new/updated unit and integration tests.
> 
> **Overview**
> Improves `collapse.sort_by` determinism and relevance preservation when multiple variants have the same sort value. Vespa’s `collapse_to_sort_value` rank profile now adds a tiny `globalSequence`-based `tie_breaker()` to `collapse_sort_value()`, and Python-side merge logic keeps the relevance representative unless the sorted variant’s sort value is *strictly* better (asc/desc aware).
> 
> Updates tests to cover tie scenarios and adjust `_originalId` expectations (only set when a representative is actually replaced), skips an unstable multinode collapse/second-phase-modifier test, and bumps version to `2.24.14`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b888c3dccd989b0b7738b22151567b7e32375b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->