### PR TITLE
Move version to components/common as single source of truth

### DIFF
--- a/.github/workflows/build_push_img.yml
+++ b/.github/workflows/build_push_img.yml
@@ -166,7 +166,8 @@ jobs:
         id: build-and-push-model-management
         uses: docker/build-push-action@v6
         with:
-          context: ./components/model_management
+          context: ./components
+          file: ./components/model_management/Dockerfile
           push: true
           platforms: ${{ env.PLATFORMS }}
           tags: ${{ steps.prepare.outputs.registry }}/${{ env.IMAGE_NAMESPACE }}/model-management:${{ env.IMAGE_TAG }}

--- a/.github/workflows/deploy-marqo-images.yml
+++ b/.github/workflows/deploy-marqo-images.yml
@@ -122,7 +122,8 @@ jobs:
         id: build-and-push-model-management
         uses: docker/build-push-action@v6
         with:
-          context: ./components/model_management
+          context: ./components
+          file: ./components/model_management/Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.prepare.outputs.model_tags }}

--- a/components/common/src/marqo_common/version.py
+++ b/components/common/src/marqo_common/version.py
@@ -1,0 +1,5 @@
+__version__ = "2.26.0"
+
+
+def get_version() -> str:
+    return f"{__version__}"

--- a/components/inference_orchestrator/src/inference_orchestrator/version.py
+++ b/components/inference_orchestrator/src/inference_orchestrator/version.py
@@ -1,3 +1,6 @@
-from marqo_common.version import __version__, get_version
+from marqo_common.version import (  # pragma: no cover - tested in components/marqo
+    __version__,
+    get_version,
+)
 
-__all__ = ["__version__", "get_version"]
+__all__ = ["__version__", "get_version"]  # pragma: no cover

--- a/components/inference_orchestrator/src/inference_orchestrator/version.py
+++ b/components/inference_orchestrator/src/inference_orchestrator/version.py
@@ -1,4 +1,3 @@
-__version__ = "2.26.0"
+from marqo_common.version import __version__, get_version
 
-def get_version() -> str:
-    return f"{__version__}"
+__all__ = ["__version__", "get_version"]

--- a/components/inference_orchestrator/src/inference_orchestrator/version.py
+++ b/components/inference_orchestrator/src/inference_orchestrator/version.py
@@ -1,6 +1,3 @@
-from marqo_common.version import (  # pragma: no cover - tested in components/marqo
-    __version__,
-    get_version,
-)
+from marqo_common.version import __version__, get_version  # pragma: no cover
 
 __all__ = ["__version__", "get_version"]  # pragma: no cover

--- a/components/inference_orchestrator/src/inference_orchestrator/version.py
+++ b/components/inference_orchestrator/src/inference_orchestrator/version.py
@@ -1,3 +1,3 @@
-from marqo_common.version import __version__, get_version  # pragma: no cover
+from marqo_common.version import __version__, get_version
 
-__all__ = ["__version__", "get_version"]  # pragma: no cover
+__all__ = ["__version__", "get_version"]

--- a/components/inference_orchestrator/tests/unit_tests/test_version.py
+++ b/components/inference_orchestrator/tests/unit_tests/test_version.py
@@ -1,0 +1,22 @@
+from unittest import TestCase
+
+from marqo_common.version import __version__ as common_version
+from marqo_common.version import get_version as common_get_version
+
+from inference_orchestrator.version import __version__, get_version
+
+
+class TestVersion(TestCase):
+    def test_version_format(self):
+        """Version string should follow semver format."""
+        self.assertRegex(__version__, r"^\d+\.\d+\.\d+$")
+
+    def test_get_version_returns_version(self):
+        self.assertEqual(get_version(), __version__)
+
+    def test_version_matches_common(self):
+        """Component version should be sourced from marqo_common."""
+        self.assertEqual(__version__, common_version)
+
+    def test_get_version_matches_common(self):
+        self.assertEqual(get_version(), common_get_version())

--- a/components/marqo/src/marqo/version.py
+++ b/components/marqo/src/marqo/version.py
@@ -1,5 +1,3 @@
-__version__ = "2.26.0"
+from marqo_common.version import __version__, get_version
 
-
-def get_version() -> str:
-    return f"{__version__}"
+__all__ = ["__version__", "get_version"]

--- a/components/marqo/tests/unit_tests/marqo/test_version.py
+++ b/components/marqo/tests/unit_tests/marqo/test_version.py
@@ -1,4 +1,3 @@
-import re
 from unittest import TestCase
 
 from marqo_common.version import __version__ as common_version, get_version as common_get_version

--- a/components/marqo/tests/unit_tests/marqo/test_version.py
+++ b/components/marqo/tests/unit_tests/marqo/test_version.py
@@ -1,0 +1,21 @@
+import re
+from unittest import TestCase
+
+from marqo_common.version import __version__ as common_version, get_version as common_get_version
+from marqo.version import __version__, get_version
+
+
+class TestVersion(TestCase):
+    def test_version_format(self):
+        """Version string should follow semver format."""
+        self.assertRegex(__version__, r"^\d+\.\d+\.\d+$")
+
+    def test_get_version_returns_version(self):
+        self.assertEqual(get_version(), __version__)
+
+    def test_version_matches_common(self):
+        """Component version should be sourced from marqo_common."""
+        self.assertEqual(__version__, common_version)
+
+    def test_get_version_matches_common(self):
+        self.assertEqual(get_version(), common_get_version())

--- a/components/model_management/Dockerfile
+++ b/components/model_management/Dockerfile
@@ -1,8 +1,17 @@
+# =============================================================================
+# IMPORTANT: Build context must be the 'components/' directory.
+# Run:  docker build -f model_management/Dockerfile -t mmc .   (from components/)
+# =============================================================================
+
+# Stage 0: Validate build context - ensures 'common/' is accessible
+FROM busybox AS context_check
+COPY common/pyproject.toml /tmp/context_validated
+
 FROM python:3.11-slim AS base
 
 ARG COMMITHASH
 
-WORKDIR /app
+WORKDIR /app/model_management
 
 # System deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -12,18 +21,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install uv
 RUN pip install --no-cache-dir uv
 
+# Validate build context (this COPY forces the context_check stage to run)
+COPY --from=context_check /tmp/context_validated /tmp/.context_ok
+
+# Copy common package first (needed for local dependency)
+COPY common /app/common
+
 # Copy project metadata
-COPY pyproject.toml uv.lock ./
+COPY model_management/pyproject.toml model_management/uv.lock ./
 
 # Install dependencies from lockfile
 RUN uv sync --no-dev
 
 # Copy source
-COPY src ./src
+COPY model_management/src ./src
 
 # Set Python path
-ENV PYTHONPATH=/app/src
-ENV PATH="/app/.venv/bin:$PATH"
+ENV PYTHONPATH=/app/model_management/src
+ENV PATH="/app/model_management/.venv/bin:$PATH"
 ENV MARQO_HOST=0.0.0.0
 RUN echo $COMMITHASH > build_info.txt
 

--- a/components/model_management/pyproject.toml
+++ b/components/model_management/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "s3fs>=2025.9.0",
     "tqdm>=4.67.1",
     "uvicorn>=0.35.0",
+    "marqo-common",
 ]
 
 [dependency-groups]
@@ -46,6 +47,9 @@ source = [
     "src/",
     "*/marqo/components/model_management/src/",
 ]
+
+[tool.uv.sources]
+marqo-common = {path = "../common", editable = true}
 
 [tool.coverage.report]
 exclude_lines = [

--- a/components/model_management/src/model_management/version.py
+++ b/components/model_management/src/model_management/version.py
@@ -1,5 +1,3 @@
-__version__ = "2.25.0"
+from marqo_common.version import __version__, get_version
 
-
-def get_version() -> str:
-    return f"{__version__}"
+__all__ = ["__version__", "get_version"]

--- a/components/model_management/src/model_management/version.py
+++ b/components/model_management/src/model_management/version.py
@@ -1,6 +1,3 @@
-from marqo_common.version import (
-    __version__,
-    get_version,
-)  # pragma: no cover - tested in components/marqo
+from marqo_common.version import __version__, get_version  # pragma: no cover
 
 __all__ = ["__version__", "get_version"]  # pragma: no cover

--- a/components/model_management/src/model_management/version.py
+++ b/components/model_management/src/model_management/version.py
@@ -1,3 +1,6 @@
-from marqo_common.version import __version__, get_version
+from marqo_common.version import (
+    __version__,
+    get_version,
+)  # pragma: no cover - tested in components/marqo
 
-__all__ = ["__version__", "get_version"]
+__all__ = ["__version__", "get_version"]  # pragma: no cover

--- a/components/model_management/src/model_management/version.py
+++ b/components/model_management/src/model_management/version.py
@@ -1,3 +1,3 @@
-from marqo_common.version import __version__, get_version  # pragma: no cover
+from marqo_common.version import __version__, get_version
 
-__all__ = ["__version__", "get_version"]  # pragma: no cover
+__all__ = ["__version__", "get_version"]

--- a/components/model_management/tests/unit_tests/test_version.py
+++ b/components/model_management/tests/unit_tests/test_version.py
@@ -1,0 +1,23 @@
+from unittest import TestCase
+
+from marqo_common.version import (
+    __version__ as common_version,
+    get_version as common_get_version,
+)
+from model_management.version import __version__, get_version
+
+
+class TestVersion(TestCase):
+    def test_version_format(self):
+        """Version string should follow semver format."""
+        self.assertRegex(__version__, r"^\d+\.\d+\.\d+$")
+
+    def test_get_version_returns_version(self):
+        self.assertEqual(get_version(), __version__)
+
+    def test_version_matches_common(self):
+        """Component version should be sourced from marqo_common."""
+        self.assertEqual(__version__, common_version)
+
+    def test_get_version_matches_common(self):
+        self.assertEqual(get_version(), common_get_version())

--- a/components/model_management/uv.lock
+++ b/components/model_management/uv.lock
@@ -441,6 +441,11 @@ wheels = [
 ]
 
 [[package]]
+name = "marqo-common"
+version = "0.1.0"
+source = { editable = "../common" }
+
+[[package]]
 name = "marqo-model-management"
 version = "0.0.1"
 source = { virtual = "." }
@@ -449,6 +454,7 @@ dependencies = [
     { name = "fsspec" },
     { name = "httpx" },
     { name = "jinja2" },
+    { name = "marqo-common" },
     { name = "orjson" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -474,6 +480,7 @@ requires-dist = [
     { name = "fsspec", specifier = ">=2025.9.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "jinja2", specifier = ">=3.1.6" },
+    { name = "marqo-common", editable = "../common" },
     { name = "orjson", specifier = ">=3.11.3" },
     { name = "pydantic", specifier = ">=2.11.9" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },

--- a/compose-inference.yaml
+++ b/compose-inference.yaml
@@ -55,7 +55,9 @@ services:
 
   mmc:
     image: 424082663841.dkr.ecr.us-east-1.amazonaws.com/marqoai/model-management:latest
-    build: ./components/model_management
+    build:
+      context: ./components
+      dockerfile: model_management/Dockerfile
     stdin_open: true
     tty: true
     environment:

--- a/compose-model-management.yaml
+++ b/compose-model-management.yaml
@@ -55,7 +55,9 @@ services:
 
   mmc:
     image: 424082663841.dkr.ecr.us-east-1.amazonaws.com/marqoai/model-management:latest
-    build: ./components/model_management
+    build:
+      context: ./components
+      dockerfile: model_management/Dockerfile
     stdin_open: true
     tty: true
     environment:

--- a/compose.yaml
+++ b/compose.yaml
@@ -84,7 +84,9 @@ services:
 
   mmc:
     image: 424082663841.dkr.ecr.us-east-1.amazonaws.com/marqoai/model-management:latest
-    build: ./components/model_management
+    build:
+      context: ./components
+      dockerfile: model_management/Dockerfile
     stdin_open: true
     tty: true
     environment:


### PR DESCRIPTION
## Summary
- Created `components/common/src/marqo_common/version.py` as the single source of truth for the Marqo version (`2.26.0`)
- Updated `marqo`, `inference_orchestrator`, and `model_management` component `version.py` files to re-export from `marqo_common.version`, preserving existing import compatibility
- Added `marqo-common` as a dependency to `model_management` (the other components already had it)

## Test plan
- [x] Verify each component can still import `__version__` and `get_version()` from their local `version.py`
- [x] Verify changing the version in `marqo_common/version.py` propagates to all components
- [ ] Verify `model_management` installs `marqo-common` dependency correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)