### PR TITLE
Add update_index_settings API for modifying modelProperties

### DIFF
--- a/src/marqo/api/models/update_index_settings.py
+++ b/src/marqo/api/models/update_index_settings.py
@@ -1,0 +1,9 @@
+from typing import Dict, Any
+
+import pydantic.v1
+
+from marqo.base_model import StrictBaseModel
+
+
+class UpdateIndexSettingsBodyParams(StrictBaseModel):
+    model_properties: Dict[str, Any] = pydantic.v1.Field(alias='modelProperties')

--- a/src/marqo/core/exceptions.py
+++ b/src/marqo/core/exceptions.py
@@ -78,6 +78,10 @@ class UnsupportedFeatureError(InvalidArgumentError):
     pass
 
 
+class InvalidModelPropertiesError(InvalidArgumentError):
+    pass
+
+
 class ZeroMagnitudeVectorError(InvalidArgumentError):
     pass
 

--- a/src/marqo/core/index_management/index_management.py
+++ b/src/marqo/core/index_management/index_management.py
@@ -1,6 +1,6 @@
+import json
 from contextlib import contextmanager
-from typing import List, Tuple, Dict
-from typing import Optional
+from typing import List, Tuple, Dict, Any, Optional
 import difflib
 
 import semver
@@ -411,18 +411,25 @@ class IndexManagement:
 
             return result
 
-    def update_index_settings_by_settings_dict(self, index_name: str, settings_dict: dict) -> None:
+    def update_index_settings_by_settings_dict(
+        self, index_name: str, settings_dict: dict,
+        force: bool = False, dry_run: bool = False
+    ) -> Dict[str, Any]:
         """
         Update index settings for an existing index. Currently only supports updating modelProperties.
 
         Args:
             index_name: Name of the index to update
             settings_dict: Dictionary of settings to update. Only 'modelProperties' is allowed.
+            force: If True, deploy even if validation fails
+            dry_run: If True, return diff without deploying
+
+        Returns:
+            Dict with keys: updated, error, oldSettings, newSettings, settingsDiff, reason
 
         Raises:
             IndexNotFoundError: If the index does not exist
             InternalError: If settings_dict contains disallowed keys
-            InvalidModelPropertiesError: If updated model properties are invalid
         """
         # Validate that only allowed keys are being modified
         disallowed_keys = set(settings_dict.keys()) - self._ALLOWED_MODIFIED_SETTINGS
@@ -438,9 +445,73 @@ class IndexManagement:
             if "modelProperties" in settings_dict:
                 updated_model_properties = settings_dict["modelProperties"]
                 current_properties = index.model.get_properties()
-                self.validate_updated_model_properties(current_properties, updated_model_properties)
+
+                old_settings = {"modelProperties": current_properties}
+                new_settings = {"modelProperties": updated_model_properties}
+
+                # Check if settings actually changed
+                if old_settings == new_settings:
+                    return {
+                        "updated": False,
+                        "error": False,
+                        "oldSettings": old_settings,
+                        "newSettings": new_settings,
+                        "settingsDiff": "",
+                        "reason": "No changes detected"
+                    }
+
+                # Generate diff
+                old_json = json.dumps(old_settings, indent=2, sort_keys=True).splitlines(keepends=True)
+                new_json = json.dumps(new_settings, indent=2, sort_keys=True).splitlines(keepends=True)
+                settings_diff = "".join(difflib.unified_diff(
+                    old_json, new_json,
+                    fromfile="current", tofile="updated"
+                ))
+
+                result = {
+                    "updated": False,
+                    "error": False,
+                    "oldSettings": old_settings,
+                    "newSettings": new_settings,
+                    "settingsDiff": settings_diff,
+                    "reason": ""
+                }
+
+                # Validate
+                validation_error = None
+                try:
+                    self.validate_updated_model_properties(current_properties, updated_model_properties)
+                except InvalidModelPropertiesError as e:
+                    validation_error = e
+
+                if dry_run:
+                    if validation_error:
+                        result["error"] = True
+                        result["reason"] = f"Validation error (dry run): {validation_error}"
+                    else:
+                        result["reason"] = "Dry run: validation passed, no changes applied"
+                    return result
+
+                if validation_error and not force:
+                    result["error"] = True
+                    result["reason"] = f"Validation error: {validation_error}"
+                    return result
+
+                # Deploy: either validation passed or force=True
                 updated_index = self._updated_index_with_model_properties(index, updated_model_properties)
                 self._get_vespa_application().update_index_setting(updated_index)
+
+                # Refresh cache
+                from marqo.tensor_search import index_meta_cache
+                index_meta_cache.get_index(self, index_name, force_refresh=True)
+
+                result["updated"] = True
+                if validation_error and force:
+                    result["error"] = True
+                    result["reason"] = f"Force applied despite validation error: {validation_error}"
+                else:
+                    result["reason"] = "Settings updated successfully"
+                return result
 
     @staticmethod
     def validate_updated_model_properties(current: dict, updated: dict) -> None:

--- a/src/marqo/core/index_management/index_management.py
+++ b/src/marqo/core/index_management/index_management.py
@@ -412,154 +412,186 @@ class IndexManagement:
             return result
 
     def update_index_settings_by_settings_dict(
-        self, index_name: str, settings_dict: dict,
-        force: bool = False, dry_run: bool = False
+            self, index_name: str, settings_dict: dict,
+            force: bool = False, dry_run: bool = False
     ) -> Dict[str, Any]:
         """
-        Update index settings for an existing index. Currently only supports updating modelProperties.
+        Update index settings by settings dict. No schema update. Currently only modelProperties can be updated.
+
+        When calling this method, you must consider the scenario distributed Marqo instances. Some Marqo instances
+        could still be running the old version so the updated modelProperties must be compatible with the old version.
+
+        This method:
+        1. Retrieves the existing index
+        2. Validates the updated settings
+        3. Behavior based on parameters:
+           - dry_run=True: Show changes, never deploy
+           - dry_run=False, force=False: Deploy only if validation passes
+           - dry_run=False, force=True: Always deploy, despite validation errors
 
         Args:
             index_name: Name of the index to update
-            settings_dict: Dictionary of settings to update. Only 'modelProperties' is allowed.
-            force: If True, deploy even if validation fails
-            dry_run: If True, return diff without deploying
+            settings_dict: Settings dict to update the index, currently only modelProperties can be updated.
+            force: If True, skip validation and proceed with update. Default is False.
+            dry_run: If True, show what would change without applying the update. Default is False.
 
         Returns:
-            Dict with keys: updated, error, oldSettings, newSettings, settingsDiff, reason
+            Dict with update status:
+            {
+                "updated": bool,                    # Whether settings were actually deployed
+                "error": bool,                      # Whether there was a validation error
+                "oldSettings": dict,                # Current settings (for updated fields only)
+                "newSettings": dict,                # Proposed new settings (for updated fields only)
+                "settingsDiff": str,                # Unified diff between old and new settings
+                "reason": str,                      # Explanation of the result
+            }
 
         Raises:
-            IndexNotFoundError: If the index does not exist
-            InternalError: If settings_dict contains disallowed keys
+            IndexNotFoundError: If an index does not exist
+            OperationConflictError: If deployment lock cannot be acquired
         """
-        # Validate that only allowed keys are being modified
-        disallowed_keys = set(settings_dict.keys()) - self._ALLOWED_MODIFIED_SETTINGS
-        if disallowed_keys:
-            raise InternalError(
-                f"The following settings cannot be modified: {disallowed_keys}. "
-                f"Only {self._ALLOWED_MODIFIED_SETTINGS} can be modified."
-            )
+        if not set(settings_dict.keys()).issubset(self._ALLOWED_MODIFIED_SETTINGS):  # pragma: no cover
+            # Should not happen since we validate the settings in the API layer
+            raise InternalError(f"Only the following settings can be updated: {self._ALLOWED_MODIFIED_SETTINGS}. "
+                                f"Provided settings: {list(settings_dict.keys())}")
 
         with self._vespa_deployment_lock():
-            index = self.get_index(index_name)
+            existing_index = self.get_index(index_name)
+            updated_version = existing_index.version + 1 if existing_index.version is not None else 1
+            updated_index = existing_index.copy(deep=True, update={'version': updated_version})
+
+            # Build old and new settings for comparison
+            old_settings = {}
+            new_settings = {}
 
             if "modelProperties" in settings_dict:
-                updated_model_properties = settings_dict["modelProperties"]
-                current_properties = index.model.get_properties()
+                old_settings["modelProperties"] = existing_index.model.properties
+                new_settings["modelProperties"] = settings_dict["modelProperties"]
 
-                old_settings = {"modelProperties": current_properties}
-                new_settings = {"modelProperties": updated_model_properties}
+            # Check if settings actually changed
+            settings_changed = old_settings != new_settings
 
-                # Check if settings actually changed
-                if old_settings == new_settings:
-                    return {
-                        "updated": False,
-                        "error": False,
-                        "oldSettings": old_settings,
-                        "newSettings": new_settings,
-                        "settingsDiff": "",
-                        "reason": "No changes detected"
-                    }
+            # Generate settings diff
+            old_settings_json = json.dumps(old_settings, indent=2, sort_keys=True)
+            new_settings_json = json.dumps(new_settings, indent=2, sort_keys=True)
+            old_settings_lines = old_settings_json.splitlines(keepends=True)
+            new_settings_lines = new_settings_json.splitlines(keepends=True)
+            diff_lines = list(difflib.unified_diff(
+                old_settings_lines,
+                new_settings_lines,
+                fromfile='old_settings',
+                tofile='new_settings',
+                lineterm=''
+            ))
+            settings_diff = ''.join(diff_lines) if diff_lines else ''
 
-                # Generate diff
-                old_json = json.dumps(old_settings, indent=2, sort_keys=True).splitlines(keepends=True)
-                new_json = json.dumps(new_settings, indent=2, sort_keys=True).splitlines(keepends=True)
-                settings_diff = "".join(difflib.unified_diff(
-                    old_json, new_json,
-                    fromfile="current", tofile="updated"
-                ))
+            # Initialize response template
+            result = {
+                "updated": False,
+                "error": False,
+                "oldSettings": old_settings,
+                "newSettings": new_settings,
+                "settingsDiff": settings_diff,
+                "reason": "",
+            }
 
-                result = {
-                    "updated": False,
-                    "error": False,
-                    "oldSettings": old_settings,
-                    "newSettings": new_settings,
-                    "settingsDiff": settings_diff,
-                    "reason": ""
-                }
-
-                # Validate
-                validation_error = None
-                try:
-                    self.validate_updated_model_properties(current_properties, updated_model_properties)
-                except InvalidModelPropertiesError as e:
-                    validation_error = e
-
-                if dry_run:
-                    if validation_error:
-                        result["error"] = True
-                        result["reason"] = f"Validation error (dry run): {validation_error}"
-                    else:
-                        result["reason"] = "Dry run: validation passed, no changes applied"
-                    return result
-
-                if validation_error and not force:
-                    result["error"] = True
-                    result["reason"] = f"Validation error: {validation_error}"
-                    return result
-
-                # Deploy: either validation passed or force=True
-                updated_index = self._updated_index_with_model_properties(index, updated_model_properties)
-                self._get_vespa_application().update_index_setting(updated_index)
-
-                # Refresh cache
-                from marqo.tensor_search import index_meta_cache
-                index_meta_cache.get_index(self, index_name, force_refresh=True)
-
-                result["updated"] = True
-                if validation_error and force:
-                    result["error"] = True
-                    result["reason"] = f"Force applied despite validation error: {validation_error}"
-                else:
-                    result["reason"] = "Settings updated successfully"
+            # Scenario 1: No changes needed
+            if not settings_changed:
+                logger.info(f'Settings for index {index_name} are already up to date')
+                result["reason"] = "Settings are already up to date"
                 return result
 
+            # Validate unless force=True
+            validation_error = None
+            try:
+                if "modelProperties" in settings_dict:
+                    self.validate_updated_model_properties(
+                        existing_index.model.properties,
+                        settings_dict["modelProperties"]
+                    )
+            except InvalidModelPropertiesError as e:
+                validation_error = e
+                result["error"] = True
+
+            # Scenario 2: dry_run=True - never deploy, just return info
+            if dry_run:
+                logger.info(f'Dry run for index {index_name} - showing settings changes without deploying')
+                if validation_error:
+                    result["reason"] = f"Dry run - validation would fail: {str(validation_error)}"
+                else:
+                    result["reason"] = "Dry run - no changes deployed"
+                return result
+
+            # Scenario 3: dry_run=False, force=False - block if validation fails
+            if validation_error and not force:
+                result["reason"] = "Validation failed: " + str(validation_error)
+                return result
+
+            # Scenario 4: dry_run=False, force=True OR validation passed - proceed with deployment
+            if "modelProperties" in settings_dict:
+                updated_index = self._updated_index_with_model_properties(updated_index, settings_dict["modelProperties"])
+
+            logger.debug(f'Updating index {updated_index.name} with settings: {settings_dict}')
+            self._get_vespa_application().update_index_setting(updated_index)
+            logger.info(f'Successfully updated settings for index {index_name}')
+
+            result["updated"] = True
+            if force and validation_error:
+                result["reason"] = "Update forced despite validation errors: " + str(validation_error)
+            else:
+                result["reason"] = "Settings updated successfully"
+            from marqo.tensor_search import index_meta_cache
+            index_meta_cache.get_index(self, index_name, force_refresh=True)  # Refresh cache
+            return result
+
     @staticmethod
-    def validate_updated_model_properties(current: dict, updated: dict) -> None:
+    def validate_updated_model_properties(current_model_properties: dict, updated_model_properties: dict) -> None:
         """
-        Validate that the updated model properties are compatible with the current ones.
-        Ensures dimensions and type are unchanged, and no keys are removed.
+        Validate the updated model properties to ensure compatibility with the current model properties.
 
         Args:
-            current: Current model properties
-            updated: Updated model properties
+            current_model_properties: current model properties, as a dict
+            updated_model_properties: updated model properties, as a dict
+
+        Returns:
+            None
 
         Raises:
-            InvalidModelPropertiesError: If validation fails
+            InvalidModelPropertiesError: If the updated model properties is not compatible with the current model properties.
         """
-        if current.get("dimensions") != updated.get("dimensions"):
-            raise InvalidModelPropertiesError(
-                f"Cannot change model dimensions. "
-                f"Current: {current.get('dimensions')}, Updated: {updated.get('dimensions')}"
-            )
+        must_unchanged_keys = ["dimensions", "type"]
 
-        if current.get("type") != updated.get("type"):
-            raise InvalidModelPropertiesError(
-                f"Cannot change model type. "
-                f"Current: {current.get('type')}, Updated: {updated.get('type')}"
-            )
+        for key in must_unchanged_keys:
+            if current_model_properties.get(key) != updated_model_properties.get(key):
+                raise InvalidModelPropertiesError(
+                    f"Updating model properties resulting in change of '{key}' is not allowed. "
+                    f"Current '{key}': {current_model_properties.get(key)}, "
+                    f"updated '{key}': {updated_model_properties.get(key)} "
+                )
 
-        removed_keys = set(current.keys()) - set(updated.keys())
-        if removed_keys:
+        current_keys = set(current_model_properties.keys())
+        updated_keys = set(updated_model_properties.keys())
+
+        if not current_keys.issubset(updated_keys):
             raise InvalidModelPropertiesError(
-                f"Cannot remove keys from model properties: {removed_keys}"
+                f"The updated model properties must contain all keys in the current model properties for compatibility. "
+                f"Current model properties keys: {current_keys}, updated model properties keys: {updated_keys} "
             )
 
     def _updated_index_with_model_properties(self, index: MarqoIndex, model_properties: dict) -> MarqoIndex:
         """
-        Create a copy of the index with updated model properties and custom=True.
+        Create a new MarqoIndex object with updated model properties.
 
         Args:
-            index: The existing index
-            model_properties: New model properties
+            index: The index object to update.
+            model_properties: A dictionary of model properties to update.
 
         Returns:
-            Updated MarqoIndex copy
+            A new MarqoIndex object with updated model properties.
         """
-        updated_model = index.model.copy(update={
-            'properties': model_properties,
-            'custom': True
-        })
-        return index.copy(update={'model': updated_model})
+        index.model.properties = model_properties
+        index.model.custom = True  # Mark the model as custom if model properties are updated
+        return index
 
     def _get_existing_indexes(self) -> List[MarqoIndex]:
         """

--- a/src/marqo/core/index_management/index_management.py
+++ b/src/marqo/core/index_management/index_management.py
@@ -10,7 +10,7 @@ import marqo.vespa.vespa_client
 from marqo import version, marqo_docs
 from marqo.core import constants
 from marqo.core.distributed_lock.zookeeper_distributed_lock import get_deployment_lock
-from marqo.core.exceptions import IndexNotFoundError, ApplicationNotInitializedError
+from marqo.core.exceptions import IndexNotFoundError, ApplicationNotInitializedError, InvalidModelPropertiesError
 from marqo.core.exceptions import OperationConflictError
 from marqo.core.exceptions import ZookeeperLockNotAcquiredError, InternalError, UnsupportedFeatureError
 from marqo.core.index_management.vespa_application_package import VespaApplicationPackage, VespaApplicationFileStore, \
@@ -33,6 +33,7 @@ class IndexManagement:
     _MINIMUM_VESPA_VERSION_TO_SUPPORT_FAST_FILE_DISTRIBUTION = semver.VersionInfo.parse('8.396.18')
     _MARQO_SETTINGS_SCHEMA_NAME = 'marqo__settings'
     _MARQO_CONFIG_DOC_ID = 'marqo__config'
+    _ALLOWED_MODIFIED_SETTINGS = {"modelProperties"}
 
     def __init__(self,
                  vespa_client: VespaClient,
@@ -409,6 +410,85 @@ class IndexManagement:
                 result["reason"] = "Schema updated successfully"
 
             return result
+
+    def update_index_settings_by_settings_dict(self, index_name: str, settings_dict: dict) -> None:
+        """
+        Update index settings for an existing index. Currently only supports updating modelProperties.
+
+        Args:
+            index_name: Name of the index to update
+            settings_dict: Dictionary of settings to update. Only 'modelProperties' is allowed.
+
+        Raises:
+            IndexNotFoundError: If the index does not exist
+            InternalError: If settings_dict contains disallowed keys
+            InvalidModelPropertiesError: If updated model properties are invalid
+        """
+        # Validate that only allowed keys are being modified
+        disallowed_keys = set(settings_dict.keys()) - self._ALLOWED_MODIFIED_SETTINGS
+        if disallowed_keys:
+            raise InternalError(
+                f"The following settings cannot be modified: {disallowed_keys}. "
+                f"Only {self._ALLOWED_MODIFIED_SETTINGS} can be modified."
+            )
+
+        with self._vespa_deployment_lock():
+            index = self.get_index(index_name)
+
+            if "modelProperties" in settings_dict:
+                updated_model_properties = settings_dict["modelProperties"]
+                current_properties = index.model.get_properties()
+                self.validate_updated_model_properties(current_properties, updated_model_properties)
+                updated_index = self._updated_index_with_model_properties(index, updated_model_properties)
+                self._get_vespa_application().update_index_setting(updated_index)
+
+    @staticmethod
+    def validate_updated_model_properties(current: dict, updated: dict) -> None:
+        """
+        Validate that the updated model properties are compatible with the current ones.
+        Ensures dimensions and type are unchanged, and no keys are removed.
+
+        Args:
+            current: Current model properties
+            updated: Updated model properties
+
+        Raises:
+            InvalidModelPropertiesError: If validation fails
+        """
+        if current.get("dimensions") != updated.get("dimensions"):
+            raise InvalidModelPropertiesError(
+                f"Cannot change model dimensions. "
+                f"Current: {current.get('dimensions')}, Updated: {updated.get('dimensions')}"
+            )
+
+        if current.get("type") != updated.get("type"):
+            raise InvalidModelPropertiesError(
+                f"Cannot change model type. "
+                f"Current: {current.get('type')}, Updated: {updated.get('type')}"
+            )
+
+        removed_keys = set(current.keys()) - set(updated.keys())
+        if removed_keys:
+            raise InvalidModelPropertiesError(
+                f"Cannot remove keys from model properties: {removed_keys}"
+            )
+
+    def _updated_index_with_model_properties(self, index: MarqoIndex, model_properties: dict) -> MarqoIndex:
+        """
+        Create a copy of the index with updated model properties and custom=True.
+
+        Args:
+            index: The existing index
+            model_properties: New model properties
+
+        Returns:
+            Updated MarqoIndex copy
+        """
+        updated_model = index.model.copy(update={
+            'properties': model_properties,
+            'custom': True
+        })
+        return index.copy(update={'model': updated_model})
 
     def _get_existing_indexes(self) -> List[MarqoIndex]:
         """

--- a/src/marqo/core/index_management/vespa_application_package.py
+++ b/src/marqo/core/index_management/vespa_application_package.py
@@ -811,6 +811,24 @@ class VespaApplicationPackage:
         else:
             raise InternalError("Deployment activation requires ApplicationPackageDeploymentSessionStore")
 
+    def update_index_setting(self, index: MarqoIndex) -> None:
+        """
+        Update index settings only (no schema .sd change). Persists settings and deploys.
+
+        Args:
+            index: Index with updated settings
+        """
+        if not self.has_index(index.name):
+            raise IndexNotFoundError(f"Index {index.name} not found")
+
+        version = index.version + 1 if index.version is not None else 1
+        self._index_setting_store.save_index_setting(index.copy(update={
+            'version': version,
+            'updated_at': int(time.time())
+        }))
+        self._persist_index_settings()
+        self._deploy()
+
     def has_schema(self, name: str) -> bool:
         return self._store.file_exists('schemas', f'{name}.sd')
 

--- a/src/marqo/core/index_management/vespa_application_package.py
+++ b/src/marqo/core/index_management/vespa_application_package.py
@@ -812,20 +812,10 @@ class VespaApplicationPackage:
             raise InternalError("Deployment activation requires ApplicationPackageDeploymentSessionStore")
 
     def update_index_setting(self, index: MarqoIndex) -> None:
-        """
-        Update index settings only (no schema .sd change). Persists settings and deploys.
-
-        Args:
-            index: Index with updated settings
-        """
         if not self.has_index(index.name):
             raise IndexNotFoundError(f"Index {index.name} not found")
 
-        version = index.version + 1 if index.version is not None else 1
-        self._index_setting_store.save_index_setting(index.copy(update={
-            'version': version,
-            'updated_at': int(time.time())
-        }))
+        self._index_setting_store.save_index_setting(index)
         self._persist_index_settings()
         self._deploy()
 

--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -425,6 +425,25 @@ def apply_latest_schema_template(index_name: str, force: bool = False, dry_run: 
     return JSONResponse(content=result, status_code=200)
 
 
+@app.patch("/indexes/{index_name}/index-settings")
+@utils.enable_ops_api()
+def update_index_settings(index_name: str, settings_dict: dict,
+                          marqo_config: config.Config = Depends(get_config)):
+    """
+    Update index settings for an existing index. Currently only supports updating modelProperties.
+    This is an internal/ops API gated by MARQO_ENABLE_OPS_API=true.
+    """
+    from marqo.api.models.update_index_settings import UpdateIndexSettingsBodyParams
+    body = parse_request_object(UpdateIndexSettingsBodyParams, settings_dict)
+    marqo_config.index_management.update_index_settings_by_settings_dict(
+        index_name, body.dict(by_alias=True)
+    )
+    return JSONResponse(
+        content={"message": "Index settings update is successful."},
+        status_code=200
+    )
+
+
 @app.get("/indexes/{index_name}/health")
 def check_index_health(index_name: str, marqo_config: config.Config = Depends(get_config)):
     """

--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -430,14 +430,11 @@ def apply_latest_schema_template(index_name: str, force: bool = False, dry_run: 
 def update_index_settings(index_name: str, settings_dict: dict,
                           force: bool = False, dry_run: bool = False,
                           marqo_config: config.Config = Depends(get_config)):
-    """
-    Update index settings for an existing index. Currently only supports updating modelProperties.
-    This is an internal/ops API gated by MARQO_ENABLE_OPS_API=true.
-    """
+    """An internal API used for testing processes. Not to be used by users."""
     from marqo.api.models.update_index_settings import UpdateIndexSettingsBodyParams
     body = parse_request_object(UpdateIndexSettingsBodyParams, settings_dict)
     res = marqo_config.index_management.update_index_settings_by_settings_dict(
-        index_name, body.dict(by_alias=True), force=force, dry_run=dry_run
+        index_name=index_name, settings_dict=body.dict(by_alias=True), force=force, dry_run=dry_run
     )
     return JSONResponse(content=res)
 

--- a/src/marqo/tensor_search/api.py
+++ b/src/marqo/tensor_search/api.py
@@ -428,6 +428,7 @@ def apply_latest_schema_template(index_name: str, force: bool = False, dry_run: 
 @app.patch("/indexes/{index_name}/index-settings")
 @utils.enable_ops_api()
 def update_index_settings(index_name: str, settings_dict: dict,
+                          force: bool = False, dry_run: bool = False,
                           marqo_config: config.Config = Depends(get_config)):
     """
     Update index settings for an existing index. Currently only supports updating modelProperties.
@@ -435,13 +436,10 @@ def update_index_settings(index_name: str, settings_dict: dict,
     """
     from marqo.api.models.update_index_settings import UpdateIndexSettingsBodyParams
     body = parse_request_object(UpdateIndexSettingsBodyParams, settings_dict)
-    marqo_config.index_management.update_index_settings_by_settings_dict(
-        index_name, body.dict(by_alias=True)
+    res = marqo_config.index_management.update_index_settings_by_settings_dict(
+        index_name, body.dict(by_alias=True), force=force, dry_run=dry_run
     )
-    return JSONResponse(
-        content={"message": "Index settings update is successful."},
-        status_code=200
-    )
+    return JSONResponse(content=res)
 
 
 @app.get("/indexes/{index_name}/health")

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.24.14"
+__version__ = "2.24.15"
 
 def get_version() -> str:
     return f"{__version__}"

--- a/tests/integ_tests/core/index_management/test_index_settings_update.py
+++ b/tests/integ_tests/core/index_management/test_index_settings_update.py
@@ -1,0 +1,129 @@
+import os
+import time
+import unittest
+
+from marqo import version
+from marqo.core.exceptions import IndexNotFoundError, InvalidModelPropertiesError
+from marqo.core.index_management.index_management import IndexManagement
+from marqo.core.models.marqo_index import Model
+from marqo.core.models.marqo_index_request import UnstructuredMarqoIndexRequest
+from tests.integ_tests.marqo_test import MarqoTestCase
+
+
+class TestIndexSettingsUpdate(MarqoTestCase):
+    """Integration tests for the update_index_settings feature.
+
+    These tests require Vespa to be running locally.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.index_management = IndexManagement(
+            self.vespa_client,
+            zookeeper_client=self.zookeeper_client,
+            enable_index_operations=True,
+            deployment_timeout_seconds=30,
+            convergence_timeout_seconds=120
+        )
+        self._test_dir = str(os.path.dirname(os.path.abspath(__file__)))
+        # Bootstrap vespa to ensure it's ready
+        self.index_management.bootstrap_vespa()
+
+    def _create_semi_structured_index(self, index_name: str, model: Model) -> None:
+        """Helper to create a semi-structured index."""
+        request = UnstructuredMarqoIndexRequest(
+            name=index_name,
+            model=model,
+            treat_urls_and_pointers_as_images=False,
+            treat_urls_and_pointers_as_media=False,
+            filter_string_max_length=100,
+        )
+        self.index_management.create_index(request)
+
+    def test_update_model_properties_e2e(self):
+        """Test updating model properties on an existing index end-to-end."""
+        index_name = f"test_update_props_{int(time.time())}"
+
+        try:
+            # Create index with a custom model
+            self._create_semi_structured_index(
+                index_name,
+                model=Model(
+                    name='my-custom-model',
+                    properties={
+                        "dimensions": 384,
+                        "type": "open_clip",
+                        "name": "ViT-B-16",
+                        "url": "https://old-url.com/model.pt",
+                    },
+                    custom=True
+                )
+            )
+
+            # Verify index exists
+            index = self.index_management.get_index(index_name)
+            self.assertEqual(index.model.properties["url"], "https://old-url.com/model.pt")
+
+            # Update model properties
+            new_properties = {
+                "dimensions": 384,
+                "type": "open_clip",
+                "name": "ViT-B-16",
+                "url": "https://new-url.com/model.pt",
+            }
+            self.index_management.update_index_settings_by_settings_dict(
+                index_name, {"modelProperties": new_properties}
+            )
+
+            # Verify update
+            updated_index = self.index_management.get_index(index_name)
+            self.assertEqual(updated_index.model.properties["url"], "https://new-url.com/model.pt")
+            self.assertTrue(updated_index.model.custom)
+            # Version should have incremented
+            self.assertGreater(updated_index.version, index.version or 0)
+        finally:
+            try:
+                self.index_management.delete_index_by_name(index_name)
+            except Exception:
+                pass
+
+    def test_update_non_existent_index_raises_error(self):
+        """Test that updating a non-existent index raises IndexNotFoundError."""
+        with self.assertRaises(IndexNotFoundError):
+            self.index_management.update_index_settings_by_settings_dict(
+                "non_existent_index",
+                {"modelProperties": {"dimensions": 384, "type": "hf"}}
+            )
+
+    def test_update_dimension_change_raises_error(self):
+        """Test that changing dimensions raises InvalidModelPropertiesError."""
+        index_name = f"test_dim_change_{int(time.time())}"
+
+        try:
+            self._create_semi_structured_index(
+                index_name,
+                model=Model(
+                    name='my-custom-model',
+                    properties={
+                        "dimensions": 384,
+                        "type": "open_clip",
+                        "url": "https://example.com/model.pt",
+                    },
+                    custom=True
+                )
+            )
+
+            with self.assertRaises(InvalidModelPropertiesError):
+                self.index_management.update_index_settings_by_settings_dict(
+                    index_name,
+                    {"modelProperties": {
+                        "dimensions": 768,  # Changed!
+                        "type": "open_clip",
+                        "url": "https://example.com/model.pt",
+                    }}
+                )
+        finally:
+            try:
+                self.index_management.delete_index_by_name(index_name)
+            except Exception:
+                pass

--- a/tests/integ_tests/core/index_management/test_index_settings_update.py
+++ b/tests/integ_tests/core/index_management/test_index_settings_update.py
@@ -241,7 +241,7 @@ class TestIndexSettingsUpdate(MarqoTestCase):
 
             self.assertFalse(result["updated"])
             self.assertFalse(result["error"])
-            self.assertIn("No changes", result["reason"])
+            self.assertEqual(result["reason"], "Settings are already up to date")
 
             # Version should NOT have changed
             index_after = self.index_management.get_index(index_name)

--- a/tests/integ_tests/core/index_management/test_index_settings_update.py
+++ b/tests/integ_tests/core/index_management/test_index_settings_update.py
@@ -6,7 +6,6 @@ from marqo import version
 from marqo.core.exceptions import IndexNotFoundError, InvalidModelPropertiesError
 from marqo.core.index_management.index_management import IndexManagement
 from marqo.core.models.marqo_index import Model
-from marqo.core.models.marqo_index_request import UnstructuredMarqoIndexRequest
 from tests.integ_tests.marqo_test import MarqoTestCase
 
 
@@ -29,25 +28,14 @@ class TestIndexSettingsUpdate(MarqoTestCase):
         # Bootstrap vespa to ensure it's ready
         self.index_management.bootstrap_vespa()
 
-    def _create_semi_structured_index(self, index_name: str, model: Model) -> None:
-        """Helper to create a semi-structured index."""
-        request = UnstructuredMarqoIndexRequest(
-            name=index_name,
-            model=model,
-            treat_urls_and_pointers_as_images=False,
-            treat_urls_and_pointers_as_media=False,
-            filter_string_max_length=100,
-        )
-        self.index_management.create_index(request)
-
     def test_update_model_properties_e2e(self):
         """Test updating model properties on an existing index end-to-end."""
         index_name = f"test_update_props_{int(time.time())}"
 
         try:
             # Create index with a custom model
-            self._create_semi_structured_index(
-                index_name,
+            request = self.unstructured_marqo_index_request(
+                name=index_name,
                 model=Model(
                     name='my-custom-model',
                     properties={
@@ -59,6 +47,7 @@ class TestIndexSettingsUpdate(MarqoTestCase):
                     custom=True
                 )
             )
+            self.index_management.create_index(request)
 
             # Verify index exists
             index = self.index_management.get_index(index_name)
@@ -100,18 +89,20 @@ class TestIndexSettingsUpdate(MarqoTestCase):
         index_name = f"test_dim_change_{int(time.time())}"
 
         try:
-            self._create_semi_structured_index(
-                index_name,
+            request = self.unstructured_marqo_index_request(
+                name=index_name,
                 model=Model(
                     name='my-custom-model',
                     properties={
                         "dimensions": 384,
                         "type": "open_clip",
+                        "name": "ViT-B-16",
                         "url": "https://example.com/model.pt",
                     },
                     custom=True
                 )
             )
+            self.index_management.create_index(request)
 
             with self.assertRaises(InvalidModelPropertiesError):
                 self.index_management.update_index_settings_by_settings_dict(
@@ -119,6 +110,7 @@ class TestIndexSettingsUpdate(MarqoTestCase):
                     {"modelProperties": {
                         "dimensions": 768,  # Changed!
                         "type": "open_clip",
+                        "name": "ViT-B-16",
                         "url": "https://example.com/model.pt",
                     }}
                 )

--- a/tests/integ_tests/core/index_management/test_index_settings_update.py
+++ b/tests/integ_tests/core/index_management/test_index_settings_update.py
@@ -5,7 +5,12 @@ import unittest
 from marqo import version
 from marqo.core.exceptions import IndexNotFoundError, InvalidModelPropertiesError
 from marqo.core.index_management.index_management import IndexManagement
+from marqo.core.models.add_docs_params import AddDocsParams
 from marqo.core.models.marqo_index import Model
+from marqo.inference.native_inference.load_model import (
+    get_available_models, _create_model_cache_key
+)
+from marqo.tensor_search import tensor_search
 from tests.integ_tests.marqo_test import MarqoTestCase
 
 
@@ -246,6 +251,124 @@ class TestIndexSettingsUpdate(MarqoTestCase):
             # Version should NOT have changed
             index_after = self.index_management.get_index(index_name)
             self.assertEqual(index_before.version, index_after.version)
+        finally:
+            try:
+                self.index_management.delete_index_by_name(index_name)
+            except Exception:
+                pass
+
+    def test_change_name_reloads_model(self):
+        """Test that changing 'name' in model properties causes a new model cache entry."""
+        index_name = f"test_cache_reload_{int(time.time())}"
+        model_name = "my-custom-model"
+        original_properties = {"name": "random/small", "dimensions": 32, "type": "random"}
+
+        try:
+            request = self.unstructured_marqo_index_request(
+                name=index_name,
+                model=Model(name=model_name, properties=original_properties, custom=True)
+            )
+            self.index_management.create_index(request)
+
+            # Add a document and search to trigger model loading
+            self.add_documents(
+                config=self.config,
+                add_docs_params=AddDocsParams(
+                    index_name=index_name,
+                    docs=[{"_id": "1", "text_field": "hello world"}],
+                    tensor_fields=["text_field"],
+                    device="cpu"
+                )
+            )
+            tensor_search.search(
+                config=self.config, index_name=index_name, text="hello", device="cpu"
+            )
+
+            # Verify original cache key exists
+            original_key = _create_model_cache_key(model_name, "cpu", original_properties)
+            self.assertIn(original_key, get_available_models(),
+                          "Original model cache key should exist after first search")
+
+            # Update: change properties['name'] from random/small to random/large
+            new_properties = {**original_properties, "name": "random/large"}
+            result = self.index_management.update_index_settings_by_settings_dict(
+                index_name, {"modelProperties": new_properties}, force=True
+            )
+            self.assertTrue(result["updated"])
+
+            # Search again to trigger model loading with new properties
+            tensor_search.search(
+                config=self.config, index_name=index_name, text="hello", device="cpu"
+            )
+
+            # Verify new cache key is different and exists
+            new_key = _create_model_cache_key(model_name, "cpu", new_properties)
+            self.assertNotEqual(original_key, new_key,
+                                "Cache key should change when properties['name'] changes")
+            self.assertIn(new_key, get_available_models(),
+                          "New model cache key should exist after search with updated properties")
+        finally:
+            try:
+                self.index_management.delete_index_by_name(index_name)
+            except Exception:
+                pass
+
+    def test_add_triton_model_name_does_not_reload_model(self):
+        """Test that adding tritonModelName does NOT create a new model cache entry."""
+        index_name = f"test_cache_no_reload_{int(time.time())}"
+        model_name = "my-custom-model-2"
+        original_properties = {"name": "random/small", "dimensions": 32, "type": "random"}
+
+        try:
+            request = self.unstructured_marqo_index_request(
+                name=index_name,
+                model=Model(name=model_name, properties=original_properties, custom=True)
+            )
+            self.index_management.create_index(request)
+
+            # Add a document and search to trigger model loading
+            self.add_documents(
+                config=self.config,
+                add_docs_params=AddDocsParams(
+                    index_name=index_name,
+                    docs=[{"_id": "1", "text_field": "hello world"}],
+                    tensor_fields=["text_field"],
+                    device="cpu"
+                )
+            )
+            tensor_search.search(
+                config=self.config, index_name=index_name, text="hello", device="cpu"
+            )
+
+            # Verify original cache key exists
+            original_key = _create_model_cache_key(model_name, "cpu", original_properties)
+            self.assertIn(original_key, get_available_models(),
+                          "Original model cache key should exist after first search")
+            keys_before = set(k for k in get_available_models().keys()
+                              if k.startswith(model_name))
+
+            # Update: add tritonModelName (not part of cache key formula)
+            new_properties = {**original_properties, "tritonModelName": "some-triton-model"}
+            result = self.index_management.update_index_settings_by_settings_dict(
+                index_name, {"modelProperties": new_properties}
+            )
+            self.assertTrue(result["updated"])
+
+            # Search again with updated properties
+            tensor_search.search(
+                config=self.config, index_name=index_name, text="hello", device="cpu"
+            )
+
+            # Cache key should be identical since tritonModelName is not in the key
+            new_key = _create_model_cache_key(model_name, "cpu", new_properties)
+            self.assertEqual(original_key, new_key,
+                             "Cache key should NOT change when only tritonModelName is added")
+            self.assertIn(original_key, get_available_models(),
+                          "Same cache key should still exist")
+            keys_after = set(k for k in get_available_models().keys()
+                             if k.startswith(model_name))
+            self.assertEqual(keys_before, keys_after,
+                             "No new cache keys should be added for this model")
         finally:
             try:
                 self.index_management.delete_index_by_name(index_name)

--- a/tests/integ_tests/core/index_management/test_index_settings_update.py
+++ b/tests/integ_tests/core/index_management/test_index_settings_update.py
@@ -60,9 +60,11 @@ class TestIndexSettingsUpdate(MarqoTestCase):
                 "name": "ViT-B-16",
                 "url": "https://new-url.com/model.pt",
             }
-            self.index_management.update_index_settings_by_settings_dict(
+            result = self.index_management.update_index_settings_by_settings_dict(
                 index_name, {"modelProperties": new_properties}
             )
+
+            self.assertTrue(result["updated"])
 
             # Verify update
             updated_index = self.index_management.get_index(index_name)
@@ -85,7 +87,7 @@ class TestIndexSettingsUpdate(MarqoTestCase):
             )
 
     def test_update_dimension_change_raises_error(self):
-        """Test that changing dimensions raises InvalidModelPropertiesError."""
+        """Test that changing dimensions returns an error result."""
         index_name = f"test_dim_change_{int(time.time())}"
 
         try:
@@ -104,16 +106,146 @@ class TestIndexSettingsUpdate(MarqoTestCase):
             )
             self.index_management.create_index(request)
 
-            with self.assertRaises(InvalidModelPropertiesError):
-                self.index_management.update_index_settings_by_settings_dict(
-                    index_name,
-                    {"modelProperties": {
-                        "dimensions": 768,  # Changed!
+            result = self.index_management.update_index_settings_by_settings_dict(
+                index_name,
+                {"modelProperties": {
+                    "dimensions": 768,  # Changed!
+                    "type": "open_clip",
+                    "name": "ViT-B-16",
+                    "url": "https://example.com/model.pt",
+                }}
+            )
+
+            self.assertTrue(result["error"])
+            self.assertFalse(result["updated"])
+        finally:
+            try:
+                self.index_management.delete_index_by_name(index_name)
+            except Exception:
+                pass
+
+    def test_dry_run_does_not_modify_index(self):
+        """Test that dry_run returns diff without changing index."""
+        index_name = f"test_dry_run_{int(time.time())}"
+
+        try:
+            request = self.unstructured_marqo_index_request(
+                name=index_name,
+                model=Model(
+                    name='my-custom-model',
+                    properties={
+                        "dimensions": 384,
                         "type": "open_clip",
                         "name": "ViT-B-16",
-                        "url": "https://example.com/model.pt",
-                    }}
+                        "url": "https://old-url.com/model.pt",
+                    },
+                    custom=True
                 )
+            )
+            self.index_management.create_index(request)
+
+            new_properties = {
+                "dimensions": 384,
+                "type": "open_clip",
+                "name": "ViT-B-16",
+                "url": "https://new-url.com/model.pt",
+            }
+            result = self.index_management.update_index_settings_by_settings_dict(
+                index_name, {"modelProperties": new_properties}, dry_run=True
+            )
+
+            self.assertFalse(result["updated"])
+            self.assertFalse(result["error"])
+            self.assertIn("old-url", result["settingsDiff"])
+            self.assertIn("new-url", result["settingsDiff"])
+
+            # Verify index was NOT modified
+            index = self.index_management.get_index(index_name)
+            self.assertEqual(index.model.properties["url"], "https://old-url.com/model.pt")
+        finally:
+            try:
+                self.index_management.delete_index_by_name(index_name)
+            except Exception:
+                pass
+
+    def test_force_applies_update(self):
+        """Test that force=True deploys despite validation errors."""
+        index_name = f"test_force_{int(time.time())}"
+
+        try:
+            request = self.unstructured_marqo_index_request(
+                name=index_name,
+                model=Model(
+                    name='my-custom-model',
+                    properties={
+                        "dimensions": 384,
+                        "type": "open_clip",
+                        "name": "ViT-B-16",
+                        "url": "https://old-url.com/model.pt",
+                    },
+                    custom=True
+                )
+            )
+            self.index_management.create_index(request)
+
+            # Change dimensions (normally invalid) with force=True
+            result = self.index_management.update_index_settings_by_settings_dict(
+                index_name,
+                {"modelProperties": {
+                    "dimensions": 768,  # Changed!
+                    "type": "open_clip",
+                    "name": "ViT-B-16",
+                    "url": "https://old-url.com/model.pt",
+                }},
+                force=True
+            )
+
+            self.assertTrue(result["updated"])
+            self.assertTrue(result["error"])  # Still flagged as error
+
+            # Verify index was modified despite validation error
+            updated_index = self.index_management.get_index(index_name)
+            self.assertEqual(updated_index.model.properties["dimensions"], 768)
+        finally:
+            try:
+                self.index_management.delete_index_by_name(index_name)
+            except Exception:
+                pass
+
+    def test_no_changes_returns_early(self):
+        """Test that identical settings return early without deploying."""
+        index_name = f"test_no_changes_{int(time.time())}"
+
+        try:
+            props = {
+                "dimensions": 384,
+                "type": "open_clip",
+                "name": "ViT-B-16",
+                "url": "https://example.com/model.pt",
+            }
+            request = self.unstructured_marqo_index_request(
+                name=index_name,
+                model=Model(
+                    name='my-custom-model',
+                    properties=props,
+                    custom=True
+                )
+            )
+            self.index_management.create_index(request)
+
+            index_before = self.index_management.get_index(index_name)
+
+            result = self.index_management.update_index_settings_by_settings_dict(
+                index_name, {"modelProperties": props}
+            )
+
+            self.assertFalse(result["updated"])
+            self.assertFalse(result["error"])
+            self.assertIn("No changes", result["reason"])
+
+            # Version should NOT have changed
+            index_after = self.index_management.get_index(index_name)
+            self.assertEqual(index_before.version, index_after.version)
         finally:
             try:
                 self.index_management.delete_index_by_name(index_name)

--- a/tests/unit_tests/marqo/core/index_management/test_update_index_settings.py
+++ b/tests/unit_tests/marqo/core/index_management/test_update_index_settings.py
@@ -32,110 +32,110 @@ class TestUpdateIndexSettings(MarqoTestCase):
         self.index_management._vespa_deployment_lock = Mock(return_value=mock_deployment_lock)
         return mock_vespa_app, mock_deployment_lock
 
-    def test_update_model_properties_semi_structured_non_custom(self):
-        """Test successful update for semi-structured index with non-custom model."""
-        existing_index = self.semi_structured_marqo_index(
-            name="test_index",
-            model=Model(name='hf/e5-small'),
-            version=1
-        )
-        # Non-custom model: properties come from registry
-        existing_index.model.properties = {
-            "dimensions": 384,
-            "type": "hf",
-            "name": "hf/e5-small",
-        }
-        existing_index.model.custom = False
-
-        mock_vespa_app, _ = self._setup_mocks(existing_index)
-
-        new_properties = {
-            "dimensions": 384,
-            "type": "hf",
-            "name": "hf/e5-small",
-            "url": "https://new-url.com/model.pt",
-        }
-
-        self.index_management.update_index_settings_by_settings_dict(
-            "test_index", {"modelProperties": new_properties}
-        )
-
-        mock_vespa_app.update_index_setting.assert_called_once()
-        updated_index = mock_vespa_app.update_index_setting.call_args[0][0]
-        self.assertEqual(updated_index.model.properties, new_properties)
-        self.assertTrue(updated_index.model.custom)
-
-    def test_update_model_properties_semi_structured_custom(self):
-        """Test successful update for semi-structured index with custom model."""
-        existing_index = self.semi_structured_marqo_index(
-            name="test_index",
-            model=Model(
-                name='my-custom-model',
-                properties={
-                    "dimensions": 768,
-                    "type": "open_clip",
-                    "name": "ViT-B-16",
+    @patch("marqo.tensor_search.index_meta_cache.get_index")
+    def test_update_model_properties_by_index_type_and_custom_flag(self, mock_cache_get_index):
+        """Test successful update for different index types and custom flags."""
+        cases = [
+            ("semi_structured_non_custom", self.semi_structured_marqo_index(
+                name="test_index", model=Model(name='hf/e5-small'), version=1
+            ), False, {"dimensions": 384, "type": "hf", "name": "hf/e5-small"}),
+            ("semi_structured_custom", self.semi_structured_marqo_index(
+                name="test_index",
+                model=Model(name='my-custom-model', properties={
+                    "dimensions": 768, "type": "open_clip", "name": "ViT-B-16",
                     "url": "https://old-url.com/model.pt",
-                },
-                custom=True
-            ),
-            version=1
-        )
-
-        mock_vespa_app, _ = self._setup_mocks(existing_index)
-
-        new_properties = {
-            "dimensions": 768,
-            "type": "open_clip",
-            "name": "ViT-B-16",
-            "url": "https://new-url.com/model.pt",
-        }
-
-        self.index_management.update_index_settings_by_settings_dict(
-            "test_index", {"modelProperties": new_properties}
-        )
-
-        mock_vespa_app.update_index_setting.assert_called_once()
-        updated_index = mock_vespa_app.update_index_setting.call_args[0][0]
-        self.assertEqual(updated_index.model.properties, new_properties)
-        self.assertTrue(updated_index.model.custom)
-
-    def test_update_model_properties_structured_index(self):
-        """Test successful update for structured index."""
-        existing_index = self.structured_marqo_index(
-            name="test_index",
-            schema_name="marqo__test_index",
-            model=Model(
-                name='my-custom-model',
-                properties={
-                    "dimensions": 768,
-                    "type": "open_clip",
-                    "name": "ViT-B-16",
+                }, custom=True),
+                version=1
+            ), True, {"dimensions": 768, "type": "open_clip", "name": "ViT-B-16"}),
+            ("structured_custom", self.structured_marqo_index(
+                name="test_index", schema_name="marqo__test_index",
+                model=Model(name='my-custom-model', properties={
+                    "dimensions": 768, "type": "open_clip", "name": "ViT-B-16",
                     "url": "https://old-url.com/model.pt",
-                },
-                custom=True
-            ),
-        )
+                }, custom=True),
+            ), True, {"dimensions": 768, "type": "open_clip", "name": "ViT-B-16"}),
+            ("structured_non_custom", self.structured_marqo_index(
+                name="test_index", schema_name="marqo__test_index",
+                model=Model(name='hf/e5-small'),
+            ), False, {"dimensions": 384, "type": "hf", "name": "hf/e5-small"}),
+        ]
 
-        mock_vespa_app, _ = self._setup_mocks(existing_index)
+        for label, existing_index, is_custom, base_props in cases:
+            with self.subTest(label):
+                if not is_custom:
+                    existing_index.model.properties = base_props.copy()
+                    existing_index.model.custom = False
 
-        new_properties = {
-            "dimensions": 768,
-            "type": "open_clip",
-            "name": "ViT-B-16",
-            "url": "https://new-url.com/model.pt",
-        }
+                mock_vespa_app, _ = self._setup_mocks(existing_index)
 
-        self.index_management.update_index_settings_by_settings_dict(
-            "test_index", {"modelProperties": new_properties}
-        )
+                new_properties = {**base_props, "url": "https://new-url.com/model.pt"}
 
-        mock_vespa_app.update_index_setting.assert_called_once()
-        updated_index = mock_vespa_app.update_index_setting.call_args[0][0]
-        self.assertEqual(updated_index.model.properties, new_properties)
-        self.assertTrue(updated_index.model.custom)
+                result = self.index_management.update_index_settings_by_settings_dict(
+                    "test_index", {"modelProperties": new_properties}
+                )
 
-    def test_non_existent_index_raises_index_not_found(self):
+                self.assertTrue(result["updated"])
+                self.assertFalse(result["error"])
+                mock_vespa_app.update_index_setting.assert_called_once()
+                updated_index = mock_vespa_app.update_index_setting.call_args[0][0]
+                self.assertEqual(updated_index.model.properties, new_properties)
+                self.assertTrue(updated_index.model.custom)
+
+    def test_update_index_settings_validation_errors(self):
+        """Test that validation errors are returned in result dict."""
+        cases = [
+            ("dimension_change", {
+                "dimensions": 384, "type": "open_clip", "name": "ViT-B-16",
+                "url": "https://new-url.com/model.pt",
+            }, "dimensions"),
+            ("type_change", {
+                "dimensions": 768, "type": "hf", "name": "ViT-B-16",
+                "url": "https://new-url.com/model.pt",
+            }, "type"),
+            ("key_removal", {
+                "dimensions": 768, "type": "open_clip", "name": "ViT-B-16",
+                # "url" key removed
+            }, "remove"),
+        ]
+
+        for label, new_props, expected_in_reason in cases:
+            with self.subTest(label):
+                existing_index = self.semi_structured_marqo_index(
+                    name="test_index",
+                    model=Model(name='my-custom-model', properties={
+                        "dimensions": 768, "type": "open_clip", "name": "ViT-B-16",
+                        "url": "https://old-url.com/model.pt",
+                    }, custom=True),
+                    version=1
+                )
+                mock_vespa_app, _ = self._setup_mocks(existing_index)
+
+                result = self.index_management.update_index_settings_by_settings_dict(
+                    "test_index", {"modelProperties": new_props}
+                )
+
+                self.assertTrue(result["error"])
+                self.assertFalse(result["updated"])
+                self.assertIn(expected_in_reason, result["reason"].lower())
+                mock_vespa_app.update_index_setting.assert_not_called()
+
+    def test_update_index_settings_disallowed_settings(self):
+        """Test that disallowed settings keys raise InternalError."""
+        cases = [
+            ("single_disallowed", {"someOtherSetting": "value"}, "someOtherSetting"),
+            ("multiple_disallowed", {"foo": 1, "bar": 2}, "foo"),
+            ("mixed_allowed_disallowed", {"modelProperties": {"dimensions": 384}, "extra": "x"}, "extra"),
+        ]
+
+        for label, settings_dict, expected_key in cases:
+            with self.subTest(label):
+                with self.assertRaises(InternalError) as ctx:
+                    self.index_management.update_index_settings_by_settings_dict(
+                        "test_index", settings_dict
+                    )
+                self.assertIn(expected_key, str(ctx.exception))
+
+    def test_update_index_settings_non_existent_index(self):
         """Test that updating a non-existent index raises IndexNotFoundError."""
         mock_deployment_lock = MagicMock()
         self.index_management.get_index = Mock(
@@ -148,134 +148,112 @@ class TestUpdateIndexSettings(MarqoTestCase):
                 "test_index", {"modelProperties": {"dimensions": 384, "type": "hf"}}
             )
 
-    def test_dimension_change_raises_invalid_model_properties(self):
-        """Test that changing dimensions raises InvalidModelPropertiesError."""
+    def test_update_index_settings_no_changes(self):
+        """Test no-op when properties haven't changed."""
         existing_index = self.semi_structured_marqo_index(
             name="test_index",
-            model=Model(
-                name='my-custom-model',
-                properties={
-                    "dimensions": 768,
-                    "type": "open_clip",
-                    "name": "ViT-B-16",
-                    "url": "https://old-url.com/model.pt",
-                },
-                custom=True
-            ),
+            model=Model(name='my-custom-model', properties={
+                "dimensions": 768, "type": "open_clip", "name": "ViT-B-16",
+                "url": "https://example.com/model.pt",
+            }, custom=True),
             version=1
         )
+        mock_vespa_app, _ = self._setup_mocks(existing_index)
 
-        self._setup_mocks(existing_index)
+        result = self.index_management.update_index_settings_by_settings_dict(
+            "test_index",
+            {"modelProperties": {
+                "dimensions": 768, "type": "open_clip", "name": "ViT-B-16",
+                "url": "https://example.com/model.pt",
+            }}
+        )
 
-        with self.assertRaises(InvalidModelPropertiesError) as ctx:
-            self.index_management.update_index_settings_by_settings_dict(
-                "test_index",
-                {"modelProperties": {
-                    "dimensions": 384,  # changed!
-                    "type": "open_clip",
-                    "name": "ViT-B-16",
-                    "url": "https://new-url.com/model.pt",
-                }}
-            )
-        self.assertIn("dimensions", str(ctx.exception))
+        self.assertFalse(result["updated"])
+        self.assertFalse(result["error"])
+        self.assertIn("No changes", result["reason"])
+        mock_vespa_app.update_index_setting.assert_not_called()
 
-    def test_type_change_raises_invalid_model_properties(self):
-        """Test that changing type raises InvalidModelPropertiesError."""
+    @patch("marqo.tensor_search.index_meta_cache.get_index")
+    def test_dry_run_and_force_combinations(self, mock_cache_get_index):
+        """Test all combinations of dry_run, force, and valid/invalid updates."""
+        valid_props = {
+            "dimensions": 768, "type": "open_clip", "name": "ViT-B-16",
+            "url": "https://new-url.com/model.pt",
+        }
+        invalid_props = {
+            "dimensions": 384,  # changed dimension
+            "type": "open_clip", "name": "ViT-B-16",
+            "url": "https://new-url.com/model.pt",
+        }
+
+        cases = [
+            # (label, dry_run, force, props, expected_updated, expected_error, should_deploy)
+            ("dry_run_valid", True, False, valid_props, False, False, False),
+            ("dry_run_invalid", True, False, invalid_props, False, True, False),
+            ("dry_run_force_valid", True, True, valid_props, False, False, False),
+            ("dry_run_force_invalid", True, True, invalid_props, False, True, False),
+            ("no_dry_run_no_force_valid", False, False, valid_props, True, False, True),
+            ("no_dry_run_no_force_invalid", False, False, invalid_props, False, True, False),
+            ("force_valid", False, True, valid_props, True, False, True),
+            ("force_invalid", False, True, invalid_props, True, True, True),
+        ]
+
+        for label, dry_run, force, props, exp_updated, exp_error, should_deploy in cases:
+            with self.subTest(label):
+                existing_index = self.semi_structured_marqo_index(
+                    name="test_index",
+                    model=Model(name='my-custom-model', properties={
+                        "dimensions": 768, "type": "open_clip", "name": "ViT-B-16",
+                        "url": "https://old-url.com/model.pt",
+                    }, custom=True),
+                    version=1
+                )
+                mock_vespa_app, _ = self._setup_mocks(existing_index)
+
+                result = self.index_management.update_index_settings_by_settings_dict(
+                    "test_index", {"modelProperties": props},
+                    force=force, dry_run=dry_run
+                )
+
+                self.assertEqual(result["updated"], exp_updated, f"updated mismatch for {label}")
+                self.assertEqual(result["error"], exp_error, f"error mismatch for {label}")
+                if should_deploy:
+                    mock_vespa_app.update_index_setting.assert_called_once()
+                else:
+                    mock_vespa_app.update_index_setting.assert_not_called()
+
+    @patch("marqo.tensor_search.index_meta_cache.get_index")
+    def test_result_contains_diff_and_settings(self, mock_cache_get_index):
+        """Verify result dict structure and diff content."""
         existing_index = self.semi_structured_marqo_index(
             name="test_index",
-            model=Model(
-                name='my-custom-model',
-                properties={
-                    "dimensions": 768,
-                    "type": "open_clip",
-                    "name": "ViT-B-16",
-                    "url": "https://old-url.com/model.pt",
-                },
-                custom=True
-            ),
+            model=Model(name='my-custom-model', properties={
+                "dimensions": 768, "type": "open_clip", "name": "ViT-B-16",
+                "url": "https://old-url.com/model.pt",
+            }, custom=True),
             version=1
         )
+        mock_vespa_app, _ = self._setup_mocks(existing_index)
 
-        self._setup_mocks(existing_index)
-
-        with self.assertRaises(InvalidModelPropertiesError) as ctx:
-            self.index_management.update_index_settings_by_settings_dict(
-                "test_index",
-                {"modelProperties": {
-                    "dimensions": 768,
-                    "type": "hf",  # changed!
-                    "name": "ViT-B-16",
-                    "url": "https://new-url.com/model.pt",
-                }}
-            )
-        self.assertIn("type", str(ctx.exception))
-
-    def test_key_removal_raises_invalid_model_properties(self):
-        """Test that removing keys raises InvalidModelPropertiesError."""
-        existing_index = self.semi_structured_marqo_index(
-            name="test_index",
-            model=Model(
-                name='my-custom-model',
-                properties={
-                    "dimensions": 768,
-                    "type": "open_clip",
-                    "name": "ViT-B-16",
-                    "url": "https://old-url.com/model.pt",
-                },
-                custom=True
-            ),
-            version=1
+        new_properties = {
+            "dimensions": 768, "type": "open_clip", "name": "ViT-B-16",
+            "url": "https://new-url.com/model.pt",
+        }
+        result = self.index_management.update_index_settings_by_settings_dict(
+            "test_index", {"modelProperties": new_properties}
         )
 
-        self._setup_mocks(existing_index)
+        # Check all expected keys exist
+        for key in ("updated", "error", "oldSettings", "newSettings", "settingsDiff", "reason"):
+            self.assertIn(key, result)
 
-        with self.assertRaises(InvalidModelPropertiesError) as ctx:
-            self.index_management.update_index_settings_by_settings_dict(
-                "test_index",
-                {"modelProperties": {
-                    "dimensions": 768,
-                    "type": "open_clip",
-                    "name": "ViT-B-16",
-                    # "url" key removed!
-                }}
-            )
-        self.assertIn("remove", str(ctx.exception).lower())
+        # Check settings content
+        self.assertEqual(result["oldSettings"]["modelProperties"]["url"], "https://old-url.com/model.pt")
+        self.assertEqual(result["newSettings"]["modelProperties"]["url"], "https://new-url.com/model.pt")
 
-    def test_disallowed_settings_key_raises_internal_error(self):
-        """Test that disallowed settings keys raise InternalError."""
-        with self.assertRaises(InternalError) as ctx:
-            self.index_management.update_index_settings_by_settings_dict(
-                "test_index",
-                {"modelProperties": {"dimensions": 384}, "someOtherSetting": "value"}
-            )
-        self.assertIn("someOtherSetting", str(ctx.exception))
-
-    def test_validate_updated_model_properties_success(self):
-        """Test that valid updates pass validation."""
-        current = {"dimensions": 768, "type": "open_clip", "url": "https://old.com"}
-        updated = {"dimensions": 768, "type": "open_clip", "url": "https://new.com", "extra_key": "value"}
-
-        # Should not raise
-        IndexManagement.validate_updated_model_properties(current, updated)
-
-    def test_updated_index_sets_custom_true(self):
-        """Test that _updated_index_with_model_properties sets custom=True."""
-        existing_index = self.semi_structured_marqo_index(
-            name="test_index",
-            model=Model(name='hf/e5-small'),
-            version=1
-        )
-        existing_index.model.custom = False
-
-        new_properties = {"dimensions": 384, "type": "hf"}
-        updated = self.index_management._updated_index_with_model_properties(
-            existing_index, new_properties
-        )
-
-        self.assertTrue(updated.model.custom)
-        self.assertEqual(updated.model.properties, new_properties)
-        # Original should be unchanged
-        self.assertFalse(existing_index.model.custom)
+        # Check diff contains the URLs
+        self.assertIn("old-url", result["settingsDiff"])
+        self.assertIn("new-url", result["settingsDiff"])
 
 
 class TestUpdateIndexSettingsBodyParams(unittest.TestCase):
@@ -432,7 +410,12 @@ class TestUpdateIndexSettingsApiEndpoint(unittest.TestCase):
 
         mock_config = Mock()
         mock_index_mgmt = Mock()
-        mock_index_mgmt.update_index_settings_by_settings_dict = Mock(return_value=None)
+        self._mock_result = {
+            "updated": True, "error": False,
+            "oldSettings": {}, "newSettings": {},
+            "settingsDiff": "", "reason": "Settings updated successfully"
+        }
+        mock_index_mgmt.update_index_settings_by_settings_dict = Mock(return_value=self._mock_result)
         mock_config.index_management = mock_index_mgmt
         self.mock_config = mock_config
         self.mock_index_mgmt = mock_index_mgmt
@@ -452,10 +435,11 @@ class TestUpdateIndexSettingsApiEndpoint(unittest.TestCase):
         )
 
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.json(), {"message": "Index settings update is successful."})
+        self.assertEqual(resp.json(), self._mock_result)
         self.mock_index_mgmt.update_index_settings_by_settings_dict.assert_called_once_with(
             "my_index",
-            {"modelProperties": {"dimensions": 384, "type": "hf", "name": "hf/e5-small"}}
+            {"modelProperties": {"dimensions": 384, "type": "hf", "name": "hf/e5-small"}},
+            force=False, dry_run=False
         )
 
     @patch.dict("os.environ", {"MARQO_ENABLE_OPS_API": "true"})

--- a/tests/unit_tests/marqo/core/index_management/test_update_index_settings.py
+++ b/tests/unit_tests/marqo/core/index_management/test_update_index_settings.py
@@ -1,0 +1,274 @@
+import unittest
+from unittest.mock import Mock, MagicMock, patch
+
+import marqo.version
+from marqo.core.exceptions import IndexNotFoundError, InternalError, InvalidModelPropertiesError
+from marqo.core.index_management.index_management import IndexManagement
+from marqo.core.models.marqo_index import Model
+from marqo.vespa.vespa_client import VespaClient
+from tests.unit_tests.marqo_test import MarqoTestCase
+
+
+class TestUpdateIndexSettings(MarqoTestCase):
+    def setUp(self):
+        self.mock_vespa_client = Mock(spec=VespaClient)
+        self.mock_zookeeper_client = Mock()
+        self.index_management = IndexManagement(
+            vespa_client=self.mock_vespa_client,
+            zookeeper_client=self.mock_zookeeper_client,
+            enable_index_operations=True
+        )
+
+    def _setup_mocks(self, existing_index):
+        """Helper to set up common mocks."""
+        mock_vespa_app = Mock()
+        mock_deployment_lock = MagicMock()
+        self.index_management.get_index = Mock(return_value=existing_index)
+        self.index_management._get_vespa_application = Mock(return_value=mock_vespa_app)
+        self.index_management._vespa_deployment_lock = Mock(return_value=mock_deployment_lock)
+        return mock_vespa_app, mock_deployment_lock
+
+    def test_update_model_properties_semi_structured_non_custom(self):
+        """Test successful update for semi-structured index with non-custom model."""
+        existing_index = self.semi_structured_marqo_index(
+            name="test_index",
+            model=Model(name='hf/e5-small'),
+            version=1
+        )
+        # Non-custom model: properties come from registry
+        existing_index.model.properties = {
+            "dimensions": 384,
+            "type": "hf",
+            "name": "hf/e5-small",
+        }
+        existing_index.model.custom = False
+
+        mock_vespa_app, _ = self._setup_mocks(existing_index)
+
+        new_properties = {
+            "dimensions": 384,
+            "type": "hf",
+            "name": "hf/e5-small",
+            "url": "https://new-url.com/model.pt",
+        }
+
+        self.index_management.update_index_settings_by_settings_dict(
+            "test_index", {"modelProperties": new_properties}
+        )
+
+        mock_vespa_app.update_index_setting.assert_called_once()
+        updated_index = mock_vespa_app.update_index_setting.call_args[0][0]
+        self.assertEqual(updated_index.model.properties, new_properties)
+        self.assertTrue(updated_index.model.custom)
+
+    def test_update_model_properties_semi_structured_custom(self):
+        """Test successful update for semi-structured index with custom model."""
+        existing_index = self.semi_structured_marqo_index(
+            name="test_index",
+            model=Model(
+                name='my-custom-model',
+                properties={
+                    "dimensions": 768,
+                    "type": "open_clip",
+                    "name": "ViT-B-16",
+                    "url": "https://old-url.com/model.pt",
+                },
+                custom=True
+            ),
+            version=1
+        )
+
+        mock_vespa_app, _ = self._setup_mocks(existing_index)
+
+        new_properties = {
+            "dimensions": 768,
+            "type": "open_clip",
+            "name": "ViT-B-16",
+            "url": "https://new-url.com/model.pt",
+        }
+
+        self.index_management.update_index_settings_by_settings_dict(
+            "test_index", {"modelProperties": new_properties}
+        )
+
+        mock_vespa_app.update_index_setting.assert_called_once()
+        updated_index = mock_vespa_app.update_index_setting.call_args[0][0]
+        self.assertEqual(updated_index.model.properties, new_properties)
+        self.assertTrue(updated_index.model.custom)
+
+    def test_update_model_properties_structured_index(self):
+        """Test successful update for structured index."""
+        existing_index = self.structured_marqo_index(
+            name="test_index",
+            schema_name="marqo__test_index",
+            model=Model(
+                name='my-custom-model',
+                properties={
+                    "dimensions": 768,
+                    "type": "open_clip",
+                    "name": "ViT-B-16",
+                    "url": "https://old-url.com/model.pt",
+                },
+                custom=True
+            ),
+        )
+
+        mock_vespa_app, _ = self._setup_mocks(existing_index)
+
+        new_properties = {
+            "dimensions": 768,
+            "type": "open_clip",
+            "name": "ViT-B-16",
+            "url": "https://new-url.com/model.pt",
+        }
+
+        self.index_management.update_index_settings_by_settings_dict(
+            "test_index", {"modelProperties": new_properties}
+        )
+
+        mock_vespa_app.update_index_setting.assert_called_once()
+        updated_index = mock_vespa_app.update_index_setting.call_args[0][0]
+        self.assertEqual(updated_index.model.properties, new_properties)
+        self.assertTrue(updated_index.model.custom)
+
+    def test_non_existent_index_raises_index_not_found(self):
+        """Test that updating a non-existent index raises IndexNotFoundError."""
+        mock_deployment_lock = MagicMock()
+        self.index_management.get_index = Mock(
+            side_effect=IndexNotFoundError("Index test_index not found")
+        )
+        self.index_management._vespa_deployment_lock = Mock(return_value=mock_deployment_lock)
+
+        with self.assertRaises(IndexNotFoundError):
+            self.index_management.update_index_settings_by_settings_dict(
+                "test_index", {"modelProperties": {"dimensions": 384, "type": "hf"}}
+            )
+
+    def test_dimension_change_raises_invalid_model_properties(self):
+        """Test that changing dimensions raises InvalidModelPropertiesError."""
+        existing_index = self.semi_structured_marqo_index(
+            name="test_index",
+            model=Model(
+                name='my-custom-model',
+                properties={
+                    "dimensions": 768,
+                    "type": "open_clip",
+                    "name": "ViT-B-16",
+                    "url": "https://old-url.com/model.pt",
+                },
+                custom=True
+            ),
+            version=1
+        )
+
+        self._setup_mocks(existing_index)
+
+        with self.assertRaises(InvalidModelPropertiesError) as ctx:
+            self.index_management.update_index_settings_by_settings_dict(
+                "test_index",
+                {"modelProperties": {
+                    "dimensions": 384,  # changed!
+                    "type": "open_clip",
+                    "name": "ViT-B-16",
+                    "url": "https://new-url.com/model.pt",
+                }}
+            )
+        self.assertIn("dimensions", str(ctx.exception))
+
+    def test_type_change_raises_invalid_model_properties(self):
+        """Test that changing type raises InvalidModelPropertiesError."""
+        existing_index = self.semi_structured_marqo_index(
+            name="test_index",
+            model=Model(
+                name='my-custom-model',
+                properties={
+                    "dimensions": 768,
+                    "type": "open_clip",
+                    "name": "ViT-B-16",
+                    "url": "https://old-url.com/model.pt",
+                },
+                custom=True
+            ),
+            version=1
+        )
+
+        self._setup_mocks(existing_index)
+
+        with self.assertRaises(InvalidModelPropertiesError) as ctx:
+            self.index_management.update_index_settings_by_settings_dict(
+                "test_index",
+                {"modelProperties": {
+                    "dimensions": 768,
+                    "type": "hf",  # changed!
+                    "name": "ViT-B-16",
+                    "url": "https://new-url.com/model.pt",
+                }}
+            )
+        self.assertIn("type", str(ctx.exception))
+
+    def test_key_removal_raises_invalid_model_properties(self):
+        """Test that removing keys raises InvalidModelPropertiesError."""
+        existing_index = self.semi_structured_marqo_index(
+            name="test_index",
+            model=Model(
+                name='my-custom-model',
+                properties={
+                    "dimensions": 768,
+                    "type": "open_clip",
+                    "name": "ViT-B-16",
+                    "url": "https://old-url.com/model.pt",
+                },
+                custom=True
+            ),
+            version=1
+        )
+
+        self._setup_mocks(existing_index)
+
+        with self.assertRaises(InvalidModelPropertiesError) as ctx:
+            self.index_management.update_index_settings_by_settings_dict(
+                "test_index",
+                {"modelProperties": {
+                    "dimensions": 768,
+                    "type": "open_clip",
+                    "name": "ViT-B-16",
+                    # "url" key removed!
+                }}
+            )
+        self.assertIn("remove", str(ctx.exception).lower())
+
+    def test_disallowed_settings_key_raises_internal_error(self):
+        """Test that disallowed settings keys raise InternalError."""
+        with self.assertRaises(InternalError) as ctx:
+            self.index_management.update_index_settings_by_settings_dict(
+                "test_index",
+                {"modelProperties": {"dimensions": 384}, "someOtherSetting": "value"}
+            )
+        self.assertIn("someOtherSetting", str(ctx.exception))
+
+    def test_validate_updated_model_properties_success(self):
+        """Test that valid updates pass validation."""
+        current = {"dimensions": 768, "type": "open_clip", "url": "https://old.com"}
+        updated = {"dimensions": 768, "type": "open_clip", "url": "https://new.com", "extra_key": "value"}
+
+        # Should not raise
+        IndexManagement.validate_updated_model_properties(current, updated)
+
+    def test_updated_index_sets_custom_true(self):
+        """Test that _updated_index_with_model_properties sets custom=True."""
+        existing_index = self.semi_structured_marqo_index(
+            name="test_index",
+            model=Model(name='hf/e5-small'),
+            version=1
+        )
+        existing_index.model.custom = False
+
+        new_properties = {"dimensions": 384, "type": "hf"}
+        updated = self.index_management._updated_index_with_model_properties(
+            existing_index, new_properties
+        )
+
+        self.assertTrue(updated.model.custom)
+        self.assertEqual(updated.model.properties, new_properties)
+        # Original should be unchanged
+        self.assertFalse(existing_index.model.custom)

--- a/tests/unit_tests/marqo/core/index_management/test_update_index_settings.py
+++ b/tests/unit_tests/marqo/core/index_management/test_update_index_settings.py
@@ -3,7 +3,6 @@ from unittest.mock import Mock, MagicMock, patch
 
 import pydantic.v1
 
-import marqo.version
 from marqo.api.models.update_index_settings import UpdateIndexSettingsBodyParams
 from marqo.core.exceptions import IndexNotFoundError, InternalError, InvalidModelPropertiesError
 from marqo.core.index_management.index_management import IndexManagement
@@ -14,6 +13,8 @@ from tests.unit_tests.marqo_test import MarqoTestCase
 
 
 class TestUpdateIndexSettings(MarqoTestCase):
+    """Tests for the update_index_settings_by_settings_dict functionality in IndexManagement."""
+
     def setUp(self):
         self.mock_vespa_client = Mock(spec=VespaClient)
         self.mock_zookeeper_client = Mock()
@@ -23,237 +24,366 @@ class TestUpdateIndexSettings(MarqoTestCase):
             enable_index_operations=True
         )
 
-    def _setup_mocks(self, existing_index):
-        """Helper to set up common mocks."""
-        mock_vespa_app = Mock()
-        mock_deployment_lock = MagicMock()
-        self.index_management.get_index = Mock(return_value=existing_index)
-        self.index_management._get_vespa_application = Mock(return_value=mock_vespa_app)
-        self.index_management._vespa_deployment_lock = Mock(return_value=mock_deployment_lock)
-        return mock_vespa_app, mock_deployment_lock
+        self.original_model_properties = {
+            "type": "open_clip",
+            "name": "ViTB-B-16",
+            "dimensions": 512
+        }
+        self.valid_updated_properties = {
+            "type": "open_clip",
+            "name": "ViTB-B-26",
+            "dimensions": 512
+        }
+        self.invalid_updated_properties = {
+            "type": "open_clip",
+            "name": "ViTB-B-26",
+            "dimensions": 768  # Changed dimensions - invalid
+        }
 
-    @patch("marqo.tensor_search.index_meta_cache.get_index")
-    def test_update_model_properties_by_index_type_and_custom_flag(self, mock_cache_get_index):
-        """Test successful update for different index types and custom flags."""
-        cases = [
-            ("semi_structured_non_custom", self.semi_structured_marqo_index(
-                name="test_index", model=Model(name='hf/e5-small'), version=1
-            ), False, {"dimensions": 384, "type": "hf", "name": "hf/e5-small"}),
-            ("semi_structured_custom", self.semi_structured_marqo_index(
-                name="test_index",
-                model=Model(name='my-custom-model', properties={
-                    "dimensions": 768, "type": "open_clip", "name": "ViT-B-16",
-                    "url": "https://old-url.com/model.pt",
-                }, custom=True),
-                version=1
-            ), True, {"dimensions": 768, "type": "open_clip", "name": "ViT-B-16"}),
-            ("structured_custom", self.structured_marqo_index(
-                name="test_index", schema_name="marqo__test_index",
-                model=Model(name='my-custom-model', properties={
-                    "dimensions": 768, "type": "open_clip", "name": "ViT-B-16",
-                    "url": "https://old-url.com/model.pt",
-                }, custom=True),
-            ), True, {"dimensions": 768, "type": "open_clip", "name": "ViT-B-16"}),
-            ("structured_non_custom", self.structured_marqo_index(
-                name="test_index", schema_name="marqo__test_index",
-                model=Model(name='hf/e5-small'),
-            ), False, {"dimensions": 384, "type": "hf", "name": "hf/e5-small"}),
+    def test_update_model_properties_by_index_type_and_custom_flag(self):
+        """Test updating model properties for different index types and custom flags."""
+        test_cases = [
+            {
+                "name": "semistructured_custom",
+                "index_factory": self.semi_structured_marqo_index,
+                "custom": True,
+            },
+            {
+                "name": "semistructured_non_custom",
+                "index_factory": self.semi_structured_marqo_index,
+                "custom": False,
+            },
+            {
+                "name": "structured_custom",
+                "index_factory": self.structured_marqo_index,
+                "custom": True,
+            },
+            {
+                "name": "structured_non_custom",
+                "index_factory": self.structured_marqo_index,
+                "custom": False,
+            },
         ]
 
-        for label, existing_index, is_custom, base_props in cases:
-            with self.subTest(label):
-                if not is_custom:
-                    existing_index.model.properties = base_props.copy()
-                    existing_index.model.custom = False
+        for test_case in test_cases:
+            with self.subTest(test_case["name"]):
+                with patch('marqo.core.index_management.index_management.IndexManagement.get_index') as mock_get_index, \
+                        patch("marqo.core.index_management.index_management.IndexManagement._get_vespa_application") as mock_vespa_app:
+                    mock_app = MagicMock()
+                    mock_vespa_app.return_value = mock_app
 
-                mock_vespa_app, _ = self._setup_mocks(existing_index)
+                    original_index = test_case["index_factory"](
+                        name="test_index",
+                        schema_name="test_schema",
+                        model=Model(name="default-model", properties=self.original_model_properties, custom=test_case["custom"])
+                    )
 
-                new_properties = {**base_props, "url": "https://new-url.com/model.pt"}
+                    mock_get_index.return_value = original_index
 
-                result = self.index_management.update_index_settings_by_settings_dict(
-                    "test_index", {"modelProperties": new_properties}
-                )
+                    result = self.index_management.update_index_settings_by_settings_dict(
+                        index_name="test_index",
+                        settings_dict={"modelProperties": self.valid_updated_properties}
+                    )
 
-                self.assertTrue(result["updated"])
-                self.assertFalse(result["error"])
-                mock_vespa_app.update_index_setting.assert_called_once()
-                updated_index = mock_vespa_app.update_index_setting.call_args[0][0]
-                self.assertEqual(updated_index.model.properties, new_properties)
-                self.assertTrue(updated_index.model.custom)
+                    # Verify result structure
+                    self.assertTrue(result["updated"])
+                    self.assertFalse(result["error"])
+                    self.assertEqual(result["reason"], "Settings updated successfully")
+                    self.assertIn("settingsDiff", result)
+
+                    mock_app.update_index_setting.assert_called_once()
+                    updated_index_settings = mock_app.update_index_setting.call_args[0][0]
+
+                    original_index_settings_dict = original_index.dict()
+                    updated_index_settings_dict = updated_index_settings.dict()
+
+                    # Model properties should be updated
+                    self.assertEqual(self.valid_updated_properties, updated_index_settings_dict["model"]["properties"])
+                    # Custom should be set to True after update
+                    self.assertTrue(updated_index_settings_dict["model"]["custom"])
+
+                    # Version should be updated
+                    original_version = original_index_settings_dict.get("version")
+                    updated_version = updated_index_settings_dict.get("version")
+                    if original_version is None:
+                        self.assertEqual(1, updated_version)
+                    else:
+                        self.assertEqual(original_version + 1, updated_version)
 
     def test_update_index_settings_validation_errors(self):
-        """Test that validation errors are returned in result dict."""
-        cases = [
-            ("dimension_change", {
-                "dimensions": 384, "type": "open_clip", "name": "ViT-B-16",
-                "url": "https://new-url.com/model.pt",
-            }, "dimensions"),
-            ("type_change", {
-                "dimensions": 768, "type": "hf", "name": "ViT-B-16",
-                "url": "https://new-url.com/model.pt",
-            }, "type"),
-            ("key_removal", {
-                "dimensions": 768, "type": "open_clip", "name": "ViT-B-16",
-                # "url" key removed
-            }, "remove"),
+        """Test that validation errors are properly returned for invalid model property changes."""
+        test_cases = [
+            {
+                "name": "change_dimensions",
+                "updated_properties": {"type": "open_clip", "name": "ViTB-B-16", "dimensions": 768},
+                "expected_error_contains": "dimensions",
+            },
+            {
+                "name": "change_type",
+                "updated_properties": {"type": "hf", "name": "ViTB-B-16", "dimensions": 512},
+                "expected_error_contains": "type",
+            },
+            {
+                "name": "remove_required_key",
+                "original_properties": {"type": "open_clip", "name": "ViTB-B-16", "dimensions": 512, "url": "https://example.com/model"},
+                "updated_properties": {"type": "open_clip", "name": "ViTB-B-26", "dimensions": 512},
+                "expected_error_contains": "must contain all keys",
+            },
         ]
 
-        for label, new_props, expected_in_reason in cases:
-            with self.subTest(label):
-                existing_index = self.semi_structured_marqo_index(
-                    name="test_index",
-                    model=Model(name='my-custom-model', properties={
-                        "dimensions": 768, "type": "open_clip", "name": "ViT-B-16",
-                        "url": "https://old-url.com/model.pt",
-                    }, custom=True),
-                    version=1
-                )
-                mock_vespa_app, _ = self._setup_mocks(existing_index)
+        for test_case in test_cases:
+            with self.subTest(test_case["name"]):
+                with patch('marqo.core.index_management.index_management.IndexManagement.get_index') as mock_get_index:
+                    original_properties = test_case.get("original_properties", self.original_model_properties)
+                    original_index = self.semi_structured_marqo_index(
+                        name="test_index",
+                        schema_name="test_schema",
+                        model=Model(name="default-model", properties=original_properties, custom=True)
+                    )
+                    mock_get_index.return_value = original_index
 
-                result = self.index_management.update_index_settings_by_settings_dict(
-                    "test_index", {"modelProperties": new_props}
-                )
+                    result = self.index_management.update_index_settings_by_settings_dict(
+                        index_name="test_index",
+                        settings_dict={"modelProperties": test_case["updated_properties"]}
+                    )
 
-                self.assertTrue(result["error"])
-                self.assertFalse(result["updated"])
-                self.assertIn(expected_in_reason, result["reason"].lower())
-                mock_vespa_app.update_index_setting.assert_not_called()
+                    self.assertFalse(result["updated"])
+                    self.assertTrue(result["error"])
+                    self.assertIn(test_case["expected_error_contains"], result["reason"])
 
     def test_update_index_settings_disallowed_settings(self):
-        """Test that disallowed settings keys raise InternalError."""
-        cases = [
-            ("single_disallowed", {"someOtherSetting": "value"}, "someOtherSetting"),
-            ("multiple_disallowed", {"foo": 1, "bar": 2}, "foo"),
-            ("mixed_allowed_disallowed", {"modelProperties": {"dimensions": 384}, "extra": "x"}, "extra"),
+        """Test that updating with disallowed settings raises InternalError."""
+        test_cases = [
+            {
+                "name": "single_disallowed",
+                "settings_dict": {"normalizeEmbeddings": False},
+            },
+            {
+                "name": "multiple_disallowed",
+                "settings_dict": {"normalizeEmbeddings": False, "distanceMetric": "cosine"},
+            },
+            {
+                "name": "mixed_allowed_and_disallowed",
+                "settings_dict": {
+                    "modelProperties": {"type": "open_clip", "name": "ViTB-B-26", "dimensions": 512},
+                    "normalizeEmbeddings": False
+                },
+            },
         ]
 
-        for label, settings_dict, expected_key in cases:
-            with self.subTest(label):
-                with self.assertRaises(InternalError) as ctx:
-                    self.index_management.update_index_settings_by_settings_dict(
-                        "test_index", settings_dict
+        for test_case in test_cases:
+            with self.subTest(test_case["name"]):
+                with patch('marqo.core.index_management.index_management.IndexManagement.get_index') as mock_get_index:
+                    original_index = self.semi_structured_marqo_index(
+                        name="test_index",
+                        schema_name="test_schema",
+                        model=Model(name="default-model", properties=self.original_model_properties, custom=True)
                     )
-                self.assertIn(expected_key, str(ctx.exception))
+                    mock_get_index.return_value = original_index
+
+                    with self.assertRaises(InternalError) as context:
+                        self.index_management.update_index_settings_by_settings_dict(
+                            index_name="test_index",
+                            settings_dict=test_case["settings_dict"]
+                        )
+
+                    self.assertIn("Only the following settings can be updated", str(context.exception))
 
     def test_update_index_settings_non_existent_index(self):
-        """Test that updating a non-existent index raises IndexNotFoundError."""
-        mock_deployment_lock = MagicMock()
-        self.index_management.get_index = Mock(
-            side_effect=IndexNotFoundError("Index test_index not found")
-        )
-        self.index_management._vespa_deployment_lock = Mock(return_value=mock_deployment_lock)
+        """Test updating settings for an index that does not exist."""
+        with patch('marqo.core.index_management.index_management.IndexManagement.get_index') as mock_get_index:
+            mock_get_index.side_effect = IndexNotFoundError("Index non_existent_index not found")
 
-        with self.assertRaises(IndexNotFoundError):
-            self.index_management.update_index_settings_by_settings_dict(
-                "test_index", {"modelProperties": {"dimensions": 384, "type": "hf"}}
-            )
+            with self.assertRaises(IndexNotFoundError) as context:
+                self.index_management.update_index_settings_by_settings_dict(
+                    index_name="non_existent_index",
+                    settings_dict={"modelProperties": self.valid_updated_properties}
+                )
+
+            self.assertIn("non_existent_index", str(context.exception))
 
     def test_update_index_settings_no_changes(self):
-        """Test no-op when properties haven't changed."""
-        existing_index = self.semi_structured_marqo_index(
-            name="test_index",
-            model=Model(name='my-custom-model', properties={
-                "dimensions": 768, "type": "open_clip", "name": "ViT-B-16",
-                "url": "https://example.com/model.pt",
-            }, custom=True),
-            version=1
-        )
-        mock_vespa_app, _ = self._setup_mocks(existing_index)
+        """Test that no update occurs when settings are already up to date."""
+        with patch('marqo.core.index_management.index_management.IndexManagement.get_index') as mock_get_index, \
+                patch("marqo.core.index_management.index_management.IndexManagement._get_vespa_application") as mock_vespa_app:
+            mock_app = MagicMock()
+            mock_vespa_app.return_value = mock_app
 
-        result = self.index_management.update_index_settings_by_settings_dict(
-            "test_index",
-            {"modelProperties": {
-                "dimensions": 768, "type": "open_clip", "name": "ViT-B-16",
-                "url": "https://example.com/model.pt",
-            }}
-        )
+            original_index = self.semi_structured_marqo_index(
+                name="test_index",
+                schema_name="test_schema",
+                model=Model(name="default-model", properties=self.original_model_properties, custom=True)
+            )
+            mock_get_index.return_value = original_index
 
-        self.assertFalse(result["updated"])
-        self.assertFalse(result["error"])
-        self.assertIn("No changes", result["reason"])
-        mock_vespa_app.update_index_setting.assert_not_called()
+            # Try to update with the same properties
+            result = self.index_management.update_index_settings_by_settings_dict(
+                index_name="test_index",
+                settings_dict={"modelProperties": self.original_model_properties}
+            )
 
-    @patch("marqo.tensor_search.index_meta_cache.get_index")
-    def test_dry_run_and_force_combinations(self, mock_cache_get_index):
-        """Test all combinations of dry_run, force, and valid/invalid updates."""
-        valid_props = {
-            "dimensions": 768, "type": "open_clip", "name": "ViT-B-16",
-            "url": "https://new-url.com/model.pt",
-        }
-        invalid_props = {
-            "dimensions": 384,  # changed dimension
-            "type": "open_clip", "name": "ViT-B-16",
-            "url": "https://new-url.com/model.pt",
-        }
+            self.assertFalse(result["updated"])
+            self.assertFalse(result["error"])
+            self.assertEqual(result["reason"], "Settings are already up to date")
+            mock_app.update_index_setting.assert_not_called()
 
-        cases = [
-            # (label, dry_run, force, props, expected_updated, expected_error, should_deploy)
-            ("dry_run_valid", True, False, valid_props, False, False, False),
-            ("dry_run_invalid", True, False, invalid_props, False, True, False),
-            ("dry_run_force_valid", True, True, valid_props, False, False, False),
-            ("dry_run_force_invalid", True, True, invalid_props, False, True, False),
-            ("no_dry_run_no_force_valid", False, False, valid_props, True, False, True),
-            ("no_dry_run_no_force_invalid", False, False, invalid_props, False, True, False),
-            ("force_valid", False, True, valid_props, True, False, True),
-            ("force_invalid", False, True, invalid_props, True, True, True),
+    def test_dry_run_and_force_combinations(self):
+        """Test all combinations of dry_run and force with valid/invalid changes."""
+        test_cases = [
+            # dry_run=True always prevents deployment regardless of force
+            {
+                "name": "dry_run=True, force=False, valid",
+                "dry_run": True,
+                "force": False,
+                "properties": "valid",
+                "expected_updated": False,
+                "expected_error": False,
+                "expected_deployed": False,
+                "expected_reason_contains": "Dry run",
+            },
+            {
+                "name": "dry_run=True, force=True, valid",
+                "dry_run": True,
+                "force": True,
+                "properties": "valid",
+                "expected_updated": False,
+                "expected_error": False,
+                "expected_deployed": False,
+                "expected_reason_contains": "Dry run",
+            },
+            {
+                "name": "dry_run=True, force=False, invalid",
+                "dry_run": True,
+                "force": False,
+                "properties": "invalid",
+                "expected_updated": False,
+                "expected_error": True,
+                "expected_deployed": False,
+                "expected_reason_contains": "Dry run - validation would fail",
+            },
+            {
+                "name": "dry_run=True, force=True, invalid",
+                "dry_run": True,
+                "force": True,
+                "properties": "invalid",
+                "expected_updated": False,
+                "expected_error": True,
+                "expected_deployed": False,
+                "expected_reason_contains": "Dry run - validation would fail",
+            },
+            # dry_run=False with force=False - deploys only if valid
+            {
+                "name": "dry_run=False, force=False, valid",
+                "dry_run": False,
+                "force": False,
+                "properties": "valid",
+                "expected_updated": True,
+                "expected_error": False,
+                "expected_deployed": True,
+                "expected_reason_contains": "Settings updated successfully",
+            },
+            {
+                "name": "dry_run=False, force=False, invalid",
+                "dry_run": False,
+                "force": False,
+                "properties": "invalid",
+                "expected_updated": False,
+                "expected_error": True,
+                "expected_deployed": False,
+                "expected_reason_contains": "Validation failed",
+            },
+            # dry_run=False with force=True - always deploys
+            {
+                "name": "dry_run=False, force=True, valid",
+                "dry_run": False,
+                "force": True,
+                "properties": "valid",
+                "expected_updated": True,
+                "expected_error": False,
+                "expected_deployed": True,
+                "expected_reason_contains": "Settings updated successfully",
+            },
+            {
+                "name": "dry_run=False, force=True, invalid",
+                "dry_run": False,
+                "force": True,
+                "properties": "invalid",
+                "expected_updated": True,
+                "expected_error": True,
+                "expected_deployed": True,
+                "expected_reason_contains": "Update forced despite validation errors",
+            },
         ]
 
-        for label, dry_run, force, props, exp_updated, exp_error, should_deploy in cases:
-            with self.subTest(label):
-                existing_index = self.semi_structured_marqo_index(
-                    name="test_index",
-                    model=Model(name='my-custom-model', properties={
-                        "dimensions": 768, "type": "open_clip", "name": "ViT-B-16",
-                        "url": "https://old-url.com/model.pt",
-                    }, custom=True),
-                    version=1
-                )
-                mock_vespa_app, _ = self._setup_mocks(existing_index)
+        for test_case in test_cases:
+            with self.subTest(test_case["name"]):
+                with patch('marqo.core.index_management.index_management.IndexManagement.get_index') as mock_get_index, \
+                        patch("marqo.core.index_management.index_management.IndexManagement._get_vespa_application") as mock_vespa_app:
+                    mock_app = MagicMock()
+                    mock_vespa_app.return_value = mock_app
 
-                result = self.index_management.update_index_settings_by_settings_dict(
-                    "test_index", {"modelProperties": props},
-                    force=force, dry_run=dry_run
-                )
+                    original_index = self.semi_structured_marqo_index(
+                        name="test_index",
+                        schema_name="test_schema",
+                        model=Model(name="default-model", properties=self.original_model_properties, custom=True)
+                    )
+                    mock_get_index.return_value = original_index
 
-                self.assertEqual(result["updated"], exp_updated, f"updated mismatch for {label}")
-                self.assertEqual(result["error"], exp_error, f"error mismatch for {label}")
-                if should_deploy:
-                    mock_vespa_app.update_index_setting.assert_called_once()
-                else:
-                    mock_vespa_app.update_index_setting.assert_not_called()
+                    properties = self.valid_updated_properties if test_case["properties"] == "valid" else self.invalid_updated_properties
 
-    @patch("marqo.tensor_search.index_meta_cache.get_index")
-    def test_result_contains_diff_and_settings(self, mock_cache_get_index):
-        """Verify result dict structure and diff content."""
-        existing_index = self.semi_structured_marqo_index(
-            name="test_index",
-            model=Model(name='my-custom-model', properties={
-                "dimensions": 768, "type": "open_clip", "name": "ViT-B-16",
-                "url": "https://old-url.com/model.pt",
-            }, custom=True),
-            version=1
-        )
-        mock_vespa_app, _ = self._setup_mocks(existing_index)
+                    result = self.index_management.update_index_settings_by_settings_dict(
+                        index_name="test_index",
+                        settings_dict={"modelProperties": properties},
+                        dry_run=test_case["dry_run"],
+                        force=test_case["force"]
+                    )
 
-        new_properties = {
-            "dimensions": 768, "type": "open_clip", "name": "ViT-B-16",
-            "url": "https://new-url.com/model.pt",
-        }
-        result = self.index_management.update_index_settings_by_settings_dict(
-            "test_index", {"modelProperties": new_properties}
-        )
+                    self.assertEqual(result["updated"], test_case["expected_updated"],
+                                     f"Expected updated={test_case['expected_updated']}")
+                    self.assertEqual(result["error"], test_case["expected_error"],
+                                     f"Expected error={test_case['expected_error']}")
+                    self.assertIn(test_case["expected_reason_contains"], result["reason"])
 
-        # Check all expected keys exist
-        for key in ("updated", "error", "oldSettings", "newSettings", "settingsDiff", "reason"):
-            self.assertIn(key, result)
+                    if test_case["expected_deployed"]:
+                        mock_app.update_index_setting.assert_called_once()
+                    else:
+                        mock_app.update_index_setting.assert_not_called()
 
-        # Check settings content
-        self.assertEqual(result["oldSettings"]["modelProperties"]["url"], "https://old-url.com/model.pt")
-        self.assertEqual(result["newSettings"]["modelProperties"]["url"], "https://new-url.com/model.pt")
+    def test_result_contains_diff_and_settings(self):
+        """Test that the result contains settingsDiff, oldSettings, and newSettings fields."""
+        with patch('marqo.core.index_management.index_management.IndexManagement.get_index') as mock_get_index, \
+                patch("marqo.core.index_management.index_management.IndexManagement._get_vespa_application") as mock_vespa_app:
+            mock_app = MagicMock()
+            mock_vespa_app.return_value = mock_app
 
-        # Check diff contains the URLs
-        self.assertIn("old-url", result["settingsDiff"])
-        self.assertIn("new-url", result["settingsDiff"])
+            original_index = self.semi_structured_marqo_index(
+                name="test_index",
+                schema_name="test_schema",
+                model=Model(name="default-model", properties=self.original_model_properties, custom=True)
+            )
+            mock_get_index.return_value = original_index
+
+            result = self.index_management.update_index_settings_by_settings_dict(
+                index_name="test_index",
+                settings_dict={"modelProperties": self.valid_updated_properties},
+                dry_run=True
+            )
+
+            # Check all expected fields are present
+            self.assertIn("settingsDiff", result)
+            self.assertIn("oldSettings", result)
+            self.assertIn("newSettings", result)
+            self.assertIn("updated", result)
+            self.assertIn("error", result)
+            self.assertIn("reason", result)
+
+            # Check settings values
+            self.assertEqual(result["oldSettings"]["modelProperties"], self.original_model_properties)
+            self.assertEqual(result["newSettings"]["modelProperties"], self.valid_updated_properties)
+
+            # Diff should contain unified diff markers
+            self.assertIn("---", result["settingsDiff"])
+            self.assertIn("+++", result["settingsDiff"])
 
 
 class TestUpdateIndexSettingsBodyParams(unittest.TestCase):
@@ -332,7 +462,9 @@ class TestVespaApplicationPackageUpdateIndexSetting(MarqoTestCase):
         self.vespa_app._index_setting_store.save_index_setting(index)
         self.mock_store.save_file.reset_mock()
 
+        # Caller bumps version before calling update_index_setting
         updated_index = index.copy(update={
+            'version': 2,
             'model': index.model.copy(update={'properties': {"dimensions": 384, "type": "hf"}, 'custom': True})
         })
 
@@ -361,8 +493,8 @@ class TestVespaApplicationPackageUpdateIndexSetting(MarqoTestCase):
 
         self.mock_store.deploy_application.assert_not_called()
 
-    def test_update_index_setting_increments_version(self):
-        """Test that update_index_setting increments the version."""
+    def test_update_index_setting_preserves_version(self):
+        """Test that update_index_setting saves with the version provided (caller bumps version)."""
         # First save with version=None (gets stored as version=1)
         index = self.semi_structured_marqo_index(
             name="test_index",
@@ -375,14 +507,15 @@ class TestVespaApplicationPackageUpdateIndexSetting(MarqoTestCase):
 
         self.mock_store.save_file.reset_mock()
 
-        # update_index_setting should bump version from 1 to 2
-        self.vespa_app.update_index_setting(stored)
+        # Caller bumps version before calling update_index_setting
+        updated = stored.copy(update={'version': 2})
+        self.vespa_app.update_index_setting(updated)
 
         saved_index = self.vespa_app._index_setting_store.get_index("test_index")
         self.assertEqual(saved_index.version, 2)
 
-    def test_update_index_setting_none_version(self):
-        """Test that update_index_setting handles None version correctly."""
+    def test_update_index_setting_caller_bumps_version(self):
+        """Test that update_index_setting works when caller provides bumped version."""
         index = self.semi_structured_marqo_index(
             name="test_index",
             schema_name="marqo__test_index",
@@ -392,12 +525,13 @@ class TestVespaApplicationPackageUpdateIndexSetting(MarqoTestCase):
         self.vespa_app._index_setting_store.save_index_setting(index)
         self.mock_store.save_file.reset_mock()
 
-        # Now the stored index has version=1, update it
+        # Caller bumps version from 1 to 2
         stored = self.vespa_app._index_setting_store.get_index("test_index")
-        self.vespa_app.update_index_setting(stored)
+        updated = stored.copy(update={'version': 2})
+        self.vespa_app.update_index_setting(updated)
 
-        updated = self.vespa_app._index_setting_store.get_index("test_index")
-        self.assertEqual(updated.version, 2)
+        result = self.vespa_app._index_setting_store.get_index("test_index")
+        self.assertEqual(result.version, 2)
 
 
 class TestUpdateIndexSettingsApiEndpoint(unittest.TestCase):
@@ -437,8 +571,8 @@ class TestUpdateIndexSettingsApiEndpoint(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json(), self._mock_result)
         self.mock_index_mgmt.update_index_settings_by_settings_dict.assert_called_once_with(
-            "my_index",
-            {"modelProperties": {"dimensions": 384, "type": "hf", "name": "hf/e5-small"}},
+            index_name="my_index",
+            settings_dict={"modelProperties": {"dimensions": 384, "type": "hf", "name": "hf/e5-small"}},
             force=False, dry_run=False
         )
 

--- a/tests/unit_tests/marqo/core/index_management/test_update_index_settings.py
+++ b/tests/unit_tests/marqo/core/index_management/test_update_index_settings.py
@@ -1,9 +1,13 @@
 import unittest
 from unittest.mock import Mock, MagicMock, patch
 
+import pydantic.v1
+
 import marqo.version
+from marqo.api.models.update_index_settings import UpdateIndexSettingsBodyParams
 from marqo.core.exceptions import IndexNotFoundError, InternalError, InvalidModelPropertiesError
 from marqo.core.index_management.index_management import IndexManagement
+from marqo.core.index_management.vespa_application_package import VespaApplicationPackage, VespaApplicationStore
 from marqo.core.models.marqo_index import Model
 from marqo.vespa.vespa_client import VespaClient
 from tests.unit_tests.marqo_test import MarqoTestCase
@@ -272,3 +276,207 @@ class TestUpdateIndexSettings(MarqoTestCase):
         self.assertEqual(updated.model.properties, new_properties)
         # Original should be unchanged
         self.assertFalse(existing_index.model.custom)
+
+
+class TestUpdateIndexSettingsBodyParams(unittest.TestCase):
+    """Tests for the UpdateIndexSettingsBodyParams request model."""
+
+    def test_valid_request_with_alias(self):
+        """Test parsing a valid request using the modelProperties alias."""
+        body = UpdateIndexSettingsBodyParams(**{"modelProperties": {"dimensions": 384, "type": "hf"}})
+        self.assertEqual(body.model_properties, {"dimensions": 384, "type": "hf"})
+
+    def test_valid_request_with_field_name(self):
+        """Test parsing a valid request using the model_properties field name."""
+        body = UpdateIndexSettingsBodyParams(**{"model_properties": {"dimensions": 384, "type": "hf"}})
+        self.assertEqual(body.model_properties, {"dimensions": 384, "type": "hf"})
+
+    def test_dict_by_alias(self):
+        """Test that .dict(by_alias=True) returns modelProperties key."""
+        body = UpdateIndexSettingsBodyParams(**{"modelProperties": {"dimensions": 384}})
+        result = body.dict(by_alias=True)
+        self.assertIn("modelProperties", result)
+        self.assertEqual(result["modelProperties"], {"dimensions": 384})
+
+    def test_missing_model_properties_raises_validation_error(self):
+        """Test that missing modelProperties raises a validation error."""
+        with self.assertRaises(pydantic.v1.ValidationError):
+            UpdateIndexSettingsBodyParams(**{})
+
+    def test_extra_field_raises_validation_error(self):
+        """Test that extra fields are rejected (StrictBaseModel)."""
+        with self.assertRaises(pydantic.v1.ValidationError):
+            UpdateIndexSettingsBodyParams(**{
+                "modelProperties": {"dimensions": 384},
+                "extraField": "not_allowed"
+            })
+
+
+class TestVespaApplicationPackageUpdateIndexSetting(MarqoTestCase):
+    """Tests for VespaApplicationPackage.update_index_setting()."""
+
+    def setUp(self):
+        self.mock_store = Mock(spec=VespaApplicationStore)
+        self.mock_store.read_text_file.side_effect = self._mock_read_text_file
+        self.mock_store.file_exists.side_effect = self._mock_file_exists
+        self.vespa_app = VespaApplicationPackage(self.mock_store)
+
+    def _mock_file_exists(self, *paths):
+        return paths in (('marqo_config.json',), ('services.xml',))
+
+    def _mock_read_text_file(self, *paths):
+        if paths == ('services.xml',):
+            return '''<?xml version="1.0" encoding="utf-8"?>
+<services xmlns:deploy="vespa" xmlns:preprocess="properties">
+    <container>
+        <document-api/>
+        <document-processing/>
+        <search/>
+    </container>
+    <content>
+        <documents>
+        </documents>
+    </content>
+</services>'''
+        elif paths == ('marqo_config.json',):
+            return '{"version": "2.24.0"}'
+        else:
+            return None
+
+    def test_update_index_setting_success(self):
+        """Test successful settings-only update persists and deploys."""
+        index = self.semi_structured_marqo_index(
+            name="test_index",
+            schema_name="marqo__test_index",
+            version=1
+        )
+        # Add the index to the store so has_index returns True
+        self.vespa_app._index_setting_store.save_index_setting(index)
+        self.mock_store.save_file.reset_mock()
+
+        updated_index = index.copy(update={
+            'model': index.model.copy(update={'properties': {"dimensions": 384, "type": "hf"}, 'custom': True})
+        })
+
+        self.vespa_app.update_index_setting(updated_index)
+
+        # Should persist index settings (2 calls: settings + history)
+        # and deploy (1 call)
+        self.mock_store.deploy_application.assert_called_once()
+        # Settings file + history file = at least 2 save_file calls
+        settings_calls = [
+            c for c in self.mock_store.save_file.call_args_list
+            if any('marqo_index_settings' in str(a) for a in c[0])
+        ]
+        self.assertEqual(len(settings_calls), 2)
+
+    def test_update_index_setting_not_found(self):
+        """Test that updating a non-existent index raises IndexNotFoundError."""
+        index = self.semi_structured_marqo_index(
+            name="nonexistent_index",
+            schema_name="marqo__nonexistent",
+            version=1
+        )
+
+        with self.assertRaises(IndexNotFoundError):
+            self.vespa_app.update_index_setting(index)
+
+        self.mock_store.deploy_application.assert_not_called()
+
+    def test_update_index_setting_increments_version(self):
+        """Test that update_index_setting increments the version."""
+        # First save with version=None (gets stored as version=1)
+        index = self.semi_structured_marqo_index(
+            name="test_index",
+            schema_name="marqo__test_index",
+            version=None
+        )
+        self.vespa_app._index_setting_store.save_index_setting(index)
+        stored = self.vespa_app._index_setting_store.get_index("test_index")
+        self.assertEqual(stored.version, 1)
+
+        self.mock_store.save_file.reset_mock()
+
+        # update_index_setting should bump version from 1 to 2
+        self.vespa_app.update_index_setting(stored)
+
+        saved_index = self.vespa_app._index_setting_store.get_index("test_index")
+        self.assertEqual(saved_index.version, 2)
+
+    def test_update_index_setting_none_version(self):
+        """Test that update_index_setting handles None version correctly."""
+        index = self.semi_structured_marqo_index(
+            name="test_index",
+            schema_name="marqo__test_index",
+            version=None
+        )
+        # save_index_setting with version=None assigns version=1
+        self.vespa_app._index_setting_store.save_index_setting(index)
+        self.mock_store.save_file.reset_mock()
+
+        # Now the stored index has version=1, update it
+        stored = self.vespa_app._index_setting_store.get_index("test_index")
+        self.vespa_app.update_index_setting(stored)
+
+        updated = self.vespa_app._index_setting_store.get_index("test_index")
+        self.assertEqual(updated.version, 2)
+
+
+class TestUpdateIndexSettingsApiEndpoint(unittest.TestCase):
+    """Tests for the PATCH /indexes/{index_name}/index-settings API endpoint."""
+
+    def setUp(self):
+        from marqo.tensor_search import api
+        from starlette.testclient import TestClient
+        self.api = api
+
+        mock_config = Mock()
+        mock_index_mgmt = Mock()
+        mock_index_mgmt.update_index_settings_by_settings_dict = Mock(return_value=None)
+        mock_config.index_management = mock_index_mgmt
+        self.mock_config = mock_config
+        self.mock_index_mgmt = mock_index_mgmt
+
+        self.api.app.dependency_overrides[self.api.get_config] = lambda: mock_config
+        self.client = TestClient(self.api.app, raise_server_exceptions=False)
+
+    def tearDown(self):
+        self.api.app.dependency_overrides.clear()
+
+    @patch.dict("os.environ", {"MARQO_ENABLE_OPS_API": "true"})
+    def test_update_index_settings_success(self):
+        """Test successful PATCH /indexes/{index_name}/index-settings."""
+        resp = self.client.patch(
+            "/indexes/my_index/index-settings",
+            json={"modelProperties": {"dimensions": 384, "type": "hf", "name": "hf/e5-small"}}
+        )
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"message": "Index settings update is successful."})
+        self.mock_index_mgmt.update_index_settings_by_settings_dict.assert_called_once_with(
+            "my_index",
+            {"modelProperties": {"dimensions": 384, "type": "hf", "name": "hf/e5-small"}}
+        )
+
+    @patch.dict("os.environ", {"MARQO_ENABLE_OPS_API": "true"})
+    def test_update_index_settings_invalid_body(self):
+        """Test PATCH with missing modelProperties returns validation error."""
+        resp = self.client.patch(
+            "/indexes/my_index/index-settings",
+            json={}
+        )
+
+        self.assertIn(resp.status_code, [400, 422])
+
+    @patch.dict("os.environ", {}, clear=False)
+    def test_update_index_settings_ops_api_disabled(self):
+        """Test PATCH is rejected when MARQO_ENABLE_OPS_API is not set."""
+        import os
+        os.environ.pop("MARQO_ENABLE_OPS_API", None)
+
+        resp = self.client.patch(
+            "/indexes/my_index/index-settings",
+            json={"modelProperties": {"dimensions": 384, "type": "hf"}}
+        )
+
+        self.assertNotEqual(resp.status_code, 200)


### PR DESCRIPTION
## Change Summary
Backport the `update_index_settings` feature from mainline to `releases/2.24`. This adds a `PATCH /indexes/{index_name}/index-settings` endpoint (gated by `MARQO_ENABLE_OPS_API=true`) that allows updating `modelProperties` on an existing index without recreating it.

**Changes:**
- Added `InvalidModelPropertiesError` exception in `core/exceptions.py` (maps to HTTP 400 via existing `InvalidArgumentError` handler)
- Added `update_index_setting()` method to `VespaApplicationPackage` — saves settings JSON only (no schema `.sd` change), persists, and deploys
- Added `update_index_settings_by_settings_dict()`, `validate_updated_model_properties()`, and `_updated_index_with_model_properties()` to `IndexManagement`
- Added `UpdateIndexSettingsBodyParams` request model in `api/models/update_index_settings.py`
- Added `PATCH /indexes/{index_name}/index-settings` endpoint in `api.py`

**Validation rules:**
- Only `modelProperties` can be modified (other keys raise `InternalError`)
- Dimensions and type must remain unchanged
- No keys can be removed from model properties
- Updated model is forced to `custom=True`

## Related Jira Ticket
N/A

## Checklist
- [x] Tests have been added for changes
- [x] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [x] Python client changes linked or N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches index settings persistence and triggers Vespa deployments for live indexes; incorrect validation/force usage could leave indexes with incompatible model configs despite being ops-gated and well-tested.
> 
> **Overview**
> Adds a new ops-gated endpoint `PATCH /indexes/{index_name}/index-settings` that updates an existing index’s `modelProperties` without regenerating schemas, supporting `dry_run` diffs and optional `force` to apply changes despite validation failures.
> 
> Implements a settings-only deployment path via `IndexManagement.update_index_settings_by_settings_dict()` and `VespaApplicationPackage.update_index_setting()`, including version bumping, index meta-cache refresh, and compatibility checks that prevent changing `dimensions`/`type` or removing existing model property keys (surfaced as the new `InvalidModelPropertiesError`).
> 
> Includes new request model `UpdateIndexSettingsBodyParams`, bumps version to `2.24.15`, and adds unit + integration coverage for validation, dry-run/force behavior, persistence/deploy behavior, and model-cache effects.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35ed44adbd434c9d108c8ba451df89356bbbf0f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->