### PR TITLE
Fix bf16 issue

### DIFF
--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2
@@ -109,7 +109,7 @@ schema {{ index.schema_name }} {
             indexing: summary
         }
 
-        field {{ field.embeddings_field_name }} type tensor<{{ index.vector_numeric_type }}>(p{}, x[{{ dimension }}]) {
+        field {{ field.embeddings_field_name }} type tensor<{{ index.vector_numeric_type.value }}>(p{}, x[{{ dimension }}]) {
             indexing: attribute | index | summary
             attribute {
                 distance-metric: {{ index.distance_metric.value }}
@@ -143,7 +143,7 @@ schema {{ index.schema_name }} {
             query({{ field.embeddings_field_name }}): 0
             {% endfor -%}
             query(marqo__bm25_aggregator): 0
-            query(marqo__query_embedding) tensor<{{ index.vector_numeric_type }}>(x[{{ dimension }}])
+            query(marqo__query_embedding) tensor<{{ index.vector_numeric_type.value }}>(x[{{ dimension }}])
             query(marqo__mult_weights_lexical) tensor<double>(p{})
             query(marqo__add_weights_lexical) tensor<double>(p{})
             query(marqo__mult_weights_tensor) tensor<double>(p{})
@@ -457,7 +457,7 @@ schema {{ index.schema_name }} {
         inputs {
             query(marqo__fields_to_rank_lexical) tensor<int8>(p{})
             query(marqo__fields_to_rank_tensor) tensor<int8>(p{})
-            query(marqo__query_embedding) tensor<{{ index.vector_numeric_type }}>(x[{{ dimension }}])
+            query(marqo__query_embedding) tensor<{{ index.vector_numeric_type.value }}>(x[{{ dimension }}])
             query(marqo__mult_weights_lexical) tensor<double>(p{})
             query(marqo__add_weights_lexical) tensor<double>(p{})
             query(marqo__mult_weights_tensor) tensor<double>(p{})
@@ -570,7 +570,7 @@ schema {{ index.schema_name }} {
         {%- endfor %}
         {%- for field in index.tensor_fields %}
         summary {{ field.chunk_field_name }} type array<string> {}
-        summary {{ field.embeddings_field_name }} type tensor<{{ index.vector_numeric_type }}>(p{}, x[{{ dimension }}]) {}
+        summary {{ field.embeddings_field_name }} type tensor<{{ index.vector_numeric_type.value }}>(p{}, x[{{ dimension }}]) {}
         {%- endfor %}
     }
 

--- a/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2
+++ b/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2
@@ -109,7 +109,7 @@ schema {{ index.schema_name }} {
             indexing: summary
         }
 
-        field {{ field.embeddings_field_name }} type tensor<float>(p{}, x[{{ dimension }}]) {
+        field {{ field.embeddings_field_name }} type tensor<{{ index.vector_numeric_type }}>(p{}, x[{{ dimension }}]) {
             indexing: attribute | index | summary
             attribute {
                 distance-metric: {{ index.distance_metric.value }}
@@ -143,7 +143,7 @@ schema {{ index.schema_name }} {
             query({{ field.embeddings_field_name }}): 0
             {% endfor -%}
             query(marqo__bm25_aggregator): 0
-            query(marqo__query_embedding) tensor<float>(x[{{ dimension }}])
+            query(marqo__query_embedding) tensor<{{ index.vector_numeric_type }}>(x[{{ dimension }}])
             query(marqo__mult_weights_lexical) tensor<double>(p{})
             query(marqo__add_weights_lexical) tensor<double>(p{})
             query(marqo__mult_weights_tensor) tensor<double>(p{})
@@ -457,7 +457,7 @@ schema {{ index.schema_name }} {
         inputs {
             query(marqo__fields_to_rank_lexical) tensor<int8>(p{})
             query(marqo__fields_to_rank_tensor) tensor<int8>(p{})
-            query(marqo__query_embedding) tensor<float>(x[{{ dimension }}])
+            query(marqo__query_embedding) tensor<{{ index.vector_numeric_type }}>(x[{{ dimension }}])
             query(marqo__mult_weights_lexical) tensor<double>(p{})
             query(marqo__add_weights_lexical) tensor<double>(p{})
             query(marqo__mult_weights_tensor) tensor<double>(p{})
@@ -570,7 +570,7 @@ schema {{ index.schema_name }} {
         {%- endfor %}
         {%- for field in index.tensor_fields %}
         summary {{ field.chunk_field_name }} type array<string> {}
-        summary {{ field.embeddings_field_name }} type tensor<float>(p{}, x[{{ dimension }}]) {}
+        summary {{ field.embeddings_field_name }} type tensor<{{ index.vector_numeric_type }}>(p{}, x[{{ dimension }}]) {}
         {%- endfor %}
     }
 

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.24.14"
+__version__ = "2.24.16"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/tests/integ_tests/core/semi_structured_vespa_index/test_semi_structured_vespa_schema.py
+++ b/tests/integ_tests/core/semi_structured_vespa_index/test_semi_structured_vespa_schema.py
@@ -78,6 +78,31 @@ class TestSemiStructuredVespaSchema(MarqoTestCase):
             self._remove_empty_lines_in_schema(generated_schema)
         )
 
+    def test_semi_structured_index_schema_with_bfloat16(self):
+        """Test that the schema uses tensor<bfloat16> when vector_numeric_type is Bfloat16."""
+        lexical_fields = ['text_field']
+        tensor_fields = ['tensor_field']
+        expected_schema = self._read_schema_from_file(
+            'test_schemas/semi_structured_vespa_index_schema_one_lexical_one_tensor_field_bfloat16.sd'
+        )
+
+        test_marqo_index_request = self.unstructured_marqo_index_request(
+            name="test_semi_structured_schema",
+            hnsw_config=HnswConfig(ef_construction=512, m=16),
+            distance_metric=DistanceMetric.PrenormalizedAngular,
+            vector_numeric_type=VectorNumericType.Bfloat16,
+        )
+
+        _, index = SemiStructuredVespaSchema(test_marqo_index_request).generate_schema()
+        marqo_index = self._populate_fields(index, lexical_fields, tensor_fields)
+        generated_schema = SemiStructuredVespaSchema.generate_vespa_schema(marqo_index)
+
+        self.maxDiff = None
+        self.assertEqual(
+            self._remove_empty_lines_in_schema(expected_schema),
+            self._remove_empty_lines_in_schema(generated_schema)
+        )
+
     def test_semi_structured_index_schema_with_pre_2_16(self):
         """
         Test that the schema is generated correctly when the marqo version is older than 2.16.0.


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the generated Vespa schema tensor types, which can affect index compatibility and query/ranking behavior if the numeric type is misconfigured; test coverage reduces risk.
> 
> **Overview**
> Semi-structured Vespa schema generation now parameterizes embedding tensor types using `index.vector_numeric_type` (instead of hardcoding `tensor<float>`), covering the stored embedding field, query embedding inputs, and vector summaries.
> 
> Bumps version to `2.24.16` and adds an integration test to assert schema output for `VectorNumericType.Bfloat16`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26f33ee4bc7547c9dd55adf4d14eaa69d83d160c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->