### PR TITLE
fix: correct typos 'occured' and 'whn'

### DIFF
--- a/components/inference_orchestrator/src/inference_orchestrator/api/telemetry.py
+++ b/components/inference_orchestrator/src/inference_orchestrator/api/telemetry.py
@@ -15,7 +15,7 @@ logger = get_logger(__name__)
 
 
 class TimerError(Exception):
-    """An error occured whn operating on a metric timer (e.g. stopping a stopped timer)"""
+    """An error occurred when operating on a metric timer (e.g. stopping a stopped timer)"""
 
     pass
 

--- a/components/marqo/src/marqo/tensor_search/telemetry.py
+++ b/components/marqo/src/marqo/tensor_search/telemetry.py
@@ -15,7 +15,7 @@ logger = get_logger(__name__)
 
 
 class TimerError(Exception):
-    """An error occured whn operating on a metric timer (e.g. stopping a stopped timer)"""
+    """An error occurred when operating on a metric timer (e.g. stopping a stopped timer)"""
     pass
 
 


### PR DESCRIPTION
Fixed typos in TimerError docstring across two telemetry modules.