### PR TITLE
fix: compare specific fields in compatibility tests instead of strict equality

### DIFF
--- a/components/marqo/tests/compatibility_tests/base_test_case/base_compatibility_test.py
+++ b/components/marqo/tests/compatibility_tests/base_test_case/base_compatibility_test.py
@@ -100,5 +100,8 @@ class BaseCompatibilityTestCase(MarqoTestCase, ABC):
                     )
                     expected_hit.pop(field)
                     actual_hit.pop(field)
-            self.assertEqual(expected_hit, actual_hit,
-                             f"Hit results do not match. Expected: {expected_hit}, Got: {actual_hit}")
+            for field, value in expected_hit.items():
+                self.assertEqual(
+                    value, actual_hit.get(field),
+                    f"Field '{field}' does not match. Expected: {expected_hit}, Got: {actual_hit}"
+                )


### PR DESCRIPTION
## Summary
- `_compare_search_results` in `BaseCompatibilityTestCase` used strict `assertEqual` on hit dicts, causing failures when newer Marqo versions add new response fields (e.g. `_pre_rerank_score`)
- Changed to iterate over expected hit fields and assert each one matches in the actual hit, ignoring any extra fields present in the newer response

## Test plan
- [ ] Run backwards compatibility orchestrator on GH Actions to confirm `test_search_with_global_score_modifiers` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that makes comparisons tolerant to additive response fields; low risk aside from potentially masking unexpected extra fields in search hits.
> 
> **Overview**
> Backwards-compatibility search tests now compare hits by asserting only the *expected* fields match, rather than requiring full dict equality.
> 
> In `BaseCompatibilityTestCase._compare_search_results`, score fields are still compared with `assertAlmostEqual`, but the remaining validation iterates expected keys and ignores any additional fields returned by newer Marqo versions (e.g., new score-related metadata).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ad901f7aed1a4d7238217bd87580fd20ebcd2c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->