### PR TITLE
Add QEMU to ARM64 workflow

### DIFF
--- a/.github/workflows/arm64_cpu_api_tests.yml
+++ b/.github/workflows/arm64_cpu_api_tests.yml
@@ -59,8 +59,11 @@ jobs:
       - name: Install py-marqo
         run: bash scripts/install_pymarqo.sh ${{ inputs.py_marqo_branch }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Start vespa
         run: |


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes that affect how Docker images are built in the ARM64 test job; low risk outside potential build/emulation flakiness.
> 
> **Overview**
> Updates the ARM64 CPU API test GitHub Actions workflow to initialize QEMU before Docker builds, enabling cross-architecture emulation when needed.
> 
> Also bumps the Docker Buildx setup action from `docker/setup-buildx-action@v2` to `@v3` in the same workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f905d1d5add768a9a31c470c941a7ed5e0267a60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->