### PR TITLE
Fix bf16: parameterize tensor numeric type in schema

### DIFF
--- a/components/marqo/tests/api_tests/v1/tests/api_tests/test_bfloat16.py
+++ b/components/marqo/tests/api_tests/v1/tests/api_tests/test_bfloat16.py
@@ -54,11 +54,12 @@ class TestBfloat16(MarqoTestCase):
         )
         self.assertEqual("doc3", lexical_res["hits"][0]["_id"])
 
-        # Hybrid search
+        # Hybrid search - still works with bf16 vectors, should return all relevant docs
         hybrid_res = self.client.index(self.unstructured_index_name).search(
             q="fox jumping", search_method="HYBRID"
         )
-        self.assertEqual(3, len(hybrid_res["hits"]))
+        hits = [hit["_id"] for hit in hybrid_res["hits"]]
+        self.assertEqual(["doc1", "doc2", "doc3"], hits)
 
     def test_bfloat16_get_document_with_vectors(self):
         """Verify that documents can be retrieved with their bf16 vectors."""

--- a/components/marqo/tests/api_tests/v1/tests/api_tests/test_bfloat16.py
+++ b/components/marqo/tests/api_tests/v1/tests/api_tests/test_bfloat16.py
@@ -1,7 +1,5 @@
 import uuid
 
-from marqo.client import Client
-
 from tests.marqo_test import MarqoTestCase
 
 
@@ -14,7 +12,6 @@ class TestBfloat16(MarqoTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.client = Client(**cls.client_settings)
 
         cls.create_indexes([
             {

--- a/components/marqo/tests/api_tests/v1/tests/api_tests/test_bfloat16.py
+++ b/components/marqo/tests/api_tests/v1/tests/api_tests/test_bfloat16.py
@@ -60,25 +60,23 @@ class TestBfloat16(MarqoTestCase):
         )
         self.assertFalse(res["errors"])
 
-        # Tensor search
+        # Tensor search - semantic match should rank doc1 first
         tensor_res = self.client.index(self.unstructured_index_name).search(
             q="fox jumping", search_method="TENSOR"
         )
-        self.assertGreater(len(tensor_res["hits"]), 0)
         self.assertEqual("doc1", tensor_res["hits"][0]["_id"])
 
-        # Lexical search
+        # Lexical search - keyword match should rank doc3 first
         lexical_res = self.client.index(self.unstructured_index_name).search(
             q="programming language", search_method="LEXICAL"
         )
-        self.assertGreater(len(lexical_res["hits"]), 0)
         self.assertEqual("doc3", lexical_res["hits"][0]["_id"])
 
         # Hybrid search
         hybrid_res = self.client.index(self.unstructured_index_name).search(
             q="fox jumping", search_method="HYBRID"
         )
-        self.assertGreater(len(hybrid_res["hits"]), 0)
+        self.assertEqual(3, len(hybrid_res["hits"]))
 
     def test_structured_bfloat16_add_and_search(self):
         """Add documents to structured bf16 index and verify all search methods work."""
@@ -90,25 +88,23 @@ class TestBfloat16(MarqoTestCase):
         res = self.client.index(self.structured_index_name).add_documents(documents)
         self.assertFalse(res["errors"])
 
-        # Tensor search
+        # Tensor search - semantic match should rank doc1 first
         tensor_res = self.client.index(self.structured_index_name).search(
             q="fox jumping", search_method="TENSOR"
         )
-        self.assertGreater(len(tensor_res["hits"]), 0)
         self.assertEqual("doc1", tensor_res["hits"][0]["_id"])
 
-        # Lexical search
+        # Lexical search - keyword match should rank doc3 first
         lexical_res = self.client.index(self.structured_index_name).search(
             q="programming language", search_method="LEXICAL"
         )
-        self.assertGreater(len(lexical_res["hits"]), 0)
         self.assertEqual("doc3", lexical_res["hits"][0]["_id"])
 
         # Hybrid search
         hybrid_res = self.client.index(self.structured_index_name).search(
             q="fox jumping", search_method="HYBRID"
         )
-        self.assertGreater(len(hybrid_res["hits"]), 0)
+        self.assertEqual(3, len(hybrid_res["hits"]))
 
     def test_bfloat16_get_document_with_vectors(self):
         """Verify that documents can be retrieved with their bf16 vectors."""
@@ -122,4 +118,3 @@ class TestBfloat16(MarqoTestCase):
         )
         self.assertEqual("vec_doc1", doc["_id"])
         self.assertIn("_tensor_facets", doc)
-        self.assertGreater(len(doc["_tensor_facets"]), 0)

--- a/components/marqo/tests/api_tests/v1/tests/api_tests/test_bfloat16.py
+++ b/components/marqo/tests/api_tests/v1/tests/api_tests/test_bfloat16.py
@@ -6,11 +6,10 @@ from tests.marqo_test import MarqoTestCase
 
 
 class TestBfloat16(MarqoTestCase):
-    """End-to-end tests for creating indexes with bfloat16 vector numeric type,
+    """End-to-end tests for creating an unstructured index with bfloat16 vector numeric type,
     indexing documents, and searching."""
 
     unstructured_index_name = "bf16_unstructured_" + str(uuid.uuid4()).replace('-', '')
-    structured_index_name = "bf16_structured_" + str(uuid.uuid4()).replace('-', '')
 
     @classmethod
     def setUpClass(cls):
@@ -24,32 +23,17 @@ class TestBfloat16(MarqoTestCase):
                 "model": "hf/all-MiniLM-L6-v2",
                 "vectorNumericType": "bfloat16",
             },
-            {
-                "indexName": cls.structured_index_name,
-                "type": "structured",
-                "model": "hf/all-MiniLM-L6-v2",
-                "vectorNumericType": "bfloat16",
-                "allFields": [
-                    {"name": "title", "type": "text", "features": ["lexical_search"]},
-                ],
-                "tensorFields": ["title"],
-            },
         ])
 
-        cls.indexes_to_delete = [cls.unstructured_index_name, cls.structured_index_name]
+        cls.indexes_to_delete = [cls.unstructured_index_name]
 
-    def test_unstructured_bfloat16_settings(self):
-        """Verify unstructured bf16 index has correct vectorNumericType setting."""
+    def test_bfloat16_settings(self):
+        """Verify bf16 index has correct vectorNumericType setting."""
         settings = self.client.index(self.unstructured_index_name).get_settings()
         self.assertEqual("bfloat16", settings["vectorNumericType"])
 
-    def test_structured_bfloat16_settings(self):
-        """Verify structured bf16 index has correct vectorNumericType setting."""
-        settings = self.client.index(self.structured_index_name).get_settings()
-        self.assertEqual("bfloat16", settings["vectorNumericType"])
-
-    def test_unstructured_bfloat16_add_and_search(self):
-        """Add documents to unstructured bf16 index and verify all search methods work."""
+    def test_bfloat16_add_and_search(self):
+        """Add documents to bf16 index and verify all search methods work."""
         documents = [
             {"_id": "doc1", "title": "The quick brown fox jumps over the lazy dog"},
             {"_id": "doc2", "title": "A fast auburn canine leaps above a sleepy hound"},
@@ -74,34 +58,6 @@ class TestBfloat16(MarqoTestCase):
 
         # Hybrid search
         hybrid_res = self.client.index(self.unstructured_index_name).search(
-            q="fox jumping", search_method="HYBRID"
-        )
-        self.assertEqual(3, len(hybrid_res["hits"]))
-
-    def test_structured_bfloat16_add_and_search(self):
-        """Add documents to structured bf16 index and verify all search methods work."""
-        documents = [
-            {"_id": "doc1", "title": "The quick brown fox jumps over the lazy dog"},
-            {"_id": "doc2", "title": "A fast auburn canine leaps above a sleepy hound"},
-            {"_id": "doc3", "title": "Python is a popular programming language"},
-        ]
-        res = self.client.index(self.structured_index_name).add_documents(documents)
-        self.assertFalse(res["errors"])
-
-        # Tensor search - semantic match should rank doc1 first
-        tensor_res = self.client.index(self.structured_index_name).search(
-            q="fox jumping", search_method="TENSOR"
-        )
-        self.assertEqual("doc1", tensor_res["hits"][0]["_id"])
-
-        # Lexical search - keyword match should rank doc3 first
-        lexical_res = self.client.index(self.structured_index_name).search(
-            q="programming language", search_method="LEXICAL"
-        )
-        self.assertEqual("doc3", lexical_res["hits"][0]["_id"])
-
-        # Hybrid search
-        hybrid_res = self.client.index(self.structured_index_name).search(
             q="fox jumping", search_method="HYBRID"
         )
         self.assertEqual(3, len(hybrid_res["hits"]))

--- a/components/marqo/tests/api_tests/v1/tests/api_tests/test_bfloat16.py
+++ b/components/marqo/tests/api_tests/v1/tests/api_tests/test_bfloat16.py
@@ -1,6 +1,6 @@
 import uuid
 
-from marqo.errors import MarqoWebError
+from marqo.client import Client
 
 from tests.marqo_test import MarqoTestCase
 
@@ -9,104 +9,117 @@ class TestBfloat16(MarqoTestCase):
     """End-to-end tests for creating indexes with bfloat16 vector numeric type,
     indexing documents, and searching."""
 
-    def setUp(self) -> None:
-        super().setUp()
-        self.index_name = "test_bf16_" + str(uuid.uuid4()).replace('-', '')
+    unstructured_index_name = "bf16_unstructured_" + str(uuid.uuid4()).replace('-', '')
+    structured_index_name = "bf16_structured_" + str(uuid.uuid4()).replace('-', '')
 
-    def tearDown(self):
-        super().tearDown()
-        try:
-            self.client.delete_index(index_name=self.index_name)
-        except MarqoWebError:
-            pass
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.client = Client(**cls.client_settings)
 
-    def test_unstructured_bfloat16_index_add_and_search(self):
-        """Create an unstructured bf16 index, add documents, and verify all search methods work."""
-        self.client.create_index(
-            index_name=self.index_name,
-            type="unstructured",
-            model="hf/all-MiniLM-L6-v2",
-            vector_numeric_type="bfloat16",
-        )
+        cls.create_indexes([
+            {
+                "indexName": cls.unstructured_index_name,
+                "type": "unstructured",
+                "model": "hf/all-MiniLM-L6-v2",
+                "vectorNumericType": "bfloat16",
+            },
+            {
+                "indexName": cls.structured_index_name,
+                "type": "structured",
+                "model": "hf/all-MiniLM-L6-v2",
+                "vectorNumericType": "bfloat16",
+                "allFields": [
+                    {"name": "title", "type": "text", "features": ["lexical_search"]},
+                ],
+                "tensorFields": ["title"],
+            },
+        ])
 
+        cls.indexes_to_delete = [cls.unstructured_index_name, cls.structured_index_name]
+
+    def test_unstructured_bfloat16_settings(self):
+        """Verify unstructured bf16 index has correct vectorNumericType setting."""
+        settings = self.client.index(self.unstructured_index_name).get_settings()
+        self.assertEqual("bfloat16", settings["vectorNumericType"])
+
+    def test_structured_bfloat16_settings(self):
+        """Verify structured bf16 index has correct vectorNumericType setting."""
+        settings = self.client.index(self.structured_index_name).get_settings()
+        self.assertEqual("bfloat16", settings["vectorNumericType"])
+
+    def test_unstructured_bfloat16_add_and_search(self):
+        """Add documents to unstructured bf16 index and verify all search methods work."""
         documents = [
             {"_id": "doc1", "title": "The quick brown fox jumps over the lazy dog"},
             {"_id": "doc2", "title": "A fast auburn canine leaps above a sleepy hound"},
             {"_id": "doc3", "title": "Python is a popular programming language"},
         ]
-        res = self.client.index(self.index_name).add_documents(documents, tensor_fields=["title"])
+        res = self.client.index(self.unstructured_index_name).add_documents(
+            documents, tensor_fields=["title"]
+        )
         self.assertFalse(res["errors"])
 
-        # Verify index settings
-        settings = self.client.index(self.index_name).get_settings()
-        self.assertEqual("bfloat16", settings["vectorNumericType"])
-
         # Tensor search
-        tensor_res = self.client.index(self.index_name).search(q="fox jumping", search_method="TENSOR")
+        tensor_res = self.client.index(self.unstructured_index_name).search(
+            q="fox jumping", search_method="TENSOR"
+        )
         self.assertGreater(len(tensor_res["hits"]), 0)
         self.assertEqual("doc1", tensor_res["hits"][0]["_id"])
 
         # Lexical search
-        lexical_res = self.client.index(self.index_name).search(q="programming language", search_method="LEXICAL")
+        lexical_res = self.client.index(self.unstructured_index_name).search(
+            q="programming language", search_method="LEXICAL"
+        )
         self.assertGreater(len(lexical_res["hits"]), 0)
         self.assertEqual("doc3", lexical_res["hits"][0]["_id"])
 
         # Hybrid search
-        hybrid_res = self.client.index(self.index_name).search(q="fox jumping", search_method="HYBRID")
+        hybrid_res = self.client.index(self.unstructured_index_name).search(
+            q="fox jumping", search_method="HYBRID"
+        )
         self.assertGreater(len(hybrid_res["hits"]), 0)
 
-    def test_structured_bfloat16_index_add_and_search(self):
-        """Create a structured bf16 index, add documents, and verify all search methods work."""
-        self.client.create_index(
-            index_name=self.index_name,
-            type="structured",
-            model="hf/all-MiniLM-L6-v2",
-            vector_numeric_type="bfloat16",
-            all_fields=[
-                {"name": "title", "type": "text", "features": ["lexical_search"]},
-            ],
-            tensor_fields=["title"],
-        )
-
+    def test_structured_bfloat16_add_and_search(self):
+        """Add documents to structured bf16 index and verify all search methods work."""
         documents = [
             {"_id": "doc1", "title": "The quick brown fox jumps over the lazy dog"},
             {"_id": "doc2", "title": "A fast auburn canine leaps above a sleepy hound"},
             {"_id": "doc3", "title": "Python is a popular programming language"},
         ]
-        res = self.client.index(self.index_name).add_documents(documents)
+        res = self.client.index(self.structured_index_name).add_documents(documents)
         self.assertFalse(res["errors"])
 
-        # Verify index settings
-        settings = self.client.index(self.index_name).get_settings()
-        self.assertEqual("bfloat16", settings["vectorNumericType"])
-
         # Tensor search
-        tensor_res = self.client.index(self.index_name).search(q="fox jumping", search_method="TENSOR")
+        tensor_res = self.client.index(self.structured_index_name).search(
+            q="fox jumping", search_method="TENSOR"
+        )
         self.assertGreater(len(tensor_res["hits"]), 0)
         self.assertEqual("doc1", tensor_res["hits"][0]["_id"])
 
         # Lexical search
-        lexical_res = self.client.index(self.index_name).search(q="programming language", search_method="LEXICAL")
+        lexical_res = self.client.index(self.structured_index_name).search(
+            q="programming language", search_method="LEXICAL"
+        )
         self.assertGreater(len(lexical_res["hits"]), 0)
         self.assertEqual("doc3", lexical_res["hits"][0]["_id"])
 
         # Hybrid search
-        hybrid_res = self.client.index(self.index_name).search(q="fox jumping", search_method="HYBRID")
+        hybrid_res = self.client.index(self.structured_index_name).search(
+            q="fox jumping", search_method="HYBRID"
+        )
         self.assertGreater(len(hybrid_res["hits"]), 0)
 
     def test_bfloat16_get_document_with_vectors(self):
         """Verify that documents can be retrieved with their bf16 vectors."""
-        self.client.create_index(
-            index_name=self.index_name,
-            type="unstructured",
-            model="hf/all-MiniLM-L6-v2",
-            vector_numeric_type="bfloat16",
+        documents = [{"_id": "vec_doc1", "title": "test document for vector retrieval"}]
+        self.client.index(self.unstructured_index_name).add_documents(
+            documents, tensor_fields=["title"]
         )
 
-        documents = [{"_id": "doc1", "title": "test document for vector retrieval"}]
-        self.client.index(self.index_name).add_documents(documents, tensor_fields=["title"])
-
-        doc = self.client.index(self.index_name).get_document("doc1", expose_facets=True)
-        self.assertEqual("doc1", doc["_id"])
+        doc = self.client.index(self.unstructured_index_name).get_document(
+            "vec_doc1", expose_facets=True
+        )
+        self.assertEqual("vec_doc1", doc["_id"])
         self.assertIn("_tensor_facets", doc)
         self.assertGreater(len(doc["_tensor_facets"]), 0)

--- a/components/marqo/tests/api_tests/v1/tests/api_tests/test_bfloat16.py
+++ b/components/marqo/tests/api_tests/v1/tests/api_tests/test_bfloat16.py
@@ -1,0 +1,112 @@
+import uuid
+
+from marqo.errors import MarqoWebError
+
+from tests.marqo_test import MarqoTestCase
+
+
+class TestBfloat16(MarqoTestCase):
+    """End-to-end tests for creating indexes with bfloat16 vector numeric type,
+    indexing documents, and searching."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.index_name = "test_bf16_" + str(uuid.uuid4()).replace('-', '')
+
+    def tearDown(self):
+        super().tearDown()
+        try:
+            self.client.delete_index(index_name=self.index_name)
+        except MarqoWebError:
+            pass
+
+    def test_unstructured_bfloat16_index_add_and_search(self):
+        """Create an unstructured bf16 index, add documents, and verify all search methods work."""
+        self.client.create_index(
+            index_name=self.index_name,
+            type="unstructured",
+            model="hf/all-MiniLM-L6-v2",
+            vector_numeric_type="bfloat16",
+        )
+
+        documents = [
+            {"_id": "doc1", "title": "The quick brown fox jumps over the lazy dog"},
+            {"_id": "doc2", "title": "A fast auburn canine leaps above a sleepy hound"},
+            {"_id": "doc3", "title": "Python is a popular programming language"},
+        ]
+        res = self.client.index(self.index_name).add_documents(documents, tensor_fields=["title"])
+        self.assertFalse(res["errors"])
+
+        # Verify index settings
+        settings = self.client.index(self.index_name).get_settings()
+        self.assertEqual("bfloat16", settings["vectorNumericType"])
+
+        # Tensor search
+        tensor_res = self.client.index(self.index_name).search(q="fox jumping", search_method="TENSOR")
+        self.assertGreater(len(tensor_res["hits"]), 0)
+        self.assertEqual("doc1", tensor_res["hits"][0]["_id"])
+
+        # Lexical search
+        lexical_res = self.client.index(self.index_name).search(q="programming language", search_method="LEXICAL")
+        self.assertGreater(len(lexical_res["hits"]), 0)
+        self.assertEqual("doc3", lexical_res["hits"][0]["_id"])
+
+        # Hybrid search
+        hybrid_res = self.client.index(self.index_name).search(q="fox jumping", search_method="HYBRID")
+        self.assertGreater(len(hybrid_res["hits"]), 0)
+
+    def test_structured_bfloat16_index_add_and_search(self):
+        """Create a structured bf16 index, add documents, and verify all search methods work."""
+        self.client.create_index(
+            index_name=self.index_name,
+            type="structured",
+            model="hf/all-MiniLM-L6-v2",
+            vector_numeric_type="bfloat16",
+            all_fields=[
+                {"name": "title", "type": "text", "features": ["lexical_search"]},
+            ],
+            tensor_fields=["title"],
+        )
+
+        documents = [
+            {"_id": "doc1", "title": "The quick brown fox jumps over the lazy dog"},
+            {"_id": "doc2", "title": "A fast auburn canine leaps above a sleepy hound"},
+            {"_id": "doc3", "title": "Python is a popular programming language"},
+        ]
+        res = self.client.index(self.index_name).add_documents(documents)
+        self.assertFalse(res["errors"])
+
+        # Verify index settings
+        settings = self.client.index(self.index_name).get_settings()
+        self.assertEqual("bfloat16", settings["vectorNumericType"])
+
+        # Tensor search
+        tensor_res = self.client.index(self.index_name).search(q="fox jumping", search_method="TENSOR")
+        self.assertGreater(len(tensor_res["hits"]), 0)
+        self.assertEqual("doc1", tensor_res["hits"][0]["_id"])
+
+        # Lexical search
+        lexical_res = self.client.index(self.index_name).search(q="programming language", search_method="LEXICAL")
+        self.assertGreater(len(lexical_res["hits"]), 0)
+        self.assertEqual("doc3", lexical_res["hits"][0]["_id"])
+
+        # Hybrid search
+        hybrid_res = self.client.index(self.index_name).search(q="fox jumping", search_method="HYBRID")
+        self.assertGreater(len(hybrid_res["hits"]), 0)
+
+    def test_bfloat16_get_document_with_vectors(self):
+        """Verify that documents can be retrieved with their bf16 vectors."""
+        self.client.create_index(
+            index_name=self.index_name,
+            type="unstructured",
+            model="hf/all-MiniLM-L6-v2",
+            vector_numeric_type="bfloat16",
+        )
+
+        documents = [{"_id": "doc1", "title": "test document for vector retrieval"}]
+        self.client.index(self.index_name).add_documents(documents, tensor_fields=["title"])
+
+        doc = self.client.index(self.index_name).get_document("doc1", expose_facets=True)
+        self.assertEqual("doc1", doc["_id"])
+        self.assertIn("_tensor_facets", doc)
+        self.assertGreater(len(doc["_tensor_facets"]), 0)

--- a/components/marqo/tests/api_tests/v1/tests/api_tests/test_bfloat16.py
+++ b/components/marqo/tests/api_tests/v1/tests/api_tests/test_bfloat16.py
@@ -1,3 +1,4 @@
+import struct
 import uuid
 
 from tests.marqo_test import MarqoTestCase
@@ -71,3 +72,15 @@ class TestBfloat16(MarqoTestCase):
         )
         self.assertEqual("vec_doc1", doc["_id"])
         self.assertIn("_tensor_facets", doc)
+
+        embedding = doc["_tensor_facets"][0]["_embedding"]
+        for val in embedding:
+            self.assertEqual(val, self._float_to_bfloat16(val),
+                             f"Value {val} does not have bfloat16 precision")
+
+    @staticmethod
+    def _float_to_bfloat16(value: float) -> float:
+        """Round-trip a float through bfloat16 precision by truncating the lower 16 bits."""
+        float32_bytes = struct.pack('>f', value)
+        bfloat16_bytes = float32_bytes[:2] + b'\x00\x00'
+        return struct.unpack('>f', bfloat16_bytes)[0]

--- a/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_one_tensor_field_bfloat16.sd
+++ b/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_one_tensor_field_bfloat16.sd
@@ -1,5 +1,4 @@
-{# semi_structured_vespa_schema_template_2_16.sd.jinja2 -#}
-schema {{ index.schema_name }} {
+schema marqo__test_00semi_00structured_00schema {
     document {
         field marqo__id type string {
             indexing: attribute | summary
@@ -20,7 +19,6 @@ schema {{ index.schema_name }} {
                                   rank: filter }
         }
 
-        {# Reserved fields for bool, int and float fields -#}
         field marqo__int_fields type map<string, long> {
             indexing: summary
             struct-field key { indexing : attribute
@@ -53,7 +51,6 @@ schema {{ index.schema_name }} {
         }
 
         field marqo__short_string_fields type map<string, string> {
-            {#- indexing:summary is left out here since each short string has a corresponding lexical field  #}
             struct-field key { indexing : attribute
                                attribute: fast-search
                                rank: filter }
@@ -62,7 +59,6 @@ schema {{ index.schema_name }} {
                                   rank: filter }
         }
 
-        {# All int and float fields will be added score modifiers -#}
         field marqo__score_modifiers type tensor<double>(p{}) {
             indexing: attribute | summary
         }
@@ -71,79 +67,40 @@ schema {{ index.schema_name }} {
             indexing: summary
         }
 
-        {% if collapse_field -%}
-        field {{ collapse_field.name }} type string {
-            indexing: attribute | summary
-            attribute: fast-search
-            rank: filter
-        }
-        {% endif -%}
-
-        {% for lexical_field in index.lexical_fields -%}
-        field {{ lexical_field.lexical_field_name }} type string {
-            {%- if lexical_field.language %}
-            indexing {
-                "{{ lexical_field.language }}" | set_language;
-                index | summary;
-            }
-            {%- else %}
+        field marqo__lexical_text_field type string {
             indexing: index | summary
-            {%- endif %}
             index: enable-bm25
-            {%- if lexical_field.stemming %}
-            stemming: {{ lexical_field.stemming.value }}
-            {%- endif %}
         }
-        {% endfor -%}
-
-        {% for string_array_field in index.string_array_fields -%}
-        field {{ string_array_field.string_array_field_name }} type array<string> {
-            indexing: attribute | summary
-            attribute: fast-search
-            rank: filter
-        }
-        {% endfor -%}
-
-        {% for field in index.tensor_fields -%}
-        field {{ field.chunk_field_name }} type array<string> {
+        field marqo__chunks_tensor_field type array<string> {
             indexing: summary
         }
 
-        field {{ field.embeddings_field_name }} type tensor<{{ index.vector_numeric_type.value }}>(p{}, x[{{ dimension }}]) {
+        field marqo__embeddings_tensor_field type tensor<bfloat16>(p{}, x[32]) {
             indexing: attribute | index | summary
             attribute {
-                distance-metric: {{ index.distance_metric.value }}
+                distance-metric: prenormalized-angular
             }
             index {
                 hnsw {
-                    max-links-per-node: {{ index.hnsw_config.m }}
-                    neighbors-to-explore-at-insert: {{ index.hnsw_config.ef_construction }}
+                    max-links-per-node: 16
+                    neighbors-to-explore-at-insert: 512
                 }
             }
         }
-        {% endfor -%}
-
         field marqo__vector_count type int {
             indexing: attribute | summary
         }
     }
 
-    {% if index.lexical_field_map -%}
     fieldset default {
-        fields: {{ ", ".join(index.lexical_field_map.keys()) }}
+        fields: marqo__lexical_text_field
     }
-    {% endif -%}
-
     rank-profile base_rank_profile inherits default {
         inputs {
-            {% for lexical_field in index.lexical_fields -%}
-            query({{ lexical_field.lexical_field_name }}): 0
-            {% endfor -%}
-            {% for field in index.tensor_fields -%}
-            query({{ field.embeddings_field_name }}): 0
-            {% endfor -%}
+            query(marqo__lexical_text_field): 0
+            query(marqo__embeddings_tensor_field): 0
             query(marqo__bm25_aggregator): 0
-            query(marqo__query_embedding) tensor<{{ index.vector_numeric_type.value }}>(x[{{ dimension }}])
+            query(marqo__query_embedding) tensor<bfloat16>(x[32])
             query(marqo__mult_weights_lexical) tensor<double>(p{})
             query(marqo__add_weights_lexical) tensor<double>(p{})
             query(marqo__mult_weights_tensor) tensor<double>(p{})
@@ -168,10 +125,6 @@ schema {{ index.schema_name }} {
             query(marqo__recency_grow_scale_seconds) double: 604800.0
             query(marqo__recency_grow_offset_seconds) double: 0.0
             query(marqo__recency_grow_from) double: 0.5
-            {%- if collapse_field %}
-
-            query(marqo__collapse_sort_weights) tensor<double>(p{})
-            {%- endif %}
 
             # Custom Score Global Reranking
             query(marqo__custom_score_mult_weights_global) tensor<double>(p{})
@@ -291,55 +244,23 @@ schema {{ index.schema_name }} {
             expression: add_modifier(query(marqo__add_weights_global))
         }
 
-        {% macro max_score(score_macro, fields) -%}
-            {%- set length = fields|length -%}
-            {%- if length == 0 -%}
-                0
-            {%- elif length == 1 -%}
-                {{ score_macro(fields[0]) }}
-            {%- else -%}
-                max({{ max_score(score_macro, fields[0:1]) }}, {{ max_score(score_macro, fields[1:]) }})
-            {%- endif -%}
-        {% endmacro -%}
-
-        {% macro lexical_score(field) -%}
-            if (query({{ field.lexical_field_name }}) > 0, bm25({{ field.lexical_field_name }}), 0)
-        {%- endmacro -%}
-
-        {% macro embedding_score(field) -%}
-            if (query({{ field.embeddings_field_name }}) > 0, closeness(field, {{ field.embeddings_field_name }}), 0)
-        {%- endmacro -%}
-
-        {% macro sum_score(score_macro, fields) -%}
-            {%- set add = joiner(" + ") -%}
-            {%- for field in fields -%}{{ add() }}{{ score_macro(field) }}{%- endfor -%}
-        {% endmacro -%}
-
-        {% if index.lexical_fields -%}
         function lexical_score_sum() {
-            expression: {{ sum_score(lexical_score, index.lexical_fields) }}
+            expression: if (query(marqo__lexical_text_field) > 0, bm25(marqo__lexical_text_field), 0)
         }
 
-        {% macro count_lexical_fields() -%}
-            {%- set add = joiner(" + ") -%}
-            {%- for field in index.lexical_fields -%}{{ add() }}if (query({{ field.lexical_field_name }}) > 0, 1, 0){%- endfor -%}
-        {% endmacro -%}
         function lexical_score_avg() {
-            expression: ({{ sum_score(lexical_score, index.lexical_fields) }}) / max(1, {{ count_lexical_fields() }})
+            expression: (if (query(marqo__lexical_text_field) > 0, bm25(marqo__lexical_text_field), 0)) / max(1, if (query(marqo__lexical_text_field) > 0, 1, 0))
         }
 
         function lexical_score_max() {
-            expression: {{ max_score(lexical_score, index.lexical_fields) }}
+            expression: if (query(marqo__lexical_text_field) > 0, bm25(marqo__lexical_text_field), 0)
         }
 
         function lexical_score() {
             expression: if (query(marqo__bm25_aggregator) == 0, lexical_score_sum(), if (query(marqo__bm25_aggregator) == 1, lexical_score_avg(), lexical_score_max()))
         }
-        {% endif -%}
-
-        {# We provide this function even without the tensor field to support embed requests -#}
         function embedding_score() {
-            expression: {{ max_score(embedding_score, index.tensor_fields) }}
+            expression: if (query(marqo__embeddings_tensor_field) > 0, closeness(field, marqo__embeddings_tensor_field), 0)
         }
 
         function sort_field_value(sort_weights) {
@@ -358,16 +279,6 @@ schema {{ index.schema_name }} {
             expression: sort_field_value(query(marqo__sort_field_weights_2))
         }
 
-        {% if collapse_field -%}
-        function collapse_field_hash() {
-            expression: attribute({{ collapse_field.name }})
-        }
-
-        function collapse_sort_value() {
-            expression: if (count(query(marqo__collapse_sort_weights) * attribute(marqo__score_modifiers)) == 0, -1e50, reduce(query(marqo__collapse_sort_weights) * attribute(marqo__score_modifiers), prod))
-        }
-
-        {% endif -%}
         match-features {
             global_mult_modifier
             global_add_modifier
@@ -376,59 +287,22 @@ schema {{ index.schema_name }} {
             sort_field_value_2
             recency_score
 
-            {% if collapse_field %}collapse_field_hash{% endif %}
         }
-
-        {# Per-field closeness score (similarity to marqo__query_embedding) for custom score rerank summary-features.
-           Formulas match Vespa's closeness() rank feature (to_rawscore) per distance metric (higher = closer).
-           Sources:
-             angular: github.com/vespa-engine/vespa/blob/master/searchlib/src/vespa/searchlib/tensor/angular_distance.cpp
-             prenormalized-angular: github.com/vespa-engine/vespa/blob/master/searchlib/src/vespa/searchlib/tensor/prenormalized_angular_distance.cpp
-             euclidean: github.com/vespa-engine/vespa/blob/master/searchlib/src/vespa/searchlib/tensor/euclidean_distance.cpp
-             dotproduct: github.com/vespa-engine/vespa/blob/master/searchlib/src/vespa/searchlib/tensor/mips_distance_transform.cpp
-             hamming: github.com/vespa-engine/vespa/blob/master/searchlib/src/vespa/searchlib/tensor/hamming_distance.cpp
-           Dotproduct note: Vespa's native closeness() for dotproduct returns the raw dot product, which is unbounded
-           and can be negative. We use (1 + cosine_similarity) / 2 instead: dividing by vector norms bounds the value
-           to [-1, 1] regardless of normalizeEmbeddings, then the (1+d)/2 transform maps to [0, 1].
-           Not supported for geodegrees. #}
-        {% if index.tensor_fields and index.distance_metric.value != 'geodegrees' %}
-        {% for field in index.tensor_fields %}
-        function ranking_closeness_metric_{{ field.name }}() {
-            {%- if index.distance_metric.value == 'angular' %}
-            expression: reduce(1.0 / (1.0 + acos(min(1.0, max(-1.0, cosine_similarity(attribute({{ field.embeddings_field_name }}), query(marqo__query_embedding), x))))), sum)
-            {%- elif index.distance_metric.value == 'prenormalized-angular' %}
-            expression: reduce(1.0 / (2.0 - cosine_similarity(attribute({{ field.embeddings_field_name }}), query(marqo__query_embedding), x)), sum)
-            {%- elif index.distance_metric.value == 'euclidean' %}
-            expression: reduce(1.0 / (1.0 + euclidean_distance(attribute({{ field.embeddings_field_name }}), query(marqo__query_embedding), x)), sum)
-            {%- elif index.distance_metric.value == 'dotproduct' %}
-            expression: reduce((1.0 + cosine_similarity(attribute({{ field.embeddings_field_name }}), query(marqo__query_embedding), x)) / 2.0, sum)
-            {%- elif index.distance_metric.value == 'hamming' %}
-            expression: reduce(1.0 / (1.0 + hamming(attribute({{ field.embeddings_field_name }}), query(marqo__query_embedding))), sum)
-            {%- endif %}
+        function ranking_closeness_metric_tensor_field() {
+            expression: reduce(1.0 / (2.0 - cosine_similarity(attribute(marqo__embeddings_tensor_field), query(marqo__query_embedding), x)), sum)
         }
-        {% endfor %}
-        {% endif %}
-
-        {% if (index.tensor_fields and index.distance_metric.value != 'geodegrees') or index.lexical_fields %}
         summary-features {
-            {% if index.tensor_fields and index.distance_metric.value != 'geodegrees' %}
-            {% for field in index.tensor_fields %}
-            ranking_closeness_metric_{{ field.name }}
-            {% endfor %}
-            {% endif %}
-            {% for lexical_field in index.lexical_fields %}
-            bm25({{ lexical_field.lexical_field_name }})
-            {% endfor %}
+            ranking_closeness_metric_tensor_field
+            bm25(marqo__lexical_text_field)
         }
-        {% endif %}
     }
 
-    {% if index.lexical_fields -%}
     rank-profile bm25 inherits base_rank_profile {
         first-phase {
             expression: modify(lexical_score(), query(marqo__mult_weights_lexical), query(marqo__add_weights_lexical))
         }
     }
+
     rank-profile hybrid_bm25_second_phase_modifiers inherits base_rank_profile {
         first-phase {
             expression: lexical_score()
@@ -437,75 +311,22 @@ schema {{ index.schema_name }} {
             expression: modify(firstPhase, query(marqo__mult_weights_lexical), query(marqo__add_weights_lexical))
         }
     }
-    {% if collapse_field -%}
-    rank-profile bm25_diversity inherits bm25 {
-        diversity {
-            attribute: {{ collapse_field.name }}
-            min-groups: {{ collapse_field.min_groups }}
-        }
-        second-phase {
-            expression: firstPhase
-        }
-    }
-    rank-profile hybrid_bm25_second_phase_modifiers_diversity inherits hybrid_bm25_second_phase_modifiers {
-        diversity {
-            attribute: {{ collapse_field.name }}
-            min-groups: {{ collapse_field.min_groups }}
-        }
-        second-phase {
-            expression: modify(firstPhase, query(marqo__mult_weights_lexical), query(marqo__add_weights_lexical))
-        }
-    }
-    rank-profile collapse_to_sort_value inherits base_rank_profile{
-        first-phase {
-            expression: collapse_sort_value()
-        }
-        diversity {
-            attribute: {{ collapse_field.name }}
-            min-groups: {{ collapse_field.min_groups }}
-        }
-        second-phase {
-            expression: firstPhase
-        }
-    }
-    {% endif -%}
-    {% endif -%}
 
-    {# We provide this rank profile even without the tensor field to support embed requests -#}
     rank-profile embedding_similarity inherits base_rank_profile {
         first-phase {
             expression: modify(embedding_score(), query(marqo__mult_weights_tensor), query(marqo__add_weights_tensor))
         }
-        {% if index.tensor_fields -%}
         match-features inherits base_rank_profile {
-            {%- for field in index.tensor_fields %}
-            closest({{ field.embeddings_field_name }})
-            {%- endfor %}
-            {%- for field in index.tensor_fields %}
-            distance(field, {{ field.embeddings_field_name }})
-            {%- endfor %}
-        }
-        {%- endif %}
-    }
-
-    {% if collapse_field -%}
-    rank-profile embedding_similarity_diversity inherits embedding_similarity {
-        diversity {
-            attribute: {{ collapse_field.name }}
-            min-groups: {{ collapse_field.min_groups }}
-        }
-        second-phase {
-            expression: firstPhase
+            closest(marqo__embeddings_tensor_field)
+            distance(field, marqo__embeddings_tensor_field)
         }
     }
-    {% endif -%}
 
-    {% if index.lexical_fields and index.tensor_fields -%}
     rank-profile hybrid_custom_searcher inherits default {
         inputs {
             query(marqo__fields_to_rank_lexical) tensor<int8>(p{})
             query(marqo__fields_to_rank_tensor) tensor<int8>(p{})
-            query(marqo__query_embedding) tensor<{{ index.vector_numeric_type.value }}>(x[{{ dimension }}])
+            query(marqo__query_embedding) tensor<bfloat16>(x[32])
             query(marqo__mult_weights_lexical) tensor<double>(p{})
             query(marqo__add_weights_lexical) tensor<double>(p{})
             query(marqo__mult_weights_tensor) tensor<double>(p{})
@@ -530,10 +351,6 @@ schema {{ index.schema_name }} {
             query(marqo__recency_grow_scale_seconds) double: 604800.0
             query(marqo__recency_grow_offset_seconds) double: 0.0
             query(marqo__recency_grow_from) double: 0.5
-            {%- if collapse_field %}
-
-            query(marqo__collapse_sort_weights) tensor<double>(p{})
-            {%- endif %}
 
             # Custom Score Global Reranking
             query(marqo__custom_score_mult_weights_global) tensor<double>(p{})
@@ -549,12 +366,8 @@ schema {{ index.schema_name }} {
             expression: modify(embedding_score(), query(marqo__mult_weights_tensor), query(marqo__add_weights_tensor))
         }
         match-features inherits base_rank_profile {
-            {%- for field in index.tensor_fields %}
-            closest({{ field.embeddings_field_name }})
-            {%- endfor %}
-            {%- for field in index.tensor_fields %}
-            distance(field, {{ field.embeddings_field_name }})
-            {%- endfor %}
+            closest(marqo__embeddings_tensor_field)
+            distance(field, marqo__embeddings_tensor_field)
         }
     }
 
@@ -564,26 +377,7 @@ schema {{ index.schema_name }} {
         }
     }
 
-    {% if collapse_field -%}
-    rank-profile hybrid_bm25_then_embedding_similarity_diversity inherits hybrid_bm25_then_embedding_similarity {
-        diversity {
-            attribute: {{ collapse_field.name }}
-            min-groups: {{ collapse_field.min_groups }}
-        }
-    }
-
-    rank-profile hybrid_embedding_similarity_then_bm25_diversity inherits hybrid_embedding_similarity_then_bm25 {
-        diversity {
-            attribute: {{ collapse_field.name }}
-            min-groups: {{ collapse_field.min_groups }}
-        }
-        second-phase {
-            expression: firstPhase
-        }
-    }
-    {% endif -%}
-
-    {%- endif %}
+    
 
     document-summary all-non-vector-summary {
         summary marqo__id type string {}
@@ -591,18 +385,9 @@ schema {{ index.schema_name }} {
         summary marqo__bool_fields type map<string, byte> {}
         summary marqo__int_fields type map<string, long> {}
         summary marqo__float_fields type map<string, double> {}
-        {% if collapse_field -%}
-        summary {{ collapse_field.name }} type string {}
-        {% endif -%}
-        {% for string_array_field in index.string_array_fields -%}
-        summary {{ string_array_field.string_array_field_name }} type array<string> {source: {{ string_array_field.string_array_field_name }}}
-        {% endfor -%}
-        {%- for lexical_field in index.lexical_fields %}
-        summary {{ lexical_field.name }} type string {source: {{ lexical_field.lexical_field_name }}}
-        {%- endfor %}
-        {%- for field in index.tensor_fields %}
-        summary {{ field.chunk_field_name }} type array<string> {}
-        {%- endfor %}
+        
+        summary text_field type string {source: marqo__lexical_text_field}
+        summary marqo__chunks_tensor_field type array<string> {}
     }
 
     document-summary all-vector-summary {
@@ -611,29 +396,13 @@ schema {{ index.schema_name }} {
         summary marqo__bool_fields type map<string, byte> {}
         summary marqo__int_fields type map<string, long> {}
         summary marqo__float_fields type map<string, double> {}
-        {% if collapse_field -%}
-        summary {{ collapse_field.name }} type string {}
-        {% endif -%}
-        {% for string_array_field in index.string_array_fields -%}
-        summary {{ string_array_field.string_array_field_name }} type array<string> {source: {{ string_array_field.string_array_field_name }}}
-        {% endfor -%}
-        {%- for lexical_field in index.lexical_fields %}
-        summary {{ lexical_field.name }} type string {source: {{ lexical_field.lexical_field_name }}}
-        {%- endfor %}
-        {%- for field in index.tensor_fields %}
-        summary {{ field.chunk_field_name }} type array<string> {}
-        summary {{ field.embeddings_field_name }} type tensor<{{ index.vector_numeric_type.value }}>(p{}, x[{{ dimension }}]) {}
-        {%- endfor %}
+        
+        summary text_field type string {source: marqo__lexical_text_field}
+        summary marqo__chunks_tensor_field type array<string> {}
+        summary marqo__embeddings_tensor_field type tensor<bfloat16>(p{}, x[32]) {}
     }
 
-    {# Minimal dummy summary used when filling to compute ranking_score_fieldN and bm25 for custom score rerank #}
     document-summary dummy-light-summary {
         summary marqo__id type string {}
     }
-
-    {% if collapse_field -%}
-    document-summary collapse-minimal-summary {
-        summary {{ collapse_field.name }} type string {}
-    }
-    {%- endif %}
 }

--- a/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_one_tensor_field_bfloat16.sd
+++ b/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_schemas/semi_structured_vespa_index_schema_one_lexical_one_tensor_field_bfloat16.sd
@@ -120,6 +120,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_center_seconds) double: 0
             query(marqo__recency_grow_enabled): 0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0
@@ -137,7 +138,7 @@ schema marqo__test_00semi_00structured_00schema {
         }
 
         function age_in_seconds() {
-            expression: now() - get_timestamp()
+            expression: if (query(marqo__recency_center_seconds) > 0, query(marqo__recency_center_seconds) - get_timestamp(), now() - get_timestamp())
         }
 
         # ============ UNIFIED SCORING FUNCTIONS ============
@@ -346,6 +347,7 @@ schema marqo__test_00semi_00structured_00schema {
             query(marqo__recency_scale_seconds) double: 604800.0
             query(marqo__recency_offset_seconds) double: 0.0
             query(marqo__recency_decay_to) double: 0.5
+            query(marqo__recency_center_seconds) double: 0
             query(marqo__recency_grow_enabled): 0
             query(marqo__recency_grow_function_type): 0
             query(marqo__recency_grow_scale_seconds) double: 604800.0

--- a/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_semi_structured_vespa_schema.py
+++ b/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_semi_structured_vespa_schema.py
@@ -88,6 +88,31 @@ class TestSemiStructuredVespaSchema(MarqoTestCase):
             self._remove_whitespace_in_schema(generated_schema)
         )
 
+    def test_semi_structured_index_schema_with_bfloat16(self):
+        """Test that the schema uses tensor<bfloat16> when vector_numeric_type is Bfloat16."""
+        lexical_fields = ['text_field']
+        tensor_fields = ['tensor_field']
+        expected_schema = self._read_schema_from_file(
+            'test_schemas/semi_structured_vespa_index_schema_one_lexical_one_tensor_field_bfloat16.sd'
+        )
+
+        test_marqo_index_request = self.unstructured_marqo_index_request(
+            name="test_semi_structured_schema",
+            hnsw_config=HnswConfig(ef_construction=512, m=16),
+            distance_metric=DistanceMetric.PrenormalizedAngular,
+            vector_numeric_type=VectorNumericType.Bfloat16,
+        )
+
+        _, index = SemiStructuredVespaSchema(test_marqo_index_request).generate_schema()
+        marqo_index = self._populate_fields(index, lexical_fields, tensor_fields)
+        generated_schema = SemiStructuredVespaSchema.generate_vespa_schema(marqo_index)
+
+        self.maxDiff = None
+        self.assertEqual(
+            self._remove_empty_lines_in_schema(expected_schema),
+            self._remove_empty_lines_in_schema(generated_schema)
+        )
+
     def test_semi_structured_index_schema_with_pre_2_16(self):
         """
         Test that the schema is generated correctly when the marqo version is older than 2.16.0.

--- a/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_semi_structured_vespa_schema.py
+++ b/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_semi_structured_vespa_schema.py
@@ -109,8 +109,8 @@ class TestSemiStructuredVespaSchema(MarqoTestCase):
 
         self.maxDiff = None
         self.assertEqual(
-            self._remove_empty_lines_in_schema(expected_schema),
-            self._remove_empty_lines_in_schema(generated_schema)
+            self._remove_whitespace_in_schema(expected_schema),
+            self._remove_whitespace_in_schema(generated_schema)
         )
 
     def test_semi_structured_index_schema_with_pre_2_16(self):


### PR DESCRIPTION
Replace hardcoded tensor<float> with tensor<{{ index.vector_numeric_type.value }}> in the semi-structured Vespa schema template so bfloat16 indexes generate correct schema definitions for embeddings, query inputs, and vector summaries.

## Change Summary
<!-- Describe the key changes this PR introduces -->

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

