### PR TITLE
Add center and applyToSubqueries parameters to recency scoring

### DIFF
--- a/components/marqo/src/marqo/core/constants.py
+++ b/components/marqo/src/marqo/core/constants.py
@@ -66,6 +66,7 @@ QUERY_INPUT_RECENCY_GROW_FUNCTION_TYPE = 'marqo__recency_grow_function_type'
 QUERY_INPUT_RECENCY_GROW_SCALE_SECONDS = 'marqo__recency_grow_scale_seconds'
 QUERY_INPUT_RECENCY_GROW_OFFSET_SECONDS = 'marqo__recency_grow_offset_seconds'
 MARQO_RECENCY_GROW_MINIMUM_VERSION = semver.VersionInfo.parse('2.24.9')
+MARQO_RECENCY_CENTER_AND_SUBQUERIES_MINIMUM_VERSION = semver.VersionInfo.parse('2.25.1')
 
 # For recency center and subquery control
 QUERY_INPUT_RECENCY_CENTER_SECONDS = 'marqo__recency_center_seconds'

--- a/components/marqo/src/marqo/core/constants.py
+++ b/components/marqo/src/marqo/core/constants.py
@@ -66,3 +66,8 @@ QUERY_INPUT_RECENCY_GROW_FUNCTION_TYPE = 'marqo__recency_grow_function_type'
 QUERY_INPUT_RECENCY_GROW_SCALE_SECONDS = 'marqo__recency_grow_scale_seconds'
 QUERY_INPUT_RECENCY_GROW_OFFSET_SECONDS = 'marqo__recency_grow_offset_seconds'
 MARQO_RECENCY_GROW_MINIMUM_VERSION = semver.VersionInfo.parse('2.24.9')
+
+# For recency center and subquery control
+QUERY_INPUT_RECENCY_CENTER_SECONDS = 'marqo__recency_center_seconds'
+QUERY_INPUT_RECENCY_APPLY_TO_TENSOR = 'marqo__recency_apply_to_tensor'
+QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL = 'marqo__recency_apply_to_lexical'

--- a/components/marqo/src/marqo/core/models/marqo_index.py
+++ b/components/marqo/src/marqo/core/models/marqo_index.py
@@ -740,6 +740,16 @@ class SemiStructuredMarqoIndex(UnstructuredMarqoIndex):
             lambda: self.parsed_schema_template_version() >= constants.MARQO_RECENCY_GROW_MINIMUM_VERSION)
 
     @property
+    def index_supports_recency_center_and_subqueries(self) -> bool:
+        """
+        Check if the index schema supports recency center and applyToSubqueries parameters.
+        These parameters were added in version 2.25.1.
+        """
+        return self._cache_or_get(
+            'index_supports_recency_center_and_subqueries',
+            lambda: self.parsed_schema_template_version() >= constants.MARQO_RECENCY_CENTER_AND_SUBQUERIES_MINIMUM_VERSION)
+
+    @property
     def index_supports_second_phase_lexical_score_modifiers(self) -> bool:
         """
         Check if the index schema supports second phase lexical score modifiers.

--- a/components/marqo/src/marqo/core/search/hybrid_search.py
+++ b/components/marqo/src/marqo/core/search/hybrid_search.py
@@ -326,6 +326,22 @@ class HybridSearch:
                         f"created with Marqo {str(constants.MARQO_RECENCY_GROW_MINIMUM_VERSION)} or later. "
                         f"This index was created with schema version {marqo_index.schema_template_version or marqo_index.marqo_version}."
                     )
+            # Check if center requires newer schema version
+            if recency_parameters.center is not None:
+                if not marqo_index.index_supports_recency_center_and_subqueries:
+                    raise core_exceptions.UnsupportedFeatureError(
+                        f"Recency center parameter (center) is only supported for unstructured indexes "
+                        f"created with Marqo {str(constants.MARQO_RECENCY_CENTER_AND_SUBQUERIES_MINIMUM_VERSION)} or later. "
+                        f"This index was created with schema version {marqo_index.schema_template_version or marqo_index.marqo_version}."
+                    )
+            # Check if applyToSubqueries requires newer schema version
+            if recency_parameters.apply_to_subqueries is not None:
+                if not marqo_index.index_supports_recency_center_and_subqueries:
+                    raise core_exceptions.UnsupportedFeatureError(
+                        f"Recency applyToSubqueries parameter (applyToSubqueries) is only supported for unstructured indexes "
+                        f"created with Marqo {str(constants.MARQO_RECENCY_CENTER_AND_SUBQUERIES_MINIMUM_VERSION)} or later. "
+                        f"This index was created with schema version {marqo_index.schema_template_version or marqo_index.marqo_version}."
+                    )
 
         if hybrid_parameters.secondPhaseModifier:
             if not isinstance(marqo_index, SemiStructuredMarqoIndex):

--- a/components/marqo/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/components/marqo/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -138,12 +138,13 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
             query['marqo__recency_enabled'] = True
             query['marqo__recency_apply_in_global_ranking_phase'] = marqo_query.recency_parameters.apply_in_ranking_phase != ApplyInRankingPhase.EXCLUDE_GLOBAL
 
-            # Set apply_to_subqueries flags (default to both if None)
+            # Set apply_to_subqueries flags as top-level query properties (not ranking features)
+            # so Java can read them via query.properties().getInteger()
             apply_to = marqo_query.recency_parameters.apply_to_subqueries
             if apply_to is None:
                 apply_to = ["tensor", "lexical"]
-            query_input[constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR] = 1 if "tensor" in apply_to else 0
-            query_input[constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL] = 1 if "lexical" in apply_to else 0
+            query[constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR] = 1 if "tensor" in apply_to else 0
+            query[constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL] = 1 if "lexical" in apply_to else 0
 
         # add lexical specific hybrid parameters
         if marqo_query.hybrid_parameters.secondPhaseModifier:

--- a/components/marqo/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/components/marqo/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -139,12 +139,12 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
             query['marqo__recency_apply_in_global_ranking_phase'] = marqo_query.recency_parameters.apply_in_ranking_phase != ApplyInRankingPhase.EXCLUDE_GLOBAL
 
             # Set apply_to_subqueries flags as top-level query properties (not ranking features)
-            # so Java can read them via query.properties().getInteger()
+            # so Java can read them via query.properties().getBoolean()
             apply_to = marqo_query.recency_parameters.apply_to_subqueries
             if apply_to is None:
                 apply_to = ["tensor", "lexical"]
-            query[constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR] = 1 if "tensor" in apply_to else 0
-            query[constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL] = 1 if "lexical" in apply_to else 0
+            query[constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR] = "tensor" in apply_to
+            query[constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL] = "lexical" in apply_to
 
         # add lexical specific hybrid parameters
         if marqo_query.hybrid_parameters.secondPhaseModifier:

--- a/components/marqo/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/components/marqo/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -138,6 +138,13 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
             query['marqo__recency_enabled'] = True
             query['marqo__recency_apply_in_global_ranking_phase'] = marqo_query.recency_parameters.apply_in_ranking_phase != ApplyInRankingPhase.EXCLUDE_GLOBAL
 
+            # Set apply_to_subqueries flags (default to both if None)
+            apply_to = marqo_query.recency_parameters.apply_to_subqueries
+            if apply_to is None:
+                apply_to = ["tensor", "lexical"]
+            query_input[constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR] = 1 if "tensor" in apply_to else 0
+            query_input[constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL] = 1 if "lexical" in apply_to else 0
+
         # add lexical specific hybrid parameters
         if marqo_query.hybrid_parameters.secondPhaseModifier:
             if marqo_query.collapse:
@@ -172,6 +179,9 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
             # Default to 0.0 for multiplicative mode (None means multiplicative)
             constants.QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT: recency_params.add_to_score_weight if recency_params.add_to_score_weight is not None else 0.0
         }
+
+        # Center timestamp: 0 means "use now()", positive value means fixed reference point
+        result[constants.QUERY_INPUT_RECENCY_CENTER_SECONDS] = recency_params.center if recency_params.center is not None else 0
 
         # grow params, the recency_params validation ensures all or nothing for these params
         if recency_params.grow_from is not None:

--- a/components/marqo/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2
+++ b/components/marqo/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_schema_template_2_16.sd.jinja2
@@ -163,6 +163,7 @@ schema {{ index.schema_name }} {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_center_seconds) double: 0
             query(marqo__recency_grow_enabled): 0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0
@@ -180,7 +181,7 @@ schema {{ index.schema_name }} {
         }
 
         function age_in_seconds() {
-            expression: now() - get_timestamp()
+            expression: if (query(marqo__recency_center_seconds) > 0, query(marqo__recency_center_seconds) - get_timestamp(), now() - get_timestamp())
         }
 
         # ============ UNIFIED SCORING FUNCTIONS ============
@@ -477,6 +478,7 @@ schema {{ index.schema_name }} {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_center_seconds) double: 0
             query(marqo__recency_grow_enabled): 0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0

--- a/components/marqo/src/marqo/tensor_search/models/api_models.py
+++ b/components/marqo/src/marqo/tensor_search/models/api_models.py
@@ -228,15 +228,14 @@ class SearchQuery(BaseMarqoModel):
                 f"Search method is {search_method}."
             )
 
-        # Must be RRF ranking method (or default which is RRF)
+        # Must be Disjunction retrieval method (or default which is Disjunction)
         hybrid_parameters = values.get('hybridParameters')
         if hybrid_parameters is not None:
-            from marqo.core.models.hybrid_parameters import RankingMethod
-            ranking_method = hybrid_parameters.rankingMethod
-            if ranking_method is not None and ranking_method != RankingMethod.RRF:
+            retrieval_method = hybrid_parameters.retrievalMethod
+            if retrieval_method is not None and retrieval_method != RetrievalMethod.Disjunction:
                 raise ValueError(
-                    f"'applyToSubqueries' can only be used with 'rrf' ranking method. "
-                    f"Ranking method is '{ranking_method}'."
+                    f"'applyToSubqueries' can only be used with 'disjunction' retrieval method. "
+                    f"Retrieval method is '{retrieval_method}'."
                 )
 
         return values

--- a/components/marqo/src/marqo/tensor_search/models/api_models.py
+++ b/components/marqo/src/marqo/tensor_search/models/api_models.py
@@ -214,6 +214,34 @@ class SearchQuery(BaseMarqoModel):
         return values
 
     @root_validator(pre=False)
+    def validate_apply_to_subqueries_only_for_hybrid_rrf(cls, values):
+        """Validate that applyToSubqueries is only used with HYBRID search and RRF ranking."""
+        recency_parameters = values.get('recencyParameters')
+        if recency_parameters is None or recency_parameters.apply_to_subqueries is None:
+            return values
+
+        # Must be HYBRID search
+        search_method = values.get('searchMethod')
+        if search_method.upper() != SearchMethod.HYBRID:
+            raise ValueError(
+                f"'applyToSubqueries' can only be used with 'HYBRID' search. "
+                f"Search method is {search_method}."
+            )
+
+        # Must be RRF ranking method (or default which is RRF)
+        hybrid_parameters = values.get('hybridParameters')
+        if hybrid_parameters is not None:
+            from marqo.core.models.hybrid_parameters import RankingMethod
+            ranking_method = hybrid_parameters.rankingMethod
+            if ranking_method is not None and ranking_method != RankingMethod.RRF:
+                raise ValueError(
+                    f"'applyToSubqueries' can only be used with 'rrf' ranking method. "
+                    f"Ranking method is '{ranking_method}'."
+                )
+
+        return values
+
+    @root_validator(pre=False)
     def validate_facet_exclude_terms_in_filter(cls, values):
         """Validate that excluded facet fields appear in filter string.
 

--- a/components/marqo/src/marqo/tensor_search/models/recency_parameters.py
+++ b/components/marqo/src/marqo/tensor_search/models/recency_parameters.py
@@ -242,19 +242,6 @@ class RecencyParameters(BaseModel):
             raise ValueError(f"center must be non-negative, got: {v}")
         return v
 
-    @validator('apply_to_subqueries')
-    def validate_apply_to_subqueries(cls, v: Optional[List[str]]) -> Optional[List[str]]:
-        """Validate that apply_to_subqueries contains only valid values."""
-        if v is not None:
-            valid_values = {"tensor", "lexical"}
-            for item in v:
-                if item not in valid_values:
-                    raise ValueError(
-                        f"Invalid value '{item}' in apply_to_subqueries. "
-                        f"Allowed values are: {sorted(valid_values)}"
-                    )
-        return v
-
     @root_validator
     def validate_grow_params_all_or_nothing(cls, values):
         """Validate that grow parameters are either all provided or all omitted.

--- a/components/marqo/src/marqo/tensor_search/models/recency_parameters.py
+++ b/components/marqo/src/marqo/tensor_search/models/recency_parameters.py
@@ -236,6 +236,13 @@ class RecencyParameters(BaseModel):
 
         return v
 
+    @validator('apply_to_subqueries')
+    def deduplicate_apply_to_subqueries(cls, v):
+        """Remove duplicate values while preserving order."""
+        if v is not None:
+            return list(dict.fromkeys(v))
+        return v
+
     @root_validator
     def validate_grow_params_all_or_nothing(cls, values):
         """Validate that grow parameters are either all provided or all omitted.

--- a/components/marqo/src/marqo/tensor_search/models/recency_parameters.py
+++ b/components/marqo/src/marqo/tensor_search/models/recency_parameters.py
@@ -1,7 +1,7 @@
 """Recency parameters for time-based score boosting."""
 
 from enum import Enum
-from typing import Optional
+from typing import List, Literal, Optional
 from pydantic.v1 import BaseModel, Field, validator, root_validator
 from marqo.core.utils.duration_parser import parse_duration_to_seconds
 
@@ -104,6 +104,24 @@ class RecencyParameters(BaseModel):
         description=(
             "If provided, applies recency as an additive factor instead of multiplicative. "
             "Formula: final_score = modified_score + (recency_score * addToScoreWeight)."
+        )
+    )
+
+    center: Optional[float] = Field(
+        default=None,
+        alias="center",
+        description=(
+            "Fixed Unix epoch timestamp (seconds) to use as the reference point instead of now(). "
+            "When provided, recency scores become reproducible across queries."
+        )
+    )
+
+    apply_to_subqueries: Optional[List[Literal["tensor", "lexical"]]] = Field(
+        default=None,
+        alias="applyToSubqueries",
+        description=(
+            "Controls which hybrid subqueries receive recency boosting. "
+            "Default (None) applies to both. Examples: ['tensor'], ['lexical'], ['tensor', 'lexical'], []."
         )
     )
 
@@ -215,6 +233,26 @@ class RecencyParameters(BaseModel):
         if seconds < 0:
             raise ValueError(f"grow_offset must be greater than or equal to 0, got: {v} ({seconds} seconds)")
 
+        return v
+
+    @validator('center')
+    def validate_center(cls, v: Optional[float]) -> Optional[float]:
+        """Validate that center is non-negative if provided."""
+        if v is not None and v < 0:
+            raise ValueError(f"center must be non-negative, got: {v}")
+        return v
+
+    @validator('apply_to_subqueries')
+    def validate_apply_to_subqueries(cls, v: Optional[List[str]]) -> Optional[List[str]]:
+        """Validate that apply_to_subqueries contains only valid values."""
+        if v is not None:
+            valid_values = {"tensor", "lexical"}
+            for item in v:
+                if item not in valid_values:
+                    raise ValueError(
+                        f"Invalid value '{item}' in apply_to_subqueries. "
+                        f"Allowed values are: {sorted(valid_values)}"
+                    )
         return v
 
     @root_validator

--- a/components/marqo/src/marqo/tensor_search/models/recency_parameters.py
+++ b/components/marqo/src/marqo/tensor_search/models/recency_parameters.py
@@ -109,6 +109,7 @@ class RecencyParameters(BaseModel):
 
     center: Optional[float] = Field(
         default=None,
+        ge=0,
         alias="center",
         description=(
             "Fixed Unix epoch timestamp (seconds) to use as the reference point instead of now(). "
@@ -233,13 +234,6 @@ class RecencyParameters(BaseModel):
         if seconds < 0:
             raise ValueError(f"grow_offset must be greater than or equal to 0, got: {v} ({seconds} seconds)")
 
-        return v
-
-    @validator('center')
-    def validate_center(cls, v: Optional[float]) -> Optional[float]:
-        """Validate that center is non-negative if provided."""
-        if v is not None and v < 0:
-            raise ValueError(f"center must be non-negative, got: {v}")
         return v
 
     @root_validator

--- a/components/marqo/src/marqo/version.py
+++ b/components/marqo/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.25.0"
+__version__ = "2.25.1"
 
 
 def get_version() -> str:

--- a/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_fields_with_collapse_fields.sd
+++ b/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_fields_with_collapse_fields.sd
@@ -157,6 +157,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_center_seconds) double: 0
             query(marqo__recency_grow_enabled): 0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0
@@ -172,7 +173,7 @@ schema marqo__test_00semi_00structured_00schema {
         }
 
         function age_in_seconds() {
-            expression: now() - get_timestamp()
+            expression: if (query(marqo__recency_center_seconds) > 0, query(marqo__recency_center_seconds) - get_timestamp(), now() - get_timestamp())
         }
 
         # ============ UNIFIED SCORING FUNCTIONS ============
@@ -421,6 +422,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_center_seconds) double: 0
             query(marqo__recency_grow_enabled): 0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0

--- a/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_lexical_tensor_and_string_array_fields.sd
+++ b/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_lexical_tensor_and_string_array_fields.sd
@@ -152,6 +152,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_center_seconds) double: 0
             query(marqo__recency_grow_enabled): 0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0
@@ -165,7 +166,7 @@ schema marqo__test_00semi_00structured_00schema {
         }
 
         function age_in_seconds() {
-            expression: now() - get_timestamp()
+            expression: if (query(marqo__recency_center_seconds) > 0, query(marqo__recency_center_seconds) - get_timestamp(), now() - get_timestamp())
         }
 
         # ============ UNIFIED SCORING FUNCTIONS ============
@@ -369,6 +370,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_center_seconds) double: 0
             query(marqo__recency_grow_enabled): 0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0

--- a/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_lexical_tensor_fields.sd
+++ b/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_multiple_lexical_tensor_fields.sd
@@ -142,6 +142,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_center_seconds) double: 0
             query(marqo__recency_grow_enabled): 0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0
@@ -155,7 +156,7 @@ schema marqo__test_00semi_00structured_00schema {
         }
 
         function age_in_seconds() {
-            expression: now() - get_timestamp()
+            expression: if (query(marqo__recency_center_seconds) > 0, query(marqo__recency_center_seconds) - get_timestamp(), now() - get_timestamp())
         }
 
         # ============ UNIFIED SCORING FUNCTIONS ============
@@ -349,6 +350,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_center_seconds) double: 0
             query(marqo__recency_grow_enabled): 0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0

--- a/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_no_field.sd
+++ b/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_no_field.sd
@@ -95,6 +95,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_center_seconds) double: 0
             query(marqo__recency_grow_enabled): 0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0
@@ -108,7 +109,7 @@ schema marqo__test_00semi_00structured_00schema {
         }
 
         function age_in_seconds() {
-            expression: now() - get_timestamp()
+            expression: if (query(marqo__recency_center_seconds) > 0, query(marqo__recency_center_seconds) - get_timestamp(), now() - get_timestamp())
         }
 
         # ============ UNIFIED SCORING FUNCTIONS ============

--- a/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_field.sd
+++ b/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_field.sd
@@ -103,6 +103,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_center_seconds) double: 0
             query(marqo__recency_grow_enabled): 0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0
@@ -116,7 +117,7 @@ schema marqo__test_00semi_00structured_00schema {
         }
 
         function age_in_seconds() {
-            expression: now() - get_timestamp()
+            expression: if (query(marqo__recency_center_seconds) > 0, query(marqo__recency_center_seconds) - get_timestamp(), now() - get_timestamp())
         }
 
         # ============ UNIFIED SCORING FUNCTIONS ============

--- a/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_one_tensor_field.sd
+++ b/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_one_tensor_field.sd
@@ -120,6 +120,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_center_seconds) double: 0
             query(marqo__recency_grow_enabled): 0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0
@@ -133,7 +134,7 @@ schema marqo__test_00semi_00structured_00schema {
         }
 
         function age_in_seconds() {
-            expression: now() - get_timestamp()
+            expression: if (query(marqo__recency_center_seconds) > 0, query(marqo__recency_center_seconds) - get_timestamp(), now() - get_timestamp())
         }
 
         # ============ UNIFIED SCORING FUNCTIONS ============
@@ -335,6 +336,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_center_seconds) double: 0
             query(marqo__recency_grow_enabled): 0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0

--- a/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_one_tensor_one_string_array_field.sd
+++ b/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_one_tensor_one_string_array_field.sd
@@ -125,6 +125,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_center_seconds) double: 0
             query(marqo__recency_grow_enabled): 0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0
@@ -138,7 +139,7 @@ schema marqo__test_00semi_00structured_00schema {
         }
 
         function age_in_seconds() {
-            expression: now() - get_timestamp()
+            expression: if (query(marqo__recency_center_seconds) > 0, query(marqo__recency_center_seconds) - get_timestamp(), now() - get_timestamp())
         }
 
         # ============ UNIFIED SCORING FUNCTIONS ============
@@ -340,6 +341,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_center_seconds) double: 0
             query(marqo__recency_grow_enabled): 0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0

--- a/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_string_array_field.sd
+++ b/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_string_array_field.sd
@@ -100,6 +100,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_center_seconds) double: 0
             query(marqo__recency_grow_enabled): 0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0
@@ -113,7 +114,7 @@ schema marqo__test_00semi_00structured_00schema {
         }
 
         function age_in_seconds() {
-            expression: now() - get_timestamp()
+            expression: if (query(marqo__recency_center_seconds) > 0, query(marqo__recency_center_seconds) - get_timestamp(), now() - get_timestamp())
         }
 
         # ============ UNIFIED SCORING FUNCTIONS ============

--- a/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_tensor_field.sd
+++ b/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_tensor_field.sd
@@ -112,6 +112,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_center_seconds) double: 0
             query(marqo__recency_grow_enabled): 0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0
@@ -125,7 +126,7 @@ schema marqo__test_00semi_00structured_00schema {
         }
 
         function age_in_seconds() {
-            expression: now() - get_timestamp()
+            expression: if (query(marqo__recency_center_seconds) > 0, query(marqo__recency_center_seconds) - get_timestamp(), now() - get_timestamp())
         }
 
         # ============ UNIFIED SCORING FUNCTIONS ============

--- a/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
+++ b/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
@@ -1680,46 +1680,46 @@ class TestRecencyScoring(MarqoTestCase):
 
                 variant_scores = self._extract_scores(hits)
 
-                # Find docs that appear in both result sets and are affected by recency
-                common_affected = [
-                    doc_id for doc_id in set(baseline_scores) & set(variant_scores)
-                    if variant_scores[doc_id]['recency'] is not None
-                    and abs(variant_scores[doc_id]['recency'] - 1.0) > 0.01
-                    and baseline_scores[doc_id]['tensor'] is not None
-                    and baseline_scores[doc_id]['lexical'] is not None
-                ]
-                self.assertGreater(len(common_affected), 0, "Should have common docs affected by recency")
+                # Verify baseline and variant return the same doc IDs
+                baseline_ids = set(baseline_scores)
+                variant_ids = set(variant_scores)
+                self.assertEqual(baseline_ids, variant_ids,
+                    f"Baseline and variant should return the same doc IDs. "
+                    f"Only in baseline: {baseline_ids - variant_ids}, "
+                    f"Only in variant: {variant_ids - baseline_ids}")
 
-                for doc_id in common_affected:
+                for doc_id in variant_scores:
                     b = baseline_scores[doc_id]
                     v = variant_scores[doc_id]
                     recency = v['recency']
 
-                    # 2. Check tensor scores
-                    if recency_on_tensor:
-                        expected_tensor = b['tensor'] * recency
-                        self.assertAlmostEqual(
-                            expected_tensor, v['tensor'], places=3,
-                            msg=f"Doc {doc_id}: tensor score should be baseline * recency"
-                        )
-                    else:
-                        self.assertAlmostEqual(
-                            b['tensor'], v['tensor'], places=5,
-                            msg=f"Doc {doc_id}: tensor score should match baseline"
-                        )
+                    # 2. Check tensor scores (skip if baseline has no tensor score)
+                    if b['tensor'] is not None:
+                        if recency_on_tensor:
+                            expected_tensor = b['tensor'] * recency
+                            self.assertAlmostEqual(
+                                expected_tensor, v['tensor'], places=5,
+                                msg=f"Doc {doc_id}: tensor score should be baseline * recency"
+                            )
+                        else:
+                            self.assertAlmostEqual(
+                                b['tensor'], v['tensor'], places=5,
+                                msg=f"Doc {doc_id}: tensor score should match baseline"
+                            )
 
-                    # 3. Check lexical scores
-                    if recency_on_lexical:
-                        expected_lexical = b['lexical'] * recency
-                        self.assertAlmostEqual(
-                            expected_lexical, v['lexical'], places=3,
-                            msg=f"Doc {doc_id}: lexical score should be baseline * recency"
-                        )
-                    else:
-                        self.assertAlmostEqual(
-                            b['lexical'], v['lexical'], places=5,
-                            msg=f"Doc {doc_id}: lexical score should match baseline"
-                        )
+                    # 3. Check lexical scores (skip if baseline has no lexical score)
+                    if b['lexical'] is not None:
+                        if recency_on_lexical:
+                            expected_lexical = b['lexical'] * recency
+                            self.assertAlmostEqual(
+                                expected_lexical, v['lexical'], places=5,
+                                msg=f"Doc {doc_id}: lexical score should be baseline * recency"
+                            )
+                        else:
+                            self.assertAlmostEqual(
+                                b['lexical'], v['lexical'], places=5,
+                                msg=f"Doc {doc_id}: lexical score should match baseline"
+                            )
 
     def test_center_produces_reproducible_scores(self):
         """Test that center parameter produces the same scores across multiple queries.

--- a/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
+++ b/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
@@ -11,6 +11,8 @@ from datetime import datetime, timedelta
 import math
 import pytest
 
+from pydantic.v1 import ValidationError
+
 from marqo.core.exceptions import UnsupportedFeatureError
 from marqo.core.models.add_docs_params import AddDocsParams
 from marqo.core.models.hybrid_parameters import HybridParameters, RetrievalMethod, RankingMethod
@@ -18,6 +20,7 @@ from marqo.core.models.marqo_index import *
 from marqo.core.models.marqo_index_request import FieldRequest
 from marqo.tensor_search import tensor_search
 from marqo.tensor_search.enums import SearchMethod
+from marqo.tensor_search.models.api_models import SearchQuery
 from marqo.tensor_search.models.recency_parameters import RecencyParameters, ApplyInRankingPhase
 from marqo.tensor_search.models.relevance_cutoff_model import (
     RelevanceCutoffModel, RelevanceCutoffMethod
@@ -1332,11 +1335,9 @@ class TestRecencyScoring(MarqoTestCase):
 
     def test_non_hybrid_search_method_not_supported(self):
         """Recency requires HYBRID search method (validated at API layer)."""
-        from marqo.tensor_search.models.api_models import SearchQuery
-
         for search_method in ["TENSOR", "LEXICAL"]:
             with self.subTest(search_method=search_method):
-                with self.assertRaises(ValueError) as ctx:
+                with self.assertRaises(ValidationError) as ctx:
                     SearchQuery(
                         q="product",
                         searchMethod=search_method,
@@ -1356,11 +1357,9 @@ class TestRecencyScoring(MarqoTestCase):
 
     def test_apply_to_subqueries_non_hybrid_fails(self):
         """applyToSubqueries requires HYBRID search method."""
-        from marqo.tensor_search.models.api_models import SearchQuery
-
         for search_method in ["TENSOR", "LEXICAL"]:
             with self.subTest(search_method=search_method):
-                with self.assertRaises(ValueError) as ctx:
+                with self.assertRaises(ValidationError) as ctx:
                     SearchQuery(
                         q="product",
                         searchMethod=search_method,
@@ -1373,15 +1372,13 @@ class TestRecencyScoring(MarqoTestCase):
                     )
                 self.assertIn("HYBRID", str(ctx.exception))
 
-    def test_apply_to_subqueries_non_rrf_fails(self):
-        """applyToSubqueries requires RRF ranking method."""
-        from marqo.tensor_search.models.api_models import SearchQuery
-
-        with self.assertRaises(ValueError) as ctx:
+    def test_apply_to_subqueries_non_disjunction_fails(self):
+        """applyToSubqueries requires disjunction retrieval method."""
+        with self.assertRaises(ValidationError) as ctx:
             SearchQuery(
                 q="product",
                 searchMethod="HYBRID",
-                hybridParameters={"rankingMethod": "tensor", "retrievalMethod": "lexical"},
+                hybridParameters={"retrievalMethod": "lexical", "rankingMethod": "lexical"},
                 recencyParameters={
                     "recencyField": "timestamp",
                     "scale": "7d",
@@ -1389,15 +1386,13 @@ class TestRecencyScoring(MarqoTestCase):
                     "applyToSubqueries": ["tensor"],
                 }
             )
-        self.assertIn("rrf", str(ctx.exception).lower())
+        self.assertIn("disjunction", str(ctx.exception).lower())
 
     def test_sort_by_with_non_exclude_global_fails(self):
         """sortBy + recency should fail unless exclude-global."""
-        from marqo.tensor_search.models.api_models import SearchQuery
-
         for phase in ["all", "only-global"]:
             with self.subTest(phase=phase):
-                with self.assertRaises(ValueError) as ctx:
+                with self.assertRaises(ValidationError) as ctx:
                     SearchQuery(
                         q="product",
                         searchMethod="HYBRID",
@@ -1575,7 +1570,7 @@ class TestRecencyScoring(MarqoTestCase):
             (
                 "negative center value",
                 {"recency_field": "timestamp", "center": -1.0},
-                "center must be non-negative"
+                "ensure this value is greater than or equal to 0"
             ),
             (
                 "invalid apply_to_subqueries value",
@@ -1591,7 +1586,7 @@ class TestRecencyScoring(MarqoTestCase):
 
         for description, kwargs, expected_error in validation_cases:
             with self.subTest(case=description):
-                with self.assertRaises(ValueError) as ctx:
+                with self.assertRaises(ValidationError) as ctx:
                     RecencyParameters(**kwargs)
                 self.assertIn(
                     expected_error,
@@ -1721,6 +1716,8 @@ class TestRecencyScoring(MarqoTestCase):
                                 msg=f"Doc {doc_id}: lexical score should match baseline"
                             )
 
+    @pytest.mark.skip_for_multinode(
+        "Multi-nodes will return different lexical results so we can not assert on the results.")
     def test_center_produces_reproducible_scores(self):
         """Test that center parameter produces the same scores across multiple queries.
 

--- a/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
+++ b/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
@@ -1328,13 +1328,12 @@ class TestRecencyScoring(MarqoTestCase):
 
     def test_non_hybrid_search_method_not_supported(self):
         """Recency requires HYBRID search method (validated at API layer)."""
-        from marqo.tensor_search.models.api_models import BulkSearchQueryEntity
+        from marqo.tensor_search.models.api_models import SearchQuery
 
         for search_method in ["TENSOR", "LEXICAL"]:
             with self.subTest(search_method=search_method):
                 with self.assertRaises(ValueError) as ctx:
-                    BulkSearchQueryEntity(
-                        index=self.main_index.name,
+                    SearchQuery(
                         q="product",
                         searchMethod=search_method,
                         recencyParameters={
@@ -1351,15 +1350,82 @@ class TestRecencyScoring(MarqoTestCase):
                     "Error should mention HYBRID search"
                 )
 
+    def test_apply_to_subqueries_non_hybrid_fails(self):
+        """applyToSubqueries requires HYBRID search method."""
+        from marqo.tensor_search.models.api_models import SearchQuery
+
+        for search_method in ["TENSOR", "LEXICAL"]:
+            with self.subTest(search_method=search_method):
+                with self.assertRaises(ValueError) as ctx:
+                    SearchQuery(
+                        q="product",
+                        searchMethod=search_method,
+                        recencyParameters={
+                            "recencyField": "timestamp",
+                            "scale": "7d",
+                            "decayTo": 0.5,
+                            "applyToSubqueries": ["tensor"],
+                        }
+                    )
+                self.assertIn("HYBRID", str(ctx.exception))
+
+    def test_apply_to_subqueries_non_rrf_fails(self):
+        """applyToSubqueries requires RRF ranking method."""
+        from marqo.tensor_search.models.api_models import SearchQuery
+
+        with self.assertRaises(ValueError) as ctx:
+            SearchQuery(
+                q="product",
+                searchMethod="HYBRID",
+                hybridParameters={"rankingMethod": "tensor", "retrievalMethod": "lexical"},
+                recencyParameters={
+                    "recencyField": "timestamp",
+                    "scale": "7d",
+                    "decayTo": 0.5,
+                    "applyToSubqueries": ["tensor"],
+                }
+            )
+        self.assertIn("rrf", str(ctx.exception).lower())
+
+    def test_apply_to_subqueries_with_hybrid_rrf_succeeds(self):
+        """applyToSubqueries with HYBRID search and RRF ranking is valid."""
+        from marqo.tensor_search.models.api_models import SearchQuery
+
+        # Explicit RRF
+        query = SearchQuery(
+            q="product",
+            searchMethod="HYBRID",
+            hybridParameters={"rankingMethod": "rrf", "retrievalMethod": "disjunction"},
+            recencyParameters={
+                "recencyField": "timestamp",
+                "scale": "7d",
+                "decayTo": 0.5,
+                "applyToSubqueries": ["tensor"],
+            }
+        )
+        self.assertIsNotNone(query.recencyParameters)
+
+        # Default hybrid parameters (RRF is default)
+        query2 = SearchQuery(
+            q="product",
+            searchMethod="HYBRID",
+            recencyParameters={
+                "recencyField": "timestamp",
+                "scale": "7d",
+                "decayTo": 0.5,
+                "applyToSubqueries": ["lexical"],
+            }
+        )
+        self.assertIsNotNone(query2.recencyParameters)
+
     def test_sort_by_with_non_exclude_global_fails(self):
         """sortBy + recency should fail unless exclude-global."""
-        from marqo.tensor_search.models.api_models import BulkSearchQueryEntity
+        from marqo.tensor_search.models.api_models import SearchQuery
 
         for phase in ["all", "only-global"]:
             with self.subTest(phase=phase):
                 with self.assertRaises(ValueError) as ctx:
-                    BulkSearchQueryEntity(
-                        index=self.main_index.name,
+                    SearchQuery(
                         q="product",
                         searchMethod="HYBRID",
                         recencyParameters={
@@ -1533,6 +1599,21 @@ class TestRecencyScoring(MarqoTestCase):
                  "grow_from": 0.5, "grow_function": "exponential"},
                 "Grow parameters must be either all provided or all omitted"
             ),
+            (
+                "negative center value",
+                {"recency_field": "timestamp", "center": -1.0},
+                "center must be non-negative"
+            ),
+            (
+                "invalid apply_to_subqueries value",
+                {"recency_field": "timestamp", "apply_to_subqueries": ["invalid"]},
+                "unexpected value; permitted:"
+            ),
+            (
+                "mixed invalid apply_to_subqueries",
+                {"recency_field": "timestamp", "apply_to_subqueries": ["tensor", "bad"]},
+                "unexpected value; permitted:"
+            ),
         ]
 
         for description, kwargs, expected_error in validation_cases:
@@ -1546,95 +1627,89 @@ class TestRecencyScoring(MarqoTestCase):
                 )
 
 
-class TestRecencyCenterAndApplyToSubqueries(MarqoTestCase):
-    """Integration tests for center and applyToSubqueries recency parameters."""
-
-    @classmethod
-    def setUpClass(cls) -> None:
-        super().setUpClass()
-
-        cls.main_index_request = cls.unstructured_marqo_index_request(
-            model=Model(name='hf/all-MiniLM-L6-v2')
-        )
-
-        cls.indexes = cls.create_indexes([cls.main_index_request])
-        cls.main_index = cls.indexes[0]
-
-    def _add_test_documents(self):
-        """Add documents with known timestamps for testing."""
+    def test_apply_to_subqueries_accepted_and_returns_results(self):
+        """Test that various applyToSubqueries values are accepted in hybrid RRF search."""
         now = datetime.now()
         documents = [
-            {
-                "_id": "doc-recent",
-                "title": "recent document about technology",
-                "timestamp": (now - timedelta(hours=1)).timestamp(),
-            },
-            {
-                "_id": "doc-old",
-                "title": "old document about technology",
-                "timestamp": (now - timedelta(days=14)).timestamp(),
-            },
-            {
-                "_id": "doc-medium",
-                "title": "medium age document about technology",
-                "timestamp": (now - timedelta(days=3)).timestamp(),
-            },
+            {"_id": "doc-recent", "title": "recent document about technology",
+             "timestamp": (now - timedelta(hours=1)).timestamp()},
+            {"_id": "doc-old", "title": "old document about technology",
+             "timestamp": (now - timedelta(days=14)).timestamp()},
+            {"_id": "doc-medium", "title": "medium age document about technology",
+             "timestamp": (now - timedelta(days=3)).timestamp()},
         ]
-
         self.add_documents(
             self.config,
-            AddDocsParams(
-                index_name=self.main_index.name,
-                docs=documents,
-                tensor_fields=["title"],
-            ),
+            AddDocsParams(index_name=self.main_index.name, docs=documents, tensor_fields=["title"]),
         )
-        return documents
+
+        subquery_variants = [
+            ("tensor only", ["tensor"]),
+            ("lexical only", ["lexical"]),
+            ("both explicit", ["tensor", "lexical"]),
+            ("empty list", []),
+            ("default (None)", None),
+        ]
+
+        for description, apply_to in subquery_variants:
+            with self.subTest(apply_to_subqueries=description):
+                results = tensor_search.search(
+                    config=self.config,
+                    index_name=self.main_index.name,
+                    text="technology",
+                    search_method=SearchMethod.HYBRID,
+                    hybrid_parameters=HybridParameters(
+                        retrievalMethod=RetrievalMethod.Disjunction,
+                        rankingMethod=RankingMethod.RRF
+                    ),
+                    recency_parameters=RecencyParameters(
+                        recency_field="timestamp",
+                        scale="7d",
+                        decay_to=0.5,
+                        apply_to_subqueries=apply_to,
+                    ),
+                    result_count=10,
+                )
+                self.assertGreater(len(results["hits"]), 0,
+                                   f"Should return results with apply_to_subqueries={description}")
 
     def test_center_produces_reproducible_scores(self):
         """Test that center parameter produces the same scores across multiple queries."""
-        self._add_test_documents()
+        now = datetime.now()
+        documents = [
+            {"_id": "doc-recent", "title": "recent document about technology",
+             "timestamp": (now - timedelta(hours=1)).timestamp()},
+            {"_id": "doc-old", "title": "old document about technology",
+             "timestamp": (now - timedelta(days=14)).timestamp()},
+        ]
+        self.add_documents(
+            self.config,
+            AddDocsParams(index_name=self.main_index.name, docs=documents, tensor_fields=["title"]),
+        )
 
-        fixed_center = datetime.now().timestamp()
-
+        fixed_center = now.timestamp()
         recency_params = RecencyParameters(
-            recency_field="timestamp",
-            scale="7d",
-            decay_to=0.5,
-            center=fixed_center
+            recency_field="timestamp", scale="7d", decay_to=0.5, center=fixed_center
         )
 
-        # Run the same query twice
         results_1 = tensor_search.search(
-            config=self.config,
-            index_name=self.main_index.name,
-            text="technology",
-            search_method=SearchMethod.HYBRID,
+            config=self.config, index_name=self.main_index.name,
+            text="technology", search_method=SearchMethod.HYBRID,
             hybrid_parameters=HybridParameters(
-                retrievalMethod=RetrievalMethod.Disjunction,
-                rankingMethod=RankingMethod.RRF
-            ),
-            recency_parameters=recency_params,
-            result_count=10,
+                retrievalMethod=RetrievalMethod.Disjunction, rankingMethod=RankingMethod.RRF),
+            recency_parameters=recency_params, result_count=10,
         )
 
-        # Small sleep to make sure now() would differ
         time.sleep(0.1)
 
         results_2 = tensor_search.search(
-            config=self.config,
-            index_name=self.main_index.name,
-            text="technology",
-            search_method=SearchMethod.HYBRID,
+            config=self.config, index_name=self.main_index.name,
+            text="technology", search_method=SearchMethod.HYBRID,
             hybrid_parameters=HybridParameters(
-                retrievalMethod=RetrievalMethod.Disjunction,
-                rankingMethod=RankingMethod.RRF
-            ),
-            recency_parameters=recency_params,
-            result_count=10,
+                retrievalMethod=RetrievalMethod.Disjunction, rankingMethod=RankingMethod.RRF),
+            recency_parameters=recency_params, result_count=10,
         )
 
-        # Scores should be identical when using center
         self.assertEqual(len(results_1["hits"]), len(results_2["hits"]))
         for hit1, hit2 in zip(results_1["hits"], results_2["hits"]):
             self.assertEqual(hit1["_id"], hit2["_id"])
@@ -1642,304 +1717,49 @@ class TestRecencyCenterAndApplyToSubqueries(MarqoTestCase):
 
     def test_center_in_past_vs_present_gives_different_scores(self):
         """Test that center in the past vs. present gives different scores."""
-        self._add_test_documents()
+        now = datetime.now()
+        documents = [
+            {"_id": "doc-recent", "title": "recent document about technology",
+             "timestamp": (now - timedelta(hours=1)).timestamp()},
+            {"_id": "doc-old", "title": "old document about technology",
+             "timestamp": (now - timedelta(days=14)).timestamp()},
+        ]
+        self.add_documents(
+            self.config,
+            AddDocsParams(index_name=self.main_index.name, docs=documents, tensor_fields=["title"]),
+        )
 
-        now = datetime.now().timestamp()
-        past_center = (datetime.now() - timedelta(days=30)).timestamp()
+        now_ts = now.timestamp()
+        past_center = (now - timedelta(days=30)).timestamp()
 
-        # Query with center = now
         results_now = tensor_search.search(
-            config=self.config,
-            index_name=self.main_index.name,
-            text="technology",
-            search_method=SearchMethod.HYBRID,
+            config=self.config, index_name=self.main_index.name,
+            text="technology", search_method=SearchMethod.HYBRID,
             hybrid_parameters=HybridParameters(
-                retrievalMethod=RetrievalMethod.Disjunction,
-                rankingMethod=RankingMethod.RRF
-            ),
+                retrievalMethod=RetrievalMethod.Disjunction, rankingMethod=RankingMethod.RRF),
             recency_parameters=RecencyParameters(
-                recency_field="timestamp",
-                scale="7d",
-                decay_to=0.5,
-                center=now
-            ),
+                recency_field="timestamp", scale="7d", decay_to=0.5, center=now_ts),
             result_count=10,
         )
 
-        # Query with center = 30 days ago
         results_past = tensor_search.search(
-            config=self.config,
-            index_name=self.main_index.name,
-            text="technology",
-            search_method=SearchMethod.HYBRID,
+            config=self.config, index_name=self.main_index.name,
+            text="technology", search_method=SearchMethod.HYBRID,
             hybrid_parameters=HybridParameters(
-                retrievalMethod=RetrievalMethod.Disjunction,
-                rankingMethod=RankingMethod.RRF
-            ),
+                retrievalMethod=RetrievalMethod.Disjunction, rankingMethod=RankingMethod.RRF),
             recency_parameters=RecencyParameters(
-                recency_field="timestamp",
-                scale="7d",
-                decay_to=0.5,
-                center=past_center
-            ),
+                recency_field="timestamp", scale="7d", decay_to=0.5, center=past_center),
             result_count=10,
         )
 
-        # With center=30 days ago, all docs are "in the future" relative to center,
-        # so scores should differ from center=now
         scores_now = {h["_id"]: h["_score"] for h in results_now["hits"]}
         scores_past = {h["_id"]: h["_score"] for h in results_past["hits"]}
 
-        # At least one doc should have different scores
-        has_difference = False
-        for doc_id in scores_now:
-            if doc_id in scores_past:
-                if abs(scores_now[doc_id] - scores_past[doc_id]) > 0.001:
-                    has_difference = True
-                    break
+        has_difference = any(
+            abs(scores_now.get(doc_id, 0) - scores_past.get(doc_id, 0)) > 0.001
+            for doc_id in set(scores_now) | set(scores_past)
+        )
         self.assertTrue(has_difference, "Scores should differ when using different center values")
-
-    def test_apply_to_subqueries_tensor_only(self):
-        """Test applyToSubqueries=['tensor'] applies recency only to tensor subquery.
-
-        Verifies the parameter is accepted and produces valid results.
-        Uses default (global-phase) recency to check that tensor-only produces
-        the same result as both (since global-phase recency applies identically
-        regardless of apply_to_subqueries in RRF).
-        """
-        self._add_test_documents()
-
-        # With recency on both subqueries (default)
-        results_both = tensor_search.search(
-            config=self.config,
-            index_name=self.main_index.name,
-            text="technology",
-            search_method=SearchMethod.HYBRID,
-            hybrid_parameters=HybridParameters(
-                retrievalMethod=RetrievalMethod.Disjunction,
-                rankingMethod=RankingMethod.RRF
-            ),
-            recency_parameters=RecencyParameters(
-                recency_field="timestamp",
-                scale="7d",
-                decay_to=0.5,
-            ),
-            result_count=10,
-        )
-
-        # With recency on tensor only
-        results_tensor_only = tensor_search.search(
-            config=self.config,
-            index_name=self.main_index.name,
-            text="technology",
-            search_method=SearchMethod.HYBRID,
-            hybrid_parameters=HybridParameters(
-                retrievalMethod=RetrievalMethod.Disjunction,
-                rankingMethod=RankingMethod.RRF
-            ),
-            recency_parameters=RecencyParameters(
-                recency_field="timestamp",
-                scale="7d",
-                decay_to=0.5,
-                apply_to_subqueries=["tensor"],
-            ),
-            result_count=10,
-        )
-
-        # Without recency
-        results_no_recency = tensor_search.search(
-            config=self.config,
-            index_name=self.main_index.name,
-            text="technology",
-            search_method=SearchMethod.HYBRID,
-            hybrid_parameters=HybridParameters(
-                retrievalMethod=RetrievalMethod.Disjunction,
-                rankingMethod=RankingMethod.RRF
-            ),
-            result_count=10,
-        )
-
-        # Verify we got results
-        self.assertGreater(len(results_both["hits"]), 0)
-        self.assertGreater(len(results_tensor_only["hits"]), 0)
-        self.assertGreater(len(results_no_recency["hits"]), 0)
-
-        # Recency (on both) should produce different scores than no recency
-        scores_both = {h["_id"]: h["_score"] for h in results_both["hits"]}
-        scores_no_recency = {h["_id"]: h["_score"] for h in results_no_recency["hits"]}
-        has_difference = any(
-            abs(scores_both.get(doc_id, 0) - scores_no_recency.get(doc_id, 0)) > 0.001
-            for doc_id in set(scores_both) | set(scores_no_recency)
-        )
-        self.assertTrue(has_difference,
-                        "Recency should produce different scores than no recency")
-
-    def test_apply_to_subqueries_lexical_only(self):
-        """Test applyToSubqueries=['lexical'] applies recency only to lexical subquery.
-
-        Verifies the parameter is accepted and produces valid results.
-        Uses default (global-phase) recency to check that lexical-only produces
-        the same result as both (since global-phase recency applies identically
-        regardless of apply_to_subqueries in RRF).
-        """
-        self._add_test_documents()
-
-        # With recency on lexical only
-        results_lexical_only = tensor_search.search(
-            config=self.config,
-            index_name=self.main_index.name,
-            text="technology",
-            search_method=SearchMethod.HYBRID,
-            hybrid_parameters=HybridParameters(
-                retrievalMethod=RetrievalMethod.Disjunction,
-                rankingMethod=RankingMethod.RRF
-            ),
-            recency_parameters=RecencyParameters(
-                recency_field="timestamp",
-                scale="7d",
-                decay_to=0.5,
-                apply_to_subqueries=["lexical"],
-            ),
-            result_count=10,
-        )
-
-        # With recency on both
-        results_both = tensor_search.search(
-            config=self.config,
-            index_name=self.main_index.name,
-            text="technology",
-            search_method=SearchMethod.HYBRID,
-            hybrid_parameters=HybridParameters(
-                retrievalMethod=RetrievalMethod.Disjunction,
-                rankingMethod=RankingMethod.RRF
-            ),
-            recency_parameters=RecencyParameters(
-                recency_field="timestamp",
-                scale="7d",
-                decay_to=0.5,
-            ),
-            result_count=10,
-        )
-
-        # Without recency
-        results_no_recency = tensor_search.search(
-            config=self.config,
-            index_name=self.main_index.name,
-            text="technology",
-            search_method=SearchMethod.HYBRID,
-            hybrid_parameters=HybridParameters(
-                retrievalMethod=RetrievalMethod.Disjunction,
-                rankingMethod=RankingMethod.RRF
-            ),
-            result_count=10,
-        )
-
-        # Verify we got results
-        self.assertGreater(len(results_both["hits"]), 0)
-        self.assertGreater(len(results_lexical_only["hits"]), 0)
-        self.assertGreater(len(results_no_recency["hits"]), 0)
-
-        # Recency (on both) should produce different scores than no recency
-        scores_both = {h["_id"]: h["_score"] for h in results_both["hits"]}
-        scores_no_recency = {h["_id"]: h["_score"] for h in results_no_recency["hits"]}
-        has_difference = any(
-            abs(scores_both.get(doc_id, 0) - scores_no_recency.get(doc_id, 0)) > 0.001
-            for doc_id in set(scores_both) | set(scores_no_recency)
-        )
-        self.assertTrue(has_difference,
-                        "Recency should produce different scores than no recency")
-
-    def test_apply_to_subqueries_empty_applies_to_neither(self):
-        """Test applyToSubqueries=[] applies recency to neither subquery (only global phase)."""
-        self._add_test_documents()
-
-        # With recency on neither subquery
-        results_none = tensor_search.search(
-            config=self.config,
-            index_name=self.main_index.name,
-            text="technology",
-            search_method=SearchMethod.HYBRID,
-            hybrid_parameters=HybridParameters(
-                retrievalMethod=RetrievalMethod.Disjunction,
-                rankingMethod=RankingMethod.RRF
-            ),
-            recency_parameters=RecencyParameters(
-                recency_field="timestamp",
-                scale="7d",
-                decay_to=0.5,
-                apply_to_subqueries=[],
-            ),
-            result_count=10,
-        )
-
-        # With recency on both subqueries
-        results_both = tensor_search.search(
-            config=self.config,
-            index_name=self.main_index.name,
-            text="technology",
-            search_method=SearchMethod.HYBRID,
-            hybrid_parameters=HybridParameters(
-                retrievalMethod=RetrievalMethod.Disjunction,
-                rankingMethod=RankingMethod.RRF
-            ),
-            recency_parameters=RecencyParameters(
-                recency_field="timestamp",
-                scale="7d",
-                decay_to=0.5,
-            ),
-            result_count=10,
-        )
-
-        # Verify we got results
-        self.assertGreater(len(results_none["hits"]), 0)
-        self.assertGreater(len(results_both["hits"]), 0)
-
-    def test_default_apply_to_subqueries_matches_existing_behavior(self):
-        """Test that default (None) matches existing behavior (both applied)."""
-        self._add_test_documents()
-
-        # Default (no applyToSubqueries)
-        results_default = tensor_search.search(
-            config=self.config,
-            index_name=self.main_index.name,
-            text="technology",
-            search_method=SearchMethod.HYBRID,
-            hybrid_parameters=HybridParameters(
-                retrievalMethod=RetrievalMethod.Disjunction,
-                rankingMethod=RankingMethod.RRF
-            ),
-            recency_parameters=RecencyParameters(
-                recency_field="timestamp",
-                scale="7d",
-                decay_to=0.5,
-            ),
-            result_count=10,
-        )
-
-        # Explicit both
-        results_explicit_both = tensor_search.search(
-            config=self.config,
-            index_name=self.main_index.name,
-            text="technology",
-            search_method=SearchMethod.HYBRID,
-            hybrid_parameters=HybridParameters(
-                retrievalMethod=RetrievalMethod.Disjunction,
-                rankingMethod=RankingMethod.RRF
-            ),
-            recency_parameters=RecencyParameters(
-                recency_field="timestamp",
-                scale="7d",
-                decay_to=0.5,
-                apply_to_subqueries=["tensor", "lexical"],
-            ),
-            result_count=10,
-        )
-
-        # Should produce identical results
-        self.assertEqual(len(results_default["hits"]), len(results_explicit_both["hits"]))
-        for hit_default, hit_explicit in zip(results_default["hits"], results_explicit_both["hits"]):
-            self.assertEqual(hit_default["_id"], hit_explicit["_id"])
-            self.assertAlmostEqual(hit_default["_score"], hit_explicit["_score"], places=5)
 
 
 if __name__ == '__main__':

--- a/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
+++ b/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
@@ -435,12 +435,16 @@ class TestRecencyScoring(MarqoTestCase):
 
         return max(floor_value, score)
 
-    def _get_doc_age_seconds(self, hit: Dict) -> Optional[float]:
+    def _get_doc_age_seconds(self, hit: Dict, center: Optional[float] = None) -> Optional[float]:
         """Get the age in seconds for a document based on its timestamp field.
 
+        Args:
+            hit: Search result document
+            center: Fixed reference timestamp (Unix epoch seconds). Uses now() if None.
+
         Returns:
-            - Positive value: past document (timestamp < now)
-            - Negative value: future document (timestamp > now)
+            - Positive value: past document (timestamp < reference)
+            - Negative value: future document (timestamp > reference)
             - None: document has no timestamp field
         """
         doc_id = hit.get('_id')
@@ -450,8 +454,8 @@ class TestRecencyScoring(MarqoTestCase):
         # Use the actual timestamp from the document
         timestamp = hit.get('timestamp')
         if timestamp is not None:
-            current_time = datetime.now().timestamp()
-            return current_time - timestamp  # Can be negative for future docs
+            reference_time = center if center is not None else datetime.now().timestamp()
+            return reference_time - timestamp  # Can be negative for future docs
         return None
 
     # ============== Verification Helpers ==============
@@ -471,7 +475,7 @@ class TestRecencyScoring(MarqoTestCase):
             self.assertIsNotNone(actual_score, f"Recency score should be present for {doc_id}")
 
             # Calculate expected score
-            age_seconds = self._get_doc_age_seconds(hit)
+            age_seconds = self._get_doc_age_seconds(hit, center=recency_params.center)
             if age_seconds is not None:
                 expected_score = self._calculate_expected_score(
                     age_seconds, recency_params.scale, recency_params.offset, recency_params.decay_function, recency_params.decay_to,
@@ -1718,11 +1722,17 @@ class TestRecencyScoring(MarqoTestCase):
                         )
 
     def test_center_produces_reproducible_scores(self):
-        """Test that center parameter produces the same scores across multiple queries."""
+        """Test that center parameter produces the same scores across multiple queries.
+
+        Uses center=now-20min so all three documents are in the past relative to center,
+        covering a range of ages: recent (20min), medium (4d), and old (14d).
+        """
         now = datetime.now()
         documents = [
             {"_id": "doc-recent", "title": "recent document about technology",
              "timestamp": (now - timedelta(hours=1)).timestamp()},
+            {"_id": "doc-medium", "title": "medium age document about technology",
+             "timestamp": (now - timedelta(days=4)).timestamp()},
             {"_id": "doc-old", "title": "old document about technology",
              "timestamp": (now - timedelta(days=14)).timestamp()},
         ]
@@ -1731,7 +1741,7 @@ class TestRecencyScoring(MarqoTestCase):
             AddDocsParams(index_name=self.main_index.name, docs=documents, tensor_fields=["title"]),
         )
 
-        fixed_center = now.timestamp()
+        fixed_center = (now - timedelta(minutes=20)).timestamp()
         recency_params = RecencyParameters(
             recency_field="timestamp", scale="7d", decay_to=0.5, center=fixed_center
         )
@@ -1744,7 +1754,7 @@ class TestRecencyScoring(MarqoTestCase):
             recency_parameters=recency_params, result_count=10,
         )
 
-        time.sleep(0.1)
+        time.sleep(2)
 
         results_2 = tensor_search.search(
             config=self.config, index_name=self.main_index.name,
@@ -1754,56 +1764,17 @@ class TestRecencyScoring(MarqoTestCase):
             recency_parameters=recency_params, result_count=10,
         )
 
+        # Verify recency scores are correctly calculated for both runs
+        self._verify_recency_behavior(results_1['hits'], recency_params)
+        self._verify_recency_behavior(results_2['hits'], recency_params)
+
+        # Verify both runs produce identical ordering and scores
         self.assertEqual(len(results_1["hits"]), len(results_2["hits"]))
         for hit1, hit2 in zip(results_1["hits"], results_2["hits"]):
             self.assertEqual(hit1["_id"], hit2["_id"])
+            self.assertEqual(hit1["_recency_score"], hit2["_recency_score"],
+                             f"Recency score mismatch for {hit1['_id']}")
             self.assertAlmostEqual(hit1["_score"], hit2["_score"], places=5)
-
-    def test_center_in_past_vs_present_gives_different_scores(self):
-        """Test that center in the past vs. present gives different scores."""
-        now = datetime.now()
-        documents = [
-            {"_id": "doc-recent", "title": "recent document about technology",
-             "timestamp": (now - timedelta(hours=1)).timestamp()},
-            {"_id": "doc-old", "title": "old document about technology",
-             "timestamp": (now - timedelta(days=14)).timestamp()},
-        ]
-        self.add_documents(
-            self.config,
-            AddDocsParams(index_name=self.main_index.name, docs=documents, tensor_fields=["title"]),
-        )
-
-        now_ts = now.timestamp()
-        past_center = (now - timedelta(days=30)).timestamp()
-
-        results_now = tensor_search.search(
-            config=self.config, index_name=self.main_index.name,
-            text="technology", search_method=SearchMethod.HYBRID,
-            hybrid_parameters=HybridParameters(
-                retrievalMethod=RetrievalMethod.Disjunction, rankingMethod=RankingMethod.RRF),
-            recency_parameters=RecencyParameters(
-                recency_field="timestamp", scale="7d", decay_to=0.5, center=now_ts),
-            result_count=10,
-        )
-
-        results_past = tensor_search.search(
-            config=self.config, index_name=self.main_index.name,
-            text="technology", search_method=SearchMethod.HYBRID,
-            hybrid_parameters=HybridParameters(
-                retrievalMethod=RetrievalMethod.Disjunction, rankingMethod=RankingMethod.RRF),
-            recency_parameters=RecencyParameters(
-                recency_field="timestamp", scale="7d", decay_to=0.5, center=past_center),
-            result_count=10,
-        )
-
-        scores_now = {h["_id"]: h["_score"] for h in results_now["hits"]}
-        scores_past = {h["_id"]: h["_score"] for h in results_past["hits"]}
-
-        has_difference = any(
-            abs(scores_now.get(doc_id, 0) - scores_past.get(doc_id, 0)) > 0.001
-            for doc_id in set(scores_now) | set(scores_past)
-        )
-        self.assertTrue(has_difference, "Scores should differ when using different center values")
 
 
 if __name__ == '__main__':

--- a/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
+++ b/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
@@ -1581,9 +1581,9 @@ class TestRecencyCenterAndApplyToSubqueries(MarqoTestCase):
             },
         ]
 
-        tensor_search.add_documents(
-            config=self.config,
-            add_docs_params=AddDocsParams(
+        self.add_documents(
+            self.config,
+            AddDocsParams(
                 index_name=self.main_index.name,
                 docs=documents,
                 tensor_fields=["title"],

--- a/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
+++ b/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
@@ -1561,22 +1561,27 @@ class TestRecencyCenterAndApplyToSubqueries(MarqoTestCase):
         cls.main_index = cls.indexes[0]
 
     def _add_test_documents(self):
-        """Add documents with known timestamps for reproducibility tests."""
+        """Add documents with known timestamps and varying content relevance.
+
+        doc-old has the highest BM25 relevance for "technology" (short doc = high term frequency)
+        but is the oldest. doc-recent has lower BM25 relevance but is the newest. This ensures
+        recency can flip rank order in subqueries.
+        """
         now = datetime.now()
         documents = [
             {
                 "_id": "doc-recent",
-                "title": "recent document about technology",
+                "title": "recent document about technology and innovation in software engineering",
                 "timestamp": (now - timedelta(hours=1)).timestamp(),
             },
             {
                 "_id": "doc-old",
-                "title": "old document about technology",
+                "title": "technology",
                 "timestamp": (now - timedelta(days=14)).timestamp(),
             },
             {
                 "_id": "doc-medium",
-                "title": "medium age document about technology",
+                "title": "medium age document about technology and computers",
                 "timestamp": (now - timedelta(days=3)).timestamp(),
             },
         ]
@@ -1703,7 +1708,7 @@ class TestRecencyCenterAndApplyToSubqueries(MarqoTestCase):
         """Test applyToSubqueries=['tensor'] only applies recency to tensor subquery."""
         self._add_test_documents()
 
-        # With recency on both subqueries
+        # With recency on both subqueries (aggressive decay so 14-day-old doc gets near-zero recency)
         results_both = tensor_search.search(
             config=self.config,
             index_name=self.main_index.name,
@@ -1715,8 +1720,8 @@ class TestRecencyCenterAndApplyToSubqueries(MarqoTestCase):
             ),
             recency_parameters=RecencyParameters(
                 recency_field="timestamp",
-                scale="7d",
-                decay_to=0.5,
+                scale="1d",
+                decay_to=0.1,
             ),
             result_count=10,
         )
@@ -1733,8 +1738,8 @@ class TestRecencyCenterAndApplyToSubqueries(MarqoTestCase):
             ),
             recency_parameters=RecencyParameters(
                 recency_field="timestamp",
-                scale="7d",
-                decay_to=0.5,
+                scale="1d",
+                decay_to=0.1,
                 apply_to_subqueries=["tensor"],
             ),
             result_count=10,
@@ -1756,7 +1761,7 @@ class TestRecencyCenterAndApplyToSubqueries(MarqoTestCase):
         """Test applyToSubqueries=['lexical'] only applies recency to lexical subquery."""
         self._add_test_documents()
 
-        # With recency on lexical only
+        # With recency on lexical only (aggressive decay so 14-day-old doc gets near-zero recency)
         results_lexical_only = tensor_search.search(
             config=self.config,
             index_name=self.main_index.name,
@@ -1768,8 +1773,8 @@ class TestRecencyCenterAndApplyToSubqueries(MarqoTestCase):
             ),
             recency_parameters=RecencyParameters(
                 recency_field="timestamp",
-                scale="7d",
-                decay_to=0.5,
+                scale="1d",
+                decay_to=0.1,
                 apply_to_subqueries=["lexical"],
             ),
             result_count=10,
@@ -1787,8 +1792,8 @@ class TestRecencyCenterAndApplyToSubqueries(MarqoTestCase):
             ),
             recency_parameters=RecencyParameters(
                 recency_field="timestamp",
-                scale="7d",
-                decay_to=0.5,
+                scale="1d",
+                decay_to=0.1,
             ),
             result_count=10,
         )

--- a/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
+++ b/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
@@ -1387,37 +1387,6 @@ class TestRecencyScoring(MarqoTestCase):
             )
         self.assertIn("rrf", str(ctx.exception).lower())
 
-    def test_apply_to_subqueries_with_hybrid_rrf_succeeds(self):
-        """applyToSubqueries with HYBRID search and RRF ranking is valid."""
-        from marqo.tensor_search.models.api_models import SearchQuery
-
-        # Explicit RRF
-        query = SearchQuery(
-            q="product",
-            searchMethod="HYBRID",
-            hybridParameters={"rankingMethod": "rrf", "retrievalMethod": "disjunction"},
-            recencyParameters={
-                "recencyField": "timestamp",
-                "scale": "7d",
-                "decayTo": 0.5,
-                "applyToSubqueries": ["tensor"],
-            }
-        )
-        self.assertIsNotNone(query.recencyParameters)
-
-        # Default hybrid parameters (RRF is default)
-        query2 = SearchQuery(
-            q="product",
-            searchMethod="HYBRID",
-            recencyParameters={
-                "recencyField": "timestamp",
-                "scale": "7d",
-                "decayTo": 0.5,
-                "applyToSubqueries": ["lexical"],
-            }
-        )
-        self.assertIsNotNone(query2.recencyParameters)
-
     def test_sort_by_with_non_exclude_global_fails(self):
         """sortBy + recency should fail unless exclude-global."""
         from marqo.tensor_search.models.api_models import SearchQuery
@@ -1627,51 +1596,126 @@ class TestRecencyScoring(MarqoTestCase):
                 )
 
 
-    def test_apply_to_subqueries_accepted_and_returns_results(self):
-        """Test that various applyToSubqueries values are accepted in hybrid RRF search."""
-        now = datetime.now()
-        documents = [
-            {"_id": "doc-recent", "title": "recent document about technology",
-             "timestamp": (now - timedelta(hours=1)).timestamp()},
-            {"_id": "doc-old", "title": "old document about technology",
-             "timestamp": (now - timedelta(days=14)).timestamp()},
-            {"_id": "doc-medium", "title": "medium age document about technology",
-             "timestamp": (now - timedelta(days=3)).timestamp()},
-        ]
-        self.add_documents(
-            self.config,
-            AddDocsParams(index_name=self.main_index.name, docs=documents, tensor_fields=["title"]),
+    @pytest.mark.skip_for_multinode(
+        "Multi-nodes will return different lexical results so we can not assert on the results.")
+    def test_apply_to_subqueries_controls_recency_application(self):
+        """Test that applyToSubqueries controls which subquery scores are modified by recency.
+
+        Uses apply_in_ranking_phase="exclude-global" to isolate the subquery effect —
+        recency only modifies first-phase subquery scores, not the global RRF score.
+        Uses rerankDepthTensor=20 to ensure all documents appear in the tensor result set.
+
+        Baseline: no recency parameters at all.
+        For each variant, verifies:
+        - _recency_score is present and correctly calculated
+        - []: _tensor_score and _lexical_score unchanged from baseline
+        - ["tensor"]: _tensor_score = baseline * recency, _lexical_score unchanged
+        - ["lexical"]: _lexical_score = baseline * recency, _tensor_score unchanged
+        - ["tensor", "lexical"]: both scores = baseline * recency
+        """
+        self._add_shared_documents()
+
+        recency_base_params = dict(
+            recency_field="timestamp",
+            scale="60d",
+            offset="0d",
+            decay_function="exponential",
+            decay_to=0.3,
+            grow_from=0.2,
+            grow_function="linear",
+            grow_scale="45d",
+            grow_offset="1d",
+            apply_in_ranking_phase="exclude-global",
         )
 
-        subquery_variants = [
-            ("tensor only", ["tensor"]),
-            ("lexical only", ["lexical"]),
-            ("both explicit", ["tensor", "lexical"]),
-            ("empty list", []),
-            ("default (None)", None),
+        hybrid_params = HybridParameters(
+            retrievalMethod=RetrievalMethod.Disjunction,
+            rankingMethod=RankingMethod.RRF,
+            rerankDepthTensor=20,
+        )
+
+        # Baseline: no recency at all
+        baseline_result = tensor_search.search(
+            config=self.config,
+            index_name=self.main_index.name,
+            text="product",
+            search_method=SearchMethod.HYBRID,
+            hybrid_parameters=hybrid_params,
+            result_count=20,
+        )
+        baseline_scores = self._extract_scores(baseline_result['hits'])
+
+        # (apply_to, recency_on_tensor, recency_on_lexical)
+        test_cases = [
+            ([], False, False),
+            (["tensor"], True, False),
+            (["lexical"], False, True),
+            (["tensor", "lexical"], True, True),
         ]
 
-        for description, apply_to in subquery_variants:
-            with self.subTest(apply_to_subqueries=description):
-                results = tensor_search.search(
+        for apply_to, recency_on_tensor, recency_on_lexical in test_cases:
+            with self.subTest(apply_to_subqueries=apply_to):
+                recency_params = RecencyParameters(
+                    **recency_base_params,
+                    apply_to_subqueries=apply_to,
+                )
+                result = tensor_search.search(
                     config=self.config,
                     index_name=self.main_index.name,
-                    text="technology",
+                    text="product",
                     search_method=SearchMethod.HYBRID,
-                    hybrid_parameters=HybridParameters(
-                        retrievalMethod=RetrievalMethod.Disjunction,
-                        rankingMethod=RankingMethod.RRF
-                    ),
-                    recency_parameters=RecencyParameters(
-                        recency_field="timestamp",
-                        scale="7d",
-                        decay_to=0.5,
-                        apply_to_subqueries=apply_to,
-                    ),
-                    result_count=10,
+                    hybrid_parameters=hybrid_params,
+                    recency_parameters=recency_params,
+                    result_count=20,
                 )
-                self.assertGreater(len(results["hits"]), 0,
-                                   f"Should return results with apply_to_subqueries={description}")
+                hits = result['hits']
+                self.assertGreater(len(hits), 0)
+
+                # 1. Verify _recency_score is present and correct
+                self._verify_recency_behavior(hits, recency_params)
+
+                variant_scores = self._extract_scores(hits)
+
+                # Find docs that appear in both result sets and are affected by recency
+                common_affected = [
+                    doc_id for doc_id in set(baseline_scores) & set(variant_scores)
+                    if variant_scores[doc_id]['recency'] is not None
+                    and abs(variant_scores[doc_id]['recency'] - 1.0) > 0.01
+                    and baseline_scores[doc_id]['tensor'] is not None
+                    and baseline_scores[doc_id]['lexical'] is not None
+                ]
+                self.assertGreater(len(common_affected), 0, "Should have common docs affected by recency")
+
+                for doc_id in common_affected:
+                    b = baseline_scores[doc_id]
+                    v = variant_scores[doc_id]
+                    recency = v['recency']
+
+                    # 2. Check tensor scores
+                    if recency_on_tensor:
+                        expected_tensor = b['tensor'] * recency
+                        self.assertAlmostEqual(
+                            expected_tensor, v['tensor'], places=3,
+                            msg=f"Doc {doc_id}: tensor score should be baseline * recency"
+                        )
+                    else:
+                        self.assertAlmostEqual(
+                            b['tensor'], v['tensor'], places=5,
+                            msg=f"Doc {doc_id}: tensor score should match baseline"
+                        )
+
+                    # 3. Check lexical scores
+                    if recency_on_lexical:
+                        expected_lexical = b['lexical'] * recency
+                        self.assertAlmostEqual(
+                            expected_lexical, v['lexical'], places=3,
+                            msg=f"Doc {doc_id}: lexical score should be baseline * recency"
+                        )
+                    else:
+                        self.assertAlmostEqual(
+                            b['lexical'], v['lexical'], places=5,
+                            msg=f"Doc {doc_id}: lexical score should match baseline"
+                        )
 
     def test_center_produces_reproducible_scores(self):
         """Test that center parameter produces the same scores across multiple queries."""

--- a/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
+++ b/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
@@ -1546,5 +1546,355 @@ class TestRecencyScoring(MarqoTestCase):
                 )
 
 
+class TestRecencyCenterAndApplyToSubqueries(MarqoTestCase):
+    """Integration tests for center and applyToSubqueries recency parameters."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+
+        cls.main_index_request = cls.unstructured_marqo_index_request(
+            model=Model(name='hf/all-MiniLM-L6-v2')
+        )
+
+        cls.indexes = cls.create_indexes([cls.main_index_request])
+        cls.main_index = cls.indexes[0]
+
+    def _add_test_documents(self):
+        """Add documents with known timestamps for reproducibility tests."""
+        now = datetime.now()
+        documents = [
+            {
+                "_id": "doc-recent",
+                "title": "recent document about technology",
+                "timestamp": (now - timedelta(hours=1)).timestamp(),
+            },
+            {
+                "_id": "doc-old",
+                "title": "old document about technology",
+                "timestamp": (now - timedelta(days=14)).timestamp(),
+            },
+            {
+                "_id": "doc-medium",
+                "title": "medium age document about technology",
+                "timestamp": (now - timedelta(days=3)).timestamp(),
+            },
+        ]
+
+        tensor_search.add_documents(
+            config=self.config,
+            add_docs_params=AddDocsParams(
+                index_name=self.main_index.name,
+                docs=documents,
+                tensor_fields=["title"],
+            ),
+        )
+        return documents
+
+    def test_center_produces_reproducible_scores(self):
+        """Test that center parameter produces the same scores across multiple queries."""
+        self._add_test_documents()
+
+        fixed_center = datetime.now().timestamp()
+
+        recency_params = RecencyParameters(
+            recency_field="timestamp",
+            scale="7d",
+            decay_to=0.5,
+            center=fixed_center
+        )
+
+        # Run the same query twice
+        results_1 = tensor_search.search(
+            config=self.config,
+            index_name=self.main_index.name,
+            text="technology",
+            search_method=SearchMethod.HYBRID,
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                rankingMethod=RankingMethod.RRF
+            ),
+            recency_parameters=recency_params,
+            result_count=10,
+        )
+
+        # Small sleep to make sure now() would differ
+        time.sleep(0.1)
+
+        results_2 = tensor_search.search(
+            config=self.config,
+            index_name=self.main_index.name,
+            text="technology",
+            search_method=SearchMethod.HYBRID,
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                rankingMethod=RankingMethod.RRF
+            ),
+            recency_parameters=recency_params,
+            result_count=10,
+        )
+
+        # Scores should be identical when using center
+        self.assertEqual(len(results_1["hits"]), len(results_2["hits"]))
+        for hit1, hit2 in zip(results_1["hits"], results_2["hits"]):
+            self.assertEqual(hit1["_id"], hit2["_id"])
+            self.assertAlmostEqual(hit1["_score"], hit2["_score"], places=5)
+
+    def test_center_in_past_vs_present_gives_different_scores(self):
+        """Test that center in the past vs. present gives different scores."""
+        self._add_test_documents()
+
+        now = datetime.now().timestamp()
+        past_center = (datetime.now() - timedelta(days=30)).timestamp()
+
+        # Query with center = now
+        results_now = tensor_search.search(
+            config=self.config,
+            index_name=self.main_index.name,
+            text="technology",
+            search_method=SearchMethod.HYBRID,
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                rankingMethod=RankingMethod.RRF
+            ),
+            recency_parameters=RecencyParameters(
+                recency_field="timestamp",
+                scale="7d",
+                decay_to=0.5,
+                center=now
+            ),
+            result_count=10,
+        )
+
+        # Query with center = 30 days ago
+        results_past = tensor_search.search(
+            config=self.config,
+            index_name=self.main_index.name,
+            text="technology",
+            search_method=SearchMethod.HYBRID,
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                rankingMethod=RankingMethod.RRF
+            ),
+            recency_parameters=RecencyParameters(
+                recency_field="timestamp",
+                scale="7d",
+                decay_to=0.5,
+                center=past_center
+            ),
+            result_count=10,
+        )
+
+        # With center=30 days ago, all docs are "in the future" relative to center,
+        # so scores should differ from center=now
+        scores_now = {h["_id"]: h["_score"] for h in results_now["hits"]}
+        scores_past = {h["_id"]: h["_score"] for h in results_past["hits"]}
+
+        # At least one doc should have different scores
+        has_difference = False
+        for doc_id in scores_now:
+            if doc_id in scores_past:
+                if abs(scores_now[doc_id] - scores_past[doc_id]) > 0.001:
+                    has_difference = True
+                    break
+        self.assertTrue(has_difference, "Scores should differ when using different center values")
+
+    def test_apply_to_subqueries_tensor_only(self):
+        """Test applyToSubqueries=['tensor'] only applies recency to tensor subquery."""
+        self._add_test_documents()
+
+        # With recency on both subqueries
+        results_both = tensor_search.search(
+            config=self.config,
+            index_name=self.main_index.name,
+            text="technology",
+            search_method=SearchMethod.HYBRID,
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                rankingMethod=RankingMethod.RRF
+            ),
+            recency_parameters=RecencyParameters(
+                recency_field="timestamp",
+                scale="7d",
+                decay_to=0.5,
+            ),
+            result_count=10,
+        )
+
+        # With recency on tensor only
+        results_tensor_only = tensor_search.search(
+            config=self.config,
+            index_name=self.main_index.name,
+            text="technology",
+            search_method=SearchMethod.HYBRID,
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                rankingMethod=RankingMethod.RRF
+            ),
+            recency_parameters=RecencyParameters(
+                recency_field="timestamp",
+                scale="7d",
+                decay_to=0.5,
+                apply_to_subqueries=["tensor"],
+            ),
+            result_count=10,
+        )
+
+        # Results should be different (lexical subquery is not boosted in tensor_only)
+        scores_both = {h["_id"]: h["_score"] for h in results_both["hits"]}
+        scores_tensor = {h["_id"]: h["_score"] for h in results_tensor_only["hits"]}
+
+        # At least some scores should differ when recency is removed from lexical
+        has_difference = any(
+            abs(scores_both.get(doc_id, 0) - scores_tensor.get(doc_id, 0)) > 0.001
+            for doc_id in set(scores_both) | set(scores_tensor)
+        )
+        self.assertTrue(has_difference,
+                        "Scores should differ between apply_to both vs tensor-only")
+
+    def test_apply_to_subqueries_lexical_only(self):
+        """Test applyToSubqueries=['lexical'] only applies recency to lexical subquery."""
+        self._add_test_documents()
+
+        # With recency on lexical only
+        results_lexical_only = tensor_search.search(
+            config=self.config,
+            index_name=self.main_index.name,
+            text="technology",
+            search_method=SearchMethod.HYBRID,
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                rankingMethod=RankingMethod.RRF
+            ),
+            recency_parameters=RecencyParameters(
+                recency_field="timestamp",
+                scale="7d",
+                decay_to=0.5,
+                apply_to_subqueries=["lexical"],
+            ),
+            result_count=10,
+        )
+
+        # With recency on both
+        results_both = tensor_search.search(
+            config=self.config,
+            index_name=self.main_index.name,
+            text="technology",
+            search_method=SearchMethod.HYBRID,
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                rankingMethod=RankingMethod.RRF
+            ),
+            recency_parameters=RecencyParameters(
+                recency_field="timestamp",
+                scale="7d",
+                decay_to=0.5,
+            ),
+            result_count=10,
+        )
+
+        scores_both = {h["_id"]: h["_score"] for h in results_both["hits"]}
+        scores_lexical = {h["_id"]: h["_score"] for h in results_lexical_only["hits"]}
+
+        has_difference = any(
+            abs(scores_both.get(doc_id, 0) - scores_lexical.get(doc_id, 0)) > 0.001
+            for doc_id in set(scores_both) | set(scores_lexical)
+        )
+        self.assertTrue(has_difference,
+                        "Scores should differ between apply_to both vs lexical-only")
+
+    def test_apply_to_subqueries_empty_applies_to_neither(self):
+        """Test applyToSubqueries=[] applies recency to neither subquery (only global phase)."""
+        self._add_test_documents()
+
+        # With recency on neither subquery
+        results_none = tensor_search.search(
+            config=self.config,
+            index_name=self.main_index.name,
+            text="technology",
+            search_method=SearchMethod.HYBRID,
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                rankingMethod=RankingMethod.RRF
+            ),
+            recency_parameters=RecencyParameters(
+                recency_field="timestamp",
+                scale="7d",
+                decay_to=0.5,
+                apply_to_subqueries=[],
+            ),
+            result_count=10,
+        )
+
+        # With recency on both subqueries
+        results_both = tensor_search.search(
+            config=self.config,
+            index_name=self.main_index.name,
+            text="technology",
+            search_method=SearchMethod.HYBRID,
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                rankingMethod=RankingMethod.RRF
+            ),
+            recency_parameters=RecencyParameters(
+                recency_field="timestamp",
+                scale="7d",
+                decay_to=0.5,
+            ),
+            result_count=10,
+        )
+
+        # Verify we got results
+        self.assertGreater(len(results_none["hits"]), 0)
+        self.assertGreater(len(results_both["hits"]), 0)
+
+    def test_default_apply_to_subqueries_matches_existing_behavior(self):
+        """Test that default (None) matches existing behavior (both applied)."""
+        self._add_test_documents()
+
+        # Default (no applyToSubqueries)
+        results_default = tensor_search.search(
+            config=self.config,
+            index_name=self.main_index.name,
+            text="technology",
+            search_method=SearchMethod.HYBRID,
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                rankingMethod=RankingMethod.RRF
+            ),
+            recency_parameters=RecencyParameters(
+                recency_field="timestamp",
+                scale="7d",
+                decay_to=0.5,
+            ),
+            result_count=10,
+        )
+
+        # Explicit both
+        results_explicit_both = tensor_search.search(
+            config=self.config,
+            index_name=self.main_index.name,
+            text="technology",
+            search_method=SearchMethod.HYBRID,
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                rankingMethod=RankingMethod.RRF
+            ),
+            recency_parameters=RecencyParameters(
+                recency_field="timestamp",
+                scale="7d",
+                decay_to=0.5,
+                apply_to_subqueries=["tensor", "lexical"],
+            ),
+            result_count=10,
+        )
+
+        # Should produce identical results
+        self.assertEqual(len(results_default["hits"]), len(results_explicit_both["hits"]))
+        for hit_default, hit_explicit in zip(results_default["hits"], results_explicit_both["hits"]):
+            self.assertEqual(hit_default["_id"], hit_explicit["_id"])
+            self.assertAlmostEqual(hit_default["_score"], hit_explicit["_score"], places=5)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
+++ b/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
@@ -18,7 +18,7 @@ from marqo.core.models.marqo_index import *
 from marqo.core.models.marqo_index_request import FieldRequest
 from marqo.tensor_search import tensor_search
 from marqo.tensor_search.enums import SearchMethod
-from marqo.tensor_search.models.recency_parameters import RecencyParameters
+from marqo.tensor_search.models.recency_parameters import RecencyParameters, ApplyInRankingPhase
 from marqo.tensor_search.models.relevance_cutoff_model import (
     RelevanceCutoffModel, RelevanceCutoffMethod
 )
@@ -1561,27 +1561,22 @@ class TestRecencyCenterAndApplyToSubqueries(MarqoTestCase):
         cls.main_index = cls.indexes[0]
 
     def _add_test_documents(self):
-        """Add documents with known timestamps and varying content relevance.
-
-        doc-old has the highest BM25 relevance for "technology" (short doc = high term frequency)
-        but is the oldest. doc-recent has lower BM25 relevance but is the newest. This ensures
-        recency can flip rank order in subqueries.
-        """
+        """Add documents with known timestamps for testing."""
         now = datetime.now()
         documents = [
             {
                 "_id": "doc-recent",
-                "title": "recent document about technology and innovation in software engineering",
+                "title": "recent document about technology",
                 "timestamp": (now - timedelta(hours=1)).timestamp(),
             },
             {
                 "_id": "doc-old",
-                "title": "technology",
+                "title": "old document about technology",
                 "timestamp": (now - timedelta(days=14)).timestamp(),
             },
             {
                 "_id": "doc-medium",
-                "title": "medium age document about technology and computers",
+                "title": "medium age document about technology",
                 "timestamp": (now - timedelta(days=3)).timestamp(),
             },
         ]
@@ -1705,10 +1700,16 @@ class TestRecencyCenterAndApplyToSubqueries(MarqoTestCase):
         self.assertTrue(has_difference, "Scores should differ when using different center values")
 
     def test_apply_to_subqueries_tensor_only(self):
-        """Test applyToSubqueries=['tensor'] only applies recency to tensor subquery."""
+        """Test applyToSubqueries=['tensor'] applies recency only to tensor subquery.
+
+        Verifies the parameter is accepted and produces valid results.
+        Uses default (global-phase) recency to check that tensor-only produces
+        the same result as both (since global-phase recency applies identically
+        regardless of apply_to_subqueries in RRF).
+        """
         self._add_test_documents()
 
-        # With recency on both subqueries (aggressive decay so 14-day-old doc gets near-zero recency)
+        # With recency on both subqueries (default)
         results_both = tensor_search.search(
             config=self.config,
             index_name=self.main_index.name,
@@ -1720,8 +1721,8 @@ class TestRecencyCenterAndApplyToSubqueries(MarqoTestCase):
             ),
             recency_parameters=RecencyParameters(
                 recency_field="timestamp",
-                scale="1d",
-                decay_to=0.1,
+                scale="7d",
+                decay_to=0.5,
             ),
             result_count=10,
         )
@@ -1738,30 +1739,52 @@ class TestRecencyCenterAndApplyToSubqueries(MarqoTestCase):
             ),
             recency_parameters=RecencyParameters(
                 recency_field="timestamp",
-                scale="1d",
-                decay_to=0.1,
+                scale="7d",
+                decay_to=0.5,
                 apply_to_subqueries=["tensor"],
             ),
             result_count=10,
         )
 
-        # Results should be different (lexical subquery is not boosted in tensor_only)
-        scores_both = {h["_id"]: h["_score"] for h in results_both["hits"]}
-        scores_tensor = {h["_id"]: h["_score"] for h in results_tensor_only["hits"]}
+        # Without recency
+        results_no_recency = tensor_search.search(
+            config=self.config,
+            index_name=self.main_index.name,
+            text="technology",
+            search_method=SearchMethod.HYBRID,
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                rankingMethod=RankingMethod.RRF
+            ),
+            result_count=10,
+        )
 
-        # At least some scores should differ when recency is removed from lexical
+        # Verify we got results
+        self.assertGreater(len(results_both["hits"]), 0)
+        self.assertGreater(len(results_tensor_only["hits"]), 0)
+        self.assertGreater(len(results_no_recency["hits"]), 0)
+
+        # Recency (on both) should produce different scores than no recency
+        scores_both = {h["_id"]: h["_score"] for h in results_both["hits"]}
+        scores_no_recency = {h["_id"]: h["_score"] for h in results_no_recency["hits"]}
         has_difference = any(
-            abs(scores_both.get(doc_id, 0) - scores_tensor.get(doc_id, 0)) > 0.001
-            for doc_id in set(scores_both) | set(scores_tensor)
+            abs(scores_both.get(doc_id, 0) - scores_no_recency.get(doc_id, 0)) > 0.001
+            for doc_id in set(scores_both) | set(scores_no_recency)
         )
         self.assertTrue(has_difference,
-                        "Scores should differ between apply_to both vs tensor-only")
+                        "Recency should produce different scores than no recency")
 
     def test_apply_to_subqueries_lexical_only(self):
-        """Test applyToSubqueries=['lexical'] only applies recency to lexical subquery."""
+        """Test applyToSubqueries=['lexical'] applies recency only to lexical subquery.
+
+        Verifies the parameter is accepted and produces valid results.
+        Uses default (global-phase) recency to check that lexical-only produces
+        the same result as both (since global-phase recency applies identically
+        regardless of apply_to_subqueries in RRF).
+        """
         self._add_test_documents()
 
-        # With recency on lexical only (aggressive decay so 14-day-old doc gets near-zero recency)
+        # With recency on lexical only
         results_lexical_only = tensor_search.search(
             config=self.config,
             index_name=self.main_index.name,
@@ -1773,8 +1796,8 @@ class TestRecencyCenterAndApplyToSubqueries(MarqoTestCase):
             ),
             recency_parameters=RecencyParameters(
                 recency_field="timestamp",
-                scale="1d",
-                decay_to=0.1,
+                scale="7d",
+                decay_to=0.5,
                 apply_to_subqueries=["lexical"],
             ),
             result_count=10,
@@ -1792,21 +1815,39 @@ class TestRecencyCenterAndApplyToSubqueries(MarqoTestCase):
             ),
             recency_parameters=RecencyParameters(
                 recency_field="timestamp",
-                scale="1d",
-                decay_to=0.1,
+                scale="7d",
+                decay_to=0.5,
             ),
             result_count=10,
         )
 
-        scores_both = {h["_id"]: h["_score"] for h in results_both["hits"]}
-        scores_lexical = {h["_id"]: h["_score"] for h in results_lexical_only["hits"]}
+        # Without recency
+        results_no_recency = tensor_search.search(
+            config=self.config,
+            index_name=self.main_index.name,
+            text="technology",
+            search_method=SearchMethod.HYBRID,
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                rankingMethod=RankingMethod.RRF
+            ),
+            result_count=10,
+        )
 
+        # Verify we got results
+        self.assertGreater(len(results_both["hits"]), 0)
+        self.assertGreater(len(results_lexical_only["hits"]), 0)
+        self.assertGreater(len(results_no_recency["hits"]), 0)
+
+        # Recency (on both) should produce different scores than no recency
+        scores_both = {h["_id"]: h["_score"] for h in results_both["hits"]}
+        scores_no_recency = {h["_id"]: h["_score"] for h in results_no_recency["hits"]}
         has_difference = any(
-            abs(scores_both.get(doc_id, 0) - scores_lexical.get(doc_id, 0)) > 0.001
-            for doc_id in set(scores_both) | set(scores_lexical)
+            abs(scores_both.get(doc_id, 0) - scores_no_recency.get(doc_id, 0)) > 0.001
+            for doc_id in set(scores_both) | set(scores_no_recency)
         )
         self.assertTrue(has_difference,
-                        "Scores should differ between apply_to both vs lexical-only")
+                        "Recency should produce different scores than no recency")
 
     def test_apply_to_subqueries_empty_applies_to_neither(self):
         """Test applyToSubqueries=[] applies recency to neither subquery (only global phase)."""

--- a/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
+++ b/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_recency_scoring.py
@@ -1594,6 +1594,19 @@ class TestRecencyScoring(MarqoTestCase):
                     f"Error for '{description}' should contain '{expected_error}'"
                 )
 
+    def test_apply_to_subqueries_deduplicates(self):
+        """Duplicate values in applyToSubqueries are deduplicated."""
+        params = RecencyParameters(
+            recency_field="timestamp",
+            apply_to_subqueries=["tensor", "tensor"]
+        )
+        self.assertEqual(["tensor"], params.apply_to_subqueries)
+
+        params2 = RecencyParameters(
+            recency_field="timestamp",
+            apply_to_subqueries=["lexical", "tensor", "lexical"]
+        )
+        self.assertEqual(["lexical", "tensor"], params2.apply_to_subqueries)
 
     @pytest.mark.skip_for_multinode(
         "Multi-nodes will return different lexical results so we can not assert on the results.")

--- a/components/marqo/tests/unit_tests/marqo/core/models/test_marqo_index.py
+++ b/components/marqo/tests/unit_tests/marqo/core/models/test_marqo_index.py
@@ -774,3 +774,21 @@ class TestMarqoIndexSchemaVersion(MarqoTestCase):
                     **index_kwargs
                 )
                 self.assertEqual(index.index_supports_recency_grow, expected_result)
+
+    def test_index_supports_recency_center_and_subqueries(self):
+        """Test index_supports_recency_center_and_subqueries with different schema_template_version and marqo_version values."""
+        test_cases = [
+            ("schema_template_version == 2.25.0 (not supported)", {"schema_template_version": "2.25.0"}, False),
+            ("schema_template_version >= 2.25.1", {"schema_template_version": "2.25.1"}, True),
+            ("schema_template_version > 2.25.1", {"schema_template_version": "2.25.2"}, True),
+            ("schema_template_version None, marqo_version >= 2.25.1", {"marqo_version": "2.25.1", "schema_template_version": None}, True),
+            ("schema_template_version None, marqo_version < 2.25.1", {"marqo_version": "2.25.0", "schema_template_version": None}, False),
+        ]
+
+        for case_name, index_kwargs, expected_result in test_cases:
+            with self.subTest(case=case_name):
+                index = self.semi_structured_marqo_index(
+                    name="test_index",
+                    **index_kwargs
+                )
+                self.assertEqual(index.index_supports_recency_center_and_subqueries, expected_result)

--- a/components/marqo/tests/unit_tests/marqo/core/search/test_hybrid_search.py
+++ b/components/marqo/tests/unit_tests/marqo/core/search/test_hybrid_search.py
@@ -585,6 +585,84 @@ class TestRecencyValidation(TestCase):
         self.assertIn("growFrom", str(ctx.exception))
         self.assertIn(str(constants.MARQO_RECENCY_GROW_MINIMUM_VERSION), str(ctx.exception))
 
+    @patch('marqo.core.search.hybrid_search.RequestMetricsStore')
+    def test_center_recency_on_old_schema_version_raises_error(self, mock_metrics):
+        """Test that recency center parameter on old schema version raises UnsupportedFeatureError."""
+        self._setup_metrics_mock(mock_metrics)
+
+        marqo_index = Mock(spec=SemiStructuredMarqoIndex)
+        marqo_index.name = "test_index"
+        marqo_index.schema_template_version = "2.25.0"
+        marqo_index.marqo_version = "2.25.0"
+        marqo_index.model = Mock()
+        marqo_index.model.get_text_query_prefix.return_value = ""
+        marqo_index.parsed_marqo_version.return_value = semver.VersionInfo.parse("2.25.0")
+        type(marqo_index).index_supports_recency_scoring = PropertyMock(return_value=True)
+        type(marqo_index).index_supports_recency_grow = PropertyMock(return_value=True)
+        type(marqo_index).index_supports_recency_center_and_subqueries = PropertyMock(return_value=False)
+
+        config = Mock(spec=Config)
+
+        recency_params = RecencyParameters(
+            recency_field="timestamp",
+            scale="7d",
+            decay_function="exponential",
+            decay_to=0.5,
+            center=1234.0,
+        )
+
+        hybrid_search = HybridSearch()
+        with self.assertRaises(UnsupportedFeatureError) as ctx:
+            hybrid_search.search(
+                config=config,
+                marqo_index=marqo_index,
+                query="test",
+                hybrid_parameters=HybridParameters(),
+                recency_parameters=recency_params
+            )
+
+        self.assertIn("center", str(ctx.exception))
+        self.assertIn(str(constants.MARQO_RECENCY_CENTER_AND_SUBQUERIES_MINIMUM_VERSION), str(ctx.exception))
+
+    @patch('marqo.core.search.hybrid_search.RequestMetricsStore')
+    def test_apply_to_subqueries_on_old_schema_version_raises_error(self, mock_metrics):
+        """Test that recency applyToSubqueries parameter on old schema version raises UnsupportedFeatureError."""
+        self._setup_metrics_mock(mock_metrics)
+
+        marqo_index = Mock(spec=SemiStructuredMarqoIndex)
+        marqo_index.name = "test_index"
+        marqo_index.schema_template_version = "2.25.0"
+        marqo_index.marqo_version = "2.25.0"
+        marqo_index.model = Mock()
+        marqo_index.model.get_text_query_prefix.return_value = ""
+        marqo_index.parsed_marqo_version.return_value = semver.VersionInfo.parse("2.25.0")
+        type(marqo_index).index_supports_recency_scoring = PropertyMock(return_value=True)
+        type(marqo_index).index_supports_recency_grow = PropertyMock(return_value=True)
+        type(marqo_index).index_supports_recency_center_and_subqueries = PropertyMock(return_value=False)
+
+        config = Mock(spec=Config)
+
+        recency_params = RecencyParameters(
+            recency_field="timestamp",
+            scale="7d",
+            decay_function="exponential",
+            decay_to=0.5,
+            apply_to_subqueries=["tensor"],
+        )
+
+        hybrid_search = HybridSearch()
+        with self.assertRaises(UnsupportedFeatureError) as ctx:
+            hybrid_search.search(
+                config=config,
+                marqo_index=marqo_index,
+                query="test",
+                hybrid_parameters=HybridParameters(),
+                recency_parameters=recency_params
+            )
+
+        self.assertIn("applyToSubqueries", str(ctx.exception))
+        self.assertIn(str(constants.MARQO_RECENCY_CENTER_AND_SUBQUERIES_MINIMUM_VERSION), str(ctx.exception))
+
     @patch('marqo.core.search.hybrid_search.vespa_index_factory')
     @patch('marqo.core.search.hybrid_search.run_vectorise_pipeline')
     @patch('marqo.core.search.hybrid_search.utils.parse_lexical_query')

--- a/components/marqo/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_recency_query_input.py
+++ b/components/marqo/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_recency_query_input.py
@@ -681,7 +681,7 @@ class TestRecencyQueryInput(unittest.TestCase):
     # ============= ApplyToSubqueries Parameter Tests =============
 
     def test_apply_to_subqueries_default(self):
-        """Test apply_to_subqueries default (None) sets both flags to 1 as top-level query properties."""
+        """Test apply_to_subqueries default (None) sets both flags to True as top-level query properties."""
         recency_params = RecencyParameters(
             recency_field="timestamp",
             scale="7d",
@@ -699,13 +699,13 @@ class TestRecencyQueryInput(unittest.TestCase):
             result = self.vespa_index._to_vespa_hybrid_query(query)
 
         # Flags should be top-level query properties, not in query_features
-        self.assertEqual(result[constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR], 1)
-        self.assertEqual(result[constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL], 1)
+        self.assertEqual(result[constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR], True)
+        self.assertEqual(result[constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL], True)
         self.assertNotIn(constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR, result['query_features'])
         self.assertNotIn(constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL, result['query_features'])
 
     def test_apply_to_subqueries_tensor_only(self):
-        """Test apply_to_subqueries=['tensor'] sets only tensor flag to 1 as top-level query properties."""
+        """Test apply_to_subqueries=['tensor'] sets only tensor flag to True as top-level query properties."""
         recency_params = RecencyParameters(
             recency_field="timestamp",
             scale="7d",
@@ -722,11 +722,11 @@ class TestRecencyQueryInput(unittest.TestCase):
             mock_parent.return_value = {'query_features': {}}
             result = self.vespa_index._to_vespa_hybrid_query(query)
 
-        self.assertEqual(result[constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR], 1)
-        self.assertEqual(result[constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL], 0)
+        self.assertEqual(result[constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR], True)
+        self.assertEqual(result[constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL], False)
 
     def test_apply_to_subqueries_lexical_only(self):
-        """Test apply_to_subqueries=['lexical'] sets only lexical flag to 1 as top-level query properties."""
+        """Test apply_to_subqueries=['lexical'] sets only lexical flag to True as top-level query properties."""
         recency_params = RecencyParameters(
             recency_field="timestamp",
             scale="7d",
@@ -743,11 +743,11 @@ class TestRecencyQueryInput(unittest.TestCase):
             mock_parent.return_value = {'query_features': {}}
             result = self.vespa_index._to_vespa_hybrid_query(query)
 
-        self.assertEqual(result[constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR], 0)
-        self.assertEqual(result[constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL], 1)
+        self.assertEqual(result[constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR], False)
+        self.assertEqual(result[constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL], True)
 
     def test_apply_to_subqueries_empty_list(self):
-        """Test apply_to_subqueries=[] sets both flags to 0 as top-level query properties."""
+        """Test apply_to_subqueries=[] sets both flags to False as top-level query properties."""
         recency_params = RecencyParameters(
             recency_field="timestamp",
             scale="7d",
@@ -764,8 +764,8 @@ class TestRecencyQueryInput(unittest.TestCase):
             mock_parent.return_value = {'query_features': {}}
             result = self.vespa_index._to_vespa_hybrid_query(query)
 
-        self.assertEqual(result[constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR], 0)
-        self.assertEqual(result[constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL], 0)
+        self.assertEqual(result[constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR], False)
+        self.assertEqual(result[constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL], False)
 
 
 if __name__ == '__main__':

--- a/components/marqo/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_recency_query_input.py
+++ b/components/marqo/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_recency_query_input.py
@@ -681,7 +681,7 @@ class TestRecencyQueryInput(unittest.TestCase):
     # ============= ApplyToSubqueries Parameter Tests =============
 
     def test_apply_to_subqueries_default(self):
-        """Test apply_to_subqueries default (None) sets both flags to 1 in hybrid query."""
+        """Test apply_to_subqueries default (None) sets both flags to 1 as top-level query properties."""
         recency_params = RecencyParameters(
             recency_field="timestamp",
             scale="7d",
@@ -698,12 +698,14 @@ class TestRecencyQueryInput(unittest.TestCase):
             mock_parent.return_value = {'query_features': {}}
             result = self.vespa_index._to_vespa_hybrid_query(query)
 
-        query_input = result['query_features']
-        self.assertEqual(query_input[constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR], 1)
-        self.assertEqual(query_input[constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL], 1)
+        # Flags should be top-level query properties, not in query_features
+        self.assertEqual(result[constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR], 1)
+        self.assertEqual(result[constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL], 1)
+        self.assertNotIn(constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR, result['query_features'])
+        self.assertNotIn(constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL, result['query_features'])
 
     def test_apply_to_subqueries_tensor_only(self):
-        """Test apply_to_subqueries=['tensor'] sets only tensor flag to 1."""
+        """Test apply_to_subqueries=['tensor'] sets only tensor flag to 1 as top-level query properties."""
         recency_params = RecencyParameters(
             recency_field="timestamp",
             scale="7d",
@@ -720,12 +722,11 @@ class TestRecencyQueryInput(unittest.TestCase):
             mock_parent.return_value = {'query_features': {}}
             result = self.vespa_index._to_vespa_hybrid_query(query)
 
-        query_input = result['query_features']
-        self.assertEqual(query_input[constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR], 1)
-        self.assertEqual(query_input[constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL], 0)
+        self.assertEqual(result[constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR], 1)
+        self.assertEqual(result[constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL], 0)
 
     def test_apply_to_subqueries_lexical_only(self):
-        """Test apply_to_subqueries=['lexical'] sets only lexical flag to 1."""
+        """Test apply_to_subqueries=['lexical'] sets only lexical flag to 1 as top-level query properties."""
         recency_params = RecencyParameters(
             recency_field="timestamp",
             scale="7d",
@@ -742,12 +743,11 @@ class TestRecencyQueryInput(unittest.TestCase):
             mock_parent.return_value = {'query_features': {}}
             result = self.vespa_index._to_vespa_hybrid_query(query)
 
-        query_input = result['query_features']
-        self.assertEqual(query_input[constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR], 0)
-        self.assertEqual(query_input[constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL], 1)
+        self.assertEqual(result[constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR], 0)
+        self.assertEqual(result[constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL], 1)
 
     def test_apply_to_subqueries_empty_list(self):
-        """Test apply_to_subqueries=[] sets both flags to 0."""
+        """Test apply_to_subqueries=[] sets both flags to 0 as top-level query properties."""
         recency_params = RecencyParameters(
             recency_field="timestamp",
             scale="7d",
@@ -764,9 +764,8 @@ class TestRecencyQueryInput(unittest.TestCase):
             mock_parent.return_value = {'query_features': {}}
             result = self.vespa_index._to_vespa_hybrid_query(query)
 
-        query_input = result['query_features']
-        self.assertEqual(query_input[constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR], 0)
-        self.assertEqual(query_input[constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL], 0)
+        self.assertEqual(result[constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR], 0)
+        self.assertEqual(result[constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL], 0)
 
 
 if __name__ == '__main__':

--- a/components/marqo/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_recency_query_input.py
+++ b/components/marqo/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_recency_query_input.py
@@ -194,6 +194,7 @@ class TestRecencyQueryInput(unittest.TestCase):
                     constants.QUERY_INPUT_RECENCY_TIMESTAMP_KEY: {"created_at": 1.0},
                     constants.QUERY_INPUT_RECENCY_DECAY_FUNCTION_TYPE: 0,
                     constants.QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT: 0.0,
+                    constants.QUERY_INPUT_RECENCY_CENTER_SECONDS: 0,
                     # Grow parameters (disabled by default)
                     constants.QUERY_INPUT_RECENCY_GROW_ENABLED: 0,
                     constants.QUERY_INPUT_RECENCY_GROW_FROM: 1.0,
@@ -221,6 +222,7 @@ class TestRecencyQueryInput(unittest.TestCase):
                     constants.QUERY_INPUT_RECENCY_TIMESTAMP_KEY: {"updated_at": 1.0},
                     constants.QUERY_INPUT_RECENCY_DECAY_FUNCTION_TYPE: 1,
                     constants.QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT: 0.0,
+                    constants.QUERY_INPUT_RECENCY_CENTER_SECONDS: 0,
                     # Grow parameters (disabled by default)
                     constants.QUERY_INPUT_RECENCY_GROW_ENABLED: 0,
                     constants.QUERY_INPUT_RECENCY_GROW_FROM: 1.0,
@@ -248,6 +250,7 @@ class TestRecencyQueryInput(unittest.TestCase):
                     constants.QUERY_INPUT_RECENCY_TIMESTAMP_KEY: {"publish_date": 1.0},
                     constants.QUERY_INPUT_RECENCY_DECAY_FUNCTION_TYPE: 2,
                     constants.QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT: 0.0,
+                    constants.QUERY_INPUT_RECENCY_CENTER_SECONDS: 0,
                     # Grow parameters (disabled by default)
                     constants.QUERY_INPUT_RECENCY_GROW_ENABLED: 0,
                     constants.QUERY_INPUT_RECENCY_GROW_FROM: 1.0,
@@ -275,6 +278,7 @@ class TestRecencyQueryInput(unittest.TestCase):
                     constants.QUERY_INPUT_RECENCY_TIMESTAMP_KEY: {"event_time": 1.0},
                     constants.QUERY_INPUT_RECENCY_DECAY_FUNCTION_TYPE: 3,
                     constants.QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT: 0.0,
+                    constants.QUERY_INPUT_RECENCY_CENTER_SECONDS: 0,
                     # Grow parameters (disabled by default)
                     constants.QUERY_INPUT_RECENCY_GROW_ENABLED: 0,
                     constants.QUERY_INPUT_RECENCY_GROW_FROM: 1.0,
@@ -303,6 +307,7 @@ class TestRecencyQueryInput(unittest.TestCase):
                     constants.QUERY_INPUT_RECENCY_TIMESTAMP_KEY: {"created_at": 1.0},
                     constants.QUERY_INPUT_RECENCY_DECAY_FUNCTION_TYPE: 0,
                     constants.QUERY_INPUT_RECENCY_ADD_TO_SCORE_WEIGHT: 0.5,
+                    constants.QUERY_INPUT_RECENCY_CENTER_SECONDS: 0,
                     # Grow parameters (disabled by default)
                     constants.QUERY_INPUT_RECENCY_GROW_ENABLED: 0,
                     constants.QUERY_INPUT_RECENCY_GROW_FROM: 1.0,
@@ -635,6 +640,133 @@ class TestRecencyQueryInput(unittest.TestCase):
                         expected_value,
                         f"Key {key}: expected {expected_value}, got {result.get(key)}"
                     )
+
+
+    # ============= Center Parameter Tests =============
+
+    def test_center_default_zero(self):
+        """Test center defaults to 0 (sentinel for 'use now()') when None."""
+        params = RecencyParameters(recency_field="created_at")
+        result = self.vespa_index._get_recency_query_input(params)
+
+        self.assertEqual(
+            result[constants.QUERY_INPUT_RECENCY_CENTER_SECONDS],
+            0
+        )
+
+    def test_center_passed_correctly(self):
+        """Test center values are passed through correctly."""
+        center_values = [1709232000.0, 0, 1000000000, 9999999999.9]
+
+        for center in center_values:
+            with self.subTest(center=center):
+                params = RecencyParameters(
+                    recency_field="created_at",
+                    center=center
+                )
+                result = self.vespa_index._get_recency_query_input(params)
+
+                self.assertEqual(
+                    result[constants.QUERY_INPUT_RECENCY_CENTER_SECONDS],
+                    center
+                )
+
+    def test_center_in_all_query_constants(self):
+        """Test that center_seconds constant is present in output."""
+        params = RecencyParameters(recency_field="created_at")
+        result = self.vespa_index._get_recency_query_input(params)
+
+        self.assertIn(constants.QUERY_INPUT_RECENCY_CENTER_SECONDS, result)
+
+    # ============= ApplyToSubqueries Parameter Tests =============
+
+    def test_apply_to_subqueries_default(self):
+        """Test apply_to_subqueries default (None) sets both flags to 1 in hybrid query."""
+        recency_params = RecencyParameters(
+            recency_field="timestamp",
+            scale="7d",
+            offset="0d",
+            decay_function="exponential",
+            decay_to=0.5,
+        )
+
+        query = self._create_hybrid_query_with_recency("all")
+        # Override to use default apply_to_subqueries (None)
+        query.recency_parameters = recency_params
+
+        with patch('marqo.core.structured_vespa_index.structured_vespa_index.StructuredVespaIndex._to_vespa_hybrid_query') as mock_parent:
+            mock_parent.return_value = {'query_features': {}}
+            result = self.vespa_index._to_vespa_hybrid_query(query)
+
+        query_input = result['query_features']
+        self.assertEqual(query_input[constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR], 1)
+        self.assertEqual(query_input[constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL], 1)
+
+    def test_apply_to_subqueries_tensor_only(self):
+        """Test apply_to_subqueries=['tensor'] sets only tensor flag to 1."""
+        recency_params = RecencyParameters(
+            recency_field="timestamp",
+            scale="7d",
+            offset="0d",
+            decay_function="exponential",
+            decay_to=0.5,
+            apply_to_subqueries=["tensor"]
+        )
+
+        query = self._create_hybrid_query_with_recency("all")
+        query.recency_parameters = recency_params
+
+        with patch('marqo.core.structured_vespa_index.structured_vespa_index.StructuredVespaIndex._to_vespa_hybrid_query') as mock_parent:
+            mock_parent.return_value = {'query_features': {}}
+            result = self.vespa_index._to_vespa_hybrid_query(query)
+
+        query_input = result['query_features']
+        self.assertEqual(query_input[constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR], 1)
+        self.assertEqual(query_input[constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL], 0)
+
+    def test_apply_to_subqueries_lexical_only(self):
+        """Test apply_to_subqueries=['lexical'] sets only lexical flag to 1."""
+        recency_params = RecencyParameters(
+            recency_field="timestamp",
+            scale="7d",
+            offset="0d",
+            decay_function="exponential",
+            decay_to=0.5,
+            apply_to_subqueries=["lexical"]
+        )
+
+        query = self._create_hybrid_query_with_recency("all")
+        query.recency_parameters = recency_params
+
+        with patch('marqo.core.structured_vespa_index.structured_vespa_index.StructuredVespaIndex._to_vespa_hybrid_query') as mock_parent:
+            mock_parent.return_value = {'query_features': {}}
+            result = self.vespa_index._to_vespa_hybrid_query(query)
+
+        query_input = result['query_features']
+        self.assertEqual(query_input[constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR], 0)
+        self.assertEqual(query_input[constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL], 1)
+
+    def test_apply_to_subqueries_empty_list(self):
+        """Test apply_to_subqueries=[] sets both flags to 0."""
+        recency_params = RecencyParameters(
+            recency_field="timestamp",
+            scale="7d",
+            offset="0d",
+            decay_function="exponential",
+            decay_to=0.5,
+            apply_to_subqueries=[]
+        )
+
+        query = self._create_hybrid_query_with_recency("all")
+        query.recency_parameters = recency_params
+
+        with patch('marqo.core.structured_vespa_index.structured_vespa_index.StructuredVespaIndex._to_vespa_hybrid_query') as mock_parent:
+            mock_parent.return_value = {'query_features': {}}
+            result = self.vespa_index._to_vespa_hybrid_query(query)
+
+        query_input = result['query_features']
+        self.assertEqual(query_input[constants.QUERY_INPUT_RECENCY_APPLY_TO_TENSOR], 0)
+        self.assertEqual(query_input[constants.QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL], 0)
 
 
 if __name__ == '__main__':

--- a/components/marqo/tests/unit_tests/marqo/tensor_search/models/test_api_models.py
+++ b/components/marqo/tests/unit_tests/marqo/tensor_search/models/test_api_models.py
@@ -549,6 +549,104 @@ class TestSearchQuery(unittest.TestCase):
                     self.assertIsNotNone(search_query.sort_by)
 
 
+    def test_apply_to_subqueries_only_for_hybrid_search(self):
+        """Test that applyToSubqueries is only allowed for hybrid search."""
+        recency_params = RecencyParameters(
+            recency_field="created_at",
+            apply_to_subqueries=["tensor"]
+        )
+
+        # Valid: hybrid search with applyToSubqueries
+        with self.subTest("hybrid_valid"):
+            search_query = SearchQuery(
+                q="test query",
+                searchMethod=SearchMethod.HYBRID,
+                recencyParameters=recency_params
+            )
+            self.assertIsNotNone(search_query.recencyParameters)
+
+        # Invalid: tensor search with applyToSubqueries
+        with self.subTest("tensor_invalid"):
+            with self.assertRaises(ValidationError) as cm:
+                SearchQuery(
+                    q="test query",
+                    searchMethod=SearchMethod.TENSOR,
+                    recencyParameters=recency_params
+                )
+            # Should fail on "Recency parameters can only be provided for 'HYBRID' search"
+            self.assertIn("HYBRID", str(cm.exception))
+
+        # Invalid: lexical search with applyToSubqueries
+        with self.subTest("lexical_invalid"):
+            with self.assertRaises(ValidationError) as cm:
+                SearchQuery(
+                    q="test query",
+                    searchMethod=SearchMethod.LEXICAL,
+                    recencyParameters=recency_params
+                )
+            self.assertIn("HYBRID", str(cm.exception))
+
+    def test_apply_to_subqueries_only_for_rrf_ranking(self):
+        """Test that applyToSubqueries is only allowed with RRF ranking method."""
+        recency_params = RecencyParameters(
+            recency_field="created_at",
+            apply_to_subqueries=["tensor"]
+        )
+
+        # Valid: RRF ranking (explicit)
+        with self.subTest("rrf_explicit"):
+            search_query = SearchQuery(
+                q="test query",
+                searchMethod=SearchMethod.HYBRID,
+                hybridParameters=HybridParameters(rankingMethod=RankingMethod.RRF),
+                recencyParameters=recency_params
+            )
+            self.assertIsNotNone(search_query.recencyParameters)
+
+        # Valid: default ranking (which is RRF)
+        with self.subTest("default_ranking"):
+            search_query = SearchQuery(
+                q="test query",
+                searchMethod=SearchMethod.HYBRID,
+                recencyParameters=recency_params
+            )
+            self.assertIsNotNone(search_query.recencyParameters)
+
+        # Invalid: non-RRF ranking methods
+        non_rrf_methods = [
+            ("tensor_ranking", RankingMethod.Tensor, RetrievalMethod.Lexical),
+            ("lexical_ranking", RankingMethod.Lexical, RetrievalMethod.Tensor),
+        ]
+
+        for test_name, ranking_method, retrieval_method in non_rrf_methods:
+            with self.subTest(test_name):
+                with self.assertRaises(ValidationError) as cm:
+                    SearchQuery(
+                        q="test query",
+                        searchMethod=SearchMethod.HYBRID,
+                        hybridParameters=HybridParameters(
+                            rankingMethod=ranking_method,
+                            retrievalMethod=retrieval_method
+                        ),
+                        recencyParameters=recency_params
+                    )
+                self.assertIn("rrf", str(cm.exception).lower())
+
+        # Valid: applyToSubqueries is None (no restriction even with non-RRF)
+        with self.subTest("apply_to_subqueries_none_with_tensor_ranking"):
+            recency_params_no_apply = RecencyParameters(recency_field="created_at")
+            search_query = SearchQuery(
+                q="test query",
+                searchMethod=SearchMethod.HYBRID,
+                hybridParameters=HybridParameters(
+                    rankingMethod=RankingMethod.Tensor,
+                    retrievalMethod=RetrievalMethod.Lexical
+                ),
+                recencyParameters=recency_params_no_apply
+            )
+            self.assertIsNotNone(search_query.recencyParameters)
+
+
 class TestCustomVectorQuery(unittest.TestCase):
 
     def test_custom_vector_query_creation(self):

--- a/components/marqo/tests/unit_tests/marqo/tensor_search/models/test_api_models.py
+++ b/components/marqo/tests/unit_tests/marqo/tensor_search/models/test_api_models.py
@@ -612,13 +612,13 @@ class TestSearchQuery(unittest.TestCase):
             )
             self.assertIsNotNone(search_query.recencyParameters)
 
-        # Invalid: non-RRF ranking methods
-        non_rrf_methods = [
-            ("tensor_ranking", RankingMethod.Tensor, RetrievalMethod.Lexical),
-            ("lexical_ranking", RankingMethod.Lexical, RetrievalMethod.Tensor),
+        # Invalid: non-Disjunction retrieval methods
+        non_disjunction_methods = [
+            ("lexical_retrieval", RankingMethod.Lexical, RetrievalMethod.Lexical),
+            ("tensor_retrieval", RankingMethod.Tensor, RetrievalMethod.Tensor),
         ]
 
-        for test_name, ranking_method, retrieval_method in non_rrf_methods:
+        for test_name, ranking_method, retrieval_method in non_disjunction_methods:
             with self.subTest(test_name):
                 with self.assertRaises(ValidationError) as cm:
                     SearchQuery(
@@ -630,9 +630,9 @@ class TestSearchQuery(unittest.TestCase):
                         ),
                         recencyParameters=recency_params
                     )
-                self.assertIn("rrf", str(cm.exception).lower())
+                self.assertIn("disjunction", str(cm.exception).lower())
 
-        # Valid: applyToSubqueries is None (no restriction even with non-RRF)
+        # Valid: applyToSubqueries is None (no restriction even with non-Disjunction)
         with self.subTest("apply_to_subqueries_none_with_tensor_ranking"):
             recency_params_no_apply = RecencyParameters(recency_field="created_at")
             search_query = SearchQuery(

--- a/components/marqo/tests/unit_tests/marqo/tensor_search/models/test_recency_parameters.py
+++ b/components/marqo/tests/unit_tests/marqo/tensor_search/models/test_recency_parameters.py
@@ -709,3 +709,112 @@ class TestRecencyParameters(unittest.TestCase):
         self.assertEqual(params.grow_function, "gaussian")
         self.assertEqual(params.grow_scale, "21d")
         self.assertEqual(params.grow_offset, "3d")
+
+    # ============= Center Parameter Tests =============
+
+    def test_center_validation(self):
+        """Test center field validation."""
+        # Valid center values
+        valid_values = [
+            ("positive_float", 1709232000.0),
+            ("zero", 0),
+            ("large_value", 9999999999.9),
+        ]
+
+        for test_name, center in valid_values:
+            with self.subTest(test_name):
+                params = RecencyParameters(
+                    recency_field="created_at",
+                    center=center
+                )
+                self.assertEqual(params.center, center)
+
+        # Invalid center values
+        invalid_values = [
+            ("negative", -1.0),
+            ("negative_large", -1709232000.0),
+        ]
+
+        for test_name, center in invalid_values:
+            with self.subTest(test_name):
+                with self.assertRaises(ValidationError) as exc_info:
+                    RecencyParameters(
+                        recency_field="created_at",
+                        center=center
+                    )
+                error_str = str(exc_info.exception)
+                self.assertIn("center", error_str.lower())
+
+    def test_center_default_none(self):
+        """Test center defaults to None."""
+        params = RecencyParameters(recency_field="created_at")
+        self.assertIsNone(params.center)
+
+    def test_center_alias(self):
+        """Test center alias works."""
+        params = RecencyParameters(
+            recency_field="created_at",
+            center=1709232000.0
+        )
+        self.assertEqual(params.center, 1709232000.0)
+
+        # Test dict serialization with alias
+        result = params.dict(by_alias=True)
+        self.assertIn('center', result)
+        self.assertEqual(result['center'], 1709232000.0)
+
+    # ============= ApplyToSubqueries Parameter Tests =============
+
+    def test_apply_to_subqueries_validation(self):
+        """Test apply_to_subqueries field validation."""
+        # Valid values
+        valid_values = [
+            ("tensor_only", ["tensor"]),
+            ("lexical_only", ["lexical"]),
+            ("both", ["tensor", "lexical"]),
+            ("empty_list", []),
+        ]
+
+        for test_name, apply_to in valid_values:
+            with self.subTest(test_name):
+                params = RecencyParameters(
+                    recency_field="created_at",
+                    apply_to_subqueries=apply_to
+                )
+                self.assertEqual(params.apply_to_subqueries, apply_to)
+
+        # Invalid values
+        invalid_values = [
+            ("invalid_string", ["invalid"]),
+            ("mixed_invalid", ["tensor", "invalid"]),
+            ("uppercase", ["TENSOR"]),
+        ]
+
+        for test_name, apply_to in invalid_values:
+            with self.subTest(test_name):
+                with self.assertRaises(ValidationError) as exc_info:
+                    RecencyParameters(
+                        recency_field="created_at",
+                        apply_to_subqueries=apply_to
+                    )
+                error_str = str(exc_info.exception)
+                self.assertIn("apply_to_subqueries", error_str.lower().replace(" ", "_")
+                              .replace("applytosubqueries", "apply_to_subqueries"))
+
+    def test_apply_to_subqueries_default_none(self):
+        """Test apply_to_subqueries defaults to None."""
+        params = RecencyParameters(recency_field="created_at")
+        self.assertIsNone(params.apply_to_subqueries)
+
+    def test_apply_to_subqueries_alias(self):
+        """Test applyToSubqueries alias works."""
+        params = RecencyParameters(
+            recency_field="created_at",
+            applyToSubqueries=["tensor"]
+        )
+        self.assertEqual(params.apply_to_subqueries, ["tensor"])
+
+        # Test dict serialization with alias
+        result = params.dict(by_alias=True)
+        self.assertIn('applyToSubqueries', result)
+        self.assertEqual(result['applyToSubqueries'], ["tensor"])

--- a/components/marqo/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
+++ b/components/marqo/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
@@ -53,6 +53,9 @@ public class HybridSearcher extends Searcher {
     private static String QUERY_INPUT_MULT_WEIGHTS_GLOBAL = "marqo__mult_weights_global";
     private static String QUERY_INPUT_ADD_WEIGHTS_GLOBAL = "marqo__add_weights_global";
     private static String QUERY_INPUT_RECENCY_TIMESTAMP_KEY = "marqo__recency_timestamp_key";
+    private static String QUERY_INPUT_RECENCY_SHOULD_APPLY_SCORE = "marqo__recency_should_apply_score";
+    private static String QUERY_INPUT_RECENCY_APPLY_TO_TENSOR = "marqo__recency_apply_to_tensor";
+    private static String QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL = "marqo__recency_apply_to_lexical";
     private static String MARQO_SEARCH_METHOD_LEXICAL = "lexical";
     private static String MARQO_SEARCH_METHOD_TENSOR = "tensor";
     private static String QUERY_RERANK_COUNT = "ranking.rerankCount";
@@ -1377,6 +1380,28 @@ public class HybridSearcher extends Searcher {
                     (cell) -> addFieldToRankFeatures(cell, queryNew, verbose));
         } else {
             logIfVerbose("Recency timestamp key tensor is null - not present in query", verbose);
+        }
+
+        // Check applyToSubqueries flags and override recency if this subquery type shouldn't get it
+        int applyRecencyToTensor = query.properties().getInteger(
+                QUERY_INPUT_RECENCY_APPLY_TO_TENSOR, 1);
+        int applyRecencyToLexical = query.properties().getInteger(
+                QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL, 1);
+
+        boolean shouldDisableRecency = false;
+        if (retrievalMethod.equals(MARQO_SEARCH_METHOD_TENSOR) && applyRecencyToTensor == 0) {
+            shouldDisableRecency = true;
+        } else if (retrievalMethod.equals(MARQO_SEARCH_METHOD_LEXICAL) && applyRecencyToLexical == 0) {
+            shouldDisableRecency = true;
+        }
+
+        if (shouldDisableRecency) {
+            logIfVerbose(
+                    String.format("Disabling recency for %s subquery based on applyToSubqueries",
+                            retrievalMethod),
+                    verbose);
+            queryNew.getRanking().getFeatures()
+                    .put(addQueryWrapper(QUERY_INPUT_RECENCY_SHOULD_APPLY_SCORE), 0.0);
         }
 
         // Set rank profile (using RANKING method)

--- a/components/marqo/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
+++ b/components/marqo/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
@@ -53,7 +53,8 @@ public class HybridSearcher extends Searcher {
     private static String QUERY_INPUT_MULT_WEIGHTS_GLOBAL = "marqo__mult_weights_global";
     private static String QUERY_INPUT_ADD_WEIGHTS_GLOBAL = "marqo__add_weights_global";
     private static String QUERY_INPUT_RECENCY_TIMESTAMP_KEY = "marqo__recency_timestamp_key";
-    private static String QUERY_INPUT_RECENCY_SHOULD_APPLY_SCORE = "marqo__recency_should_apply_score";
+    private static String QUERY_INPUT_RECENCY_SHOULD_APPLY_SCORE =
+            "marqo__recency_should_apply_score";
     private static String QUERY_INPUT_RECENCY_APPLY_TO_TENSOR = "marqo__recency_apply_to_tensor";
     private static String QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL = "marqo__recency_apply_to_lexical";
     private static String MARQO_SEARCH_METHOD_LEXICAL = "lexical";
@@ -1383,24 +1384,27 @@ public class HybridSearcher extends Searcher {
         }
 
         // Check applyToSubqueries flags and override recency if this subquery type shouldn't get it
-        int applyRecencyToTensor = query.properties().getInteger(
-                QUERY_INPUT_RECENCY_APPLY_TO_TENSOR, 1);
-        int applyRecencyToLexical = query.properties().getInteger(
-                QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL, 1);
+        int applyRecencyToTensor =
+                query.properties().getInteger(QUERY_INPUT_RECENCY_APPLY_TO_TENSOR, 1);
+        int applyRecencyToLexical =
+                query.properties().getInteger(QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL, 1);
 
         boolean shouldDisableRecency = false;
         if (retrievalMethod.equals(MARQO_SEARCH_METHOD_TENSOR) && applyRecencyToTensor == 0) {
             shouldDisableRecency = true;
-        } else if (retrievalMethod.equals(MARQO_SEARCH_METHOD_LEXICAL) && applyRecencyToLexical == 0) {
+        } else if (retrievalMethod.equals(MARQO_SEARCH_METHOD_LEXICAL)
+                && applyRecencyToLexical == 0) {
             shouldDisableRecency = true;
         }
 
         if (shouldDisableRecency) {
             logIfVerbose(
-                    String.format("Disabling recency for %s subquery based on applyToSubqueries",
+                    String.format(
+                            "Disabling recency for %s subquery based on applyToSubqueries",
                             retrievalMethod),
                     verbose);
-            queryNew.getRanking().getFeatures()
+            queryNew.getRanking()
+                    .getFeatures()
                     .put(addQueryWrapper(QUERY_INPUT_RECENCY_SHOULD_APPLY_SCORE), 0.0);
         }
 

--- a/components/marqo/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
+++ b/components/marqo/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
@@ -1384,16 +1384,15 @@ public class HybridSearcher extends Searcher {
         }
 
         // Check applyToSubqueries flags and override recency if this subquery type shouldn't get it
-        int applyRecencyToTensor =
-                query.properties().getInteger(QUERY_INPUT_RECENCY_APPLY_TO_TENSOR, 1);
-        int applyRecencyToLexical =
-                query.properties().getInteger(QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL, 1);
+        boolean applyRecencyToTensor =
+                query.properties().getBoolean(QUERY_INPUT_RECENCY_APPLY_TO_TENSOR, true);
+        boolean applyRecencyToLexical =
+                query.properties().getBoolean(QUERY_INPUT_RECENCY_APPLY_TO_LEXICAL, true);
 
         boolean shouldDisableRecency = false;
-        if (retrievalMethod.equals(MARQO_SEARCH_METHOD_TENSOR) && applyRecencyToTensor == 0) {
+        if (retrievalMethod.equals(MARQO_SEARCH_METHOD_TENSOR) && !applyRecencyToTensor) {
             shouldDisableRecency = true;
-        } else if (retrievalMethod.equals(MARQO_SEARCH_METHOD_LEXICAL)
-                && applyRecencyToLexical == 0) {
+        } else if (retrievalMethod.equals(MARQO_SEARCH_METHOD_LEXICAL) && !applyRecencyToLexical) {
             shouldDisableRecency = true;
         }
 

--- a/components/marqo/vespa/src/test/java/ai/marqo/search/HybridSearcherRecencyTest.java
+++ b/components/marqo/vespa/src/test/java/ai/marqo/search/HybridSearcherRecencyTest.java
@@ -14,9 +14,13 @@ import com.yahoo.search.result.HitGroup;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorAddress;
 import com.yahoo.tensor.TensorType;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Unit tests for recency scoring functionality in HybridSearcher.
@@ -614,50 +618,60 @@ class HybridSearcherRecencyTest {
             assertThat(features.getDouble("query(updated_at)")).hasValue(0.5);
         }
 
-        @Test
-        void shouldDisableRecencyForTensorSubqueryWhenApplyToTensorIsFalse() {
-            Query query = new Query("search/?query=test");
-            query.properties().set("marqo__yql.tensor", "tensor yql");
-            query.properties().set("marqo__ranking.tensor.tensor", "embedding_similarity");
-            query.properties().set("marqo__recency_apply_to_tensor", false);
-            query.properties().set("marqo__recency_apply_to_lexical", true);
-
-            // Create recency timestamp key tensor
-            TensorType tensorType = new TensorType.Builder().mapped("p").build();
-            Tensor recencyTensor =
-                    Tensor.Builder.of(tensorType)
-                            .cell(TensorAddress.ofLabels("created_at"), 1.0)
-                            .build();
-            query.getRanking()
-                    .getFeatures()
-                    .put("query(marqo__recency_timestamp_key)", recencyTensor);
-
-            // Create fields to rank tensor
-            Tensor fieldsToRank =
-                    Tensor.Builder.of(tensorType)
-                            .cell(TensorAddress.ofLabels("marqo__tensor_text_field_1"), 1.0)
-                            .build();
-            query.getRanking()
-                    .getFeatures()
-                    .put("query(marqo__fields_to_rank_tensor)", fieldsToRank);
-
-            Query subQuery = hybridSearcher.createSubQuery(query, "tensor", "tensor", false);
-
-            // Recency should be disabled: marqo__recency_should_apply_score set to 0.0
-            RankFeatures features = subQuery.getRanking().getFeatures();
-            assertThat(features.getDouble("query(marqo__recency_should_apply_score)"))
-                    .hasValue(0.0);
+        static Stream<Arguments> applyToSubqueriesCases() {
+            return Stream.of(
+                    // tensor disabled when apply_to_tensor=false
+                    Arguments.of(
+                            "tensor",
+                            "embedding_similarity",
+                            "marqo__tensor_text_field_1",
+                            false,
+                            true,
+                            true),
+                    // lexical disabled when apply_to_lexical=false
+                    Arguments.of(
+                            "lexical", "bm25", "marqo__lexical_text_field_1", true, false, true),
+                    // tensor NOT disabled when apply_to_tensor=true
+                    Arguments.of(
+                            "tensor",
+                            "embedding_similarity",
+                            "marqo__tensor_text_field_1",
+                            true,
+                            false,
+                            false),
+                    // lexical NOT disabled when apply_to_lexical=true
+                    Arguments.of(
+                            "lexical", "bm25", "marqo__lexical_text_field_1", false, true, false),
+                    // defaults (not set) — recency enabled
+                    Arguments.of(
+                            "tensor",
+                            "embedding_similarity",
+                            "marqo__tensor_text_field_1",
+                            null,
+                            null,
+                            false));
         }
 
-        @Test
-        void shouldDisableRecencyForLexicalSubqueryWhenApplyToLexicalIsFalse() {
+        @ParameterizedTest
+        @MethodSource("applyToSubqueriesCases")
+        void shouldRespectApplyToSubqueryFlags(
+                String subqueryType,
+                String rankProfile,
+                String fieldKey,
+                Boolean applyToTensor,
+                Boolean applyToLexical,
+                boolean expectDisabled) {
             Query query = new Query("search/?query=test");
-            query.properties().set("marqo__yql.lexical", "lexical yql");
-            query.properties().set("marqo__ranking.lexical.lexical", "bm25");
-            query.properties().set("marqo__recency_apply_to_tensor", true);
-            query.properties().set("marqo__recency_apply_to_lexical", false);
+            query.properties().set("marqo__yql." + subqueryType, subqueryType + " yql");
+            query.properties()
+                    .set("marqo__ranking." + subqueryType + "." + subqueryType, rankProfile);
+            if (applyToTensor != null) {
+                query.properties().set("marqo__recency_apply_to_tensor", applyToTensor);
+            }
+            if (applyToLexical != null) {
+                query.properties().set("marqo__recency_apply_to_lexical", applyToLexical);
+            }
 
-            // Create recency timestamp key tensor
             TensorType tensorType = new TensorType.Builder().mapped("p").build();
             Tensor recencyTensor =
                     Tensor.Builder.of(tensorType)
@@ -667,122 +681,25 @@ class HybridSearcherRecencyTest {
                     .getFeatures()
                     .put("query(marqo__recency_timestamp_key)", recencyTensor);
 
-            // Create fields to rank tensor
             Tensor fieldsToRank =
                     Tensor.Builder.of(tensorType)
-                            .cell(TensorAddress.ofLabels("marqo__lexical_text_field_1"), 1.0)
+                            .cell(TensorAddress.ofLabels(fieldKey), 1.0)
                             .build();
             query.getRanking()
                     .getFeatures()
-                    .put("query(marqo__fields_to_rank_lexical)", fieldsToRank);
+                    .put("query(marqo__fields_to_rank_" + subqueryType + ")", fieldsToRank);
 
-            Query subQuery = hybridSearcher.createSubQuery(query, "lexical", "lexical", false);
+            Query subQuery =
+                    hybridSearcher.createSubQuery(query, subqueryType, subqueryType, false);
 
-            // Recency should be disabled: marqo__recency_should_apply_score set to 0.0
             RankFeatures features = subQuery.getRanking().getFeatures();
-            assertThat(features.getDouble("query(marqo__recency_should_apply_score)"))
-                    .hasValue(0.0);
-        }
-
-        @Test
-        void shouldNotDisableRecencyForTensorSubqueryWhenApplyToTensorIsTrue() {
-            Query query = new Query("search/?query=test");
-            query.properties().set("marqo__yql.tensor", "tensor yql");
-            query.properties().set("marqo__ranking.tensor.tensor", "embedding_similarity");
-            query.properties().set("marqo__recency_apply_to_tensor", true);
-            query.properties().set("marqo__recency_apply_to_lexical", false);
-
-            // Create recency timestamp key tensor
-            TensorType tensorType = new TensorType.Builder().mapped("p").build();
-            Tensor recencyTensor =
-                    Tensor.Builder.of(tensorType)
-                            .cell(TensorAddress.ofLabels("created_at"), 1.0)
-                            .build();
-            query.getRanking()
-                    .getFeatures()
-                    .put("query(marqo__recency_timestamp_key)", recencyTensor);
-
-            // Create fields to rank tensor
-            Tensor fieldsToRank =
-                    Tensor.Builder.of(tensorType)
-                            .cell(TensorAddress.ofLabels("marqo__tensor_text_field_1"), 1.0)
-                            .build();
-            query.getRanking()
-                    .getFeatures()
-                    .put("query(marqo__fields_to_rank_tensor)", fieldsToRank);
-
-            Query subQuery = hybridSearcher.createSubQuery(query, "tensor", "tensor", false);
-
-            // Recency should NOT be disabled
-            RankFeatures features = subQuery.getRanking().getFeatures();
-            assertThat(features.getDouble("query(marqo__recency_should_apply_score)")).isEmpty();
-        }
-
-        @Test
-        void shouldNotDisableRecencyForLexicalSubqueryWhenApplyToLexicalIsTrue() {
-            Query query = new Query("search/?query=test");
-            query.properties().set("marqo__yql.lexical", "lexical yql");
-            query.properties().set("marqo__ranking.lexical.lexical", "bm25");
-            query.properties().set("marqo__recency_apply_to_tensor", false);
-            query.properties().set("marqo__recency_apply_to_lexical", true);
-
-            // Create recency timestamp key tensor
-            TensorType tensorType = new TensorType.Builder().mapped("p").build();
-            Tensor recencyTensor =
-                    Tensor.Builder.of(tensorType)
-                            .cell(TensorAddress.ofLabels("created_at"), 1.0)
-                            .build();
-            query.getRanking()
-                    .getFeatures()
-                    .put("query(marqo__recency_timestamp_key)", recencyTensor);
-
-            // Create fields to rank tensor
-            Tensor fieldsToRank =
-                    Tensor.Builder.of(tensorType)
-                            .cell(TensorAddress.ofLabels("marqo__lexical_text_field_1"), 1.0)
-                            .build();
-            query.getRanking()
-                    .getFeatures()
-                    .put("query(marqo__fields_to_rank_lexical)", fieldsToRank);
-
-            Query subQuery = hybridSearcher.createSubQuery(query, "lexical", "lexical", false);
-
-            // Recency should NOT be disabled
-            RankFeatures features = subQuery.getRanking().getFeatures();
-            assertThat(features.getDouble("query(marqo__recency_should_apply_score)")).isEmpty();
-        }
-
-        @Test
-        void shouldDefaultToApplyRecencyToBothSubqueriesWhenFlagsNotSet() {
-            Query query = new Query("search/?query=test");
-            query.properties().set("marqo__yql.tensor", "tensor yql");
-            query.properties().set("marqo__ranking.tensor.tensor", "embedding_similarity");
-            // Do NOT set apply_to_tensor or apply_to_lexical — defaults should be true
-
-            // Create recency timestamp key tensor
-            TensorType tensorType = new TensorType.Builder().mapped("p").build();
-            Tensor recencyTensor =
-                    Tensor.Builder.of(tensorType)
-                            .cell(TensorAddress.ofLabels("created_at"), 1.0)
-                            .build();
-            query.getRanking()
-                    .getFeatures()
-                    .put("query(marqo__recency_timestamp_key)", recencyTensor);
-
-            // Create fields to rank tensor
-            Tensor fieldsToRank =
-                    Tensor.Builder.of(tensorType)
-                            .cell(TensorAddress.ofLabels("marqo__tensor_text_field_1"), 1.0)
-                            .build();
-            query.getRanking()
-                    .getFeatures()
-                    .put("query(marqo__fields_to_rank_tensor)", fieldsToRank);
-
-            Query subQuery = hybridSearcher.createSubQuery(query, "tensor", "tensor", false);
-
-            // Recency should NOT be disabled (default is true)
-            RankFeatures features = subQuery.getRanking().getFeatures();
-            assertThat(features.getDouble("query(marqo__recency_should_apply_score)")).isEmpty();
+            if (expectDisabled) {
+                assertThat(features.getDouble("query(marqo__recency_should_apply_score)"))
+                        .hasValue(0.0);
+            } else {
+                assertThat(features.getDouble("query(marqo__recency_should_apply_score)"))
+                        .isEmpty();
+            }
         }
     }
 }

--- a/components/marqo/vespa/src/test/java/ai/marqo/search/HybridSearcherRecencyTest.java
+++ b/components/marqo/vespa/src/test/java/ai/marqo/search/HybridSearcherRecencyTest.java
@@ -613,5 +613,176 @@ class HybridSearcherRecencyTest {
             assertThat(features.getDouble("query(created_at)")).hasValue(1.0);
             assertThat(features.getDouble("query(updated_at)")).hasValue(0.5);
         }
+
+        @Test
+        void shouldDisableRecencyForTensorSubqueryWhenApplyToTensorIsFalse() {
+            Query query = new Query("search/?query=test");
+            query.properties().set("marqo__yql.tensor", "tensor yql");
+            query.properties().set("marqo__ranking.tensor.tensor", "embedding_similarity");
+            query.properties().set("marqo__recency_apply_to_tensor", false);
+            query.properties().set("marqo__recency_apply_to_lexical", true);
+
+            // Create recency timestamp key tensor
+            TensorType tensorType = new TensorType.Builder().mapped("p").build();
+            Tensor recencyTensor =
+                    Tensor.Builder.of(tensorType)
+                            .cell(TensorAddress.ofLabels("created_at"), 1.0)
+                            .build();
+            query.getRanking()
+                    .getFeatures()
+                    .put("query(marqo__recency_timestamp_key)", recencyTensor);
+
+            // Create fields to rank tensor
+            Tensor fieldsToRank =
+                    Tensor.Builder.of(tensorType)
+                            .cell(TensorAddress.ofLabels("marqo__tensor_text_field_1"), 1.0)
+                            .build();
+            query.getRanking()
+                    .getFeatures()
+                    .put("query(marqo__fields_to_rank_tensor)", fieldsToRank);
+
+            Query subQuery = hybridSearcher.createSubQuery(query, "tensor", "tensor", false);
+
+            // Recency should be disabled: marqo__recency_should_apply_score set to 0.0
+            RankFeatures features = subQuery.getRanking().getFeatures();
+            assertThat(features.getDouble("query(marqo__recency_should_apply_score)"))
+                    .hasValue(0.0);
+        }
+
+        @Test
+        void shouldDisableRecencyForLexicalSubqueryWhenApplyToLexicalIsFalse() {
+            Query query = new Query("search/?query=test");
+            query.properties().set("marqo__yql.lexical", "lexical yql");
+            query.properties().set("marqo__ranking.lexical.lexical", "bm25");
+            query.properties().set("marqo__recency_apply_to_tensor", true);
+            query.properties().set("marqo__recency_apply_to_lexical", false);
+
+            // Create recency timestamp key tensor
+            TensorType tensorType = new TensorType.Builder().mapped("p").build();
+            Tensor recencyTensor =
+                    Tensor.Builder.of(tensorType)
+                            .cell(TensorAddress.ofLabels("created_at"), 1.0)
+                            .build();
+            query.getRanking()
+                    .getFeatures()
+                    .put("query(marqo__recency_timestamp_key)", recencyTensor);
+
+            // Create fields to rank tensor
+            Tensor fieldsToRank =
+                    Tensor.Builder.of(tensorType)
+                            .cell(TensorAddress.ofLabels("marqo__lexical_text_field_1"), 1.0)
+                            .build();
+            query.getRanking()
+                    .getFeatures()
+                    .put("query(marqo__fields_to_rank_lexical)", fieldsToRank);
+
+            Query subQuery = hybridSearcher.createSubQuery(query, "lexical", "lexical", false);
+
+            // Recency should be disabled: marqo__recency_should_apply_score set to 0.0
+            RankFeatures features = subQuery.getRanking().getFeatures();
+            assertThat(features.getDouble("query(marqo__recency_should_apply_score)"))
+                    .hasValue(0.0);
+        }
+
+        @Test
+        void shouldNotDisableRecencyForTensorSubqueryWhenApplyToTensorIsTrue() {
+            Query query = new Query("search/?query=test");
+            query.properties().set("marqo__yql.tensor", "tensor yql");
+            query.properties().set("marqo__ranking.tensor.tensor", "embedding_similarity");
+            query.properties().set("marqo__recency_apply_to_tensor", true);
+            query.properties().set("marqo__recency_apply_to_lexical", false);
+
+            // Create recency timestamp key tensor
+            TensorType tensorType = new TensorType.Builder().mapped("p").build();
+            Tensor recencyTensor =
+                    Tensor.Builder.of(tensorType)
+                            .cell(TensorAddress.ofLabels("created_at"), 1.0)
+                            .build();
+            query.getRanking()
+                    .getFeatures()
+                    .put("query(marqo__recency_timestamp_key)", recencyTensor);
+
+            // Create fields to rank tensor
+            Tensor fieldsToRank =
+                    Tensor.Builder.of(tensorType)
+                            .cell(TensorAddress.ofLabels("marqo__tensor_text_field_1"), 1.0)
+                            .build();
+            query.getRanking()
+                    .getFeatures()
+                    .put("query(marqo__fields_to_rank_tensor)", fieldsToRank);
+
+            Query subQuery = hybridSearcher.createSubQuery(query, "tensor", "tensor", false);
+
+            // Recency should NOT be disabled
+            RankFeatures features = subQuery.getRanking().getFeatures();
+            assertThat(features.getDouble("query(marqo__recency_should_apply_score)")).isEmpty();
+        }
+
+        @Test
+        void shouldNotDisableRecencyForLexicalSubqueryWhenApplyToLexicalIsTrue() {
+            Query query = new Query("search/?query=test");
+            query.properties().set("marqo__yql.lexical", "lexical yql");
+            query.properties().set("marqo__ranking.lexical.lexical", "bm25");
+            query.properties().set("marqo__recency_apply_to_tensor", false);
+            query.properties().set("marqo__recency_apply_to_lexical", true);
+
+            // Create recency timestamp key tensor
+            TensorType tensorType = new TensorType.Builder().mapped("p").build();
+            Tensor recencyTensor =
+                    Tensor.Builder.of(tensorType)
+                            .cell(TensorAddress.ofLabels("created_at"), 1.0)
+                            .build();
+            query.getRanking()
+                    .getFeatures()
+                    .put("query(marqo__recency_timestamp_key)", recencyTensor);
+
+            // Create fields to rank tensor
+            Tensor fieldsToRank =
+                    Tensor.Builder.of(tensorType)
+                            .cell(TensorAddress.ofLabels("marqo__lexical_text_field_1"), 1.0)
+                            .build();
+            query.getRanking()
+                    .getFeatures()
+                    .put("query(marqo__fields_to_rank_lexical)", fieldsToRank);
+
+            Query subQuery = hybridSearcher.createSubQuery(query, "lexical", "lexical", false);
+
+            // Recency should NOT be disabled
+            RankFeatures features = subQuery.getRanking().getFeatures();
+            assertThat(features.getDouble("query(marqo__recency_should_apply_score)")).isEmpty();
+        }
+
+        @Test
+        void shouldDefaultToApplyRecencyToBothSubqueriesWhenFlagsNotSet() {
+            Query query = new Query("search/?query=test");
+            query.properties().set("marqo__yql.tensor", "tensor yql");
+            query.properties().set("marqo__ranking.tensor.tensor", "embedding_similarity");
+            // Do NOT set apply_to_tensor or apply_to_lexical — defaults should be true
+
+            // Create recency timestamp key tensor
+            TensorType tensorType = new TensorType.Builder().mapped("p").build();
+            Tensor recencyTensor =
+                    Tensor.Builder.of(tensorType)
+                            .cell(TensorAddress.ofLabels("created_at"), 1.0)
+                            .build();
+            query.getRanking()
+                    .getFeatures()
+                    .put("query(marqo__recency_timestamp_key)", recencyTensor);
+
+            // Create fields to rank tensor
+            Tensor fieldsToRank =
+                    Tensor.Builder.of(tensorType)
+                            .cell(TensorAddress.ofLabels("marqo__tensor_text_field_1"), 1.0)
+                            .build();
+            query.getRanking()
+                    .getFeatures()
+                    .put("query(marqo__fields_to_rank_tensor)", fieldsToRank);
+
+            Query subQuery = hybridSearcher.createSubQuery(query, "tensor", "tensor", false);
+
+            // Recency should NOT be disabled (default is true)
+            RankFeatures features = subQuery.getRanking().getFeatures();
+            assertThat(features.getDouble("query(marqo__recency_should_apply_score)")).isEmpty();
+        }
     }
 }


### PR DESCRIPTION
## Change Summary
Add two new parameters to recency scoring:

- **`center`** — A fixed Unix epoch timestamp (seconds) to use as the reference point instead of `now()`, enabling reproducible recency scores across queries.
- **`applyToSubqueries`** — Controls which hybrid subqueries (`"tensor"`, `"lexical"`, or both) receive recency boosting in RRF hybrid search. Only valid with HYBRID search using RRF ranking.

Changes span Python models, API validation, Vespa schema template, Java HybridSearcher, and test schemas.

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
- [x] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [x] Python client changes linked or N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes recency scoring inputs and Vespa ranking behavior (including Java subquery feature overrides), which can affect search result ordering and requires schema-version gating to avoid mismatches on older indexes.
> 
> **Overview**
> Adds two new recency controls: **`center`** (fixed epoch timestamp reference) and **`applyToSubqueries`** (limit recency boosting to `tensor`, `lexical`, both, or neither) for hybrid search.
> 
> Implements schema/version gating at query time (minimum `2.25.1`), extends Vespa query inputs and schema templates to use `center` in age calculation, and passes `applyToSubqueries` as top-level query properties so `HybridSearcher` can disable recency per subquery by overriding `marqo__recency_should_apply_score`. Updates API/Pydantic validation and bumps version to `2.25.1`, with expanded unit/integration test coverage for new behaviors and compatibility errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cdae7a34b6194149523592ca7c24c0bb5f7c2cad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->