### PR TITLE
Skip shards/replicas integration tests for markdown-only PR changes

### DIFF
--- a/.github/workflows/integration_tests_with_shards_and_replicas.yml
+++ b/.github/workflows/integration_tests_with_shards_and_replicas.yml
@@ -12,6 +12,8 @@ on:
     branches:
       - mainline
       - releases/*
+    paths-ignore:
+      - '**.md'
   push:
     branches:
       - mainline


### PR DESCRIPTION
The workflow was already skipping for push events but not for pull_request events. This caused unnecessary CI runs for documentation-only changes.

Slack thread: https://marqo-ai.slack.com/archives/C05K6BFQUTF/p1775539504235909?thread_ts=1775538014.699289&cid=C05K6BFQUTF

https://claude.ai/code/session_01LnJLG8hA8uUvo2ju2uiSqe

## Change Summary
<!-- Describe the key changes this PR introduces -->

## Related Jira Ticket
<!-- Link to Jira ticket (e.g. MAR-123) -->

## Checklist
<!-- Check items that apply, add items if needed -->
- [ ] Tests have been added for changes
- [ ] Documentation has been updated
- [ ] Breaking changes are clearly identified
- [ ] Python client changes linked or N/A

<!-- Special test requirements for certain changes -->
### For new field types:
- [ ] Tests cover score modifier usage of this new type
- [ ] Test indexes updated to cover the new type for all APIs (add docs, search, partial update, etc.)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow change that only adjusts when CI triggers; main risk is accidentally skipping tests if other relevant changes are misclassified as `*.md`.
> 
> **Overview**
> Prevents the `Integration Tests with Shards and Replicas` GitHub Actions workflow from running on pull requests that only change Markdown by adding `paths-ignore: '**.md'` to the `pull_request` trigger (matching the existing `push` behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e011b5c4bbc59f6a2a2bdf6c9bf06e6b1c4dfb48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->