### PR TITLE
Scope CI workflow triggers by component

### DIFF
--- a/.github/workflows/run_required_checks_inference_orchestrator.yml
+++ b/.github/workflows/run_required_checks_inference_orchestrator.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - mainline
       - releases/*
+      - ci/scope-workflow-triggers-by-component  # Temporary: for testing path filtering
   push:
     branches:
       - mainline

--- a/.github/workflows/run_required_checks_inference_orchestrator.yml
+++ b/.github/workflows/run_required_checks_inference_orchestrator.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - mainline
       - releases/*
-      - ci/scope-workflow-triggers-by-component  # Temporary: for testing path filtering
   push:
     branches:
       - mainline

--- a/.github/workflows/run_required_checks_inference_orchestrator.yml
+++ b/.github/workflows/run_required_checks_inference_orchestrator.yml
@@ -26,12 +26,12 @@ jobs:
           fetch-depth: 0
           path: marqo
 
-      - name: Check for Non-Markdown Changes
+      - name: Check for Relevant Changes
         id: check_changes
         run: |
           cd marqo
           set -x
-          
+
           # Determine BASE_COMMIT and HEAD_COMMIT based on the event type
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
             BASE_COMMIT=${{ github.event.pull_request.base.sha }}
@@ -52,10 +52,25 @@ jobs:
           echo "Base commit: $BASE_COMMIT"
           echo "Head commit: $HEAD_COMMIT"
 
-          # Perform the diff to check for non-documentation changes
-          if git diff --name-only $BASE_COMMIT $HEAD_COMMIT -- | grep -vE '\.(md)$'; then
+          # Get changed non-documentation files
+          CHANGED_FILES=$(git diff --name-only $BASE_COMMIT $HEAD_COMMIT -- | grep -vE '\.(md)$' || true)
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No non-documentation changes found"
+            echo "non_documentation_changes_found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Inference orchestrator tests run when changes are in:
+          # - components/inference_orchestrator/
+          # - components/model_management/
+          # - components/common/
+          # - Any path outside component directories (root files, .github/, etc.)
+          # They do NOT run when changes are exclusively in components/marqo/
+          if echo "$CHANGED_FILES" | grep -qvE '^components/marqo/'; then
+            echo "Relevant changes found for inference orchestrator"
             echo "non_documentation_changes_found=true" >> "$GITHUB_OUTPUT"
           else
+            echo "Changes are only in components/marqo/, skipping inference orchestrator tests"
             echo "non_documentation_changes_found=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -81,7 +96,7 @@ jobs:
     secrets: inherit
 
   # GitHub status will rely on the result of this step to determine if the PR is ready for merge
-  Report-required-test-status:
+  Report-required-test-status-inference-orchestrator:
     needs: [Determine-changes, Run-coverage-checks]
     runs-on: ubuntu-latest
     if: always()
@@ -89,7 +104,7 @@ jobs:
       - name: Set integration test status
         run: |
           if [[ "${{ needs.Determine-changes.outputs.non_documentation_changes_found }}" == "false" ]]; then
-            echo "Tests skipped due to markdown-only changes"
+            echo "Tests skipped - no relevant changes for inference orchestrator"
           elif [[ "${{ needs.Run-coverage-checks.result }}" == "success" ]]; then
             echo "Tests completed successfully"
           else

--- a/.github/workflows/run_required_checks_marqo_api.yml
+++ b/.github/workflows/run_required_checks_marqo_api.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - mainline
       - releases/*
-      - ci/scope-workflow-triggers-by-component  # Temporary: for testing path filtering
   push:
     branches:
       - mainline

--- a/.github/workflows/run_required_checks_marqo_api.yml
+++ b/.github/workflows/run_required_checks_marqo_api.yml
@@ -84,7 +84,7 @@ jobs:
     uses: ./.github/workflows/run_required_checks_coverage_marqo_api.yml
 
   # GitHub status will rely on the result of this step to determine if the PR is ready for merge
-  Report-required-test-status:
+  Report-required-test-status-marqo-api:
     needs: [Determine-changes, Run-coverage-checks]
     runs-on: ubuntu-latest
     if: always()

--- a/.github/workflows/run_required_checks_marqo_api.yml
+++ b/.github/workflows/run_required_checks_marqo_api.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - mainline
       - releases/*
+      - ci/scope-workflow-triggers-by-component  # Temporary: for testing path filtering
   push:
     branches:
       - mainline

--- a/.github/workflows/run_required_checks_model_management.yml
+++ b/.github/workflows/run_required_checks_model_management.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - mainline
       - releases/*
+      - ci/scope-workflow-triggers-by-component  # Temporary: for testing path filtering
   push:
     branches:
       - mainline

--- a/.github/workflows/run_required_checks_model_management.yml
+++ b/.github/workflows/run_required_checks_model_management.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - mainline
       - releases/*
-      - ci/scope-workflow-triggers-by-component  # Temporary: for testing path filtering
   push:
     branches:
       - mainline

--- a/.github/workflows/run_required_checks_model_management.yml
+++ b/.github/workflows/run_required_checks_model_management.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
           path: marqo
 
-      - name: Check for Non-Markdown Changes
+      - name: Check for Relevant Changes
         id: check_changes
         run: |
           cd marqo
@@ -52,10 +52,24 @@ jobs:
           echo "Base commit: $BASE_COMMIT"
           echo "Head commit: $HEAD_COMMIT"
 
-          # Perform the diff to check for non-documentation changes
-          if git diff --name-only $BASE_COMMIT $HEAD_COMMIT -- | grep -vE '\.(md)$'; then
+          # Get changed non-documentation files
+          CHANGED_FILES=$(git diff --name-only $BASE_COMMIT $HEAD_COMMIT -- | grep -vE '\.(md)$' || true)
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No non-documentation changes found"
+            echo "non_documentation_changes_found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Model management tests run when changes are in:
+          # - components/model_management/
+          # - components/common/
+          # - Any path outside component directories (root files, .github/, etc.)
+          # They do NOT run when changes are exclusively in components/marqo/ and/or components/inference_orchestrator/
+          if echo "$CHANGED_FILES" | grep -qvE '^components/(marqo|inference_orchestrator)/'; then
+            echo "Relevant changes found for model management"
             echo "non_documentation_changes_found=true" >> "$GITHUB_OUTPUT"
           else
+            echo "Changes are only in components/marqo/ and/or components/inference_orchestrator/, skipping model management tests"
             echo "non_documentation_changes_found=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -81,7 +95,7 @@ jobs:
     secrets: inherit
 
   # GitHub status will rely on the result of this step to determine if the PR is ready for merge
-  Report-required-test-status:
+  Report-required-test-status-model-management:
     needs: [Determine-changes, Run-coverage-checks]
     runs-on: ubuntu-latest
     if: always()
@@ -89,7 +103,7 @@ jobs:
       - name: Set integration test status
         run: |
           if [[ "${{ needs.Determine-changes.outputs.non_documentation_changes_found }}" == "false" ]]; then
-            echo "Tests skipped due to markdown-only changes"
+            echo "Tests skipped - no relevant changes for model management"
           elif [[ "${{ needs.Run-coverage-checks.result }}" == "success" ]]; then
             echo "Tests completed successfully"
           else


### PR DESCRIPTION
## Summary
- Scope test workflows so only affected components run tests based on which directories changed
- API (`components/marqo/`) changes → run marqo tests only
- Inference orchestrator changes → run marqo + inference orchestrator tests
- Model management or common changes → run all tests
- Non-component changes (root files, `.github/`, etc.) → run all tests (safe default)
- Rename `Report-required-test-status` jobs to include component name (`Report-required-test-status-marqo-api`, `Report-required-test-status-inference-orchestrator`, `Report-required-test-status-model-management`) for easier GitHub branch protection rule setup

## Test plan
- [ ] Verify marqo API workflow still runs for any non-doc change
- [ ] Verify inference orchestrator workflow skips when only `components/marqo/` files change
- [ ] Verify model management workflow skips when only `components/marqo/` and/or `components/inference_orchestrator/` files change
- [ ] Verify all workflows run when `components/common/` or root-level files change
- [ ] Verify `workflow_dispatch` still runs all tests
- [ ] Update GitHub branch protection rules to use new job names

🤖 Generated with [Claude Code](https://claude.com/claude-code)