### PR TITLE
fix: use correct model name in TestSearchWithCustomScoreRerankers

### DIFF
--- a/components/marqo/tests/compatibility_tests/search/test_search_with_custom_score_rerankers.py
+++ b/components/marqo/tests/compatibility_tests/search/test_search_with_custom_score_rerankers.py
@@ -15,7 +15,7 @@ class TestSearchWithCustomScoreRerankers(BaseCompatibilityTestCase):
     unstructured_index_metadata = {
         "indexName": "test_search_api_unstructured_index_custom_score_rerankers",
         "type": "unstructured",
-        "model": "open_clip/ViT-B-16-SigLIP-512/webli"
+        "model": "open_clip/ViT-B-16-SigLIP/webli"
     }
 
     docs = [


### PR DESCRIPTION
## Summary
- `open_clip/ViT-B-16-SigLIP-512/webli` is not a supported model name, causing index creation to fail with 400
- Use `open_clip/ViT-B-16-SigLIP/webli` instead

## Test plan
- [ ] Run backwards compatibility orchestrator on GH Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single test fixture string change that only affects index creation in compatibility tests.
> 
> **Overview**
> Updates `TestSearchWithCustomScoreRerankers` compatibility test index metadata to use the supported model name `open_clip/ViT-B-16-SigLIP/webli` instead of the invalid `open_clip/ViT-B-16-SigLIP-512/webli`, preventing 400s during test index creation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f4fc20f8267299a84ddb2d6b80f1b49c53671f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->