### PR TITLE
Try to use the slim onnx image

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # Versions of various components used in the project
-TRITON_VERSION=25.08-py3
+TRITON_VERSION=25.08
 VESPA_VERSION=8.513.17
 
 # Runtime configurations for tests

--- a/compose-inference.yaml
+++ b/compose-inference.yaml
@@ -7,7 +7,7 @@ name: marqo-inference
 
 services:
   triton-gpu:
-    image: nvcr.io/nvidia/tritonserver:25.08-py3
+    image: public.ecr.aws/e3z9e6s8/marqo-triton-slim-onnxruntime:25.08-py3
     command:
       [
         "tritonserver",
@@ -35,7 +35,7 @@ services:
               capabilities: [ gpu ]
 
   triton:
-    image: nvcr.io/nvidia/tritonserver:25.08-py3
+    image: public.ecr.aws/e3z9e6s8/marqo-triton-slim-onnxruntime:25.08-py3
     command:
       [
         "tritonserver",

--- a/compose-inference.yaml
+++ b/compose-inference.yaml
@@ -7,7 +7,7 @@ name: marqo-inference
 
 services:
   triton-gpu:
-    image: public.ecr.aws/e3z9e6s8/marqo-triton-slim-onnxruntime:25.08-py3
+    image: public.ecr.aws/e3z9e6s8/marqo-triton-slim-onnxruntime:25.08
     command:
       [
         "tritonserver",
@@ -35,7 +35,7 @@ services:
               capabilities: [ gpu ]
 
   triton:
-    image: public.ecr.aws/e3z9e6s8/marqo-triton-slim-onnxruntime:25.08-py3
+    image: public.ecr.aws/e3z9e6s8/marqo-triton-slim-onnxruntime:25.08
     command:
       [
         "tritonserver",

--- a/compose-model-management.yaml
+++ b/compose-model-management.yaml
@@ -7,7 +7,7 @@ name: marqo-inference
 
 services:
   triton-gpu:
-    image: nvcr.io/nvidia/tritonserver:25.08-py3
+    image: public.ecr.aws/e3z9e6s8/marqo-triton-slim-onnxruntime:25.08-py3
     command:
       [
         "tritonserver",
@@ -35,7 +35,7 @@ services:
               capabilities: [ gpu ]
 
   triton:
-    image: nvcr.io/nvidia/tritonserver:25.08-py3
+    image: public.ecr.aws/e3z9e6s8/marqo-triton-slim-onnxruntime:25.08-py3
     command:
       [
         "tritonserver",

--- a/compose-model-management.yaml
+++ b/compose-model-management.yaml
@@ -7,7 +7,7 @@ name: marqo-inference
 
 services:
   triton-gpu:
-    image: public.ecr.aws/e3z9e6s8/marqo-triton-slim-onnxruntime:25.08-py3
+    image: public.ecr.aws/e3z9e6s8/marqo-triton-slim-onnxruntime:25.08
     command:
       [
         "tritonserver",
@@ -35,7 +35,7 @@ services:
               capabilities: [ gpu ]
 
   triton:
-    image: public.ecr.aws/e3z9e6s8/marqo-triton-slim-onnxruntime:25.08-py3
+    image: public.ecr.aws/e3z9e6s8/marqo-triton-slim-onnxruntime:25.08
     command:
       [
         "tritonserver",

--- a/compose-triton.yaml
+++ b/compose-triton.yaml
@@ -5,7 +5,7 @@ name: marqo-triton
 
 services:
   triton-gpu:
-    image: nvcr.io/nvidia/tritonserver:${TRITON_VERSION:-25.08-py3}
+    image: public.ecr.aws/e3z9e6s8/marqo-triton-slim-onnxruntime:${TRITON_VERSION:-25.08-py3}
     command:
       [
         "tritonserver",
@@ -30,7 +30,7 @@ services:
               capabilities: [ gpu ]
 
   triton:
-    image: nvcr.io/nvidia/tritonserver:25.08-py3
+    image: public.ecr.aws/e3z9e6s8/marqo-triton-slim-onnxruntime:25.08-py3
     command:
       [
         "tritonserver",

--- a/compose-triton.yaml
+++ b/compose-triton.yaml
@@ -5,7 +5,7 @@ name: marqo-triton
 
 services:
   triton-gpu:
-    image: public.ecr.aws/e3z9e6s8/marqo-triton-slim-onnxruntime:${TRITON_VERSION:-25.08-py3}
+    image: public.ecr.aws/e3z9e6s8/marqo-triton-slim-onnxruntime:${TRITON_VERSION:-25.08}
     command:
       [
         "tritonserver",
@@ -30,7 +30,7 @@ services:
               capabilities: [ gpu ]
 
   triton:
-    image: public.ecr.aws/e3z9e6s8/marqo-triton-slim-onnxruntime:25.08-py3
+    image: public.ecr.aws/e3z9e6s8/marqo-triton-slim-onnxruntime:25.08
     command:
       [
         "tritonserver",

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,7 +6,7 @@ name: marqo-all-components
 
 services:
   triton-gpu:
-    image: public.ecr.aws/e3z9e6s8/marqo-triton-slim-onnxruntime:${TRITON_VERSION:-25.08-py3}
+    image: public.ecr.aws/e3z9e6s8/marqo-triton-slim-onnxruntime:${TRITON_VERSION:-25.08}
     command:
       [
         "tritonserver",
@@ -34,7 +34,7 @@ services:
               capabilities: [ gpu ]
 
   triton:
-    image: public.ecr.aws/e3z9e6s8/marqo-triton-slim-onnxruntime:25.08-py3
+    image: public.ecr.aws/e3z9e6s8/marqo-triton-slim-onnxruntime:25.08
     command:
       [
         "tritonserver",

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,7 +6,7 @@ name: marqo-all-components
 
 services:
   triton-gpu:
-    image: nvcr.io/nvidia/tritonserver:${TRITON_VERSION:-25.08-py3}
+    image: public.ecr.aws/e3z9e6s8/marqo-triton-slim-onnxruntime:${TRITON_VERSION:-25.08-py3}
     command:
       [
         "tritonserver",
@@ -34,7 +34,7 @@ services:
               capabilities: [ gpu ]
 
   triton:
-    image: nvcr.io/nvidia/tritonserver:25.08-py3
+    image: public.ecr.aws/e3z9e6s8/marqo-triton-slim-onnxruntime:25.08-py3
     command:
       [
         "tritonserver",


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Triton Inference Server container image across all docker-compose setups, which could impact runtime compatibility, GPU behavior, or model serving if the slim image differs from NVIDIA’s official build.
> 
> **Overview**
> Switches all Docker Compose environments to run Triton from Marqo’s slim ONNX Runtime image (`public.ecr.aws/.../marqo-triton-slim-onnxruntime:25.08`) instead of `nvcr.io/nvidia/tritonserver:25.08-py3`.
> 
> Updates `.env`/compose defaults to drop the `-py3` suffix from `TRITON_VERSION`, aligning versioning with the new image tags.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72ceee6fb3c7364883966054480a3eccb8c1690f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->