### PR TITLE
Test: validate CI path filtering with marqo-only change

### DIFF
--- a/components/marqo/src/marqo/__init__.py
+++ b/components/marqo/src/marqo/__init__.py
@@ -1,1 +1,2 @@
 
+# Test change to validate CI path filtering


### PR DESCRIPTION
## Summary
- Trivial change in `components/marqo/` only to validate the CI path filtering logic

## Expected behavior
- **Marqo API tests**: should RUN (marqo changes always trigger marqo tests)
- **Inference orchestrator tests**: should SKIP (no changes outside `components/marqo/`)
- **Model management tests**: should SKIP (no changes outside `components/marqo/`)

This PR should be closed after validation. Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)