### PR TITLE
Set minSortCandidates to limit+offset

### DIFF
--- a/components/marqo/src/marqo/tensor_search/models/api_models.py
+++ b/components/marqo/src/marqo/tensor_search/models/api_models.py
@@ -476,12 +476,7 @@ class SearchQuery(BaseMarqoModel):
             )
         else:
             # If min_sort_candidates is provided, ensure it is at least as large as offset + limit
-            if sort_by.min_sort_candidates < (values.get('offset') + values.get('limit')):
-                raise ValueError(
-                    f" minSortCandidates must be at least as large as offset + limit. Received "
-                    f" minSortCandidates={sort_by.min_sort_candidates}, limit={values.get('limit')}, "
-                    f" offset={values.get('offset')} "
-                )
+            sort_by.min_sort_candidates = max(sort_by.min_sort_candidates, values.get('offset') + values.get('limit'))
         return values
 
     @root_validator(pre=False)

--- a/components/marqo/src/marqo/version.py
+++ b/components/marqo/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.25.2"
+__version__ = "2.25.3"
 
 
 def get_version() -> str:

--- a/components/marqo/tests/api_tests/v1/tests/api_tests/test_sort_by_feature.py
+++ b/components/marqo/tests/api_tests/v1/tests/api_tests/test_sort_by_feature.py
@@ -284,28 +284,24 @@ class TestSortByFeature(MarqoTestCase):
         self.assertEqual(6, response_without_sort_depth["_sortCandidates"])
 
     def test_sort_candidate_must_larger_than_limit_plus_offset(self):
-        with self.assertRaises(MarqoWebError) as cm:
-            self.client.index(self.unstructured_index_name).search(
-                q="test",
-                search_method="HYBRID",
-                limit=1,
-                offset=2,
-                sort_by={
-                    "fields": [
-                        {
-                            "fieldName": "title",
-                            "order": "asc",
-                            "missing": "last"
-                        },
-                    ],
-                    "minSortCandidates": 2
-                }
-            )
-
-        self.assertIn(
-            "minSortCandidates must be at least as large as offset + limit",
-            str(cm.exception)
+        res = self.client.index(self.unstructured_index_name).search(
+            q="test",
+            search_method="HYBRID",
+            limit=1,
+            offset=2,
+            sort_by={
+                "fields": [
+                    {
+                        "fieldName": "title",
+                        "order": "asc",
+                        "missing": "last"
+                    },
+                ],
+                "minSortCandidates": 2
+            }
         )
+        # sort candidates should be returned even if it's less than limit + offset
+        self.assertIn("_sortCandidates", res)
 
     def test_sort_by_can_not_sort_more_than_3_fields(self):
         with self.assertRaises(MarqoWebError) as cm:

--- a/components/marqo/tests/unit_tests/marqo/api/models/test_sort_by_model.py
+++ b/components/marqo/tests/unit_tests/marqo/api/models/test_sort_by_model.py
@@ -151,7 +151,7 @@ class TestSortByModels(TestCase):
             limit=50,
             offset=29
         )
-        self.assertEqual(query.sort_by.min_sort_candidates, 79)  # max(77, 50+29)
+        self.assertEqual(79, query.sort_by.min_sort_candidates)
 
     def test_sort_by_sort_candidates_with_default_limit_and_offset(self):
         query = SearchQuery(

--- a/components/marqo/tests/unit_tests/marqo/api/models/test_sort_by_model.py
+++ b/components/marqo/tests/unit_tests/marqo/api/models/test_sort_by_model.py
@@ -142,17 +142,16 @@ class TestSortByModels(TestCase):
         )
         self.assertEqual(query.sort_by.min_sort_candidates, 11)
 
-    def test_sort_by_explicit_sort_candidates_checked_against_limit_and_offset(self):
-        """Ensure an error is raised if minSortCandidates is less than offset + limit."""
-        with self.assertRaises(ValidationError) as e:
-            _ = SearchQuery(
-                q="explicit test",
-                searchMethod=SearchMethod.HYBRID,
-                sortBy=SortByModel(fields=[SortByField(fieldName="value")], min_sort_candidates=77),
-                limit=50,
-                offset=29
-            )
-        self.assertIn("minSortCandidates must be at least as large as offset + limit", str(e.exception))
+    def test_sort_by_explicit_sort_candidates_adjusted_to_offset_plus_limit(self):
+        """Ensure minSortCandidates is adjusted to offset + limit when it's smaller."""
+        query = SearchQuery(
+            q="explicit test",
+            searchMethod=SearchMethod.HYBRID,
+            sortBy=SortByModel(fields=[SortByField(fieldName="value")], min_sort_candidates=77),
+            limit=50,
+            offset=29
+        )
+        self.assertEqual(query.sort_by.min_sort_candidates, 79)  # max(77, 50+29)
 
     def test_sort_by_sort_candidates_with_default_limit_and_offset(self):
         query = SearchQuery(


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->
Changed _validate_and_set_sort_by_min_sort_candidates_parameters in SearchQuery to silently adjust minSortCandidates to offset + limit instead of raising a ValidationError when the user-provided value is too small.                                                                                                  

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

