### PR TITLE
Suppress noisy docker pull output in CI

### DIFF
--- a/.github/workflows/integration_tests_CI_model_management.yml
+++ b/.github/workflows/integration_tests_CI_model_management.yml
@@ -44,7 +44,7 @@ jobs:
           cd ../.. # Back to repo root
           mkdir ~/.cache/marqo/models -p # Ensure model cache directory exists for triton to mount
           export MARQO_MODEL_CACHE_PATH=~/.cache/marqo/models
-          docker compose -f compose-triton.yaml up -d
+          docker compose -f compose-triton.yaml up -d --quiet-pull
 
       - name: Run Integration Tests
         run: |

--- a/components/marqo/tests/compatibility_tests/docker_manager.py
+++ b/components/marqo/tests/compatibility_tests/docker_manager.py
@@ -222,7 +222,8 @@ class DockerManager:
                     "up",
                     "-d",
                     "--force-recreate",
-                    "--no-build" # To ignore any build instructions in the compose file
+                    "--no-build", # To ignore any build instructions in the compose file
+                    "--quiet-pull"
                 ],
                 check=True,
                 timeout=60


### PR DESCRIPTION
## Summary
- Add `--quiet-pull` to `docker compose up` in the model management integration test workflow and the backward compatibility test runner (`docker_manager.py`), suppressing verbose layer-by-layer pull progress logs in CI.

## Test plan
- [ ] Verify model management integration test workflow still pulls images and runs correctly
- [ ] Verify backward compatibility tests still pull and start containers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk CI/test harness change that only adjusts `docker compose up` flags; main risk is reduced visibility into pull issues if images fail to download.
> 
> **Overview**
> Reduces CI log noise by adding `--quiet-pull` to `docker compose up` when starting Triton in the model management integration test workflow and when launching containers in the backwards compatibility `DockerManager`.
> 
> No functional behavior is intended to change beyond quieter image-pull output during these test runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d85cc57a6a1aea9636378217fc768530b4579fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->