### PR TITLE
Add CONTAINS filter for semi-structured indexes (2.25.4)

### DIFF
--- a/components/marqo/src/marqo/core/search/search_filter.py
+++ b/components/marqo/src/marqo/core/search/search_filter.py
@@ -374,10 +374,9 @@ class MarqoFilterStringParser:
                         read_space_until = ')'
                     elif len(self._get_current_term_value()) == 0 and c == '[' and not read_space_until:  # start of term value
                         read_space_until = ']'
-                        if self._term_type == MarqoFilterStringParser._TermType.In:
-                            self._error('Unexpected [ after IN operator.', filter_string, i)
-                        elif self._term_type == MarqoFilterStringParser._TermType.Contains:
-                            self._error('Unexpected [ after CONTAINS operator.', filter_string, i)
+                        if self._term_type in (MarqoFilterStringParser._TermType.In,
+                                               MarqoFilterStringParser._TermType.Contains):
+                            self._error('[ and ] are only usable with the RANGE operator.', filter_string, i)
                         else:
                             self._term_type = MarqoFilterStringParser._TermType.Range
                     else:

--- a/components/marqo/src/marqo/core/search/search_filter.py
+++ b/components/marqo/src/marqo/core/search/search_filter.py
@@ -374,10 +374,12 @@ class MarqoFilterStringParser:
                         read_space_until = ')'
                     elif len(self._get_current_term_value()) == 0 and c == '[' and not read_space_until:  # start of term value
                         read_space_until = ']'
-                        if self._term_type != MarqoFilterStringParser._TermType.In:
-                            self._term_type = MarqoFilterStringParser._TermType.Range
-                        else:
+                        if self._term_type == MarqoFilterStringParser._TermType.In:
                             self._error('Unexpected [ after IN operator.', filter_string, i)
+                        elif self._term_type == MarqoFilterStringParser._TermType.Contains:
+                            self._error('Unexpected [ after CONTAINS operator.', filter_string, i)
+                        else:
+                            self._term_type = MarqoFilterStringParser._TermType.Range
                     else:
                         self._append_to_term_value(c)
 

--- a/components/marqo/src/marqo/core/search/search_filter.py
+++ b/components/marqo/src/marqo/core/search/search_filter.py
@@ -159,6 +159,23 @@ class InTerm(Term):
         return f'{self.__class__.__name__}({repr(self.field)}, {repr(self.value_list)}, {repr(self.raw)})'
 
 
+class ContainsTerm(Term):
+    def __init__(self, field: str, value: str, raw: str):
+        super().__init__(field, raw)
+        self.value = value
+
+    def __eq__(self, other):
+        return (
+                type(self) == type(other) and
+                self.field == other.field and
+                self.value == other.value and
+                self.raw == other.raw
+        )
+
+    def __repr__(self):
+        return f'{self.__class__.__name__}({repr(self.field)}, {repr(self.value)}, {repr(self.raw)})'
+
+
 class And(Operator):
     def __init__(self, left: Node, right: Node, raw: str = 'AND'):
         super().__init__(left, right, raw)
@@ -228,10 +245,13 @@ class MarqoFilterStringParser:
 
     IN_TERM_DIVIDER = ' IN ('
 
+    CONTAINS_TERM_DIVIDER = ' CONTAINS '
+
     class _TermType(Enum):
         Equality = 1
         Range = 2
         In = 3
+        Contains = 4
 
     def _term_divider_is_IN(self, i: int, filter_string: str) -> bool:
         """
@@ -244,6 +264,14 @@ class MarqoFilterStringParser:
             self._error("Expected ( after ' IN '", filter_string, i)
 
         return candidate_substring == self.IN_TERM_DIVIDER
+
+    def _term_divider_is_CONTAINS(self, i: int, filter_string: str) -> bool:
+        """
+        Given 'i' and the full filter string, determine if 'i' is at the beginning of the CONTAINS term divider.
+        The keyword 'CONTAINS' is case-insensitive.
+        """
+        candidate_substring = filter_string[i:i + len(self.CONTAINS_TERM_DIVIDER)].upper()
+        return candidate_substring == self.CONTAINS_TERM_DIVIDER
 
     def _append_to_term_value(self, c: str):
         """
@@ -405,8 +433,19 @@ class MarqoFilterStringParser:
                 self._current_raw_token.append(c)
                 escape = True
             elif c == ' ':
+                # Found the ' CONTAINS ' operator.
+                if len(self._current_token) > 0 and self._term_divider_is_CONTAINS(i, filter_string):
+                    self._read_term_value = True
+                    self._term_type = MarqoFilterStringParser._TermType.Contains
+                    self._term_field = ''.join(self._current_token)
+                    self._current_token.append(self.CONTAINS_TERM_DIVIDER)
+                    self._current_raw_token.append(self.CONTAINS_TERM_DIVIDER)
+
+                    # Skip past ' CONTAINS ' (but not the last char, the loop increments i)
+                    i += len(self.CONTAINS_TERM_DIVIDER) - 1
+
                 # Found the ' IN ' operator. Look for a list starting with '(' on the next pass.
-                if self._term_divider_is_IN(i, filter_string):
+                elif self._term_divider_is_IN(i, filter_string):
                     self._read_term_value = True
                     self._term_type = MarqoFilterStringParser._TermType.In
                     self._term_value = [[]]
@@ -540,6 +579,8 @@ class MarqoFilterStringParser:
             elif term_type == self._TermType.In:
                 # For IN terms, term_value should already be a list, not a string
                 node = InTerm(term_field, term_value, raw_token)
+            elif term_type == self._TermType.Contains:
+                node = ContainsTerm(term_field, term_value, raw_token)
             else:
                 raise InternalError(f'Unexpected term type {term_type}')
 

--- a/components/marqo/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/components/marqo/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -519,6 +519,20 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
 
             return f'({float_field_string} OR {int_field_string})'
 
+        def generate_contains_filter_string(node: search_filter.ContainsTerm) -> str:
+            node.field = self.escape(node.field)
+            marqo_index = self.get_marqo_index()
+            if node.field not in marqo_index.field_map:
+                raise InvalidArgumentError(
+                    f"CONTAINS filter requires a lexical field, but '{node.field}' "
+                    f"is not a lexical field in index '{marqo_index.name}'. "
+                    f"Available lexical fields: {', '.join(sorted(marqo_index.lexically_searchable_fields_names))}"
+                )
+            field = marqo_index.field_map[node.field]
+            lexical_field_name = field.lexical_field_name
+            escaped_value = self.escape(node.value)
+            return f'({lexical_field_name} contains "{escaped_value}")'
+
         def tree_to_filter_string(node: search_filter.Node) -> Optional[str]:
             # Skip any terms with excluded fields first - check at node level
             if (isinstance(node, search_filter.Term) or isinstance(node, search_filter.Modifier)) and exclude_terms is not None:
@@ -565,6 +579,8 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
                     return generate_range_filter_string(node)
                 elif isinstance(node, search_filter.InTerm):
                     raise InvalidArgumentError("The 'IN' filter keyword is not yet supported for unstructured indexes")
+                elif isinstance(node, search_filter.ContainsTerm):
+                    return generate_contains_filter_string(node)
 
             raise InternalError(f'Unknown node type {type(node)}')
 

--- a/components/marqo/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/components/marqo/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -521,16 +521,16 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
 
         def generate_contains_filter_string(node: search_filter.ContainsTerm) -> str:
             escaped_field = self.escape(node.field)
+            escaped_value = self.escape(node.value)
             marqo_index = self.get_marqo_index()
+            # field_map only contains lexical fields for semi-structured indexes
             if escaped_field not in marqo_index.field_map:
                 raise InvalidArgumentError(
-                    f"CONTAINS filter requires a lexical field, but '{escaped_field}' "
-                    f"is not a lexical field in index '{marqo_index.name}'. "
+                    f"CONTAINS filter field '{escaped_field}' is not found in index '{marqo_index.name}'. "
                     f"Available lexical fields: {', '.join(sorted(marqo_index.lexically_searchable_fields_names))}"
                 )
             field = marqo_index.field_map[escaped_field]
             lexical_field_name = field.lexical_field_name
-            escaped_value = self.escape(node.value)
             return f'({lexical_field_name} contains "{escaped_value}")'
 
         def tree_to_filter_string(node: search_filter.Node) -> Optional[str]:

--- a/components/marqo/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/components/marqo/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -520,15 +520,15 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
             return f'({float_field_string} OR {int_field_string})'
 
         def generate_contains_filter_string(node: search_filter.ContainsTerm) -> str:
-            node.field = self.escape(node.field)
+            escaped_field = self.escape(node.field)
             marqo_index = self.get_marqo_index()
-            if node.field not in marqo_index.field_map:
+            if escaped_field not in marqo_index.field_map:
                 raise InvalidArgumentError(
-                    f"CONTAINS filter requires a lexical field, but '{node.field}' "
+                    f"CONTAINS filter requires a lexical field, but '{escaped_field}' "
                     f"is not a lexical field in index '{marqo_index.name}'. "
                     f"Available lexical fields: {', '.join(sorted(marqo_index.lexically_searchable_fields_names))}"
                 )
-            field = marqo_index.field_map[node.field]
+            field = marqo_index.field_map[escaped_field]
             lexical_field_name = field.lexical_field_name
             escaped_value = self.escape(node.value)
             return f'({lexical_field_name} contains "{escaped_value}")'

--- a/components/marqo/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/components/marqo/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -444,53 +444,53 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
             filter_parts = []
 
             # Escape special characters in field name and value
-            node.field = self.escape(node.field)
-            node.value = self.escape(node.value)
+            escaped_field = self.escape(node.field)
+            escaped_value = self.escape(node.value)
 
             # Filter on `_id`
-            if node.field == MARQO_DOC_ID:
-                return f'({VESPA_FIELD_ID} contains "{node.value}")'
+            if escaped_field == MARQO_DOC_ID:
+                return f'({VESPA_FIELD_ID} contains "{escaped_value}")'
 
-            if self.get_marqo_index().is_collapse_field(node.field):
+            if self.get_marqo_index().is_collapse_field(escaped_field):
                 # collapse field is indexed as attribute, can be used directly in a filter term
-                return f'({node.field} contains "{node.value}")'
+                return f'({escaped_field} contains "{escaped_value}")'
 
             # Bool Filter
-            if node.value.lower() in self._FILTER_STRING_BOOL_VALUES:
-                filter_value = int(True if node.value.lower() == "true" else False)
+            if escaped_value.lower() in self._FILTER_STRING_BOOL_VALUES:
+                filter_value = int(True if escaped_value.lower() == "true" else False)
                 bool_filter_string = (f'({BOOL_FIELDS} contains '
-                                      f'sameElement(key contains "{node.field}", value = {filter_value}))')
+                                      f'sameElement(key contains "{escaped_field}", value = {filter_value}))')
                 filter_parts.append(bool_filter_string)
 
             # Short String Filter
             short_string_filter_string = (f'({SHORT_STRINGS_FIELDS} '
-                                          f'contains sameElement(key contains "{node.field}", '
-                                          f'value contains "{node.value}"))')
+                                          f'contains sameElement(key contains "{escaped_field}", '
+                                          f'value contains "{escaped_value}"))')
             filter_parts.append(short_string_filter_string)
 
             # String Array Filter
             if self.index_supports_partial_updates:
-                if node.field in self.get_marqo_index().name_to_string_array_field_map:
-                    string_array_field_name = f'{STRING_ARRAY}_{node.field}'
+                if escaped_field in self.get_marqo_index().name_to_string_array_field_map:
+                    string_array_field_name = f'{STRING_ARRAY}_{escaped_field}'
                     string_array_filter_string = (f'({string_array_field_name} contains '
-                                                  f'"{node.value}")')
+                                                  f'"{escaped_value}")')
                     filter_parts.append(string_array_filter_string)
             else:
                 string_array_filter_string = (f'({STRING_ARRAY} contains '
-                                              f'"{node.field}::{node.value}")')
+                                              f'"{escaped_field}::{escaped_value}")')
                 filter_parts.append(string_array_filter_string)
 
             # Numeric Filter
             numeric_filter_string = ""
             try:
-                numeric_value = int(node.value)
+                numeric_value = int(escaped_value)
                 numeric_filter_string = (
-                    f'({INT_FIELDS} contains sameElement(key contains "{node.field}", value = {numeric_value})) '
-                    f'OR ({FLOAT_FIELDS} contains sameElement(key contains "{node.field}", value = {numeric_value}))')
+                    f'({INT_FIELDS} contains sameElement(key contains "{escaped_field}", value = {numeric_value})) '
+                    f'OR ({FLOAT_FIELDS} contains sameElement(key contains "{escaped_field}", value = {numeric_value}))')
             except ValueError:
                 try:
-                    numeric_value = float(node.value)
-                    numeric_filter_string = f'({FLOAT_FIELDS} contains sameElement(key contains "{node.field}", value = {numeric_value}))'
+                    numeric_value = float(escaped_value)
+                    numeric_filter_string = f'({FLOAT_FIELDS} contains sameElement(key contains "{escaped_field}", value = {numeric_value}))'
                 except ValueError:
                     pass
 
@@ -503,7 +503,7 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
 
         def generate_range_filter_string(node: search_filter.RangeTerm) -> str:
             # Escape special characters in field name
-            node.field = self.escape(node.field)
+            escaped_field = self.escape(node.field)
 
             lower = f'value >= {node.lower}' if node.lower is not None else ""
             higher = f'value <= {node.upper}' if node.upper is not None else ""
@@ -512,10 +512,10 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
                 raise InternalError('RangeTerm has no lower or upper bound')
 
             float_field_string = (f'({FLOAT_FIELDS} contains '
-                                  f'sameElement(key contains "{node.field}", {bound}))')
+                                  f'sameElement(key contains "{escaped_field}", {bound}))')
 
             int_field_string = (f'({INT_FIELDS} contains '
-                                f'sameElement(key contains "{node.field}", {bound}))')
+                                f'sameElement(key contains "{escaped_field}", {bound}))')
 
             return f'({float_field_string} OR {int_field_string})'
 

--- a/components/marqo/src/marqo/core/structured_vespa_index/structured_vespa_index.py
+++ b/components/marqo/src/marqo/core/structured_vespa_index/structured_vespa_index.py
@@ -9,7 +9,7 @@ from marqo.core.models.marqo_index import *
 from marqo.core.models.marqo_query import MarqoTensorQuery, MarqoLexicalQuery, MarqoHybridQuery
 from marqo.core.structured_vespa_index import common
 from marqo.core.vespa_index.vespa_index import VespaIndex
-from marqo.exceptions import InternalError
+from marqo.exceptions import InternalError, InvalidArgumentError
 from marqo.tensor_search import utils
 from marqo.tensor_search.enums import EnvVars
 
@@ -830,6 +830,8 @@ class StructuredVespaIndex(VespaIndex):
                 elif isinstance(node, search_filter.InTerm):
                     return (f'{marqo_field_name} in '
                             f'{_convert_to_in_list_str(value_list=node.value_list, marqo_field_name=node.field, marqo_field_type=marqo_field_type)}')
+                elif isinstance(node, search_filter.ContainsTerm):
+                    raise InvalidArgumentError("The 'CONTAINS' filter keyword is not yet supported for structured indexes")
 
             raise InternalError(f'Unknown node type {type(node)}')
 

--- a/components/marqo/src/marqo/core/unstructured_vespa_index/unstructured_vespa_index.py
+++ b/components/marqo/src/marqo/core/unstructured_vespa_index/unstructured_vespa_index.py
@@ -228,6 +228,8 @@ class UnstructuredVespaIndex(VespaIndex):
                     return generate_range_filter_string(node)
                 elif isinstance(node, search_filter.InTerm):
                     raise InvalidArgumentError("The 'IN' filter keyword is not yet supported for unstructured indexes")
+                elif isinstance(node, search_filter.ContainsTerm):
+                    raise InvalidArgumentError("The 'CONTAINS' filter keyword is not yet supported for unstructured indexes")
             raise InternalError(f'Unknown node type {type(node)}')
 
         if marqo_query.filter is not None:

--- a/components/marqo/src/marqo/core/unstructured_vespa_index/unstructured_vespa_index.py
+++ b/components/marqo/src/marqo/core/unstructured_vespa_index/unstructured_vespa_index.py
@@ -229,7 +229,7 @@ class UnstructuredVespaIndex(VespaIndex):
                 elif isinstance(node, search_filter.InTerm):
                     raise InvalidArgumentError("The 'IN' filter keyword is not yet supported for unstructured indexes")
                 elif isinstance(node, search_filter.ContainsTerm):
-                    raise InvalidArgumentError("The 'CONTAINS' filter keyword is not yet supported for unstructured indexes")
+                    raise InvalidArgumentError("The 'CONTAINS' filter keyword is not yet supported for legacy unstructured indexes")
             raise InternalError(f'Unknown node type {type(node)}')
 
         if marqo_query.filter is not None:

--- a/components/marqo/src/marqo/version.py
+++ b/components/marqo/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.25.3"
+__version__ = "2.25.4"
 
 
 def get_version() -> str:

--- a/components/marqo/tests/integ_tests/tensor_search/search/test_contains_filter.py
+++ b/components/marqo/tests/integ_tests/tensor_search/search/test_contains_filter.py
@@ -32,9 +32,15 @@ class TestContainsFilter(MarqoTestCase):
             tensor_fields=["title", "description"]
         )
 
-        cls.indexes = cls.create_indexes([semi_structured_index, structured_index])
+        legacy_unstructured_index = cls.unstructured_marqo_index_request(
+            model=Model(name='hf/all-MiniLM-L6-v2'),
+            marqo_version='2.12.0'
+        )
+
+        cls.indexes = cls.create_indexes([semi_structured_index, structured_index, legacy_unstructured_index])
         cls.semi_structured_index = cls.indexes[0]
         cls.structured_index = cls.indexes[1]
+        cls.legacy_unstructured_index = cls.indexes[2]
 
     def setUp(self) -> None:
         super().setUp()
@@ -48,10 +54,11 @@ class TestContainsFilter(MarqoTestCase):
                     {"_id": "1", "title": "Hello World", "description": "A simple greeting program"},
                     {"_id": "2", "title": "World Cup", "description": "Football tournament"},
                     {"_id": "3", "title": "Python Programming", "description": "Learn python basics"},
-                    {"_id": "4", "title": "hello again", "description": "Another greeting"},
-                    {"_id": "5", "title": "Machine Learning", "description": "AI and ML concepts"},
+                    {"_id": "4", "title": "hello again", "description": "Another farewell"},
+                    {"_id": "5", "title": "Machine Learning", "description": "AI and ML concepts", "score": 5},
                     {"_id": "6", "title": "Real-time Systems", "description": "Low-latency computing"},
                     {"_id": "7", "title": "vintage t-shirt collection", "description": "fashion items"},
+                    {"_id": "8", "title": "key:value pairs", "description": 'She said "hello" loudly'},
                 ],
                 tensor_fields=["title", "description"]
             )
@@ -69,10 +76,25 @@ class TestContainsFilter(MarqoTestCase):
     def _get_ids(self, res):
         return sorted([hit["_id"] for hit in res["hits"]])
 
+    def test_no_filter_returns_all_docs(self):
+        """Searching without a filter should return all documents."""
+        res = tensor_search.search(
+            index_name=self.semi_structured_index.name,
+            config=self.config,
+            text="",
+            search_method=SearchMethod.TENSOR,
+        )
+        self.assertEqual(self._get_ids(res), ["1", "2", "3", "4", "5", "6", "7", "8"])
+
     def test_basic_contains_match(self):
         """title CONTAINS hello should match docs 1 and 4 (case-insensitive after tokenization)."""
         res = self._search("title CONTAINS hello")
         self.assertEqual(self._get_ids(res), ["1", "4"])
+
+    def test_contains_does_not_match_substring(self):
+        """CONTAINS does token-level matching, not substring matching."""
+        res = self._search("title CONTAINS ello")
+        self.assertEqual(len(res["hits"]), 0)
 
     def test_case_insensitivity(self):
         """title CONTAINS WORLD should match docs 1 and 2."""
@@ -85,29 +107,38 @@ class TestContainsFilter(MarqoTestCase):
         self.assertEqual(len(res["hits"]), 0)
 
     def test_not_contains(self):
-        """NOT (title CONTAINS hello) should match docs 2, 3, 5."""
-        res = self._search("NOT (title CONTAINS hello)", text="world programming learning")
-        ids = self._get_ids(res)
-        # All results should NOT have "hello" in title
-        for doc_id in ids:
-            self.assertNotIn(doc_id, ["1", "4"])
-        # Should include at least some of docs 2, 3, 5
-        self.assertTrue(len(ids) > 0)
+        """NOT (title CONTAINS hello) should match all docs except 1 and 4."""
+        with self.subTest("with parentheses"):
+            res = self._search("NOT (title CONTAINS hello)")
+            self.assertEqual(self._get_ids(res), ["2", "3", "5", "6", "7", "8"])
+
+        with self.subTest("without parentheses"):
+            res = self._search("NOT title CONTAINS hello")
+            self.assertEqual(self._get_ids(res), ["2", "3", "5", "6", "7", "8"])
 
     def test_contains_with_and(self):
-        """title CONTAINS hello AND description CONTAINS greeting should match docs 1 and 4."""
-        res = self._search("title CONTAINS hello AND description CONTAINS greeting")
-        self.assertEqual(self._get_ids(res), ["1", "4"])
+        """title CONTAINS hello AND description CONTAINS simple should match only doc 1.
+
+        Doc 1 has title "Hello World" and description "A simple greeting program".
+        Doc 4 has title "hello again" but description "Another farewell" (no "simple").
+        """
+        res = self._search("title CONTAINS hello AND description CONTAINS simple")
+        self.assertEqual(self._get_ids(res), ["1"])
 
     def test_contains_with_or(self):
-        """title CONTAINS python OR description CONTAINS greeting should match docs 1, 3, 4."""
+        """title CONTAINS python OR description CONTAINS greeting should match docs 1, 3."""
         res = self._search("title CONTAINS python OR description CONTAINS greeting")
-        self.assertEqual(self._get_ids(res), ["1", "3", "4"])
+        self.assertEqual(self._get_ids(res), ["1", "3"])
 
     def test_contains_combined_with_equality(self):
         """title CONTAINS world AND description:(Football tournament) should match doc 2."""
         res = self._search("title CONTAINS world AND description:(Football tournament)")
         self.assertEqual(self._get_ids(res), ["2"])
+
+    def test_contains_combined_with_range(self):
+        """title CONTAINS learning AND score:[1 TO 10] should match doc 5."""
+        res = self._search("title CONTAINS learning AND score:[1 TO 10]")
+        self.assertEqual(self._get_ids(res), ["5"])
 
     def test_contains_across_fields_no_overlap(self):
         """title CONTAINS hello AND description CONTAINS ai should return 0 hits."""
@@ -117,10 +148,7 @@ class TestContainsFilter(MarqoTestCase):
     def test_contains_with_tensor_search(self):
         """CONTAINS filter combined with tensor search."""
         res = self._search("title CONTAINS hello", text="greeting", search_method=SearchMethod.TENSOR)
-        ids = self._get_ids(res)
-        # Should only return docs with "hello" in title
-        for doc_id in ids:
-            self.assertIn(doc_id, ["1", "4"])
+        self.assertEqual(self._get_ids(res), ["1", "4"])
 
     def test_contains_with_lexical_search(self):
         """CONTAINS filter combined with lexical search."""
@@ -132,7 +160,7 @@ class TestContainsFilter(MarqoTestCase):
 
     def test_not_contains_with_and(self):
         """NOT (title CONTAINS hello) AND title CONTAINS world should match doc 2 only."""
-        res = self._search("NOT (title CONTAINS hello) AND title CONTAINS world", text="world cup")
+        res = self._search("NOT (title CONTAINS hello) AND title CONTAINS world")
         self.assertEqual(self._get_ids(res), ["2"])
 
     def test_nonexistent_field_raises_error(self):
@@ -154,8 +182,6 @@ class TestContainsFilter(MarqoTestCase):
         """description CONTAINS (simple greeting) should match doc 1 only (phrase match)."""
         res = self._search("description CONTAINS (simple greeting)")
         ids = self._get_ids(res)
-        # Doc 1 has "A simple greeting program" which contains the phrase "simple greeting"
-        # Doc 4 has "Another greeting" which does NOT contain "simple greeting" as a phrase
         self.assertEqual(ids, ["1"])
 
     def test_contains_with_hybrid_search(self):
@@ -173,26 +199,16 @@ class TestContainsFilter(MarqoTestCase):
             ),
         )
         ids = self._get_ids(res)
-        # Should only return docs with "hello" in title (docs 1 and 4)
         self.assertEqual(ids, ["1", "4"])
 
     def test_contains_with_special_characters_in_filter_value(self):
-        """Test CONTAINS filter where the filter value itself contains special characters.
-
-        Vespa tokenizes both the indexed text and the query value. For example,
-        'title CONTAINS t-shirt' sends 't-shirt' to Vespa's contains operator,
-        which tokenizes it the same way as the indexed text.
-        """
+        """Test CONTAINS filter where the filter value itself contains special characters."""
         with self.subTest("hyphen in filter value: title CONTAINS t-shirt"):
-            # Doc 7 has "vintage t-shirt collection". Vespa tokenizes "t-shirt" into
-            # tokens. The contains operator should match because the indexed text
-            # was tokenized the same way.
             res = self._search("title CONTAINS t-shirt")
             ids = self._get_ids(res)
             self.assertIn("7", ids)
 
         with self.subTest("hyphen in filter value: title CONTAINS real-time"):
-            # Doc 6 has "Real-time Systems"
             res = self._search("title CONTAINS real-time")
             ids = self._get_ids(res)
             self.assertIn("6", ids)
@@ -202,11 +218,46 @@ class TestContainsFilter(MarqoTestCase):
             ids = self._get_ids(res)
             self.assertIn("7", ids)
 
+    def test_contains_with_colon_in_value(self):
+        """Test CONTAINS filter where the indexed text contains a colon."""
+        # Doc 8 has title "key:value pairs". Vespa tokenizes "key:value" into "key" and "value".
+        res = self._search("title CONTAINS key")
+        ids = self._get_ids(res)
+        self.assertIn("8", ids)
+
+    def test_contains_with_quote_in_value(self):
+        """Test CONTAINS filter where the indexed text contains quotes."""
+        # Doc 8 has description 'She said "hello" loudly'. The token "hello" should match.
+        res = self._search("description CONTAINS hello")
+        ids = self._get_ids(res)
+        self.assertIn("8", ids)
+
     def test_structured_index_contains_raises_error(self):
         """Using CONTAINS on a structured index should raise InvalidArgumentError."""
         with self.assertRaises(InvalidArgumentError) as ctx:
             tensor_search.search(
                 index_name=self.structured_index.name,
+                config=self.config,
+                text="test",
+                filter="title CONTAINS hello",
+                search_method=SearchMethod.TENSOR,
+            )
+        self.assertIn("CONTAINS", str(ctx.exception))
+
+    def test_legacy_unstructured_index_contains_raises_error(self):
+        """Using CONTAINS on a legacy unstructured index should raise InvalidArgumentError."""
+        # Add a doc to the legacy index first
+        self.add_documents(
+            config=self.config,
+            add_docs_params=AddDocsParams(
+                index_name=self.legacy_unstructured_index.name,
+                docs=[{"_id": "1", "title": "Hello World"}],
+                tensor_fields=["title"]
+            )
+        )
+        with self.assertRaises(InvalidArgumentError) as ctx:
+            tensor_search.search(
+                index_name=self.legacy_unstructured_index.name,
                 config=self.config,
                 text="test",
                 filter="title CONTAINS hello",

--- a/components/marqo/tests/integ_tests/tensor_search/search/test_contains_filter.py
+++ b/components/marqo/tests/integ_tests/tensor_search/search/test_contains_filter.py
@@ -5,6 +5,7 @@ from unittest import mock
 from marqo.core.models.add_docs_params import AddDocsParams
 from marqo.core.models.marqo_index import *
 from marqo.core.models.marqo_index_request import FieldRequest
+from marqo.core.models.hybrid_parameters import HybridParameters, RetrievalMethod, RankingMethod
 from marqo.exceptions import InvalidArgumentError
 from marqo.tensor_search import tensor_search
 from marqo.tensor_search.enums import SearchMethod
@@ -165,6 +166,24 @@ class TestContainsFilter(MarqoTestCase):
         # Doc 1 has "A simple greeting program" which contains the phrase "simple greeting"
         # Doc 4 has "Another greeting" which does NOT contain "simple greeting" as a phrase
         self.assertEqual(ids, ["1"])
+
+    def test_contains_with_hybrid_search(self):
+        """CONTAINS filter combined with hybrid search."""
+        res = tensor_search.search(
+            config=self.config,
+            index_name=self.semi_structured_index.name,
+            text="greeting",
+            filter="title CONTAINS hello",
+            search_method=SearchMethod.HYBRID,
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                rankingMethod=RankingMethod.RRF,
+                alpha=0.5,
+            ),
+        )
+        ids = self._get_ids(res)
+        # Should only return docs with "hello" in title (docs 1 and 4)
+        self.assertEqual(ids, ["1", "4"])
 
     def test_structured_index_contains_raises_error(self):
         """Using CONTAINS on a structured index should raise InvalidArgumentError."""

--- a/components/marqo/tests/integ_tests/tensor_search/search/test_contains_filter.py
+++ b/components/marqo/tests/integ_tests/tensor_search/search/test_contains_filter.py
@@ -51,7 +51,7 @@ class TestContainsFilter(MarqoTestCase):
                     {"_id": "4", "title": "hello again", "description": "Another greeting"},
                     {"_id": "5", "title": "Machine Learning", "description": "AI and ML concepts"},
                     {"_id": "6", "title": "Real-time Systems", "description": "Low-latency computing"},
-                    {"_id": "7", "title": 'C++ "advanced" guide', "description": "Programming with backslash \\ paths"},
+                    {"_id": "7", "title": "vintage t-shirt collection", "description": "fashion items"},
                 ],
                 tensor_fields=["title", "description"]
             )
@@ -176,34 +176,29 @@ class TestContainsFilter(MarqoTestCase):
         # Should only return docs with "hello" in title (docs 1 and 4)
         self.assertEqual(ids, ["1", "4"])
 
-    def test_contains_with_special_characters(self):
-        """Test CONTAINS filter with special characters in field values.
+    def test_contains_with_special_characters_in_filter_value(self):
+        """Test CONTAINS filter where the filter value itself contains special characters.
 
-        Vespa tokenization splits on special chars like hyphens, quotes, and backslashes.
-        CONTAINS matches on individual tokens after tokenization.
+        Vespa tokenizes both the indexed text and the query value. For example,
+        'title CONTAINS t-shirt' sends 't-shirt' to Vespa's contains operator,
+        which tokenizes it the same way as the indexed text.
         """
-        with self.subTest("hyphen: title CONTAINS real should match doc 6"):
-            res = self._search("title CONTAINS real")
-            ids = self._get_ids(res)
-            self.assertIn("6", ids)
-
-        with self.subTest("hyphen: title CONTAINS time should match doc 6"):
-            res = self._search("title CONTAINS time")
-            ids = self._get_ids(res)
-            self.assertIn("6", ids)
-
-        with self.subTest("quote: title CONTAINS advanced should match doc 7"):
-            res = self._search("title CONTAINS advanced")
+        with self.subTest("hyphen in filter value: title CONTAINS t-shirt"):
+            # Doc 7 has "vintage t-shirt collection". Vespa tokenizes "t-shirt" into
+            # tokens. The contains operator should match because the indexed text
+            # was tokenized the same way.
+            res = self._search("title CONTAINS t-shirt")
             ids = self._get_ids(res)
             self.assertIn("7", ids)
 
-        with self.subTest("backslash: description CONTAINS backslash should match doc 7"):
-            res = self._search("description CONTAINS backslash")
+        with self.subTest("hyphen in filter value: title CONTAINS real-time"):
+            # Doc 6 has "Real-time Systems"
+            res = self._search("title CONTAINS real-time")
             ids = self._get_ids(res)
-            self.assertIn("7", ids)
+            self.assertIn("6", ids)
 
-        with self.subTest("plus sign: title CONTAINS c should match doc 7"):
-            res = self._search("title CONTAINS c")
+        with self.subTest("grouped value with special chars: title CONTAINS (t-shirt collection)"):
+            res = self._search("title CONTAINS (t-shirt collection)")
             ids = self._get_ids(res)
             self.assertIn("7", ids)
 

--- a/components/marqo/tests/integ_tests/tensor_search/search/test_contains_filter.py
+++ b/components/marqo/tests/integ_tests/tensor_search/search/test_contains_filter.py
@@ -57,6 +57,7 @@ class TestContainsFilter(MarqoTestCase):
                     {"_id": "3", "title": "Python Programming", "description": "Learn python basics"},
                     {"_id": "4", "title": "hello again", "description": "Another greeting"},
                     {"_id": "5", "title": "Machine Learning", "description": "AI and ML concepts"},
+                    {"_id": "6", "title": "Real-time Systems", "description": "Low-latency computing"},
                 ],
                 tensor_fields=["title", "description"]
             )
@@ -184,6 +185,23 @@ class TestContainsFilter(MarqoTestCase):
         ids = self._get_ids(res)
         # Should only return docs with "hello" in title (docs 1 and 4)
         self.assertEqual(ids, ["1", "4"])
+
+    def test_contains_with_special_characters(self):
+        """Vespa tokenization splits hyphenated words, so CONTAINS matches individual parts.
+
+        Doc 6 has title "Real-time Systems". The tokenizer splits "Real-time" into tokens
+        "real" and "time" (lowercased). This test documents that CONTAINS matches on each
+        token independently when special characters like hyphens are present.
+        """
+        with self.subTest("title CONTAINS real should match doc 6"):
+            res = self._search("title CONTAINS real")
+            ids = self._get_ids(res)
+            self.assertIn("6", ids)
+
+        with self.subTest("title CONTAINS time should match doc 6"):
+            res = self._search("title CONTAINS time")
+            ids = self._get_ids(res)
+            self.assertIn("6", ids)
 
     def test_structured_index_contains_raises_error(self):
         """Using CONTAINS on a structured index should raise InvalidArgumentError."""

--- a/components/marqo/tests/integ_tests/tensor_search/search/test_contains_filter.py
+++ b/components/marqo/tests/integ_tests/tensor_search/search/test_contains_filter.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 from marqo.core.models.add_docs_params import AddDocsParams
 from marqo.core.models.marqo_index import *
+from marqo.core.models.marqo_index_request import FieldRequest
 from marqo.exceptions import InvalidArgumentError
 from marqo.tensor_search import tensor_search
 from marqo.tensor_search.enums import SearchMethod
@@ -21,8 +22,20 @@ class TestContainsFilter(MarqoTestCase):
             model=Model(name='hf/all-MiniLM-L6-v2')
         )
 
-        cls.indexes = cls.create_indexes([semi_structured_index])
+        structured_index = cls.structured_marqo_index_request(
+            model=Model(name='hf/all-MiniLM-L6-v2'),
+            fields=[
+                FieldRequest(name="title", type=FieldType.Text,
+                             features=[FieldFeature.LexicalSearch, FieldFeature.Filter]),
+                FieldRequest(name="description", type=FieldType.Text,
+                             features=[FieldFeature.LexicalSearch, FieldFeature.Filter]),
+            ],
+            tensor_fields=["title", "description"]
+        )
+
+        cls.indexes = cls.create_indexes([semi_structured_index, structured_index])
         cls.semi_structured_index = cls.indexes[0]
+        cls.structured_index = cls.indexes[1]
 
     def setUp(self) -> None:
         super().setUp()
@@ -144,3 +157,15 @@ class TestContainsFilter(MarqoTestCase):
         """The CONTAINS keyword should be case-insensitive with mixed case."""
         res = self._search("title Contains hello")
         self.assertEqual(self._get_ids(res), ["1", "4"])
+
+    def test_structured_index_contains_raises_error(self):
+        """Using CONTAINS on a structured index should raise InvalidArgumentError."""
+        with self.assertRaises(InvalidArgumentError) as ctx:
+            tensor_search.search(
+                index_name=self.structured_index.name,
+                config=self.config,
+                text="test",
+                filter="title CONTAINS hello",
+                search_method=SearchMethod.TENSOR,
+            )
+        self.assertIn("CONTAINS", str(ctx.exception))

--- a/components/marqo/tests/integ_tests/tensor_search/search/test_contains_filter.py
+++ b/components/marqo/tests/integ_tests/tensor_search/search/test_contains_filter.py
@@ -51,10 +51,10 @@ class TestContainsFilter(MarqoTestCase):
             add_docs_params=AddDocsParams(
                 index_name=self.semi_structured_index.name,
                 docs=[
-                    {"_id": "1", "title": "Hello World", "description": "A simple greeting program"},
+                    {"_id": "1", "title": "Hello World", "description": "A simple greeting program", "score": 3},
                     {"_id": "2", "title": "World Cup", "description": "Football tournament"},
                     {"_id": "3", "title": "Python Programming", "description": "Learn python basics"},
-                    {"_id": "4", "title": "hello again", "description": "Another farewell"},
+                    {"_id": "4", "title": "hello again", "description": "Another farewell", "score": 15},
                     {"_id": "5", "title": "Machine Learning", "description": "AI and ML concepts", "score": 5},
                     {"_id": "6", "title": "Real-time Systems", "description": "Low-latency computing"},
                     {"_id": "7", "title": "vintage t-shirt collection", "description": "fashion items"},
@@ -136,9 +136,13 @@ class TestContainsFilter(MarqoTestCase):
         self.assertEqual(self._get_ids(res), ["2"])
 
     def test_contains_combined_with_range(self):
-        """title CONTAINS learning AND score:[1 TO 10] should match doc 5."""
-        res = self._search("title CONTAINS learning AND score:[1 TO 10]")
-        self.assertEqual(self._get_ids(res), ["5"])
+        """title CONTAINS hello AND score:[1 TO 10] should match only doc 1.
+
+        Docs 1 and 4 both have "hello" in title. Doc 1 has score=3 (in range),
+        doc 4 has score=15 (out of range). The AND narrows to doc 1 only.
+        """
+        res = self._search("title CONTAINS hello AND score:[1 TO 10]")
+        self.assertEqual(self._get_ids(res), ["1"])
 
     def test_contains_across_fields_no_overlap(self):
         """title CONTAINS hello AND description CONTAINS ai should return 0 hits."""
@@ -221,16 +225,28 @@ class TestContainsFilter(MarqoTestCase):
     def test_contains_with_colon_in_value(self):
         """Test CONTAINS filter where the indexed text contains a colon."""
         # Doc 8 has title "key:value pairs". Vespa tokenizes "key:value" into "key" and "value".
-        res = self._search("title CONTAINS key")
-        ids = self._get_ids(res)
-        self.assertIn("8", ids)
+        with self.subTest("token match: title CONTAINS key"):
+            res = self._search("title CONTAINS key")
+            ids = self._get_ids(res)
+            self.assertIn("8", ids)
+
+        with self.subTest("grouped value with colon: title CONTAINS (key:)"):
+            res = self._search("title CONTAINS (key:)")
+            ids = self._get_ids(res)
+            self.assertIn("8", ids)
 
     def test_contains_with_quote_in_value(self):
         """Test CONTAINS filter where the indexed text contains quotes."""
         # Doc 8 has description 'She said "hello" loudly'. The token "hello" should match.
-        res = self._search("description CONTAINS hello")
-        ids = self._get_ids(res)
-        self.assertIn("8", ids)
+        with self.subTest("token match: description CONTAINS hello"):
+            res = self._search("description CONTAINS hello")
+            ids = self._get_ids(res)
+            self.assertIn("8", ids)
+
+        with self.subTest('grouped value with quotes: description CONTAINS (\\"hello\\")'):
+            res = self._search('description CONTAINS (\\"hello\\")')
+            ids = self._get_ids(res)
+            self.assertIn("8", ids)
 
     def test_structured_index_contains_raises_error(self):
         """Using CONTAINS on a structured index should raise InvalidArgumentError."""

--- a/components/marqo/tests/integ_tests/tensor_search/search/test_contains_filter.py
+++ b/components/marqo/tests/integ_tests/tensor_search/search/test_contains_filter.py
@@ -1,0 +1,146 @@
+import os
+import unittest
+from unittest import mock
+
+from marqo.core.models.add_docs_params import AddDocsParams
+from marqo.core.models.marqo_index import *
+from marqo.exceptions import InvalidArgumentError
+from marqo.tensor_search import tensor_search
+from marqo.tensor_search.enums import SearchMethod
+from tests.integ_tests.marqo_test import MarqoTestCase
+
+
+class TestContainsFilter(MarqoTestCase):
+    """Tests for the CONTAINS filter keyword on semi-structured indexes."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+
+        semi_structured_index = cls.unstructured_marqo_index_request(
+            model=Model(name='hf/all-MiniLM-L6-v2')
+        )
+
+        cls.indexes = cls.create_indexes([semi_structured_index])
+        cls.semi_structured_index = cls.indexes[0]
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.device_patcher = mock.patch.dict(os.environ, {
+            "MARQO_BEST_AVAILABLE_DEVICE": "cpu",
+            "MARQO_MAX_CPU_MODEL_MEMORY": "15"
+        })
+        self.device_patcher.start()
+
+        # Add test documents
+        self.add_documents(
+            config=self.config,
+            add_docs_params=AddDocsParams(
+                index_name=self.semi_structured_index.name,
+                docs=[
+                    {"_id": "1", "title": "Hello World", "description": "A simple greeting program"},
+                    {"_id": "2", "title": "World Cup", "description": "Football tournament"},
+                    {"_id": "3", "title": "Python Programming", "description": "Learn python basics"},
+                    {"_id": "4", "title": "hello again", "description": "Another greeting"},
+                    {"_id": "5", "title": "Machine Learning", "description": "AI and ML concepts"},
+                ],
+                tensor_fields=["title", "description"]
+            )
+        )
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        self.device_patcher.stop()
+
+    def _search(self, filter_str, text="", search_method=SearchMethod.TENSOR):
+        return tensor_search.search(
+            index_name=self.semi_structured_index.name,
+            config=self.config,
+            text=text,
+            filter=filter_str,
+            search_method=search_method,
+        )
+
+    def _get_ids(self, res):
+        return sorted([hit["_id"] for hit in res["hits"]])
+
+    def test_basic_contains_match(self):
+        """title CONTAINS hello should match docs 1 and 4 (case-insensitive after tokenization)."""
+        res = self._search("title CONTAINS hello")
+        self.assertEqual(self._get_ids(res), ["1", "4"])
+
+    def test_case_insensitivity(self):
+        """title CONTAINS WORLD should match docs 1 and 2."""
+        res = self._search("title CONTAINS WORLD")
+        self.assertEqual(self._get_ids(res), ["1", "2"])
+
+    def test_no_match(self):
+        """title CONTAINS nonexistent should return 0 hits."""
+        res = self._search("title CONTAINS nonexistent")
+        self.assertEqual(len(res["hits"]), 0)
+
+    def test_not_contains(self):
+        """NOT (title CONTAINS hello) should match docs 2, 3, 5."""
+        res = self._search("NOT (title CONTAINS hello)", text="world programming learning")
+        ids = self._get_ids(res)
+        # All results should NOT have "hello" in title
+        for doc_id in ids:
+            self.assertNotIn(doc_id, ["1", "4"])
+        # Should include at least some of docs 2, 3, 5
+        self.assertTrue(len(ids) > 0)
+
+    def test_contains_with_and(self):
+        """title CONTAINS hello AND description CONTAINS greeting should match docs 1 and 4."""
+        res = self._search("title CONTAINS hello AND description CONTAINS greeting")
+        self.assertEqual(self._get_ids(res), ["1", "4"])
+
+    def test_contains_with_or(self):
+        """title CONTAINS python OR description CONTAINS greeting should match docs 1, 3, 4."""
+        res = self._search("title CONTAINS python OR description CONTAINS greeting")
+        self.assertEqual(self._get_ids(res), ["1", "3", "4"])
+
+    def test_contains_combined_with_equality(self):
+        """title CONTAINS world AND description:(Football tournament) should match doc 2."""
+        res = self._search("title CONTAINS world AND description:(Football tournament)")
+        self.assertEqual(self._get_ids(res), ["2"])
+
+    def test_contains_across_fields_no_overlap(self):
+        """title CONTAINS hello AND description CONTAINS ai should return 0 hits."""
+        res = self._search("title CONTAINS hello AND description CONTAINS ai")
+        self.assertEqual(len(res["hits"]), 0)
+
+    def test_contains_with_tensor_search(self):
+        """CONTAINS filter combined with tensor search."""
+        res = self._search("title CONTAINS hello", text="greeting", search_method=SearchMethod.TENSOR)
+        ids = self._get_ids(res)
+        # Should only return docs with "hello" in title
+        for doc_id in ids:
+            self.assertIn(doc_id, ["1", "4"])
+
+    def test_contains_with_lexical_search(self):
+        """CONTAINS filter combined with lexical search."""
+        res = self._search("title CONTAINS hello", text="greeting", search_method=SearchMethod.LEXICAL)
+        ids = self._get_ids(res)
+        # Should only return docs with "hello" in title
+        for doc_id in ids:
+            self.assertIn(doc_id, ["1", "4"])
+
+    def test_not_contains_with_and(self):
+        """NOT (title CONTAINS hello) AND title CONTAINS world should match doc 2 only."""
+        res = self._search("NOT (title CONTAINS hello) AND title CONTAINS world", text="world cup")
+        self.assertEqual(self._get_ids(res), ["2"])
+
+    def test_nonexistent_field_raises_error(self):
+        """Filtering on a nonexistent field should raise an error."""
+        with self.assertRaises(InvalidArgumentError):
+            self._search("nonexistent_field CONTAINS value")
+
+    def test_lowercase_contains_keyword(self):
+        """The CONTAINS keyword should be case-insensitive."""
+        res = self._search("title contains hello")
+        self.assertEqual(self._get_ids(res), ["1", "4"])
+
+    def test_mixed_case_contains_keyword(self):
+        """The CONTAINS keyword should be case-insensitive with mixed case."""
+        res = self._search("title Contains hello")
+        self.assertEqual(self._get_ids(res), ["1", "4"])

--- a/components/marqo/tests/integ_tests/tensor_search/search/test_contains_filter.py
+++ b/components/marqo/tests/integ_tests/tensor_search/search/test_contains_filter.py
@@ -1,6 +1,4 @@
-import os
 import unittest
-from unittest import mock
 
 from marqo.core.models.add_docs_params import AddDocsParams
 from marqo.core.models.marqo_index import *
@@ -40,11 +38,6 @@ class TestContainsFilter(MarqoTestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.device_patcher = mock.patch.dict(os.environ, {
-            "MARQO_BEST_AVAILABLE_DEVICE": "cpu",
-            "MARQO_MAX_CPU_MODEL_MEMORY": "15"
-        })
-        self.device_patcher.start()
 
         # Add test documents
         self.add_documents(
@@ -58,14 +51,11 @@ class TestContainsFilter(MarqoTestCase):
                     {"_id": "4", "title": "hello again", "description": "Another greeting"},
                     {"_id": "5", "title": "Machine Learning", "description": "AI and ML concepts"},
                     {"_id": "6", "title": "Real-time Systems", "description": "Low-latency computing"},
+                    {"_id": "7", "title": 'C++ "advanced" guide', "description": "Programming with backslash \\ paths"},
                 ],
                 tensor_fields=["title", "description"]
             )
         )
-
-    def tearDown(self) -> None:
-        super().tearDown()
-        self.device_patcher.stop()
 
     def _search(self, filter_str, text="", search_method=SearchMethod.TENSOR):
         return tensor_search.search(
@@ -187,21 +177,35 @@ class TestContainsFilter(MarqoTestCase):
         self.assertEqual(ids, ["1", "4"])
 
     def test_contains_with_special_characters(self):
-        """Vespa tokenization splits hyphenated words, so CONTAINS matches individual parts.
+        """Test CONTAINS filter with special characters in field values.
 
-        Doc 6 has title "Real-time Systems". The tokenizer splits "Real-time" into tokens
-        "real" and "time" (lowercased). This test documents that CONTAINS matches on each
-        token independently when special characters like hyphens are present.
+        Vespa tokenization splits on special chars like hyphens, quotes, and backslashes.
+        CONTAINS matches on individual tokens after tokenization.
         """
-        with self.subTest("title CONTAINS real should match doc 6"):
+        with self.subTest("hyphen: title CONTAINS real should match doc 6"):
             res = self._search("title CONTAINS real")
             ids = self._get_ids(res)
             self.assertIn("6", ids)
 
-        with self.subTest("title CONTAINS time should match doc 6"):
+        with self.subTest("hyphen: title CONTAINS time should match doc 6"):
             res = self._search("title CONTAINS time")
             ids = self._get_ids(res)
             self.assertIn("6", ids)
+
+        with self.subTest("quote: title CONTAINS advanced should match doc 7"):
+            res = self._search("title CONTAINS advanced")
+            ids = self._get_ids(res)
+            self.assertIn("7", ids)
+
+        with self.subTest("backslash: description CONTAINS backslash should match doc 7"):
+            res = self._search("description CONTAINS backslash")
+            ids = self._get_ids(res)
+            self.assertIn("7", ids)
+
+        with self.subTest("plus sign: title CONTAINS c should match doc 7"):
+            res = self._search("title CONTAINS c")
+            ids = self._get_ids(res)
+            self.assertIn("7", ids)
 
     def test_structured_index_contains_raises_error(self):
         """Using CONTAINS on a structured index should raise InvalidArgumentError."""

--- a/components/marqo/tests/integ_tests/tensor_search/search/test_contains_filter.py
+++ b/components/marqo/tests/integ_tests/tensor_search/search/test_contains_filter.py
@@ -71,6 +71,7 @@ class TestContainsFilter(MarqoTestCase):
             text=text,
             filter=filter_str,
             search_method=search_method,
+            result_count=10,
         )
 
     def _get_ids(self, res):
@@ -83,6 +84,7 @@ class TestContainsFilter(MarqoTestCase):
             config=self.config,
             text="",
             search_method=SearchMethod.TENSOR,
+            result_count=10,
         )
         self.assertEqual(self._get_ids(res), ["1", "2", "3", "4", "5", "6", "7", "8"])
 

--- a/components/marqo/tests/integ_tests/tensor_search/search/test_contains_filter.py
+++ b/components/marqo/tests/integ_tests/tensor_search/search/test_contains_filter.py
@@ -158,6 +158,14 @@ class TestContainsFilter(MarqoTestCase):
         res = self._search("title Contains hello")
         self.assertEqual(self._get_ids(res), ["1", "4"])
 
+    def test_contains_grouped_multiword_value(self):
+        """description CONTAINS (simple greeting) should match doc 1 only (phrase match)."""
+        res = self._search("description CONTAINS (simple greeting)")
+        ids = self._get_ids(res)
+        # Doc 1 has "A simple greeting program" which contains the phrase "simple greeting"
+        # Doc 4 has "Another greeting" which does NOT contain "simple greeting" as a phrase
+        self.assertEqual(ids, ["1"])
+
     def test_structured_index_contains_raises_error(self):
         """Using CONTAINS on a structured index should raise InvalidArgumentError."""
         with self.assertRaises(InvalidArgumentError) as ctx:

--- a/components/marqo/tests/unit_tests/marqo/core/search/test_search_filter.py
+++ b/components/marqo/tests/unit_tests/marqo/core/search/test_search_filter.py
@@ -364,6 +364,20 @@ class TestMarqoFilterStringParser(MarqoTestCase):
                 'CONTAINS with escaped space in value'
             ),
             (
+                'a CONTAINS hel\\"lo',
+                SearchFilter(
+                    ContainsTerm('a', 'hel"lo', 'a CONTAINS hel\\"lo')
+                ),
+                'CONTAINS with escaped double quote in value'
+            ),
+            (
+                'a CONTAINS hel\\\\lo',
+                SearchFilter(
+                    ContainsTerm('a', 'hel\\lo', 'a CONTAINS hel\\\\lo')
+                ),
+                'CONTAINS with escaped backslash in value'
+            ),
+            (
                 '(a CONTAINS hello) OR b:2',
                 SearchFilter(
                     root=Or(

--- a/components/marqo/tests/unit_tests/marqo/core/search/test_search_filter.py
+++ b/components/marqo/tests/unit_tests/marqo/core/search/test_search_filter.py
@@ -259,6 +259,96 @@ class TestMarqoFilterStringParser(MarqoTestCase):
                     )),
                 "Many parenthesis, nested groupings"
             ),
+            # CONTAINS term divider tests
+            (
+                'a CONTAINS hello',
+                SearchFilter(
+                    ContainsTerm('a', 'hello', 'a CONTAINS hello')
+                ),
+                'basic CONTAINS term'
+            ),
+            (
+                'a contains hello',
+                SearchFilter(
+                    ContainsTerm('a', 'hello', 'a CONTAINS hello')
+                ),
+                'lowercase contains term'
+            ),
+            (
+                'a Contains hello',
+                SearchFilter(
+                    ContainsTerm('a', 'hello', 'a CONTAINS hello')
+                ),
+                'mixed case Contains term'
+            ),
+            (
+                'a CONTAINS (hello world)',
+                SearchFilter(
+                    ContainsTerm('a', 'hello world', 'a CONTAINS (hello world)')
+                ),
+                'CONTAINS with grouped value'
+            ),
+            (
+                'a CONTAINS hello AND b:2',
+                SearchFilter(
+                    root=And(
+                        left=ContainsTerm('a', 'hello', 'a CONTAINS hello'),
+                        right=EqualityTerm('b', '2', 'b:2')
+                    )
+                ),
+                'AND with CONTAINS term'
+            ),
+            (
+                'a CONTAINS hello OR b:2',
+                SearchFilter(
+                    root=Or(
+                        left=ContainsTerm('a', 'hello', 'a CONTAINS hello'),
+                        right=EqualityTerm('b', '2', 'b:2')
+                    )
+                ),
+                'OR with CONTAINS term'
+            ),
+            (
+                'NOT a CONTAINS hello',
+                SearchFilter(
+                    root=Not(
+                        ContainsTerm('a', 'hello', 'a CONTAINS hello')
+                    ),
+                ),
+                'NOT CONTAINS term'
+            ),
+            (
+                'a CONTAINS hello AND b CONTAINS world',
+                SearchFilter(
+                    root=And(
+                        left=ContainsTerm('a', 'hello', 'a CONTAINS hello'),
+                        right=ContainsTerm('b', 'world', 'b CONTAINS world')
+                    )
+                ),
+                'AND with two CONTAINS terms'
+            ),
+            (
+                'a CONTAINS hello AND b:(Football tournament)',
+                SearchFilter(
+                    root=And(
+                        left=ContainsTerm('a', 'hello', 'a CONTAINS hello'),
+                        right=EqualityTerm('b', 'Football tournament', 'b:(Football tournament)')
+                    )
+                ),
+                'CONTAINS combined with equality'
+            ),
+            (
+                'NOT (a CONTAINS hello) AND b CONTAINS world',
+                SearchFilter(
+                    root=And(
+                        left=Not(
+                            ContainsTerm('a', 'hello', 'a CONTAINS hello')
+                        ),
+                        right=ContainsTerm('b', 'world', 'b CONTAINS world')
+                    )
+                ),
+                'NOT CONTAINS with AND'
+            ),
             # A bit of everything
             (
                 '(a:1 AND NOT (b:[1 TO 10] OR (c IN (x, y, (hello world)))))',

--- a/components/marqo/tests/unit_tests/marqo/core/search/test_search_filter.py
+++ b/components/marqo/tests/unit_tests/marqo/core/search/test_search_filter.py
@@ -455,13 +455,13 @@ class TestMarqoFilterStringParser(MarqoTestCase):
             ('a IN (1, 2 OR 3)', 'Unexpected white space', 'OR in IN term'),
             ('a IN (1, 2 AND 3)', 'Unexpected white space', 'AND in IN term'),
             ('a IN (1, 2 NOT 3)', 'Unexpected white space', 'NOT in IN term'),
-            ('a IN (1, 2, 3, [0 TO 1])', 'Unexpected [ after IN operator', 'RANGE in IN term'),
+            ('a IN (1, 2, 3, [0 TO 1])', '[ and ] are only usable with the RANGE operator', 'RANGE in IN term'),
             ('a IN (1, 2, 3))', 'Unexpected )', 'extra parenthesis in IN term'),
             ('a IN (val1, val 2, val3)', 'Unexpected white space', 'ungrouped space in IN term'),
             ('a IN 1, 2, 3)', 'Expected (', 'IN term with no opening parenthesis'),
 
             # Contains term tests
-            ('a CONTAINS [1 TO 10]', 'Unexpected [ after CONTAINS operator', 'RANGE in CONTAINS term'),
+            ('a CONTAINS [1 TO 10]', '[ and ] are only usable with the RANGE operator', 'RANGE in CONTAINS term'),
         ]
 
         for filter_string, expected_error_msg, msg in test_cases:

--- a/components/marqo/tests/unit_tests/marqo/core/search/test_search_filter.py
+++ b/components/marqo/tests/unit_tests/marqo/core/search/test_search_filter.py
@@ -349,6 +349,30 @@ class TestMarqoFilterStringParser(MarqoTestCase):
                 ),
                 'NOT CONTAINS with AND'
             ),
+            (
+                '(a CONTAINS hello)',
+                SearchFilter(
+                    ContainsTerm('a', 'hello', 'a CONTAINS hello')
+                ),
+                'CONTAINS in parentheses'
+            ),
+            (
+                'a CONTAINS hello\\ world',
+                SearchFilter(
+                    ContainsTerm('a', 'hello world', 'a CONTAINS hello\\ world')
+                ),
+                'CONTAINS with escaped space in value'
+            ),
+            (
+                '(a CONTAINS hello) OR b:2',
+                SearchFilter(
+                    root=Or(
+                        left=ContainsTerm('a', 'hello', 'a CONTAINS hello'),
+                        right=EqualityTerm('b', '2', 'b:2')
+                    )
+                ),
+                'CONTAINS as only term in complex expression with OR'
+            ),
             # A bit of everything
             (
                 '(a:1 AND NOT (b:[1 TO 10] OR (c IN (x, y, (hello world)))))',

--- a/components/marqo/tests/unit_tests/marqo/core/search/test_search_filter.py
+++ b/components/marqo/tests/unit_tests/marqo/core/search/test_search_filter.py
@@ -459,6 +459,9 @@ class TestMarqoFilterStringParser(MarqoTestCase):
             ('a IN (1, 2, 3))', 'Unexpected )', 'extra parenthesis in IN term'),
             ('a IN (val1, val 2, val3)', 'Unexpected white space', 'ungrouped space in IN term'),
             ('a IN 1, 2, 3)', 'Expected (', 'IN term with no opening parenthesis'),
+
+            # Contains term tests
+            ('a CONTAINS [1 TO 10]', 'Unexpected [ after CONTAINS operator', 'RANGE in CONTAINS term'),
         ]
 
         for filter_string, expected_error_msg, msg in test_cases:

--- a/components/marqo/tests/unit_tests/marqo/core/search/test_search_filter.py
+++ b/components/marqo/tests/unit_tests/marqo/core/search/test_search_filter.py
@@ -364,6 +364,13 @@ class TestMarqoFilterStringParser(MarqoTestCase):
                 'CONTAINS with escaped space in value'
             ),
             (
+                'a CONTAINS t-shirt',
+                SearchFilter(
+                    ContainsTerm('a', 't-shirt', 'a CONTAINS t-shirt')
+                ),
+                'CONTAINS with hyphen in value'
+            ),
+            (
                 'a CONTAINS hel\\"lo',
                 SearchFilter(
                     ContainsTerm('a', 'hel"lo', 'a CONTAINS hel\\"lo')

--- a/components/marqo/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_semi_structured_vespa_index.py
+++ b/components/marqo/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_semi_structured_vespa_index.py
@@ -91,13 +91,13 @@ class TestSemiStructuredVespaIndex(MarqoTestCase):
     def test_get_filter_string_equality_paths(self):
         """Test equality filter paths: _id, bool, string array, and float numeric."""
         test_cases = [
-            # _id filter (line 441)
+            # _id filter
             ('_id:doc123', 'marqo__id contains "doc123"'),
-            # Bool filter (line 449)
+            # Bool filter
             ('title:true', 'marqo__bool_fields'),
-            # String array filter (line 463)
+            # String array filter
             ('tags:foo', 'marqo__string_array_tags contains "foo"'),
-            # Float numeric filter (line 482)
+            # Float numeric filter
             ('title:3.14', 'marqo__float_fields'),
         ]
 

--- a/components/marqo/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_semi_structured_vespa_index.py
+++ b/components/marqo/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_semi_structured_vespa_index.py
@@ -92,16 +92,22 @@ class TestSemiStructuredVespaIndex(MarqoTestCase):
         """Test equality filter paths: _id, bool, string array, and float numeric."""
         test_cases = [
             # _id filter
-            ('_id:doc123', 'marqo__id contains "doc123"'),
+            ('_id:doc123', '(marqo__id contains "doc123")'),
             # Bool filter
-            ('title:true', 'marqo__bool_fields'),
+            ('title:true',
+             '((marqo__bool_fields contains sameElement(key contains "title", value = 1)) OR '
+             '(marqo__short_string_fields contains sameElement(key contains "title", value contains "true")))'),
             # String array filter
-            ('tags:foo', 'marqo__string_array_tags contains "foo"'),
+            ('tags:foo',
+             '((marqo__short_string_fields contains sameElement(key contains "tags", value contains "foo")) OR '
+             '(marqo__string_array_tags contains "foo"))'),
             # Float numeric filter
-            ('title:3.14', 'marqo__float_fields'),
+            ('title:3.14',
+             '((marqo__short_string_fields contains sameElement(key contains "title", value contains "3.14")) OR '
+             '(marqo__float_fields contains sameElement(key contains "title", value = 3.14)))'),
         ]
 
-        for filter_string, expected_fragment in test_cases:
+        for filter_string, expected_result in test_cases:
             with self.subTest(filter_string=filter_string):
                 marqo_query = MarqoQuery(
                     index_name=self.vespa_index._marqo_index.name,
@@ -111,7 +117,7 @@ class TestSemiStructuredVespaIndex(MarqoTestCase):
                     expose_facets=False
                 )
                 result_filter_string = self.vespa_index._get_filter_term(marqo_query)
-                self.assertIn(expected_fragment, result_filter_string)
+                self.assertEqual(expected_result, result_filter_string)
 
     def test_get_filter_string_contains(self):
         """Test CONTAINS filter generates correct Vespa syntax for lexical fields."""

--- a/components/marqo/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_semi_structured_vespa_index.py
+++ b/components/marqo/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_semi_structured_vespa_index.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 from marqo.core.models import MarqoQuery
 from marqo.core.semi_structured_vespa_index.semi_structured_vespa_index import SemiStructuredVespaIndex
+from marqo.exceptions import InvalidArgumentError
 from tests.unit_tests.marqo_test import MarqoTestCase
 
 
@@ -86,6 +87,55 @@ class TestSemiStructuredVespaIndex(MarqoTestCase):
                 )
                 result_filter_string = self.vespa_index._get_filter_term(marqo_query)
                 self.assertEqual(expected_result, result_filter_string)
+
+    def test_get_filter_string_equality_paths(self):
+        """Test equality filter paths: _id, bool, string array, and float numeric."""
+        test_cases = [
+            # _id filter (line 441)
+            ('_id:doc123', 'marqo__id contains "doc123"'),
+            # Bool filter (line 449)
+            ('title:true', 'marqo__bool_fields'),
+            # String array filter (line 463)
+            ('tags:foo', 'marqo__string_array_tags contains "foo"'),
+            # Float numeric filter (line 482)
+            ('title:3.14', 'marqo__float_fields'),
+        ]
+
+        for filter_string, expected_fragment in test_cases:
+            with self.subTest(filter_string=filter_string):
+                marqo_query = MarqoQuery(
+                    index_name=self.vespa_index._marqo_index.name,
+                    limit=10,
+                    filter=filter_string,
+                    score_modifiers=[],
+                    expose_facets=False
+                )
+                result_filter_string = self.vespa_index._get_filter_term(marqo_query)
+                self.assertIn(expected_fragment, result_filter_string)
+
+    def test_get_filter_string_contains(self):
+        """Test CONTAINS filter generates correct Vespa syntax for lexical fields."""
+        marqo_query = MarqoQuery(
+            index_name=self.vespa_index._marqo_index.name,
+            limit=10,
+            filter='title CONTAINS hello',
+            score_modifiers=[],
+            expose_facets=False
+        )
+        result_filter_string = self.vespa_index._get_filter_term(marqo_query)
+        self.assertEqual('(marqo__lexical_title contains "hello")', result_filter_string)
+
+    def test_get_filter_string_contains_nonexistent_field_raises_error(self):
+        """Test CONTAINS filter raises error for a field not in the index."""
+        marqo_query = MarqoQuery(
+            index_name=self.vespa_index._marqo_index.name,
+            limit=10,
+            filter='nonexistent CONTAINS hello',
+            score_modifiers=[],
+            expose_facets=False
+        )
+        with self.assertRaises(InvalidArgumentError):
+            self.vespa_index._get_filter_term(marqo_query)
 
     def test_vespa_to_marqo_conversion_should_handle_all_fields_from_search_result(self):
         vespa_doc = {

--- a/components/marqo/tests/unit_tests/marqo/core/structured_vespa_index/test_structured_vespa_index_methods.py
+++ b/components/marqo/tests/unit_tests/marqo/core/structured_vespa_index/test_structured_vespa_index_methods.py
@@ -11,6 +11,7 @@ from marqo.core.models.marqo_index import StructuredMarqoIndex, Model, TextPrePr
 from marqo.core.structured_vespa_index.structured_vespa_index import StructuredVespaIndex
 from marqo.core.structured_vespa_index.structured_vespa_schema import StructuredVespaSchema
 from marqo.core.exceptions import InvalidFieldNameError
+from marqo.exceptions import InvalidArgumentError
 
 
 class TestStructuredVespaIndexGetFilterString(unittest.TestCase):
@@ -117,3 +118,15 @@ class TestStructuredVespaIndexGetFilterString(unittest.TestCase):
                 else:
                     result_filter_string = self.vespa_index._get_filter_term(marqo_query)
                     self.assertIn(expected_result, result_filter_string)
+
+    def test_contains_filter_raises_error(self):
+        """CONTAINS filter is not supported for structured indexes."""
+        marqo_query = MarqoQuery(
+            index_name=self.vespa_index._marqo_index.name,
+            limit=10,
+            filter='title CONTAINS hello',
+            score_modifiers=[],
+            expose_facets=False
+        )
+        with self.assertRaises(InvalidArgumentError):
+            self.vespa_index._get_filter_term(marqo_query)

--- a/components/marqo/tests/unit_tests/marqo/core/unstructured_vespa_index/test_unstructured_vespa_index_to_vespa_query.py
+++ b/components/marqo/tests/unit_tests/marqo/core/unstructured_vespa_index/test_unstructured_vespa_index_to_vespa_query.py
@@ -10,6 +10,8 @@ from marqo.core.models.hybrid_parameters import (
     HybridParameters, RankingMethod, RetrievalMethod
 )
 from marqo.core.unstructured_vespa_index.unstructured_vespa_index import UnstructuredVespaIndex
+from marqo.core.models import MarqoQuery
+from marqo.exceptions import InvalidArgumentError
 
 
 class TestUnstructuredVespaIndexToVespaQuery(unittest.TestCase):
@@ -117,5 +119,18 @@ class TestUnstructuredVespaIndexToVespaQuery(unittest.TestCase):
                 self.assertIn('marqo__hybrid.rankingMethod', vespa_query)
 
 
+    def test_contains_filter_raises_error(self):
+        """CONTAINS filter is not supported for unstructured indexes."""
+        marqo_query = MarqoQuery(
+            index_name=self.vespa_index._marqo_index.name,
+            limit=10,
+            filter='title CONTAINS hello',
+            score_modifiers=[],
+            expose_facets=False
+        )
+        with self.assertRaises(InvalidArgumentError):
+            self.vespa_index._get_filter_term(marqo_query)
+
+
 if __name__ == '__main__':
-    unittest.main() 
+    unittest.main()

--- a/components/marqo/tests/unit_tests/marqo/core/unstructured_vespa_index/test_unstructured_vespa_index_to_vespa_query.py
+++ b/components/marqo/tests/unit_tests/marqo/core/unstructured_vespa_index/test_unstructured_vespa_index_to_vespa_query.py
@@ -120,7 +120,7 @@ class TestUnstructuredVespaIndexToVespaQuery(unittest.TestCase):
 
 
     def test_contains_filter_raises_error(self):
-        """CONTAINS filter is not supported for unstructured indexes."""
+        """CONTAINS filter is not supported for legacy unstructured indexes."""
         marqo_query = MarqoQuery(
             index_name=self.vespa_index._marqo_index.name,
             limit=10,


### PR DESCRIPTION
## Summary
- Adds `field CONTAINS value` filter syntax that leverages Vespa's existing `contains` operator on lexical fields for token-level matching
- Supports bare values (`field CONTAINS hello`) and grouped values (`field CONTAINS (multi word)`)
- Case-insensitive keyword (`CONTAINS`, `contains`, `Contains` all work)
- Raises errors for structured and unstructured indexes (semi-structured only for now)
- Fixes AST node mutation side effect in filter string generators
- Bumps version to 2.25.4

Cherry-picked from #1378 onto `releases/2.25`.

## Test plan
- [x] Unit tests for parser: CONTAINS test cases including special chars, escaping, grouped values
- [x] Unit tests for filter generation in all 3 index types (semi-structured, structured error, unstructured error)
- [x] Integration tests covering basic match, case insensitivity, NOT/AND/OR, equality combination, tensor/lexical/hybrid search, structured index error, special characters in filter values
- [x] All existing unit tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new filter operator and extends the filter parser plus Vespa query generation, which could impact search filtering behavior and escaping edge cases. Scope is limited by explicitly rejecting `CONTAINS` on structured and legacy unstructured indexes and adding broad unit/integ coverage.
> 
> **Overview**
> Adds a new `field CONTAINS value` filter operator that parses into a `ContainsTerm` AST node (case-insensitive keyword, supports grouped multi-word values) and converts it into a Vespa `contains` predicate over semi-structured lexical fields.
> 
> Updates semi-structured filter generation to avoid mutating parsed AST nodes while escaping values, validates `CONTAINS` fields against the index’s lexical `field_map`, and explicitly raises `InvalidArgumentError` for `CONTAINS` on structured and legacy unstructured indexes. Bumps version to `2.25.4` and adds unit + integration tests covering parsing, escaping/special chars, boolean/numeric/equality interactions, and unsupported-index errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a81177e8a5d2f242d751658bb2d9c05a2ab2ae32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->