### PR TITLE
Revert collapse sortby tie-breaker

### DIFF
--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2
@@ -412,10 +412,8 @@ schema {{ index.schema_name }} {
         first-phase {
             expression: collapse_final_score()
         }
-
         function tie_breaker() {
-            # Map to [1e-7, 1e-6] to ensure it is smaller than any meaningful score difference but provides deterministic tie-breaking based on global sequence
-            expression: 1e-7 + (globalSequence / 281474976710656.0) * 9e-7
+            expression: attribute(marqo__id)
         }
         function collapse_final_score() {
             expression: collapse_sort_value() + tie_breaker()

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2
@@ -410,13 +410,7 @@ schema {{ index.schema_name }} {
     }
     rank-profile collapse_to_sort_value inherits base_rank_profile{
         first-phase {
-            expression: collapse_final_score()
-        }
-        function tie_breaker() {
-            expression: attribute(marqo__id)
-        }
-        function collapse_final_score() {
-            expression: collapse_sort_value() + tie_breaker()
+            expression: collapse_sort_value()
         }
         diversity {
             attribute: {{ collapse_field.name }}

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_fields_with_collapse_fields.sd
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_fields_with_collapse_fields.sd
@@ -366,14 +366,7 @@ schema marqo__test_00semi_00structured_00schema {
     }
     rank-profile collapse_to_sort_value inherits base_rank_profile{
         first-phase {
-            expression: collapse_final_score()
-        }
-        function tie_breaker() {
-            # Map to [1e-7, 1e-6] to ensure it is smaller than any meaningful score difference but provides deterministic tie-breaking based on global sequence
-            expression: 1e-7 + (globalSequence / 281474976710656.0) * 9e-7
-        }
-        function collapse_final_score() {
-            expression: collapse_sort_value() + tie_breaker()
+            expression: collapse_sort_value()
         }
         diversity {
             attribute: parent_id

--- a/tests/integ_tests/tensor_search/integ_tests/test_collapse_fields.py
+++ b/tests/integ_tests/tensor_search/integ_tests/test_collapse_fields.py
@@ -1561,6 +1561,7 @@ class TestCollapseSortByTieBreaker(MarqoTestCase):
             )
         )
 
+    @pytest.mark.skip_for_multinode(reason="We don't have a reliable tie-breaker for multi-nodes.")
     def test_collapse_sort_by_with_ties(self):
         """When multiple documents within a group have the same sort field value (price),
         the collapse sort by should consistently select the same representative based on a tie-breaker."""
@@ -1593,7 +1594,7 @@ class TestCollapseSortByTieBreaker(MarqoTestCase):
             self.assertEqual(
                 first_result, result,
                 f"Collapse sort by with ties should consistently select the same representative "
-                f"document based on relevance as a tie-breaker, however got different results across runs. "
+                f"document in the single node setup, however got different results across runs. "
                 f"Expected result: {first_result}, Returned result: {result}, in the run {i+1}/10"
             )
 


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ranking behavior for collapse sort-by when sort values tie, which can make representative selection non-deterministic (especially across shards/nodes) and affect result stability.
> 
> **Overview**
> Removes the tie-breaker logic from the Vespa `collapse_to_sort_value` rank profile so collapse sort-by uses only `collapse_sort_value()` (no `globalSequence`-based deterministic offset).
> 
> Updates the generated test schema accordingly and marks the tie-related integration test as *single-node only* (`skip_for_multinode`), adjusting the assertion message to reflect the loss of a reliable multi-node tie-breaker.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8701982bac070455b0b0f37fd37666bffb17dcb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->