### PR TITLE
Fix an issue where min_sort_candidates is not used when trimming sort results

### DIFF
--- a/components/marqo/src/marqo/version.py
+++ b/components/marqo/src/marqo/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.25.5"
+__version__ = "2.25.6"
 
 
 def get_version() -> str:

--- a/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_search_relevance_cutoff_feature.py
+++ b/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_search_relevance_cutoff_feature.py
@@ -2065,6 +2065,11 @@ class TestRelevanceCutoffWithFacetsAndTotalHits(MarqoTestCase):
             facets={"fields": {"color": {"type": "string"}}},
             track_total_hits=True,
         )
+
         self.assertEqual(2, result["totalHits"])
         self.assertEqual(0, result["_relevantCandidates"])
         self.assertEqual(2, result["_sortCandidates"])
+
+        for hit in result["hits"]:
+            self.assertNotIn("_lexical_score", hit)
+            self.assertIn("_tensor_score", hit)

--- a/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_search_relevance_cutoff_feature.py
+++ b/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_search_relevance_cutoff_feature.py
@@ -2053,7 +2053,7 @@ class TestRelevanceCutoffWithFacetsAndTotalHits(MarqoTestCase):
         small, and min_sort_candidates is set, we use min_sort_candidates to do facets, retrieval, and sort
         """
         result = self._search(
-            query = 'void',
+            query = 'sea solar',
             relevance_cutoff={
                 "method": "relative_max_score",
                 "probeDepth": 1000,
@@ -2065,6 +2065,13 @@ class TestRelevanceCutoffWithFacetsAndTotalHits(MarqoTestCase):
             facets={"fields": {"color": {"type": "string"}}},
             track_total_hits=True,
         )
+
+        hits = [hit["_id"] for hit in result["hits"]]
+        expected_hits = ["doc6", "doc3"]
+        self.assertEqual(expected_hits, hits)
+
+        #
+        self.assertIn("facets", result)
 
         self.assertEqual(2, result["totalHits"])
         self.assertEqual(0, result["_relevantCandidates"])

--- a/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_search_relevance_cutoff_feature.py
+++ b/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_search_relevance_cutoff_feature.py
@@ -2046,3 +2046,25 @@ class TestRelevanceCutoffWithFacetsAndTotalHits(MarqoTestCase):
         for hit in result["hits"]:
             self.assertNotIn("_lexical_score", hit)
             self.assertIn("_tensor_score", hit)
+
+    def test_relevance_cutoff_when_min_sort_candidates_and_override_sort_candidates_with_relevant_candidates(self):
+        """
+        Test a special case that when override_sort_candidates_with_relevant_candidates=True, and relevantCandidates is
+        small, and min_sort_candidates is set, we use min_sort_candidates to do facets, retrieval, and sort
+        """
+        result = self._search(
+            query = 'void',
+            relevance_cutoff={
+                "method": "relative_max_score",
+                "probeDepth": 1000,
+                "parameters": {"relativeScoreFactor": 0.2},
+                "affectFacets": True,
+                "overrideSortCandidatesWithRelevantCandidates": True,
+            },
+            sort_by={"fields": [{"fieldName": "price"}], "min_sort_candidates": 2},
+            facets={"fields": {"color": {"type": "string"}}},
+            track_total_hits=True,
+        )
+        self.assertEqual(2, result["totalHits"])
+        self.assertEqual(0, result["_relevantCandidates"])
+        self.assertEqual(2, result["_sortCandidates"])

--- a/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_search_relevance_cutoff_feature.py
+++ b/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_search_relevance_cutoff_feature.py
@@ -2070,7 +2070,8 @@ class TestRelevanceCutoffWithFacetsAndTotalHits(MarqoTestCase):
         expected_hits = ["doc6", "doc3"]
         self.assertEqual(expected_hits, hits)
 
-        #
+        # Facets results is not stable due to different match set, so we only
+        # assert the existence
         self.assertIn("facets", result)
 
         self.assertEqual(2, result["totalHits"])

--- a/components/marqo/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
+++ b/components/marqo/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
@@ -333,11 +333,20 @@ public class HybridSearcher extends Searcher {
             if (relevanceCutoffOverrideSortCandidates
                     && relevantCandidates != null
                     && relevantCandidates < hitsForPostProcessing.size()) {
-                List<Hit> trimmed =
-                        new ArrayList<>(
-                                hitsForPostProcessing.asList().subList(0, relevantCandidates));
-                hitsForPostProcessing = new HitGroup();
-                trimmed.forEach(hitsForPostProcessing::add);
+
+                int targetTrimSize =
+                        (sortByMinSortCandidates != null)
+                                ? Math.max(sortByMinSortCandidates, relevantCandidates)
+                                : relevantCandidates;
+                targetTrimSize = Math.min(targetTrimSize, hitsForPostProcessing.size());
+
+                if (targetTrimSize < hitsForPostProcessing.size()) {
+                    List<Hit> trimmed =
+                            new ArrayList<>(
+                                    hitsForPostProcessing.asList().subList(0, targetTrimSize));
+                    hitsForPostProcessing = new HitGroup();
+                    trimmed.forEach(hitsForPostProcessing::add);
+                }
             }
             // If sortBy is set, we will sort the hits after post-processing
             processedHits =
@@ -363,12 +372,6 @@ public class HybridSearcher extends Searcher {
         // Extract recency multiplier from match features after post-processing (only if recency is
         // enabled)
         processedHits = extractRecencyScore(processedHits, query, verbose);
-
-        // Override sortCandidates with relevantCandidates when requested
-        if (relevanceCutoffOverrideSortCandidates && relevantCandidates != null) {
-            sortCandidates = relevantCandidates;
-        }
-
         MarqoMetadataFields marqoMetadataFields =
                 new MarqoMetadataFields(sortCandidates, probeCandidates, relevantCandidates);
 


### PR DESCRIPTION
## Change Summary
<!-- Describe the key changes this PR introduces -->

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)

