### PR TITLE
Remove LanguageBind model support

### DIFF
--- a/components/inference_orchestrator/CLAUDE.md
+++ b/components/inference_orchestrator/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 The Marqo Inference Container is a FastAPI-based service that handles ML model inference for the Marqo tensor search engine. It provides:
 
-- Model loading and management (HuggingFace, OpenCLIP, LanguageBind, etc.)
+- Model loading and management (HuggingFace, OpenCLIP, etc.)
 - Media download and preprocessing (images, text, multimodal)
 - Inference caching for improved performance
 - Triton inference server integration

--- a/components/marqo/tests/compatibility_tests/add_or_replace_documents/structured/test_add_documents_v2_12.py
+++ b/components/marqo/tests/compatibility_tests/add_or_replace_documents/structured/test_add_documents_v2_12.py
@@ -35,17 +35,6 @@ class TestAddDocumentsv2_12(BaseCompatibilityTestCase):
         }]
 
     documents = [
-        # These documents cannot be added right now, because the model open_clip/ViT-B-32/laion2b_s34b_b79k, does not support audio and video. We could change the model to something like LanguageBind/Video_V1.5_FT_Audio_FT_Image, but that fails with
-        # marqo.api.exceptions.ModelCacheManagementError: ModelCacheManagementError: You are trying to load a model with size = `8` into device = `cpu`, which is larger than the device threshold = `1.6`.Marqo CANNOT find enough space for the model.Please change the threshold by adjusting the environment variables.
-        # Since these tests are currently running on a non GPU machine, we will skip these documents for now.
-        # {
-        #     "video_field_1": "https://marqo-k400-video-test-dataset.s3.amazonaws.com/videos/---QUuC4vJs_000084_000094.mp4",
-        #     "_id": "1"
-        # },
-        # {
-        #     "audio_field_1": "https://marqo-ecs-50-audio-test-dataset.s3.amazonaws.com/audios/marqo-audio-test.mp3",
-        #     "_id": "2"
-        # },
         {
             "image_field": "https://raw.githubusercontent.com/marqo-ai/marqo-api-tests/mainline/assets/ai_hippo_realistic.png",
             "_id": "3"

--- a/components/marqo/tests/integ_tests/marqo_test.py
+++ b/components/marqo/tests/integ_tests/marqo_test.py
@@ -46,15 +46,6 @@ class TestImageUrls(str, Enum):
     HIPPO_REALISTIC_LARGE = 'https://raw.githubusercontent.com/marqo-ai/marqo-api-tests/mainline/assets/ai_hippo_realistic.png'
     HIPPO_STATUE = 'https://raw.githubusercontent.com/marqo-ai/marqo-api-tests/mainline/assets/ai_hippo_statue_small.png'
 
-    # --- Image URLs for testing different image formats ---
-    # These images are tested with OpenCLIP Encode
-    BMP_IMAGE = 'https://opensource-languagebind-models.s3.us-east-1.amazonaws.com/test-media-types/sample_bmp_image.bmp'
-    TIFF_IMAGE = 'https://opensource-languagebind-models.s3.us-east-1.amazonaws.com/test-media-types/sample_tiff_image.tiff'
-    GIF_IMAGE = 'https://opensource-languagebind-models.s3.us-east-1.amazonaws.com/test-media-types/sample_gif_image.gif'
-    PNG_IMAGE = 'https://opensource-languagebind-models.s3.us-east-1.amazonaws.com/test-media-types/sample_png_image.png'
-    JPG_IMAGE = 'https://opensource-languagebind-models.s3.us-east-1.amazonaws.com/test-media-types/sample_jpg_image.jpg'
-    WEBP_IMAGE = 'https://opensource-languagebind-models.s3.us-east-1.amazonaws.com/test-media-types/sample_webp_image.webp'
-
 
 class TestAudioUrls(str, Enum):
     __test__ = False
@@ -62,22 +53,12 @@ class TestAudioUrls(str, Enum):
     AUDIO2 = "https://marqo-ecs-50-audio-test-dataset.s3.us-east-1.amazonaws.com/audios/1-115545-C-48.wav"
     AUDIO3 = "https://marqo-ecs-50-audio-test-dataset.s3.us-east-1.amazonaws.com/audios/1-119125-A-45.wav"
 
-    MP3_AUDIO1 = "https://opensource-languagebind-models.s3.us-east-1.amazonaws.com/test-media-types/sample3.mp3"
-    ACC_AUDIO1 = "https://opensource-languagebind-models.s3.us-east-1.amazonaws.com/test-media-types/sample3.aac"
-    OGG_AUDIO1 = "https://opensource-languagebind-models.s3.us-east-1.amazonaws.com/test-media-types/sample3.ogg"
-
-    FLAC_AUDIO1 = "https://opensource-languagebind-models.s3.us-east-1.amazonaws.com/test-media-types/sample3.flac"
-
 
 class TestVideoUrls(str, Enum):
     __test__ = False
     VIDEO1 = "https://marqo-k400-video-test-dataset.s3.us-east-1.amazonaws.com/videos/--_S9IDQPLg_000135_000145.mp4"
     VIDEO2 = "https://marqo-k400-video-test-dataset.s3.us-east-1.amazonaws.com/videos/---QUuC4vJs_000084_000094.mp4"
     VIDEO3 = "https://marqo-k400-video-test-dataset.s3.us-east-1.amazonaws.com/videos/--mI_-gaZLk_000018_000028.mp4"
-
-    MKV_VIDEO1 = "https://opensource-languagebind-models.s3.us-east-1.amazonaws.com/test-media-types/sample_640x360.mkv"
-    WEBM_VIDEO1 = "https://opensource-languagebind-models.s3.us-east-1.amazonaws.com/test-media-types/sample_640x360.webm"
-    AVI_VIDEO1 = "https://opensource-languagebind-models.s3.us-east-1.amazonaws.com/test-media-types/sample_640x360.avi"
 
 
 class MarqoTestCase(unittest.TestCase):

--- a/components/marqo/tests/integ_tests/marqo_test.py
+++ b/components/marqo/tests/integ_tests/marqo_test.py
@@ -47,20 +47,6 @@ class TestImageUrls(str, Enum):
     HIPPO_STATUE = 'https://raw.githubusercontent.com/marqo-ai/marqo-api-tests/mainline/assets/ai_hippo_statue_small.png'
 
 
-class TestAudioUrls(str, Enum):
-    __test__ = False
-    AUDIO1 = "https://marqo-ecs-50-audio-test-dataset.s3.us-east-1.amazonaws.com/audios/1-100032-A-0.wav"
-    AUDIO2 = "https://marqo-ecs-50-audio-test-dataset.s3.us-east-1.amazonaws.com/audios/1-115545-C-48.wav"
-    AUDIO3 = "https://marqo-ecs-50-audio-test-dataset.s3.us-east-1.amazonaws.com/audios/1-119125-A-45.wav"
-
-
-class TestVideoUrls(str, Enum):
-    __test__ = False
-    VIDEO1 = "https://marqo-k400-video-test-dataset.s3.us-east-1.amazonaws.com/videos/--_S9IDQPLg_000135_000145.mp4"
-    VIDEO2 = "https://marqo-k400-video-test-dataset.s3.us-east-1.amazonaws.com/videos/---QUuC4vJs_000084_000094.mp4"
-    VIDEO3 = "https://marqo-k400-video-test-dataset.s3.us-east-1.amazonaws.com/videos/--mI_-gaZLk_000018_000028.mp4"
-
-
 class MarqoTestCase(unittest.TestCase):
     indexes = []
 

--- a/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_add_documents_combined.py
+++ b/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_add_documents_combined.py
@@ -114,7 +114,6 @@ class TestAddDocumentsCombined(MarqoTestCase):
         cls.unstructured_text_index_unnormalized_name = unstructured_text_index_request_unnormalized.name
 
         cls.image_indexes = cls.indexes[:3]
-        cls.languagebind_indexes = cls.indexes[3:6]
 
     def setUp(self) -> None:
         super().setUp()
@@ -213,7 +212,6 @@ class TestAddDocumentsCombined(MarqoTestCase):
             }
         ]
 
-        # Expected vector for the LanguageBind model (adjust these values based on actual output)
         expected_vector = [-0.06504671275615692, -0.03672310709953308, -0.06603428721427917,
                            -0.032505638897418976, -0.06116769462823868, -0.03929287940263748]
 

--- a/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_embed.py
+++ b/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_embed.py
@@ -70,12 +70,6 @@ class TestEmbed(MarqoTestCase):
             treat_urls_and_pointers_as_images=True
         )
 
-        unstructured_languagebind_index = cls.unstructured_marqo_index_request(
-            model=Model(name='LanguageBind/Video_V1.5_FT_Audio_FT_Image'),
-            treat_urls_and_pointers_as_images=True,
-            treat_urls_and_pointers_as_media=True
-        )
-
         # STRUCTURED indexes
         structured_default_text_index = cls.structured_marqo_index_request(
             model=Model(name="hf/all-MiniLM-L6-v2"),
@@ -147,29 +141,17 @@ class TestEmbed(MarqoTestCase):
             tensor_fields=["text_field_1", "text_field_2", "image_field_1"]
         )
 
-        structured_languagebind_index = cls.structured_marqo_index_request(
-            model=Model(name='LanguageBind/Video_V1.5_FT_Audio_FT_Image'),
-            fields=[
-                FieldRequest(name="text_field_1", type=FieldType.Text),
-                FieldRequest(name="text_field_2", type=FieldType.Text),
-                FieldRequest(name="image_field_1", type=FieldType.ImagePointer)
-            ],
-            tensor_fields=["text_field_1", "text_field_2", "image_field_1"]
-        )
-
         cls.indexes = cls.create_indexes([
             unstructured_default_text_index,
             unstructured_default_image_index,
             unstructured_image_index_with_random_model,
             unstructured_image_index_with_test_prefix,
             unstructured_image_index_request,
-            unstructured_languagebind_index,
             structured_default_text_index,
             structured_default_image_index,
             structured_image_index_request,
             structured_image_index_with_random_model,
-            structured_image_index_with_test_prefix,
-            structured_languagebind_index
+            structured_image_index_with_test_prefix
         ])
 
         # Assign to objects so they can be used in tests
@@ -178,13 +160,11 @@ class TestEmbed(MarqoTestCase):
         cls.unstructured_image_index_with_random_model = cls.indexes[2]
         cls.unstructured_image_index_with_test_prefix = cls.indexes[3]
         cls.unstructured_image_index_request = cls.indexes[4]
-        cls.unstructured_languagebind_index = cls.indexes[5]
-        cls.structured_default_text_index = cls.indexes[6]
-        cls.structured_default_image_index = cls.indexes[7]
-        cls.structured_image_index_request = cls.indexes[8]
-        cls.structured_image_index_with_random_model = cls.indexes[9]
-        cls.structured_image_index_with_test_prefix = cls.indexes[10]
-        cls.structured_languagebind_index = cls.indexes[11]
+        cls.structured_default_text_index = cls.indexes[5]
+        cls.structured_default_image_index = cls.indexes[6]
+        cls.structured_image_index_request = cls.indexes[7]
+        cls.structured_image_index_with_random_model = cls.indexes[8]
+        cls.structured_image_index_with_test_prefix = cls.indexes[9]
 
     def setUp(self) -> None:
         super().setUp()


### PR DESCRIPTION
## Change Summary

Removes all references to LanguageBind model from tests and documentation. The model was unsupported in the system (not registered in model registry) and only appeared in test setup code and URL constants that were never used.

**Changes:**
- Removed languagebind index definitions from test_embed.py
- Removed unused test URL constants (images, audio, video) from marqo_test.py
- Removed languagebind variable assignments from test_add_documents_combined.py
- Removed commented-out LanguageBind reference from compatibility tests
- Updated inference orchestrator documentation

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to documentation and test code cleanup, removing unused/unsupported model references without altering production inference logic.
> 
> **Overview**
> Removes all remaining references to the unsupported `LanguageBind` model from the repo.
> 
> Test setup is simplified by dropping `LanguageBind` index definitions/assignments and removing unused media URL enums (audio/video and extra image-format URLs), and compatibility tests no longer include the commented-out audio/video document examples. Documentation in `components/inference_orchestrator/CLAUDE.md` is updated to stop listing `LanguageBind` as a supported model family.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88204163c719fd9a3a1ab0fd9e76096ce3c64c75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->