### PR TITLE
Fix ECR image tags for compatibility tests

### DIFF
--- a/components/marqo/tests/compatibility_tests/docker_manager.py
+++ b/components/marqo/tests/compatibility_tests/docker_manager.py
@@ -183,9 +183,9 @@ class DockerManager:
         if num_provided == 0:
             # No images provided → use defaults
             self.logger.info(f"Starting Marqo container with ECR images for version: {version}")
-            api_image = f"{os_ecr_name_space}/api:{version}"
-            inference_orchestrator_image = f"{os_ecr_name_space}/inference-orchestrator:{version}"
-            model_management_image = f"{os_ecr_name_space}/model-management:{version}"
+            api_image = f"{os_ecr_name_space}/api:{version}-cloud"
+            inference_orchestrator_image = f"{os_ecr_name_space}/inference-orchestrator:{version}-cloud"
+            model_management_image = f"{os_ecr_name_space}/model-management:{version}-cloud"
         elif num_provided == 3:
             # All provided → use as-is
             self.logger.info("Starting Marqo container with all custom images.")


### PR DESCRIPTION
## Summary
- ECR images are tagged with a `-cloud` suffix (e.g., `api:2.25.0-cloud`), but the compatibility test code was constructing tags without it (e.g., `api:2.25.0`), causing image pull failures
- Added `-cloud` suffix to all three ECR image tags in `_start_marqo_container_post_2250`

## Test plan
- [ ] Re-run compatibility tests for 2.25.0 → 2.25.1 and confirm ECR images pull successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates only compatibility test container image tag construction; main risk is pulling the wrong tag if ECR naming differs from expectations.
> 
> **Overview**
> Fixes Marqo compatibility tests for versions `>= 2.25.0` by updating the default ECR image tags in `_start_marqo_container_post_2250` to include the `-cloud` suffix for `api`, `inference-orchestrator`, and `model-management`, preventing image pull failures when no custom images are provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b587067fefe7a2b29c5875fe4141be31fe2f42fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->