### PR TITLE
Fix update documents crash with special character IDs

### DIFF
--- a/components/marqo/src/marqo/core/document/document.py
+++ b/components/marqo/src/marqo/core/document/document.py
@@ -33,6 +33,8 @@ logger = get_logger(__name__)
 
 class Document:
     """A class that handles the document API in Marqo"""
+    GENERIC_UPDATE_DOCUMENT_ERROR_MESSAGE = "Marqo vector store couldn't update the document. " + \
+                                            "Please see: " + update_documents_response() + " for more details"
 
     def __init__(self, vespa_client: VespaClient, index_management: IndexManagement, inference: Inference):
         self.vespa_client = vespa_client
@@ -153,17 +155,42 @@ class Document:
         # 1. Retrieve those documents, which contain maps in the update request, from Vespa.
         # 2. If there's any documents that dont' exist in Vespa, we will append them to unsuccessful_docs
         if marqo_index.type is IndexType.SemiStructured and documents_that_contain_maps: # Only retrieve the document back if the partial update request contains maps and the index is semi-structured
-            get_batch_response = self.vespa_client.get_batch(ids = list(documents_that_contain_maps.keys()), fields = [
+            fetch_ids = list(documents_that_contain_maps.keys())
+            get_batch_response = self.vespa_client.get_batch(ids = fetch_ids, fields = [
                 VESPA_FIELD_ID, INT_FIELDS, FLOAT_FIELDS, VESPA_DOC_FIELD_TYPES, VESPA_DOC_VERSION_UUID], schema = marqo_index.schema_name)
             responses = get_batch_response.responses
-            for resp in responses:
+
+            if len(responses) != len(fetch_ids):
+                raise InternalError(
+                    f"Vespa get batch response count {len(responses)} does not match the number of requested documents "
+                    f"{len(fetch_ids)}. This likely indicates an issue with Vespa or the Vespa client."
+                )
+
+            for idx, resp in enumerate(responses):
                 if resp.document:
                     existing_vespa_documents[resp.document.fields[VESPA_FIELD_ID]] = resp.document.dict()
-                else: 
-                    id = self.extract_document_id_from_vespa_id(resp) # Extract the document id from the Vespa response. Vespa response will contain the document id even though the document was not found.
-                    unsuccessful_docs.append((documents_that_contain_maps.get(id), MarqoUpdateDocumentsItem(id = id,
-                                                                                                         status = int(api_exceptions.BadRequestError.status_code),
-                                                                                                         error = "Marqo vector store couldn't update the document. Please see: " + update_documents_response() + " for more details")))
+                else:
+                    # The order of get_batch_response is guaranteed to be the same as the order of fetch_ids,
+                    # so we can rely on the index to get the id of the document that doesn't exist in Vespa.
+                    # Vespa returned id will prune some characters e.g, #, so we have to get the id from fetch_ids
+                    # instead of resp.id
+                    id = fetch_ids[idx]
+                    unsuccessful_docs.append(
+                        (
+                            # id is from fetch_ids, and fetch_ids is from documents_that_contain_maps,
+                            # so we are sure that the id is in documents_that_contain_maps
+                            documents_that_contain_maps[id], MarqoUpdateDocumentsItem(
+                            id=id,
+                            status=int(api_exceptions.BadRequestError.status_code),
+                            # We should always return message instead of error in the documents' response.
+                            # To keep backwards compatibility, we return both
+                            message=resp.message if resp.message \
+                            else self.GENERIC_UPDATE_DOCUMENT_ERROR_MESSAGE,
+                            error=resp.message if resp.message \
+                            else self.GENERIC_UPDATE_DOCUMENT_ERROR_MESSAGE
+                            )
+                        )
+                    )
                     documents_that_contain_maps_but_dont_exist_in_vespa.add(id)
 
         for index, doc in enumerate(partial_documents):
@@ -331,5 +358,8 @@ class Document:
                                          processingTimeMs=add_docs_processing_time_ms)
 
     def extract_document_id_from_vespa_id(self, resp):
+        # TODO - This method is not reliable as Vespa might prune the document ID in the response if
+        #  the ID certain characters (e.g., #). We should update our code to either remove those illegal characters
+        #  from the document ID before feeding to Vespa, or implement a more reliable solution
         doc_id = resp.id.split('::')[-1] if resp.id else None
         return doc_id

--- a/components/marqo/src/marqo/vespa/vespa_client.py
+++ b/components/marqo/src/marqo/vespa/vespa_client.py
@@ -521,7 +521,8 @@ class VespaClient:
             timeout: Timeout in seconds per request
 
         Returns:
-            List of GetDocumentResponse objects containing the documents fetched and any missing documents (404)
+            List of GetDocumentResponse objects containing the documents fetched and any missing documents (404).
+            The order of the returned results are preserved to match the order of the input IDs.
 
         """
         if not ids:
@@ -1082,6 +1083,10 @@ class VespaClient:
                     resp = await async_client.get(
                         f'{self.document_url}/document/v1/{schema}/{schema}/docid/{id}', timeout=timeout
                     )
+            except httpx.InvalidURL as e:
+                return GetBatchDocumentResponse(
+                    status=400, pathId="", message=f"Invalid document ID: {id}. Original error: {str(e)}"
+                )
             except httpx.HTTPError as e:
                 raise VespaError(e) from e
 

--- a/components/marqo/tests/integ_tests/core/document/test_partial_update_semi_structured.py
+++ b/components/marqo/tests/integ_tests/core/document/test_partial_update_semi_structured.py
@@ -1457,3 +1457,97 @@ class TestPartialUpdate(MarqoTestCase):
             ("string_array", MarqoFieldTypes.STRING_ARRAY),
             ("lexical_field", MarqoFieldTypes.STRING)
         ])
+
+    def test_batch_update_with_nonexistent_map_doc_does_not_crash(self):
+        """Test that a batch update containing a non-existent document with map fields
+        does not crash the entire request.
+
+        Reproduces the bug where partial_update_documents raised:
+            TypeError: 'NoneType' object cannot be interpreted as an integer
+        on items.insert(loc, error_info) because get_batch returned an ID that
+        didn't match the documents_that_contain_maps dict key."""
+        update_documents = [
+            {
+                # The '#' in the ID is critical: it's a URL fragment separator, so Vespa
+                # receives a truncated ID and returns a different ID in its response.
+                # This caused documents_that_contain_maps.get(id) to return None for loc,
+                # which then crashed at items.insert(None, error_info).
+                "_id": "search-results-going out #",
+                "int_field": 10,
+                "float_field": 20.0,
+                "int_map": {
+                    "pixel_1": 4,
+                    "pixel_2": 8,
+                }
+            },
+            {
+                "_id": "2",
+                "int_field": 20,
+                "float_field": 40.0,
+            }
+        ]
+
+        # This must not raise TypeError
+        res = self.config.document.partial_update_documents(update_documents, self.index)
+
+        self.assertTrue(res.errors)
+        self.assertEqual(len(res.items), 2)
+
+        # First doc: non-existent with maps -> should be a 400 error
+        self.assertEqual(400, res.items[0].status)
+        self.assertIn("couldn't update the document", res.items[0].error)
+        # Verify the response preserves the ORIGINAL _id (with #), not Vespa's truncated version.
+        # The old code used extract_document_id_from_vespa_id(resp) which returned the truncated ID
+        # from Vespa (without #). The fix uses fetch_ids[idx] to preserve the original ID.
+        self.assertEqual("search-results-going out #", res.items[0].id)
+
+        # Second doc: existing, no maps -> should succeed
+        self.assertEqual(200, res.items[1].status)
+
+        # Verify the existing doc was actually updated
+        updated_doc = tensor_search.get_document_by_id(self.config, self.index.name, "2")
+        self.assertEqual(20, updated_doc["int_field"])
+        self.assertEqual(40.0, updated_doc["float_field"])
+
+    def test_batch_update_with_non_printable_ascii_in_id_does_not_crash(self):
+        """Test that a batch update containing a document whose _id has non-printable ASCII
+        characters does not crash the entire request.
+
+        Non-printable ASCII characters (0x00-0x1F, 0x7F) cause httpx.InvalidURL when
+        interpolated into URLs. The fix in vespa_client._get_document_async catches this
+        and returns a 400 response, and document.py surfaces it as a per-document error."""
+        non_printable_ids = [
+            "doc-with-null\x00char",
+            "doc-with-tab\tchar",
+            "doc-with-newline\nchar",
+        ]
+
+        for bad_id in non_printable_ids:
+            with self.subTest(bad_id=repr(bad_id)):
+                update_documents = [
+                    {
+                        "_id": bad_id,
+                        "int_map": {"key1": 1},  # map field triggers get_batch path
+                    },
+                    {
+                        "_id": "2",
+                        "int_field": 999,
+                    }
+                ]
+
+                # This must not raise httpx.InvalidURL or any other exception
+                res = self.config.document.partial_update_documents(update_documents, self.index)
+
+                self.assertTrue(res.errors)
+                self.assertEqual(len(res.items), 2)
+
+                # First doc: non-printable char -> should be a 400 error
+                self.assertEqual(400, res.items[0].status)
+                self.assertIsNotNone(res.items[0].error)
+
+                # Second doc: existing, valid -> should succeed
+                self.assertEqual(200, res.items[1].status)
+
+                # Verify the valid doc was actually updated
+                updated_doc = tensor_search.get_document_by_id(self.config, self.index.name, "2")
+                self.assertEqual(999, updated_doc["int_field"])

--- a/components/marqo/tests/integ_tests/vespa/test_update_documents_batch.py
+++ b/components/marqo/tests/integ_tests/vespa/test_update_documents_batch.py
@@ -104,6 +104,40 @@ class TestFeedDocumentAsync(AsyncMarqoTestCase):
         self.assertIsNone(messages[0])
         self.assertIsNotNone(messages[1])
 
+    def test_get_batch_preserves_input_order(self):
+        """Test that get_batch returns responses in the same order as the input IDs,
+        with a mix of existing and non-existing documents against real Vespa."""
+        documents = [
+            VespaDocument(id=f"order-{i}", fields={"title": f"Title {i}"})
+            for i in range(6)
+        ]
+        self.client.feed_batch(documents, self.TEST_SCHEMA)
+
+        # Request in shuffled order, mixing existing and non-existing IDs
+        requested_ids = [
+            "order-4",          # exists
+            "nonexistent-1",    # doesn't exist
+            "order-1",          # exists
+            "order-5",          # exists
+            "nonexistent-2",    # doesn't exist
+            "order-0",          # exists
+            "nonexistent-3",    # doesn't exist
+            "order-2",          # exists
+        ]
+
+        batch_response = self.client.get_batch(ids=requested_ids, schema=self.TEST_SCHEMA)
+
+        self.assertEqual(len(batch_response.responses), len(requested_ids))
+        for i, expected_id in enumerate(requested_ids):
+            resp = batch_response.responses[i]
+            actual_id = resp.id.split("::")[-1] if resp.id else None
+            self.assertEqual(actual_id, expected_id,
+                             f"Response at position {i} should be for '{expected_id}', got '{actual_id}'")
+            if expected_id.startswith("order-"):
+                self.assertEqual(resp.status, 200)
+            else:
+                self.assertEqual(resp.status, 404)
+
     def test_update_documents_batch_network_error(self):
         update_documents = [
             VespaDocument(id="doc1", fields={"title": {"assign": "Network Failure Test"}}),

--- a/components/marqo/tests/unit_tests/marqo/core/documents/test_document_partial_update.py
+++ b/components/marqo/tests/unit_tests/marqo/core/documents/test_document_partial_update.py
@@ -112,25 +112,25 @@ class TestDocumentPartialUpdateMapHandling(MarqoTestCase):
 
         self.assertIn("does not match", str(ctx.exception))
 
-    def test_existing_map_doc_is_fetched_and_used(self):
-        """Test that an existing document with maps is fetched and passed to to_vespa_partial_document.
-
-        Covers line 169 (enumerate loop) and 170-171 (document found path)."""
+    def test_existing_map_doc_passes_fetched_data_to_vespa_index(self):
+        """Test that when get_batch finds a document, its fields are passed as
+        existing_vespa_document to to_vespa_partial_document for map merging."""
         docs = [
             {"_id": "existing-doc", "int_map": {"k": 1}},
         ]
 
+        fetched_fields = {
+            VESPA_FIELD_ID: "existing-doc",
+            INT_FIELDS: '{"k": 5}',
+            FLOAT_FIELDS: "{}",
+            VESPA_DOC_FIELD_TYPES: "{}",
+            VESPA_DOC_VERSION_UUID: "abc",
+        }
         existing_resp = GetBatchDocumentResponse(
             status=200,
             pathId="/document/v1/test_schema/test_schema/docid/existing-doc",
             id="id:test_schema:test_schema::existing-doc",
-            fields={
-                VESPA_FIELD_ID: "existing-doc",
-                INT_FIELDS: '{"k": 1}',
-                FLOAT_FIELDS: "{}",
-                VESPA_DOC_FIELD_TYPES: "{}",
-                VESPA_DOC_VERSION_UUID: "abc",
-            },
+            fields=fetched_fields,
         )
         self.mock_vespa_client.get_batch.return_value = GetBatchResponse(
             responses=[existing_resp], errors=False
@@ -149,11 +149,16 @@ class TestDocumentPartialUpdateMapHandling(MarqoTestCase):
 
             self.document.partial_update_documents(docs, self.semi_structured_index)
 
-        # Verify get_batch was called with the correct IDs
-        self.mock_vespa_client.get_batch.assert_called_once()
-        call_kwargs = self.mock_vespa_client.get_batch.call_args
-        self.assertEqual(call_kwargs[1]['ids'] if 'ids' in call_kwargs[1] else call_kwargs[0][0],
-                         ["existing-doc"])
+        # Verify to_vespa_partial_document received the fetched Vespa document
+        # (second arg is the existing doc used for map merging)
+        mock_vespa_index.to_vespa_partial_document.assert_called_once()
+        call_args = mock_vespa_index.to_vespa_partial_document.call_args[0]
+        existing_doc_arg = call_args[1]
+        self.assertIsNotNone(existing_doc_arg,
+                             "Existing vespa document should be passed for map merging")
+        # document.dict() nests fields under 'fields' key
+        self.assertEqual(existing_doc_arg["fields"][VESPA_FIELD_ID], "existing-doc")
+        self.assertEqual(existing_doc_arg["fields"][INT_FIELDS], '{"k": 5}')
 
     def test_vespa_error_message_is_surfaced_in_response(self):
         """Test that Vespa's error message is preserved in the response item."""

--- a/components/marqo/tests/unit_tests/marqo/core/documents/test_document_partial_update.py
+++ b/components/marqo/tests/unit_tests/marqo/core/documents/test_document_partial_update.py
@@ -1,0 +1,192 @@
+import unittest
+from unittest.mock import MagicMock, patch, Mock
+
+from marqo.core.document.document import Document
+from marqo.core.exceptions import InternalError
+from marqo.core.models.marqo_index import IndexType
+from marqo.core.semi_structured_vespa_index.common import (
+    VESPA_FIELD_ID, INT_FIELDS, FLOAT_FIELDS, VESPA_DOC_FIELD_TYPES, VESPA_DOC_VERSION_UUID
+)
+from marqo.vespa.models.get_document_response import GetBatchDocumentResponse, GetBatchResponse
+from marqo.vespa.models import UpdateDocumentsBatchResponse, VespaDocument
+from tests.unit_tests.marqo_test import MarqoTestCase
+
+
+class TestDocumentPartialUpdateMapHandling(MarqoTestCase):
+    """Unit tests for partial_update_documents map handling in Document class.
+
+    Covers the code path where semi-structured indexes with map fields
+    fetch existing documents from Vespa via get_batch."""
+
+    def setUp(self):
+        super().setUp()
+        self.mock_vespa_client = MagicMock()
+        self.mock_index_management = MagicMock()
+        self.mock_inference = MagicMock()
+        self.document = Document(
+            vespa_client=self.mock_vespa_client,
+            index_management=self.mock_index_management,
+            inference=self.mock_inference,
+        )
+
+        self.semi_structured_index = self.semi_structured_marqo_index(
+            name="test_index",
+            schema_name="test_schema",
+            marqo_version="2.16.0",
+        )
+
+    def test_nonexistent_map_doc_returns_error_without_crash(self):
+        """Test that a non-existent doc with map fields returns a per-document error.
+
+        Covers lines 158-159 (fetch_ids, get_batch call),
+        169 (enumerate loop), and 177-178 (fetch_ids[idx] lookup and error append)."""
+        docs = [
+            {"_id": "missing-doc#special", "int_map": {"k": 1}},
+            {"_id": "valid-doc", "some_field": 42},
+        ]
+
+        # get_batch returns 404 for missing doc
+        missing_resp = GetBatchDocumentResponse(
+            status=404,
+            pathId="/document/v1/test_schema/test_schema/docid/missing-doc",
+            id="id:test_schema:test_schema::missing-doc",
+            message="Document not found",
+        )
+        self.mock_vespa_client.get_batch.return_value = GetBatchResponse(
+            responses=[missing_resp], errors=True
+        )
+
+        # update_documents_batch for the valid doc
+        mock_update_resp = MagicMock(spec=UpdateDocumentsBatchResponse)
+        mock_update_resp.errors = False
+        mock_vespa_item = MagicMock()
+        mock_vespa_item.status = 200
+        mock_vespa_item.id = "id:test_schema:test_schema::valid-doc"
+        mock_update_resp.responses = [mock_vespa_item]
+        self.mock_vespa_client.update_documents_batch.return_value = mock_update_resp
+        self.mock_vespa_client.translate_vespa_document_response.return_value = (200, None)
+
+        with patch('marqo.core.document.document.vespa_index_factory') as mock_factory:
+            mock_vespa_index = MagicMock()
+            mock_vespa_index.to_vespa_partial_document.return_value = {"id": "valid-doc", "fields": {}}
+            mock_vespa_index.get_vespa_id_field.return_value = "id"
+            mock_factory.return_value = mock_vespa_index
+
+            result = self.document.partial_update_documents(docs, self.semi_structured_index)
+
+        self.assertTrue(result.errors)
+        self.assertEqual(len(result.items), 2)
+
+        # First doc: error with original ID preserved (including #)
+        self.assertEqual(400, result.items[0].status)
+        self.assertEqual("missing-doc#special", result.items[0].id)
+        self.assertIsNotNone(result.items[0].error)
+
+        # Second doc: success
+        self.assertEqual(200, result.items[1].status)
+
+    def test_response_count_mismatch_raises_internal_error(self):
+        """Test that a mismatch between fetch_ids and responses raises InternalError.
+
+        Covers lines 163-164 (response count validation)."""
+        docs = [
+            {"_id": "doc1", "int_map": {"k": 1}},
+            {"_id": "doc2", "int_map": {"k": 2}},
+        ]
+
+        # Return only 1 response for 2 requested IDs
+        resp = GetBatchDocumentResponse(
+            status=200,
+            pathId="/document/v1/test_schema/test_schema/docid/doc1",
+            id="id:test_schema:test_schema::doc1",
+            fields={VESPA_FIELD_ID: "doc1"},
+        )
+        self.mock_vespa_client.get_batch.return_value = GetBatchResponse(
+            responses=[resp], errors=False
+        )
+
+        with patch('marqo.core.document.document.vespa_index_factory') as mock_factory:
+            mock_factory.return_value = MagicMock()
+            with self.assertRaises(InternalError) as ctx:
+                self.document.partial_update_documents(docs, self.semi_structured_index)
+
+        self.assertIn("does not match", str(ctx.exception))
+
+    def test_existing_map_doc_is_fetched_and_used(self):
+        """Test that an existing document with maps is fetched and passed to to_vespa_partial_document.
+
+        Covers line 169 (enumerate loop) and 170-171 (document found path)."""
+        docs = [
+            {"_id": "existing-doc", "int_map": {"k": 1}},
+        ]
+
+        existing_resp = GetBatchDocumentResponse(
+            status=200,
+            pathId="/document/v1/test_schema/test_schema/docid/existing-doc",
+            id="id:test_schema:test_schema::existing-doc",
+            fields={
+                VESPA_FIELD_ID: "existing-doc",
+                INT_FIELDS: '{"k": 1}',
+                FLOAT_FIELDS: "{}",
+                VESPA_DOC_FIELD_TYPES: "{}",
+                VESPA_DOC_VERSION_UUID: "abc",
+            },
+        )
+        self.mock_vespa_client.get_batch.return_value = GetBatchResponse(
+            responses=[existing_resp], errors=False
+        )
+
+        mock_update_resp = MagicMock(spec=UpdateDocumentsBatchResponse)
+        mock_update_resp.errors = False
+        mock_update_resp.responses = []
+        self.mock_vespa_client.update_documents_batch.return_value = mock_update_resp
+
+        with patch('marqo.core.document.document.vespa_index_factory') as mock_factory:
+            mock_vespa_index = MagicMock()
+            mock_vespa_index.to_vespa_partial_document.return_value = {"id": "existing-doc", "fields": {}}
+            mock_vespa_index.get_vespa_id_field.return_value = "id"
+            mock_factory.return_value = mock_vespa_index
+
+            self.document.partial_update_documents(docs, self.semi_structured_index)
+
+        # Verify get_batch was called with the correct IDs
+        self.mock_vespa_client.get_batch.assert_called_once()
+        call_kwargs = self.mock_vespa_client.get_batch.call_args
+        self.assertEqual(call_kwargs[1]['ids'] if 'ids' in call_kwargs[1] else call_kwargs[0][0],
+                         ["existing-doc"])
+
+    def test_vespa_error_message_is_surfaced_in_response(self):
+        """Test that Vespa's error message is preserved in the response item."""
+        docs = [
+            {"_id": "bad-doc", "int_map": {"k": 1}},
+        ]
+
+        error_resp = GetBatchDocumentResponse(
+            status=400,
+            pathId="",
+            message="Invalid document ID: bad-doc. Original error: some error",
+        )
+        self.mock_vespa_client.get_batch.return_value = GetBatchResponse(
+            responses=[error_resp], errors=True
+        )
+
+        mock_update_resp = MagicMock(spec=UpdateDocumentsBatchResponse)
+        mock_update_resp.errors = False
+        mock_update_resp.responses = []
+        self.mock_vespa_client.update_documents_batch.return_value = mock_update_resp
+
+        with patch('marqo.core.document.document.vespa_index_factory') as mock_factory:
+            mock_factory.return_value = MagicMock()
+            mock_factory.return_value.get_vespa_id_field.return_value = "id"
+
+            result = self.document.partial_update_documents(docs, self.semi_structured_index)
+
+        self.assertTrue(result.errors)
+        self.assertEqual(400, result.items[0].status)
+        # The vespa message should be surfaced, not the generic one
+        self.assertIn("Invalid document ID", result.items[0].error)
+        self.assertIn("Invalid document ID", result.items[0].message)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/components/marqo/tests/unit_tests/vespa/test_vespa_client.py
+++ b/components/marqo/tests/unit_tests/vespa/test_vespa_client.py
@@ -714,5 +714,128 @@ class TestVespaClient(unittest.TestCase):
         self.assertTrue(any('timed out' in c.lower() for c in error_calls))
 
 
+    @patch('marqo.vespa.vespa_client.httpx.AsyncClient')
+    def test_get_batch_preserves_input_order_with_out_of_order_completion(self, mock_async_client_class):
+        """Test that get_batch returns responses in the same order as the input IDs,
+        even when the underlying async requests complete out of order.
+
+        This is a critical assumption used by partial_update_documents, which maps
+        get_batch response positions back to original document indices."""
+        from marqo.vespa.models.get_document_response import GetBatchDocumentResponse
+
+        schema = 'test_schema'
+        ids = ['doc_a', 'doc_b', 'doc_c', 'doc_d']
+
+        for not_found_ids, subtest_name in [
+            (set(), 'all documents found'),
+            ({'doc_a', 'doc_c'}, 'some documents not found'),
+        ]:
+            with self.subTest(msg=subtest_name):
+                completion_order = []
+
+                async def mock_get_document(semaphore, async_client, doc_id, fields, schema_name, timeout,
+                                            _not_found=not_found_ids, _order=completion_order):
+                    # Stagger so tasks complete in reverse: doc_d, doc_c, doc_b, doc_a
+                    delays = {'doc_a': 0.04, 'doc_b': 0.03, 'doc_c': 0.02, 'doc_d': 0.01}
+                    await asyncio.sleep(delays[doc_id])
+                    _order.append(doc_id)
+
+                    if doc_id in _not_found:
+                        return GetBatchDocumentResponse(
+                            status=404,
+                            pathId=f'/document/v1/{schema_name}/{schema_name}/docid/{doc_id}',
+                            id=f'id:{schema_name}:{schema_name}::{doc_id}',
+                            message='Document not found',
+                        )
+                    return GetBatchDocumentResponse(
+                        status=200,
+                        pathId=f'/document/v1/{schema_name}/{schema_name}/docid/{doc_id}',
+                        id=f'id:{schema_name}:{schema_name}::{doc_id}',
+                        fields={'doc_id_field': doc_id}
+                    )
+
+                with patch.object(self.vespa_client, '_get_document_async', side_effect=mock_get_document):
+                    result = self.vespa_client.get_batch(ids=ids, schema=schema)
+
+                # Verify requests actually completed out of order
+                self.assertNotEqual(completion_order, ids,
+                                    "Test setup error: requests should complete out of order due to staggered delays")
+
+                # Verify responses are returned in the same order as input IDs
+                self.assertEqual(len(result.responses), len(ids))
+                for i, expected_id in enumerate(ids):
+                    resp = result.responses[i]
+                    actual_id = resp.id.split('::')[-1] if resp.id else None
+                    self.assertEqual(actual_id, expected_id,
+                                     f"Response at position {i} should be for '{expected_id}', got '{actual_id}'")
+
+    def test_get_document_async_catches_invalid_url_error(self):
+        """Test that _get_document_async catches httpx.InvalidURL and returns a 400 response
+        instead of crashing. This handles IDs with non-printable ASCII characters."""
+        from marqo.vespa.models.get_document_response import GetBatchDocumentResponse
+
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = httpx.InvalidURL(
+            "Invalid non-printable ASCII character in URL"
+        )
+
+        async def _run():
+            semaphore = asyncio.Semaphore(1)
+            return await self.vespa_client._get_document_async(
+                semaphore, mock_client, 'doc\x00with\x01control\x7fchars', None, 'test_schema', 60
+            )
+
+        result = asyncio.run(_run())
+
+        self.assertIsInstance(result, GetBatchDocumentResponse)
+        self.assertEqual(result.status, 400)
+        self.assertIn("Invalid document ID", result.message)
+        self.assertIn("doc\x00with\x01control\x7fchars", result.message)
+        self.assertEqual(result.path_id, "")
+        self.assertIsNone(result.document)
+
+    @patch('marqo.vespa.vespa_client.httpx.AsyncClient')
+    def test_get_batch_handles_invalid_url_ids_with_valid_ids(self, mock_async_client_class):
+        """Test that get_batch returns proper 400 responses for IDs with non-printable ASCII
+        characters while still returning correct results for valid IDs, preserving order."""
+        from marqo.vespa.models.get_document_response import GetBatchDocumentResponse
+
+        schema = 'test_schema'
+        ids = ['valid_doc', 'doc\x00invalid', 'another_valid']
+
+        async def mock_get_document(semaphore, async_client, doc_id, fields, schema_name, timeout):
+            if '\x00' in doc_id:
+                return GetBatchDocumentResponse(
+                    status=400,
+                    pathId="",
+                    message=f"Invalid document ID: {doc_id}. Original error: Invalid URL"
+                )
+            return GetBatchDocumentResponse(
+                status=200,
+                pathId=f'/document/v1/{schema_name}/{schema_name}/docid/{doc_id}',
+                id=f'id:{schema_name}:{schema_name}::{doc_id}',
+                fields={'title': f'Title for {doc_id}'}
+            )
+
+        with patch.object(self.vespa_client, '_get_document_async', side_effect=mock_get_document):
+            result = self.vespa_client.get_batch(ids=ids, schema=schema)
+
+        self.assertEqual(len(result.responses), 3)
+        self.assertTrue(result.errors)
+
+        # First: valid doc
+        self.assertEqual(result.responses[0].status, 200)
+        self.assertEqual(result.responses[0].document.fields['title'], 'Title for valid_doc')
+
+        # Second: invalid URL doc
+        self.assertEqual(result.responses[1].status, 400)
+        self.assertIn("Invalid document ID", result.responses[1].message)
+        self.assertIsNone(result.responses[1].document)
+
+        # Third: valid doc
+        self.assertEqual(result.responses[2].status, 200)
+        self.assertEqual(result.responses[2].document.fields['title'], 'Title for another_valid')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- Ports the document update bug fixes from `li/add-validation-for-update-documents-ids` to mainline (the `update_index_settings` feature was already merged)
- Fixes crash when partial update documents contain IDs with `#` or non-printable ASCII characters
- Uses index-based lookup (`fetch_ids[idx]`) instead of `extract_document_id_from_vespa_id` which was unreliable due to Vespa truncating IDs containing special characters
- Adds `httpx.InvalidURL` catch in `_get_document_async` to gracefully handle IDs with non-printable ASCII
- Adds response count validation for `get_batch` responses

## Test plan
- [ ] Unit tests pass for vespa_client (3 new tests: order preservation, InvalidURL catch, mixed valid/invalid IDs)
- [ ] Integration tests for partial update with `#` in document ID
- [ ] Integration tests for partial update with non-printable ASCII in document ID
- [ ] Integration test for get_batch order preservation

🤖 Generated with [Claude Code](https://claude.com/claude-code)