### PR TITLE
fix: conditionally expose pre_rerank_score to avoid rollback incompatibility

### DIFF
--- a/components/marqo/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/components/marqo/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -636,7 +636,8 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
         if marqo_query.global_rerank_depth is not None:
             query["marqo__hybrid.rerankDepthGlobal"] = marqo_query.global_rerank_depth
 
-        if hybrid_score_modifiers[constants.MARQO_GLOBAL_SCORE_MODIFIERS]:
+        if (hybrid_score_modifiers[constants.MARQO_GLOBAL_SCORE_MODIFIERS]
+                or hybrid_score_modifiers.get(constants.MARQO_CUSTOM_SCORE_RERANK_MODIFIERS)):
             query["marqo__expose_pre_rerank_score"] = True
 
         # Tell the custom searcher what type of custom score reranking will be done

--- a/components/marqo/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/components/marqo/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -636,6 +636,9 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
         if marqo_query.global_rerank_depth is not None:
             query["marqo__hybrid.rerankDepthGlobal"] = marqo_query.global_rerank_depth
 
+        if hybrid_score_modifiers[constants.MARQO_GLOBAL_SCORE_MODIFIERS]:
+            query["marqo__expose_pre_rerank_score"] = True
+
         # Tell the custom searcher what type of custom score reranking will be done
         if applicable_custom_score_keys:
             has_bm25 = bool(self._get_fields_to_bm25_rerank_by(applicable_custom_score_keys))

--- a/components/marqo/src/marqo/core/structured_vespa_index/structured_vespa_index.py
+++ b/components/marqo/src/marqo/core/structured_vespa_index/structured_vespa_index.py
@@ -620,6 +620,9 @@ class StructuredVespaIndex(VespaIndex):
         if marqo_query.global_rerank_depth is not None:
             query["marqo__hybrid.rerankDepthGlobal"] = marqo_query.global_rerank_depth
 
+        if hybrid_score_modifiers[constants.MARQO_GLOBAL_SCORE_MODIFIERS]:
+            query["marqo__expose_pre_rerank_score"] = True
+
         return query
 
     def _get_tensor_fields_to_search(

--- a/components/marqo/src/marqo/core/structured_vespa_index/structured_vespa_index.py
+++ b/components/marqo/src/marqo/core/structured_vespa_index/structured_vespa_index.py
@@ -620,7 +620,8 @@ class StructuredVespaIndex(VespaIndex):
         if marqo_query.global_rerank_depth is not None:
             query["marqo__hybrid.rerankDepthGlobal"] = marqo_query.global_rerank_depth
 
-        if hybrid_score_modifiers[constants.MARQO_GLOBAL_SCORE_MODIFIERS]:
+        if (hybrid_score_modifiers[constants.MARQO_GLOBAL_SCORE_MODIFIERS]
+                or hybrid_score_modifiers.get(constants.MARQO_CUSTOM_SCORE_RERANK_MODIFIERS)):
             query["marqo__expose_pre_rerank_score"] = True
 
         return query

--- a/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_custom_score_reranking_feature.py
+++ b/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_custom_score_reranking_feature.py
@@ -2123,28 +2123,6 @@ class TestCustomScoreRerankingWithOtherFeatures(MarqoTestCase):
                     self.assertIn(attr, hit, msg=f"Requested attribute {attr} must be present in hit {hit.get('_id')}")
                 self.assertEqual(hit["other_field"], f"val_{hit['_id']}")
 
-    def test_pre_rerank_score_present_when_custom_score_reranking_used(self):
-        """_pre_rerank_score appears in every hit when custom score rerank modifiers are used."""
-        self._add_tuxedo_docs()
-        res = tensor_search.search(
-            config=self.config,
-            index_name=self.index.name,
-            text="tuxedo",
-            search_method="HYBRID",
-            hybrid_parameters=HYBRID_PARAMS_TUXEDO,
-            score_modifiers=ScoreModifierLists(
-                add_to_score=[{"field_name": "marqo__score_bm25_sum", "weight": 1.0}]
-            ),
-            result_count=10,
-        )
-        self.assertGreater(len(res["hits"]), 0)
-        for hit in res["hits"]:
-            self.assertIn(
-                MARQO_DOC_PRE_RERANK_SCORE,
-                hit,
-                msg=f"Hit {hit['_id']} must have {MARQO_DOC_PRE_RERANK_SCORE} when custom score reranking is used",
-            )
-
     def test_pre_rerank_score_absent_when_no_score_modifiers(self):
         """_pre_rerank_score must not appear when no score modifiers are used."""
         self._add_tuxedo_docs()

--- a/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_custom_score_reranking_feature.py
+++ b/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_custom_score_reranking_feature.py
@@ -2123,6 +2123,47 @@ class TestCustomScoreRerankingWithOtherFeatures(MarqoTestCase):
                     self.assertIn(attr, hit, msg=f"Requested attribute {attr} must be present in hit {hit.get('_id')}")
                 self.assertEqual(hit["other_field"], f"val_{hit['_id']}")
 
+    def test_pre_rerank_score_present_when_custom_score_reranking_used(self):
+        """_pre_rerank_score appears in every hit when custom score rerank modifiers are used."""
+        self._add_tuxedo_docs()
+        res = tensor_search.search(
+            config=self.config,
+            index_name=self.index.name,
+            text="tuxedo",
+            search_method="HYBRID",
+            hybrid_parameters=HYBRID_PARAMS_TUXEDO,
+            score_modifiers=ScoreModifierLists(
+                add_to_score=[{"field_name": "marqo__score_bm25_sum", "weight": 1.0}]
+            ),
+            result_count=10,
+        )
+        self.assertGreater(len(res["hits"]), 0)
+        for hit in res["hits"]:
+            self.assertIn(
+                MARQO_DOC_PRE_RERANK_SCORE,
+                hit,
+                msg=f"Hit {hit['_id']} must have {MARQO_DOC_PRE_RERANK_SCORE} when custom score reranking is used",
+            )
+
+    def test_pre_rerank_score_absent_when_no_score_modifiers(self):
+        """_pre_rerank_score must not appear when no score modifiers are used."""
+        self._add_tuxedo_docs()
+        res = tensor_search.search(
+            config=self.config,
+            index_name=self.index.name,
+            text="tuxedo",
+            search_method="HYBRID",
+            hybrid_parameters=HYBRID_PARAMS_TUXEDO,
+            result_count=10,
+        )
+        self.assertGreater(len(res["hits"]), 0)
+        for hit in res["hits"]:
+            self.assertNotIn(
+                MARQO_DOC_PRE_RERANK_SCORE,
+                hit,
+                msg=f"Hit {hit['_id']} must not have {MARQO_DOC_PRE_RERANK_SCORE} when no score modifiers are used",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/components/marqo/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_semi_structured_vespa_index_to_vespa_query.py
+++ b/components/marqo/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_semi_structured_vespa_index_to_vespa_query.py
@@ -2077,6 +2077,36 @@ class TestSemiStructuredCustomScoreRerankToVespaQuery(unittest.TestCase):
         vespa_query = vespa_index.to_vespa_query(marqo_query)
         self.assertEqual(vespa_query["marqo__custom_score_closeness_distance_metric"], "dotproduct")
 
+    def test_expose_pre_rerank_score_set_when_global_score_modifiers_present(self):
+        """marqo__expose_pre_rerank_score is True when global (non-custom) score modifiers are used."""
+        marqo_query = self._hybrid_query(
+            score_modifiers=[
+                ScoreModifier(field='popularity', weight=1.0, type=ScoreModifierType.Add),
+            ],
+        )
+        vespa_query = self.vespa_index._get_base_vespa_hybrid_query(marqo_query)
+        self.assertTrue(vespa_query.get('marqo__expose_pre_rerank_score'))
+
+    def test_expose_pre_rerank_score_set_when_custom_score_rerank_modifiers_present(self):
+        """marqo__expose_pre_rerank_score is True when custom score rerank modifiers are used."""
+        marqo_query = self._hybrid_query(
+            score_modifiers=[
+                ScoreModifier(
+                    field=f'{MARQO_CUSTOM_SCORE_RERANK_INPUT_PREFIX}bm25_sum',
+                    weight=1.0,
+                    type=ScoreModifierType.Add,
+                ),
+            ],
+        )
+        vespa_query = self.vespa_index._get_base_vespa_hybrid_query(marqo_query)
+        self.assertTrue(vespa_query.get('marqo__expose_pre_rerank_score'))
+
+    def test_expose_pre_rerank_score_absent_when_no_score_modifiers(self):
+        """marqo__expose_pre_rerank_score is not set when no score modifiers are used."""
+        marqo_query = self._hybrid_query()
+        vespa_query = self.vespa_index._get_base_vespa_hybrid_query(marqo_query)
+        self.assertNotIn('marqo__expose_pre_rerank_score', vespa_query)
+
 
 class TestAppendCustomScoreRerankTerms(unittest.TestCase):
     """Unit tests for _append_custom_score_rerank_terms."""

--- a/components/marqo/tests/unit_tests/marqo/core/structured_vespa_index/test_structured_vespa_index_to_vespa_query.py
+++ b/components/marqo/tests/unit_tests/marqo/core/structured_vespa_index/test_structured_vespa_index_to_vespa_query.py
@@ -225,6 +225,55 @@ class TestStructuredVespaIndexToVespaQuery(unittest.TestCase):
         self.assertNotIn('marqo__custom_score_add_weights_global', str(vespa_query.get('query_features', {})))
         self.assertNotIn('marqo__custom_score_mult_weights_global', str(vespa_query.get('query_features', {})))
 
+    def _hybrid_query(self, score_modifiers=None):
+        return MarqoHybridQuery(
+            index_name='test_index',
+            limit=10,
+            offset=0,
+            vector_query=[0.1, 0.2, 0.3, 0.4],
+            or_phrases=['search'],
+            and_phrases=[],
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                rankingMethod=RankingMethod.RRF,
+                alpha=0.5,
+                rrfK=60,
+            ),
+            score_modifiers=score_modifiers,
+        )
+
+    def test_expose_pre_rerank_score_set_when_global_score_modifiers_present(self):
+        """marqo__expose_pre_rerank_score is True when global (non-custom) score modifiers are used."""
+        marqo_query = self._hybrid_query(
+            score_modifiers=[
+                ScoreModifier(field='popularity', weight=1.0, type=ScoreModifierType.Add),
+            ],
+        )
+        # Call _to_vespa_hybrid_query directly to bypass field-existence validation.
+        vespa_query = self.vespa_index._to_vespa_hybrid_query(marqo_query)
+        self.assertTrue(vespa_query.get('marqo__expose_pre_rerank_score'))
+
+    def test_expose_pre_rerank_score_set_when_custom_score_rerank_modifiers_present(self):
+        """marqo__expose_pre_rerank_score is True when custom score rerank modifiers are used."""
+        marqo_query = self._hybrid_query(
+            score_modifiers=[
+                ScoreModifier(
+                    field=f'{MARQO_CUSTOM_SCORE_RERANK_INPUT_PREFIX}bm25_sum',
+                    weight=1.0,
+                    type=ScoreModifierType.Add,
+                ),
+            ],
+        )
+        # Call _to_vespa_hybrid_query directly to bypass field-existence validation.
+        vespa_query = self.vespa_index._to_vespa_hybrid_query(marqo_query)
+        self.assertTrue(vespa_query.get('marqo__expose_pre_rerank_score'))
+
+    def test_expose_pre_rerank_score_absent_when_no_score_modifiers(self):
+        """marqo__expose_pre_rerank_score is not set when no score modifiers are used."""
+        marqo_query = self._hybrid_query()
+        vespa_query = self.vespa_index._to_vespa_hybrid_query(marqo_query)
+        self.assertNotIn('marqo__expose_pre_rerank_score', vespa_query)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/components/marqo/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
+++ b/components/marqo/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
@@ -1951,6 +1951,8 @@ public class HybridSearcher extends Searcher {
     HitGroup applyGlobalScoreModifiers(HitGroup hits, Query query, boolean verbose) {
         FeatureData hitMatchFeatures;
         Double mult_modifier, add_modifier, original_score, modified_score, recencyScore;
+        boolean exposePreRerankScore =
+                query.properties().getBoolean("marqo__expose_pre_rerank_score", false);
         if (hits.size() == 0) {
             logIfVerbose("No hits to apply score modifiers to. Returning.", verbose);
             return hits;
@@ -2091,8 +2093,11 @@ public class HybridSearcher extends Searcher {
                     }
 
                     original_score = hit.getRelevance().getScore();
-                    // Expose pre-rerank score whenever we apply any global score modifiers
-                    hit.setField(MARQO_PRE_RERANK_SCORE, original_score);
+                    // Expose pre-rerank score only when explicitly requested, so old Marqo versions
+                    // that don't know this field can still parse results after a rollback.
+                    if (exposePreRerankScore) {
+                        hit.setField(MARQO_PRE_RERANK_SCORE, original_score);
+                    }
                     double baseScore = original_score * effectiveMult + effectiveAdd;
 
                     if (!applyRecency) {

--- a/components/marqo/vespa/src/test/java/ai/marqo/search/HybridSearcherRecencyTest.java
+++ b/components/marqo/vespa/src/test/java/ai/marqo/search/HybridSearcherRecencyTest.java
@@ -702,4 +702,35 @@ class HybridSearcherRecencyTest {
             }
         }
     }
+
+    @Nested
+    class PreRerankScoreExposureTests {
+        @Test
+        void shouldNotSetPreRerankScoreWhenPropertyIsFalse() {
+            // Default: marqo__expose_pre_rerank_score is not set → false
+            Query query = new Query("search/?query=test");
+            HitGroup hits = new HitGroup();
+            hits.add(createHitWithScoreModifiers("index:test/0/doc1", 1.0, 2.0, 0.5, null));
+
+            hybridSearcher.applyGlobalScoreModifiers(hits, query, false);
+
+            assertThat(hits.get(0).getField("marqo__pre_rerank_score")).isNull();
+        }
+
+        @Test
+        void shouldSetPreRerankScoreWhenPropertyIsTrue() {
+            Query query = new Query("search/?query=test");
+            query.properties().set("marqo__expose_pre_rerank_score", true);
+            double originalRelevance = 1.0;
+            HitGroup hits = new HitGroup();
+            hits.add(
+                    createHitWithScoreModifiers(
+                            "index:test/0/doc1", originalRelevance, 2.0, 0.5, null));
+
+            hybridSearcher.applyGlobalScoreModifiers(hits, query, false);
+
+            assertThat(hits.get(0).getField("marqo__pre_rerank_score"))
+                    .isEqualTo(originalRelevance);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- After the custom score rerank feature added `_pre_rerank_score` to responses, the Vespa searcher unconditionally set `marqo__pre_rerank_score` on every hit when global score modifiers were applied
- During rollback to an older Marqo version, the new Vespa searcher keeps running and returns this field; old Marqo's strict Vespa document parser doesn't recognise it → `500 backend_data_parsing_error: Unknown field marqo__pre_rerank_score`
- Fix: gate the field behind a new query property `marqo__expose_pre_rerank_score` (default `false`) — new Marqo sets it to `true` when global score modifiers are present; old Marqo never sets it, so the field is omitted and old parsers handle results cleanly

## Changes
- `HybridSearcher.java`: read `marqo__expose_pre_rerank_score` at the start of `applyGlobalScoreModifiers`; only call `hit.setField(MARQO_PRE_RERANK_SCORE, ...)` when it's true
- `structured_vespa_index.py` + `semi_structured_vespa_index.py`: set `marqo__expose_pre_rerank_score = True` in the Vespa query when global score modifiers are present

## Test plan
- [ ] Java unit tests: 226 pass
- [ ] Python unit tests (semi-structured + structured index): 152 pass
- [ ] Run compatibility tests orchestrator on GH Actions — rollback tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change only affects whether `marqo__pre_rerank_score` is included in Vespa hits, without altering ranking math. Main risk is response-shape differences for clients relying on the field when score modifiers are present.
> 
> **Overview**
> Fixes rollback incompatibility by making Vespa’s `marqo__pre_rerank_score` field **opt-in**.
> 
> Python hybrid query builders for both structured and semi-structured indexes now set `marqo__expose_pre_rerank_score=True` only when global score modifiers or custom-score rerank modifiers are present, and `HybridSearcher.applyGlobalScoreModifiers` only attaches `marqo__pre_rerank_score` to hits when that flag is set.
> 
> Adds unit/integration coverage to ensure `_pre_rerank_score` is absent when no score modifiers are used and present when requested.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc7e2f7dcc9fc8dc831122bca093269c78258cfd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->