### PR TITLE
Add random connection close for search query

### DIFF
--- a/.github/workflows/backwards_compatibility_marqo_execution.yml
+++ b/.github/workflows/backwards_compatibility_marqo_execution.yml
@@ -111,6 +111,25 @@ jobs:
           export PYTHONPATH=./:$PYTHONPATH
           python ./scripts/vespa_local/vespa_local.py full-start
 
+      - name: Validate image inputs
+        env:
+          TO_API_IMAGE: ${{ inputs.to_api_image || github.event.inputs.to_api_image }}
+          TO_INFERENCE_ORCHESTRATOR_IMAGE: ${{ inputs.to_inference_orchestrator_image || github.event.inputs.to_inference_orchestrator_image }}
+          TO_MODEL_MANAGEMENT_IMAGE: ${{ inputs.to_model_management_image || github.event.inputs.to_model_management_image }}
+        run: |
+          missing=()
+          [ -z "$TO_API_IMAGE" ] && missing+=("to_api_image")
+          [ -z "$TO_INFERENCE_ORCHESTRATOR_IMAGE" ] && missing+=("to_inference_orchestrator_image")
+          [ -z "$TO_MODEL_MANAGEMENT_IMAGE" ] && missing+=("to_model_management_image")
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::error::Missing required image inputs: ${missing[*]}"
+            exit 1
+          fi
+          echo "All image inputs provided:"
+          echo "  API: $TO_API_IMAGE"
+          echo "  Inference Orchestrator: $TO_INFERENCE_ORCHESTRATOR_IMAGE"
+          echo "  Model Management: $TO_MODEL_MANAGEMENT_IMAGE"
+
       # Step to run the compatibility test. This step can run both backwards_compatibility and rollback tests, based on the MODE argument
       - name: Run backwards compatibility test
         id: run-backwards-compatibility

--- a/.github/workflows/build_push_img.yml
+++ b/.github/workflows/build_push_img.yml
@@ -86,10 +86,6 @@ jobs:
   Docker-Build:
     name: Build docker image
     runs-on: "runs-on=${{ github.run_id }}/family=m6i.xlarge/ami=${{ vars.MARQO_CPU_AMD64_TESTS_INSTANCE_AMI }}"
-    outputs:
-      api_image_identifier: ${{ steps.set-image-identifier-in-output.outputs.api_image_identifier }}
-      inference_orchestrator_image_identifier: ${{ steps.set-image-identifier-in-output.outputs.inference_orchestrator_image_identifier }}
-      model_management_image_identifier: ${{ steps.set-image-identifier-in-output.outputs.model_management_image_identifier}}
     environment:
       name: ${{ (inputs.push_to || github.event.inputs.push_to) == 'OS-ECR' && 'os' || 'staging' }}
 
@@ -159,29 +155,42 @@ jobs:
           platforms: ${{ env.PLATFORMS }}
           tags: ${{ steps.prepare.outputs.registry }}/${{ env.IMAGE_NAMESPACE }}/model-management:${{ env.IMAGE_TAG }}
 
-      - name: Output image_identifier
-        # By image_identifier, we refer to the complete qualified image name with the image digest (i.e 424082663841.dkr.ecr.us-east-1.amazonaws.com/marqo-compatibility-tests@sha256:1234567890abcdef)
-        id: set-image-identifier-in-output
+      - name: Write image identifiers to file
+        # Write identifiers to a file and upload as artifact to avoid GitHub Actions
+        # suppressing outputs from jobs that use an environment in reusable workflows.
         run: |
-          echo "api_image_identifier=${{ steps.prepare.outputs.registry }}/${{ env.IMAGE_NAMESPACE }}/api@${{ steps.build-and-push-api.outputs.digest }}" >> $GITHUB_OUTPUT
-          echo "inference_orchestrator_image_identifier=${{ steps.prepare.outputs.registry }}/${{ env.IMAGE_NAMESPACE }}/inference-orchestrator@${{ steps.build-and-push-inference-orchestrator.outputs.digest }}" >> $GITHUB_OUTPUT
-          echo "model_management_image_identifier=${{ steps.prepare.outputs.registry }}/${{ env.IMAGE_NAMESPACE }}/model-management@${{ steps.build-and-push-model-management.outputs.digest }}" >> $GITHUB_OUTPUT
+          mkdir -p /tmp/image-identifiers
+          echo "${{ steps.prepare.outputs.registry }}/${{ env.IMAGE_NAMESPACE }}/api@${{ steps.build-and-push-api.outputs.digest }}" > /tmp/image-identifiers/api_image_identifier.txt
+          echo "${{ steps.prepare.outputs.registry }}/${{ env.IMAGE_NAMESPACE }}/inference-orchestrator@${{ steps.build-and-push-inference-orchestrator.outputs.digest }}" > /tmp/image-identifiers/inference_orchestrator_image_identifier.txt
+          echo "${{ steps.prepare.outputs.registry }}/${{ env.IMAGE_NAMESPACE }}/model-management@${{ steps.build-and-push-model-management.outputs.digest }}" > /tmp/image-identifiers/model_management_image_identifier.txt
 
-  # This job re-exports the image identifiers without an environment.
+      - name: Upload image identifiers
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-identifiers
+          path: /tmp/image-identifiers/
+
+  # This job reads image identifiers from artifacts instead of job outputs.
   # GitHub Actions suppresses outputs from jobs that use an environment in reusable workflows,
-  # so we need this intermediary job to pass them to the caller.
+  # so we use artifacts to pass the values through without secret masking.
   expose-outputs:
     name: Expose image identifiers
     needs: Docker-Build
     runs-on: ubuntu-latest
     outputs:
-      api_image_identifier: ${{ steps.forward.outputs.api_image_identifier }}
-      inference_orchestrator_image_identifier: ${{ steps.forward.outputs.inference_orchestrator_image_identifier }}
-      model_management_image_identifier: ${{ steps.forward.outputs.model_management_image_identifier }}
+      api_image_identifier: ${{ steps.read.outputs.api_image_identifier }}
+      inference_orchestrator_image_identifier: ${{ steps.read.outputs.inference_orchestrator_image_identifier }}
+      model_management_image_identifier: ${{ steps.read.outputs.model_management_image_identifier }}
     steps:
-      - name: Forward outputs
-        id: forward
+      - name: Download image identifiers
+        uses: actions/download-artifact@v4
+        with:
+          name: image-identifiers
+          path: /tmp/image-identifiers/
+
+      - name: Read and export identifiers
+        id: read
         run: |
-          echo "api_image_identifier=${{ needs.Docker-Build.outputs.api_image_identifier }}" >> $GITHUB_OUTPUT
-          echo "inference_orchestrator_image_identifier=${{ needs.Docker-Build.outputs.inference_orchestrator_image_identifier }}" >> $GITHUB_OUTPUT
-          echo "model_management_image_identifier=${{ needs.Docker-Build.outputs.model_management_image_identifier }}" >> $GITHUB_OUTPUT
+          echo "api_image_identifier=$(cat /tmp/image-identifiers/api_image_identifier.txt)" >> $GITHUB_OUTPUT
+          echo "inference_orchestrator_image_identifier=$(cat /tmp/image-identifiers/inference_orchestrator_image_identifier.txt)" >> $GITHUB_OUTPUT
+          echo "model_management_image_identifier=$(cat /tmp/image-identifiers/model_management_image_identifier.txt)" >> $GITHUB_OUTPUT

--- a/.github/workflows/build_push_img.yml
+++ b/.github/workflows/build_push_img.yml
@@ -13,7 +13,7 @@ on:
         type: string
         default: 'mainline'
       push_to:
-        description: 'image destination. Options: "OS-ECR", "AMI-ECR"'
+        description: 'image destination. Options: "OS-ECR", "STAGING-ECR"'
         required: true
         type: string
         default: OS-ECR
@@ -52,12 +52,12 @@ on:
         type: string
         default: 'mainline'
       push_to:
-        description: 'image destination. Options: "OS-ECR", "AMI-ECR"'
+        description: 'image destination. Options: "OS-ECR", "STAGING-ECR"'
         required: true
         type: choice
         options:
           - OS-ECR
-          - AMI-ECR
+          - STAGING-ECR
         default: OS-ECR
       image_namespace:
         description: 'The prefix of the image repository, by default "marqoai-dev". We will push 3 images: {prefix}/api, {prefix}/inference-orchestrator, {prefix}/model-management'
@@ -91,7 +91,7 @@ jobs:
       inference_orchestrator_image_identifier: ${{ steps.set-image-identifier-in-output.outputs.inference_orchestrator_image_identifier }}
       model_management_image_identifier: ${{ steps.set-image-identifier-in-output.outputs.model_management_image_identifier}}
     environment:
-      name: ${{ (inputs.image_namespace || github.event.inputs.image_namespace) == 'marqoai' && 'production' || 'non-prod' }}
+      name: ${{ (inputs.push_to || github.event.inputs.push_to) == 'OS-ECR' && 'os' || 'staging' }}
 
     steps:
       - name: Set input variables
@@ -114,33 +114,21 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to OS-ECR
-        uses: docker/login-action@v2
-        if: env.PUSH_TO == 'OS-ECR'
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@master
         with:
-          registry: 424082663841.dkr.ecr.us-east-1.amazonaws.com
-          username: ${{ secrets.ECR_PUSHER_AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.ECR_PUSHER_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_OIDC_ROLE_ARN }}
+          role-session-name: build-push-marqo-image
+          aws-region: us-east-1
 
-      - name: Login to AMI-ECR
-        uses: docker/login-action@v2
-        if: env.PUSH_TO == 'AMI-ECR'
-        with:
-          registry: 975050213659.dkr.ecr.us-east-1.amazonaws.com
-          username: ${{ secrets.AMI_ECR_PUSHER_AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AMI_ECR_PUSHER_AWS_SECRET_ACCESS_KEY }}
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Set registry and image repo
+      - name: Set registry
         id: prepare
         run: |
-          if [[ "${{ env.PUSH_TO }}" == "OS-ECR" ]]; then
-            echo "registry=424082663841.dkr.ecr.us-east-1.amazonaws.com" >> $GITHUB_OUTPUT
-          elif [[ "${{ env.PUSH_TO }}" == "AMI-ECR" ]]; then
-            echo "registry=975050213659.dkr.ecr.us-east-1.amazonaws.com" >> $GITHUB_OUTPUT
-          else
-            echo "Error: Unknown PUSH_TO value '${{ env.PUSH_TO }}'. Must be 'OS-ECR' or 'AMI-ECR'." >&2
-            exit 1
-          fi
+          echo "registry=${{ steps.login-ecr.outputs.registry }}" >> $GITHUB_OUTPUT
 
       - name: Build and push api image
         id: build-and-push-api

--- a/.github/workflows/build_push_img.yml
+++ b/.github/workflows/build_push_img.yml
@@ -36,13 +36,13 @@ on:
         # By image_identifier, we refer to the
         # complete qualified image name with the image digest (i.e  424082663841.dkr.ecr.us-east-1.amazonaws.com/marqo-compatibility-tests@sha256:1234567890abcdef).      image_identifier:
         description: "The api_image_identifier (ex: 424082663841.dkr.ecr.us-east-1.amazonaws.com/marqoai-dev/api@sha256:1234567890abcdef)"
-        value: ${{ jobs.Docker-Build.outputs.api_image_identifier }}
+        value: ${{ jobs.expose-outputs.outputs.api_image_identifier }}
       inference_orchestrator_image_identifier:
         description: "The inference_orchestrator_image_identifier (ex: 424082663841.dkr.ecr.us-east-1.amazonaws.com/marqoai-dev/inference-orchestrator@sha256:1234567890abcdef)"
-        value: ${{ jobs.Docker-Build.outputs.inference_orchestrator_image_identifier }}
+        value: ${{ jobs.expose-outputs.outputs.inference_orchestrator_image_identifier }}
       model_management_image_identifier:
         description: "The model_management_image_identifier (ex: 424082663841.dkr.ecr.us-east-1.amazonaws.com/marqoai-dev/model-management@sha256:1234567890abcdef)"
-        value: ${{ jobs.Docker-Build.outputs.model_management_image_identifier }}
+        value: ${{ jobs.expose-outputs.outputs.model_management_image_identifier }}
 
   workflow_dispatch: #for manual triggers
     inputs:
@@ -166,3 +166,22 @@ jobs:
           echo "api_image_identifier=${{ steps.prepare.outputs.registry }}/${{ env.IMAGE_NAMESPACE }}/api@${{ steps.build-and-push-api.outputs.digest }}" >> $GITHUB_OUTPUT
           echo "inference_orchestrator_image_identifier=${{ steps.prepare.outputs.registry }}/${{ env.IMAGE_NAMESPACE }}/inference-orchestrator@${{ steps.build-and-push-inference-orchestrator.outputs.digest }}" >> $GITHUB_OUTPUT
           echo "model_management_image_identifier=${{ steps.prepare.outputs.registry }}/${{ env.IMAGE_NAMESPACE }}/model-management@${{ steps.build-and-push-model-management.outputs.digest }}" >> $GITHUB_OUTPUT
+
+  # This job re-exports the image identifiers without an environment.
+  # GitHub Actions suppresses outputs from jobs that use an environment in reusable workflows,
+  # so we need this intermediary job to pass them to the caller.
+  expose-outputs:
+    name: Expose image identifiers
+    needs: Docker-Build
+    runs-on: ubuntu-latest
+    outputs:
+      api_image_identifier: ${{ steps.forward.outputs.api_image_identifier }}
+      inference_orchestrator_image_identifier: ${{ steps.forward.outputs.inference_orchestrator_image_identifier }}
+      model_management_image_identifier: ${{ steps.forward.outputs.model_management_image_identifier }}
+    steps:
+      - name: Forward outputs
+        id: forward
+        run: |
+          echo "api_image_identifier=${{ needs.Docker-Build.outputs.api_image_identifier }}" >> $GITHUB_OUTPUT
+          echo "inference_orchestrator_image_identifier=${{ needs.Docker-Build.outputs.inference_orchestrator_image_identifier }}" >> $GITHUB_OUTPUT
+          echo "model_management_image_identifier=${{ needs.Docker-Build.outputs.model_management_image_identifier }}" >> $GITHUB_OUTPUT

--- a/components/marqo/src/marqo/settings/settings.py
+++ b/components/marqo/src/marqo/settings/settings.py
@@ -19,6 +19,12 @@ class Settings(BaseSettings):
         "The S3 bucket from which Marqo downloads default models."
     )
 
+    marqo_search_random_connection_close_rate: float = Field(
+        0, ge=0.0, le=1.0, alias="MARQO_SEARCH_RANDOM_CONNECTION_CLOSE_RATE",
+        description="The rate of search requests that will randomly close the connection to enforce a new connect "
+                    "instantiation. ",
+    )
+
     @field_validator("marqo_default_models_s3_bucket")
     def validate_marqo_default_models_s3_bucket(cls, value):
         if not value:

--- a/components/marqo/src/marqo/version.py
+++ b/components/marqo/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.25.1"
+__version__ = "2.25.2"
 
 
 def get_version() -> str:

--- a/components/marqo/src/marqo/vespa/vespa_client.py
+++ b/components/marqo/src/marqo/vespa/vespa_client.py
@@ -7,6 +7,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from json import JSONDecodeError
 from typing import Dict, Any, List, Optional, Union, Tuple
+import random
 from urllib.parse import urlparse
 
 import httpcore
@@ -30,9 +31,11 @@ from marqo.vespa.models.delete_document_response import DeleteDocumentResponse, 
     DeleteBatchResponse, DeleteAllDocumentsResponse
 from marqo.vespa.models.get_document_response import GetDocumentResponse, VisitDocumentsResponse, GetBatchResponse, \
     GetBatchDocumentResponse
+from marqo.settings.settings import get_settings, Settings
 
 logger = marqo.logging.get_logger(__name__)
 
+settings: Settings = get_settings()
 
 class VespaClient:
     _VESPA_ERROR_CODE_TO_EXCEPTION = {
@@ -303,8 +306,22 @@ class VespaClient:
 
         logger.debug(f'Query: {query}')
 
+        should_drop_connection = False
+        if settings.marqo_search_random_connection_close_rate > 0.0:
+            should_drop_connection = (random.random() < settings.marqo_search_random_connection_close_rate)
+
+        if should_drop_connection:
+            logger.debug(f'Query will drop connection to enforce new connection instantiation ')
+            headers = {
+                'Connection': 'close'
+            }
+        else:
+            headers = None
+
         try:
-            resp = self.http_client.post(f'{self.query_url}/search/', json=query, timeout=httpx_client_timeout)
+            resp = self.http_client.post(
+                f'{self.query_url}/search/', json=query, timeout=httpx_client_timeout, headers=headers
+            )
         except httpx.HTTPError as e:
             raise VespaError(e) from e
 

--- a/components/marqo/src/marqo/vespa/vespa_client.py
+++ b/components/marqo/src/marqo/vespa/vespa_client.py
@@ -265,6 +265,16 @@ class VespaClient:
             f"{status_info}"
         )
 
+    def _should_drop_connection(self) -> bool:
+        """
+        Whether to drop the connection or not, based on a random value and the configured drop rate.
+        :return: True if the connection should be dropped, False otherwise
+        """
+        if settings.marqo_search_random_connection_close_rate <= 0:
+            return False
+        else:
+            return random.random() < settings.marqo_search_random_connection_close_rate
+
     def query(self, yql: str, hits: int = 10, ranking: str = None, model_restrict: str = None,
               query_features: Dict[str, Any] = None, timeout: Optional[float] = None, **kwargs) -> QueryResult:
         """
@@ -306,15 +316,9 @@ class VespaClient:
 
         logger.debug(f'Query: {query}')
 
-        should_drop_connection = False
-        if settings.marqo_search_random_connection_close_rate > 0.0:
-            should_drop_connection = (random.random() < settings.marqo_search_random_connection_close_rate)
-
-        if should_drop_connection:
-            logger.debug(f'Query will drop connection to enforce new connection instantiation ')
-            headers = {
-                'Connection': 'close'
-            }
+        if self._should_drop_connection():
+            logger.debug('Dropping connection for this query according to a set rate ')
+            headers = {"Connection": "close"}
         else:
             headers = None
 

--- a/components/marqo/src/marqo/vespa/vespa_client.py
+++ b/components/marqo/src/marqo/vespa/vespa_client.py
@@ -1,20 +1,20 @@
+from concurrent.futures import ThreadPoolExecutor
+from json import JSONDecodeError
+
 import asyncio
+import certifi
+import httpcore
+import httpx
 import io
+import orjson
 import os
+import random
+import ssl
 import tarfile
 import tempfile
 import time
-from concurrent.futures import ThreadPoolExecutor
-from json import JSONDecodeError
 from typing import Dict, Any, List, Optional, Union, Tuple
-import random
 from urllib.parse import urlparse
-
-import httpcore
-import httpx
-import orjson
-import ssl
-import certifi
 
 import marqo.logging
 import marqo.vespa.concurrency as conc
@@ -22,16 +22,16 @@ from marqo.core.models import MarqoIndex
 from marqo.core.semi_structured_vespa_index.common import VESPA_DOC_FIELD_TYPES, VESPA_DOC_VERSION_UUID
 from marqo.core.semi_structured_vespa_index.marqo_field_types import MarqoFieldTypes
 from marqo.marqo_docs import update_documents_response
+from marqo.settings.settings import get_settings, Settings
 from marqo.vespa.exceptions import (VespaStatusError, VespaError, InvalidVespaApplicationError,
                                     VespaTimeoutError, VespaNotConvergedError, VespaActivationConflictError)
-from marqo.vespa.models import VespaDocument, QueryResult, Error, FeedBatchDocumentResponse, FeedBatchResponse, \
+from marqo.vespa.models import VespaDocument, QueryResult, Error, FeedBatchResponse, \
     FeedDocumentResponse, UpdateDocumentsBatchResponse, UpdateDocumentResponse, FeedBatchDocumentResponse
 from marqo.vespa.models.application_metrics import ApplicationMetrics
 from marqo.vespa.models.delete_document_response import DeleteDocumentResponse, DeleteBatchDocumentResponse, \
     DeleteBatchResponse, DeleteAllDocumentsResponse
 from marqo.vespa.models.get_document_response import GetDocumentResponse, VisitDocumentsResponse, GetBatchResponse, \
     GetBatchDocumentResponse
-from marqo.settings.settings import get_settings, Settings
 
 logger = marqo.logging.get_logger(__name__)
 

--- a/components/marqo/src/marqo/vespa/vespa_client.py
+++ b/components/marqo/src/marqo/vespa/vespa_client.py
@@ -265,7 +265,7 @@ class VespaClient:
             f"{status_info}"
         )
 
-    def _should_drop_connection(self) -> bool:
+    def _should_drop_connection(self, seed: Optional[int] = None) -> bool:
         """
         Whether to drop the connection or not, based on a random value and the configured drop rate.
         :return: True if the connection should be dropped, False otherwise
@@ -273,10 +273,12 @@ class VespaClient:
         if settings.marqo_search_random_connection_close_rate <= 0:
             return False
         else:
-            return random.random() < settings.marqo_search_random_connection_close_rate
+            rng = random.Random(seed)
+            return  rng.random()< settings.marqo_search_random_connection_close_rate
 
     def query(self, yql: str, hits: int = 10, ranking: str = None, model_restrict: str = None,
-              query_features: Dict[str, Any] = None, timeout: Optional[float] = None, **kwargs) -> QueryResult:
+              query_features: Dict[str, Any] = None, timeout: Optional[float] = None,
+              drop_connection_random_seed: Optional[int]=None, **kwargs) -> QueryResult:
         """
         Query Vespa.
         Args:
@@ -286,6 +288,9 @@ class VespaClient:
             model_restrict: Schema to restrict the query to
             query_features: Query features
             timeout: The Vespa query timeout in milliseconds. If not set, the default timeout will be used.
+            drop_connection_random_seed: An optional random seed for dropping connection randomly.
+                This is for testing purpose to make the random behavior deterministic.
+                If not set, the random seed will be truly random.
             **kwargs: Additional query parameters
         Returns:
             Query result as a VespaQueryResult object
@@ -316,7 +321,7 @@ class VespaClient:
 
         logger.debug(f'Query: {query}')
 
-        if self._should_drop_connection():
+        if self._should_drop_connection(seed=drop_connection_random_seed):
             logger.debug('Dropping connection for this query according to a set rate ')
             headers = {"Connection": "close"}
         else:

--- a/components/marqo/tests/integ_tests/marqo_test.py
+++ b/components/marqo/tests/integ_tests/marqo_test.py
@@ -1,7 +1,10 @@
+from importlib import reload
+
 import contextlib
 import dotenv
 import os
 import socket
+import sys
 import threading
 import time
 import unittest
@@ -446,6 +449,23 @@ class MarqoTestCase(unittest.TestCase):
         Assert that a specific exception is raised. Will not pass for subclasses of the expected exception.
         """
         return self._AssertRaisesContext(expected_exception)
+
+    @contextlib.contextmanager
+    def help_mock_environment_variables_in_settings(self, env_vars: dict):
+        """
+        A help function to mock environment variables in settings.
+        It reloads the settings module to make sure the new env vars are picked up, and then reloads it again
+        after the test to restore the original env vars.
+        :param env_vars: A dictionary of environment variables to mock.
+        The keys are the env var names, and the values are the env var values.
+        """
+        try:
+            with patch.dict("os.environ", env_vars, clear=True):
+                reload(sys.modules["marqo.settings.settings"])
+                yield
+        finally:
+            # os.environ is restored by patch.dict before this runs,
+            reload(sys.modules["marqo.settings.settings"])
 
 
 class AsyncMarqoTestCase(unittest.IsolatedAsyncioTestCase, MarqoTestCase):

--- a/components/marqo/tests/integ_tests/vespa/test_vespa_client.py
+++ b/components/marqo/tests/integ_tests/vespa/test_vespa_client.py
@@ -949,13 +949,14 @@ class TestVespaClient(AsyncMarqoTestCase):
         with self.help_mock_environment_variables_in_settings({"MARQO_SEARCH_RANDOM_CONNECTION_CLOSE_RATE": "0.3"}):
             reload(sys.modules["marqo.vespa.vespa_client"])
             counter = 0
-            for _ in range(10):  # run multiple times to check that Connection: close is not sent
+            for seed in range(10):  # run multiple times to check that Connection: close is not sent
                 with patch.object(httpx.Client, "post", wraps=httpx.post) as mock_post:
                     self.client.query(
                         yql="select * from sources * where title contains 'Title 1';",
-                        model_restrict=self.TEST_SCHEMA
+                        model_restrict=self.TEST_SCHEMA, drop_connection_random_seed=seed
                     )
                     headers = mock_post.call_args.kwargs.get("headers")
                     if headers and headers.get("Connection") == "close":
                         counter += 1
-            self.assertTrue(0 < counter < 10, f"Expected some requests to have 'Connection: close' but got {counter}/10")
+            self.assertEqual(4, counter)
+

--- a/components/marqo/tests/integ_tests/vespa/test_vespa_client.py
+++ b/components/marqo/tests/integ_tests/vespa/test_vespa_client.py
@@ -22,6 +22,8 @@ from marqo.vespa.models.application_metrics import ApplicationMetrics
 from marqo.vespa.models.query_result import Error
 from marqo.vespa.vespa_client import VespaClient
 from tests.integ_tests.marqo_test import AsyncMarqoTestCase
+from importlib import reload
+import sys
 
 
 class TestVespaClient(AsyncMarqoTestCase):
@@ -912,3 +914,48 @@ class TestVespaClient(AsyncMarqoTestCase):
                     yql="select * from sources * where title contains 'Title 1';",
                     timeout=7000 # 7 seconds Vespa timeout, 8 seconds httpx timeout
                 )
+
+    def test_marqo_search_random_connection_close_rate_1(self):
+        """Test that query sends 'Connection: close' header based on the configured random close rate."""
+        documents = [
+            {"id": "doc1", "fields": {"title": "Title 1", "contents": "Content 1"}},
+        ]
+        self.pyvespa_client.feed_iterable(documents, self.TEST_SCHEMA)
+
+        with self.help_mock_environment_variables_in_settings({"MARQO_SEARCH_RANDOM_CONNECTION_CLOSE_RATE": "1.0"}):
+            reload(sys.modules["marqo.vespa.vespa_client"])  # reload module to apply env var change
+            with patch.object(httpx.Client, "post", wraps=httpx.post) as mock_post:
+                self.client.query(
+                    yql="select * from sources * where title contains 'Title 1';",
+                    model_restrict=self.TEST_SCHEMA
+                )
+                headers = mock_post.call_args.kwargs.get("headers") or {}
+                self.assertEqual("close", headers.get("Connection"), )
+
+    def test_marqo_search_random_connection_close_rate_0(self):
+        with self.help_mock_environment_variables_in_settings({"MARQO_SEARCH_RANDOM_CONNECTION_CLOSE_RATE": "0.0"}):
+            reload(sys.modules["marqo.vespa.vespa_client"])
+            for _ in range(10):  # run multiple times to check that Connection: close is not sent
+                with patch.object(httpx.Client, "post", wraps=httpx.post) as mock_post:
+                    self.client.query(
+                        yql="select * from sources * where title contains 'Title 1';",
+                        model_restrict=self.TEST_SCHEMA
+                    )
+                    headers = mock_post.call_args.kwargs.get("headers")
+                    if headers:
+                        self.assertNotIn("Connection", headers)
+
+    def test_marqo_search_random_connection_close_rate_0_1(self):
+        with self.help_mock_environment_variables_in_settings({"MARQO_SEARCH_RANDOM_CONNECTION_CLOSE_RATE": "0.3"}):
+            reload(sys.modules["marqo.vespa.vespa_client"])
+            counter = 0
+            for _ in range(10):  # run multiple times to check that Connection: close is not sent
+                with patch.object(httpx.Client, "post", wraps=httpx.post) as mock_post:
+                    self.client.query(
+                        yql="select * from sources * where title contains 'Title 1';",
+                        model_restrict=self.TEST_SCHEMA
+                    )
+                    headers = mock_post.call_args.kwargs.get("headers")
+                    if headers and headers.get("Connection") == "close":
+                        counter += 1
+            self.assertTrue(0 < counter < 10, f"Expected some requests to have 'Connection: close' but got {counter}/10")

--- a/components/marqo/tests/integ_tests/vespa/test_vespa_client.py
+++ b/components/marqo/tests/integ_tests/vespa/test_vespa_client.py
@@ -1,16 +1,18 @@
+from importlib import reload
+
 import asyncio
 import functools
-import json
-import os
-import time
-import unittest
-from unittest.mock import Mock, patch
-
 import httpcore
 import httpx
+import json
 import orjson
+import os
 import pytest
+import sys
+import time
+import unittest
 import vespa.application as pyvespa
+from unittest.mock import Mock, patch
 
 from marqo.tensor_search.api import generate_config
 from marqo.tensor_search.enums import EnvVars
@@ -22,8 +24,6 @@ from marqo.vespa.models.application_metrics import ApplicationMetrics
 from marqo.vespa.models.query_result import Error
 from marqo.vespa.vespa_client import VespaClient
 from tests.integ_tests.marqo_test import AsyncMarqoTestCase
-from importlib import reload
-import sys
 
 
 class TestVespaClient(AsyncMarqoTestCase):

--- a/components/marqo/tests/unit_tests/marqo/test_settings.py
+++ b/components/marqo/tests/unit_tests/marqo/test_settings.py
@@ -77,6 +77,49 @@ class TestSettings(unittest.TestCase):
             self.assertEqual(settings.marqo_default_models_s3_bucket, "s3://marqo-default-models-os")
 
 
+class TestRandomConnectionCloseRateSetting(unittest.TestCase):
+    """Tests for the marqo_search_random_connection_close_rate setting."""
+
+    def test_default_rate_is_zero(self):
+        """Test that the default random connection close rate is 0."""
+        with patch.dict("os.environ", {}, clear=True):
+            settings = Settings()
+            self.assertEqual(settings.marqo_search_random_connection_close_rate, 0)
+
+    def test_rate_from_env_var(self):
+        """Test setting rate via MARQO_SEARCH_RANDOM_CONNECTION_CLOSE_RATE env var."""
+        test_cases = [
+            ("0", 0.0),
+            ("0.0", 0.0),
+            ("0.5", 0.5),
+            ("1.0", 1.0),
+            ("0.01", 0.01),
+        ]
+        for env_value, expected in test_cases:
+            with self.subTest(env_value=env_value):
+                with patch.dict("os.environ", {"MARQO_SEARCH_RANDOM_CONNECTION_CLOSE_RATE": env_value}, clear=True):
+                    settings = Settings()
+                    self.assertAlmostEqual(settings.marqo_search_random_connection_close_rate, expected)
+
+    def test_rate_rejects_value_above_1(self):
+        """Test that a rate above 1.0 is rejected."""
+        with patch.dict("os.environ", {"MARQO_SEARCH_RANDOM_CONNECTION_CLOSE_RATE": "1.5"}, clear=True):
+            with self.assertRaises(ValidationError):
+                Settings()
+
+    def test_rate_rejects_negative_value(self):
+        """Test that a negative rate is rejected."""
+        with patch.dict("os.environ", {"MARQO_SEARCH_RANDOM_CONNECTION_CLOSE_RATE": "-0.1"}, clear=True):
+            with self.assertRaises(ValidationError):
+                Settings()
+
+    def test_rate_rejects_non_numeric_value(self):
+        """Test that a non-numeric rate is rejected."""
+        with patch.dict("os.environ", {"MARQO_SEARCH_RANDOM_CONNECTION_CLOSE_RATE": "abc"}, clear=True):
+            with self.assertRaises(ValidationError):
+                Settings()
+
+
 class TestGetSettings(unittest.TestCase):
     """Tests for the get_settings function."""
 

--- a/components/marqo/tests/unit_tests/vespa/test_vespa_client.py
+++ b/components/marqo/tests/unit_tests/vespa/test_vespa_client.py
@@ -624,62 +624,67 @@ class TestVespaClient(unittest.TestCase):
 
     @patch('marqo.vespa.vespa_client.settings')
     @patch('marqo.vespa.vespa_client.random')
-    def test_should_drop_connection_returns_false_when_rate_is_zero(self, mock_random, mock_settings):
-        """Test that _should_drop_connection returns False when rate is 0."""
-        mock_settings.marqo_search_random_connection_close_rate = 0
-        self.assertFalse(self.vespa_client._should_drop_connection())
-        mock_random.random.assert_not_called()
-
-    @patch('marqo.vespa.vespa_client.settings')
-    @patch('marqo.vespa.vespa_client.random')
-    def test_should_drop_connection_returns_true_when_random_below_rate(self, mock_random, mock_settings):
-        """Test that _should_drop_connection returns True when random value is below the rate."""
+    def test_query_sends_connection_close_header_when_random_below_rate(self, mock_random, mock_settings):
+        """Test that query sends 'Connection: close' header when random value is below the configured rate."""
         mock_settings.marqo_search_random_connection_close_rate = 0.5
         mock_random.random.return_value = 0.3
-        self.assertTrue(self.vespa_client._should_drop_connection())
 
-    @patch('marqo.vespa.vespa_client.settings')
-    @patch('marqo.vespa.vespa_client.random')
-    def test_should_drop_connection_returns_false_when_random_above_rate(self, mock_random, mock_settings):
-        """Test that _should_drop_connection returns False when random value is above the rate."""
-        mock_settings.marqo_search_random_connection_close_rate = 0.5
-        mock_random.random.return_value = 0.7
-        self.assertFalse(self.vespa_client._should_drop_connection())
-
-    @patch('marqo.vespa.vespa_client.settings')
-    @patch('marqo.vespa.vespa_client.random')
-    def test_should_drop_connection_rate_1_always_drops(self, mock_random, mock_settings):
-        """Test that _should_drop_connection always returns True when rate is 1.0."""
-        mock_settings.marqo_search_random_connection_close_rate = 1.0
-        mock_random.random.return_value = 0.999
-        self.assertTrue(self.vespa_client._should_drop_connection())
-
-    def test_query_sends_connection_close_header_when_dropping(self):
-        """Test that query sends 'connection: close' header when _should_drop_connection is True."""
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.text = '{"root": {"id": "test", "relevance": 1.0, "children": []}}'
 
-        with patch.object(self.vespa_client, '_should_drop_connection', return_value=True), \
-             patch.object(httpx.Client, 'post', return_value=mock_response) as mock_post:
+        with patch.object(httpx.Client, 'post', return_value=mock_response) as mock_post:
             self.vespa_client.query(yql="select * from sources * where test;")
             headers = mock_post.call_args.kwargs["headers"]
             self.assertEqual(headers, {"Connection": "close"})
 
-    def test_query_sends_no_connection_close_header_when_not_dropping(self):
-        """Test that query does not send 'connection: close' header when _should_drop_connection is False."""
+    @patch('marqo.vespa.vespa_client.settings')
+    @patch('marqo.vespa.vespa_client.random')
+    def test_query_no_connection_close_header_when_random_above_rate(self, mock_random, mock_settings):
+        """Test that query does not send 'Connection: close' header when random value is above the configured rate."""
+        mock_settings.marqo_search_random_connection_close_rate = 0.5
+        mock_random.random.return_value = 0.7
+
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.text = '{"root": {"id": "test", "relevance": 1.0, "children": []}}'
 
-        with patch.object(self.vespa_client, '_should_drop_connection', return_value=False), \
-             patch.object(httpx.Client, 'post', return_value=mock_response) as mock_post:
+        with patch.object(httpx.Client, 'post', return_value=mock_response) as mock_post:
             self.vespa_client.query(yql="select * from sources * where test;")
             headers = mock_post.call_args.kwargs["headers"]
-            # When not dropping, headers should not contain 'connection: close'
             if headers:
                 self.assertNotIn("Connection", headers)
-            # headers can be None or empty dict, both are acceptable
+
+    @patch('marqo.vespa.vespa_client.settings')
+    def test_query_no_connection_close_header_when_rate_is_zero(self, mock_settings):
+        """Test that query does not send 'Connection: close' header when rate is 0 (default)."""
+        mock_settings.marqo_search_random_connection_close_rate = 0
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = '{"root": {"id": "test", "relevance": 1.0, "children": []}}'
+
+        with patch.object(httpx.Client, 'post', return_value=mock_response) as mock_post:
+            self.vespa_client.query(yql="select * from sources * where test;")
+            headers = mock_post.call_args.kwargs["headers"]
+            if headers:
+                self.assertNotIn("Connection", headers)
+
+    @patch('marqo.vespa.vespa_client.settings')
+    @patch('marqo.vespa.vespa_client.random')
+    def test_query_connection_close_header_with_rate_1(self, mock_random, mock_settings):
+        """Test that query always sends 'Connection: close' header when rate is 1.0."""
+        mock_settings.marqo_search_random_connection_close_rate = 1.0
+        mock_random.random.return_value = 0.999
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = '{"root": {"id": "test", "relevance": 1.0, "children": []}}'
+
+        with patch.object(httpx.Client, 'post', return_value=mock_response) as mock_post:
+            self.vespa_client.query(yql="select * from sources * where test;")
+            headers = mock_post.call_args.kwargs["headers"]
+            self.assertEqual(headers, {"Connection": "close"})
 
     @patch('marqo.vespa.vespa_client.logger')
     def test_wait_for_convergence_retries_on_httpx_timeout(self, mock_logger):

--- a/components/marqo/tests/unit_tests/vespa/test_vespa_client.py
+++ b/components/marqo/tests/unit_tests/vespa/test_vespa_client.py
@@ -622,38 +622,27 @@ class TestVespaClient(unittest.TestCase):
 
         mock_logger.warning.assert_not_called()
 
-    @patch('marqo.vespa.vespa_client.settings')
-    def test_query_sends_connection_close_header_when_random_below_rate(self, mock_settings):
-        """Test that query sends 'Connection: close' header when seeded random value is below the configured rate."""
-        mock_settings.marqo_search_random_connection_close_rate = 0.5
-        # Seed 0 produces random.Random(0).random() ≈ 0.844, seed 3 produces ≈ 0.236
-        # Find a seed that produces a value below 0.5
-        import random as random_module
-        seed = next(s for s in range(100) if random_module.Random(s).random() < 0.5)
-
+    def test_query_sends_connection_close_header_when_should_drop(self):
+        """Test that query sends 'Connection: close' header when _should_drop_connection returns True."""
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.text = '{"root": {"id": "test", "relevance": 1.0, "children": []}}'
 
-        with patch.object(httpx.Client, 'post', return_value=mock_response) as mock_post:
-            self.vespa_client.query(yql="select * from sources * where test;", drop_connection_random_seed=seed)
+        with patch.object(self.vespa_client, '_should_drop_connection', return_value=True), \
+             patch.object(httpx.Client, 'post', return_value=mock_response) as mock_post:
+            self.vespa_client.query(yql="select * from sources * where test;")
             headers = mock_post.call_args.kwargs["headers"]
             self.assertEqual(headers, {"Connection": "close"})
 
-    @patch('marqo.vespa.vespa_client.settings')
-    def test_query_no_connection_close_header_when_random_above_rate(self, mock_settings):
-        """Test that query does not send 'Connection: close' header when seeded random value is above the configured rate."""
-        mock_settings.marqo_search_random_connection_close_rate = 0.5
-        # Find a seed that produces a value above 0.5
-        import random as random_module
-        seed = next(s for s in range(100) if random_module.Random(s).random() >= 0.5)
-
+    def test_query_no_connection_close_header_when_should_not_drop(self):
+        """Test that query does not send 'Connection: close' header when _should_drop_connection returns False."""
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.text = '{"root": {"id": "test", "relevance": 1.0, "children": []}}'
 
-        with patch.object(httpx.Client, 'post', return_value=mock_response) as mock_post:
-            self.vespa_client.query(yql="select * from sources * where test;", drop_connection_random_seed=seed)
+        with patch.object(self.vespa_client, '_should_drop_connection', return_value=False), \
+             patch.object(httpx.Client, 'post', return_value=mock_response) as mock_post:
+            self.vespa_client.query(yql="select * from sources * where test;")
             headers = mock_post.call_args.kwargs["headers"]
             if headers:
                 self.assertNotIn("Connection", headers)

--- a/components/marqo/tests/unit_tests/vespa/test_vespa_client.py
+++ b/components/marqo/tests/unit_tests/vespa/test_vespa_client.py
@@ -623,34 +623,37 @@ class TestVespaClient(unittest.TestCase):
         mock_logger.warning.assert_not_called()
 
     @patch('marqo.vespa.vespa_client.settings')
-    @patch('marqo.vespa.vespa_client.random')
-    def test_query_sends_connection_close_header_when_random_below_rate(self, mock_random, mock_settings):
-        """Test that query sends 'Connection: close' header when random value is below the configured rate."""
+    def test_query_sends_connection_close_header_when_random_below_rate(self, mock_settings):
+        """Test that query sends 'Connection: close' header when seeded random value is below the configured rate."""
         mock_settings.marqo_search_random_connection_close_rate = 0.5
-        mock_random.random.return_value = 0.3
+        # Seed 0 produces random.Random(0).random() ≈ 0.844, seed 3 produces ≈ 0.236
+        # Find a seed that produces a value below 0.5
+        import random as random_module
+        seed = next(s for s in range(100) if random_module.Random(s).random() < 0.5)
 
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.text = '{"root": {"id": "test", "relevance": 1.0, "children": []}}'
 
         with patch.object(httpx.Client, 'post', return_value=mock_response) as mock_post:
-            self.vespa_client.query(yql="select * from sources * where test;")
+            self.vespa_client.query(yql="select * from sources * where test;", drop_connection_random_seed=seed)
             headers = mock_post.call_args.kwargs["headers"]
             self.assertEqual(headers, {"Connection": "close"})
 
     @patch('marqo.vespa.vespa_client.settings')
-    @patch('marqo.vespa.vespa_client.random')
-    def test_query_no_connection_close_header_when_random_above_rate(self, mock_random, mock_settings):
-        """Test that query does not send 'Connection: close' header when random value is above the configured rate."""
+    def test_query_no_connection_close_header_when_random_above_rate(self, mock_settings):
+        """Test that query does not send 'Connection: close' header when seeded random value is above the configured rate."""
         mock_settings.marqo_search_random_connection_close_rate = 0.5
-        mock_random.random.return_value = 0.7
+        # Find a seed that produces a value above 0.5
+        import random as random_module
+        seed = next(s for s in range(100) if random_module.Random(s).random() >= 0.5)
 
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.text = '{"root": {"id": "test", "relevance": 1.0, "children": []}}'
 
         with patch.object(httpx.Client, 'post', return_value=mock_response) as mock_post:
-            self.vespa_client.query(yql="select * from sources * where test;")
+            self.vespa_client.query(yql="select * from sources * where test;", drop_connection_random_seed=seed)
             headers = mock_post.call_args.kwargs["headers"]
             if headers:
                 self.assertNotIn("Connection", headers)
@@ -671,20 +674,26 @@ class TestVespaClient(unittest.TestCase):
                 self.assertNotIn("Connection", headers)
 
     @patch('marqo.vespa.vespa_client.settings')
-    @patch('marqo.vespa.vespa_client.random')
-    def test_query_connection_close_header_with_rate_1(self, mock_random, mock_settings):
+    def test_query_connection_close_header_with_rate_1(self, mock_settings):
         """Test that query always sends 'Connection: close' header when rate is 1.0."""
         mock_settings.marqo_search_random_connection_close_rate = 1.0
-        mock_random.random.return_value = 0.999
 
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.text = '{"root": {"id": "test", "relevance": 1.0, "children": []}}'
 
         with patch.object(httpx.Client, 'post', return_value=mock_response) as mock_post:
-            self.vespa_client.query(yql="select * from sources * where test;")
+            self.vespa_client.query(yql="select * from sources * where test;", drop_connection_random_seed=42)
             headers = mock_post.call_args.kwargs["headers"]
             self.assertEqual(headers, {"Connection": "close"})
+
+    @patch('marqo.vespa.vespa_client.settings')
+    def test_should_drop_connection_is_reproducible_with_same_seed(self, mock_settings):
+        """Test that _should_drop_connection returns the same result for the same seed."""
+        mock_settings.marqo_search_random_connection_close_rate = 0.5
+        result1 = self.vespa_client._should_drop_connection(seed=42)
+        result2 = self.vespa_client._should_drop_connection(seed=42)
+        self.assertEqual(result1, result2)
 
     @patch('marqo.vespa.vespa_client.logger')
     def test_wait_for_convergence_retries_on_httpx_timeout(self, mock_logger):

--- a/components/marqo/tests/unit_tests/vespa/test_vespa_client.py
+++ b/components/marqo/tests/unit_tests/vespa/test_vespa_client.py
@@ -622,6 +622,65 @@ class TestVespaClient(unittest.TestCase):
 
         mock_logger.warning.assert_not_called()
 
+    @patch('marqo.vespa.vespa_client.settings')
+    @patch('marqo.vespa.vespa_client.random')
+    def test_should_drop_connection_returns_false_when_rate_is_zero(self, mock_random, mock_settings):
+        """Test that _should_drop_connection returns False when rate is 0."""
+        mock_settings.marqo_search_random_connection_close_rate = 0
+        self.assertFalse(self.vespa_client._should_drop_connection())
+        mock_random.random.assert_not_called()
+
+    @patch('marqo.vespa.vespa_client.settings')
+    @patch('marqo.vespa.vespa_client.random')
+    def test_should_drop_connection_returns_true_when_random_below_rate(self, mock_random, mock_settings):
+        """Test that _should_drop_connection returns True when random value is below the rate."""
+        mock_settings.marqo_search_random_connection_close_rate = 0.5
+        mock_random.random.return_value = 0.3
+        self.assertTrue(self.vespa_client._should_drop_connection())
+
+    @patch('marqo.vespa.vespa_client.settings')
+    @patch('marqo.vespa.vespa_client.random')
+    def test_should_drop_connection_returns_false_when_random_above_rate(self, mock_random, mock_settings):
+        """Test that _should_drop_connection returns False when random value is above the rate."""
+        mock_settings.marqo_search_random_connection_close_rate = 0.5
+        mock_random.random.return_value = 0.7
+        self.assertFalse(self.vespa_client._should_drop_connection())
+
+    @patch('marqo.vespa.vespa_client.settings')
+    @patch('marqo.vespa.vespa_client.random')
+    def test_should_drop_connection_rate_1_always_drops(self, mock_random, mock_settings):
+        """Test that _should_drop_connection always returns True when rate is 1.0."""
+        mock_settings.marqo_search_random_connection_close_rate = 1.0
+        mock_random.random.return_value = 0.999
+        self.assertTrue(self.vespa_client._should_drop_connection())
+
+    def test_query_sends_connection_close_header_when_dropping(self):
+        """Test that query sends 'connection: close' header when _should_drop_connection is True."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = '{"root": {"id": "test", "relevance": 1.0, "children": []}}'
+
+        with patch.object(self.vespa_client, '_should_drop_connection', return_value=True), \
+             patch.object(httpx.Client, 'post', return_value=mock_response) as mock_post:
+            self.vespa_client.query(yql="select * from sources * where test;")
+            headers = mock_post.call_args.kwargs["headers"]
+            self.assertEqual(headers, {"Connection": "close"})
+
+    def test_query_sends_no_connection_close_header_when_not_dropping(self):
+        """Test that query does not send 'connection: close' header when _should_drop_connection is False."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = '{"root": {"id": "test", "relevance": 1.0, "children": []}}'
+
+        with patch.object(self.vespa_client, '_should_drop_connection', return_value=False), \
+             patch.object(httpx.Client, 'post', return_value=mock_response) as mock_post:
+            self.vespa_client.query(yql="select * from sources * where test;")
+            headers = mock_post.call_args.kwargs["headers"]
+            # When not dropping, headers should not contain 'connection: close'
+            if headers:
+                self.assertNotIn("Connection", headers)
+            # headers can be None or empty dict, both are acceptable
+
     @patch('marqo.vespa.vespa_client.logger')
     def test_wait_for_convergence_retries_on_httpx_timeout(self, mock_logger):
         """Test that httpx timeout exceptions are caught and retried."""

--- a/components/marqo/tests/unit_tests/vespa/test_vespa_client.py
+++ b/components/marqo/tests/unit_tests/vespa/test_vespa_client.py
@@ -672,7 +672,7 @@ class TestVespaClient(unittest.TestCase):
         mock_response.text = '{"root": {"id": "test", "relevance": 1.0, "children": []}}'
 
         with patch.object(httpx.Client, 'post', return_value=mock_response) as mock_post:
-            self.vespa_client.query(yql="select * from sources * where test;", drop_connection_random_seed=42)
+            self.vespa_client.query(yql="select * from sources * where test;", drop_connection_random_seed=12)
             headers = mock_post.call_args.kwargs["headers"]
             self.assertEqual(headers, {"Connection": "close"})
 


### PR DESCRIPTION
## Change Summary
 - Add random connection close for search queries: Introduces a configurable MARQO_SEARCH_RANDOM_CONNECTION_CLOSE_RATE environment variable (float, 0.0-1.0, default 0) that randomly sends a Connection: close header on search queries. This forces periodic connection recycling to Vespa, which can help mitigate  issues with stale connections in long-running deployments.                                                                                                                                                                                                                                                                
- CI/CD workflow updates: Renames AMI-ECR to STAGING-ECR and switches from static AWS credentials to OIDC-based role assumption for ECR authentication.                                                                                                                                                                   
- Version bump: 2.25.1 -> 2.25.2    

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

