### PR TITLE
Fix lexical queries with mixed required/optional terms using rank()

### DIFF
--- a/components/marqo/src/marqo/core/models/hybrid_parameters.py
+++ b/components/marqo/src/marqo/core/models/hybrid_parameters.py
@@ -161,6 +161,19 @@ class HybridParameters(StrictBaseModel):
         return values
 
     @root_validator(pre=False)
+    def validate_lexical_operand_with_rerank_depth(cls, values):
+        lexical_operand = values.get('lexicalOperand')
+        rerank_depth_lexical = values.get('rerankDepthLexical')
+
+        if rerank_depth_lexical is not None and lexical_operand in [LexicalOperand.And, LexicalOperand.Or]:
+            raise ValueError(
+                f"'rerankDepthLexical' cannot be used with lexicalOperand='{lexical_operand}'. "
+                f"'rerankDepthLexical' only has an effect with weakAnd. "
+                f"Either remove 'rerankDepthLexical' or set lexicalOperand to 'weakAnd' (or omit it)."
+            )
+        return values
+
+    @root_validator(pre=False)
     def validate_weakand_parameters(cls, values):
         rerank_depth_lexical = values.get('rerankDepthLexical')
         weak_and_parameters = values.get('weakAndParameters')

--- a/components/marqo/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/components/marqo/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -109,10 +109,28 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
         elif isinstance(marqo_query, MarqoTensorQuery):
             return StructuredVespaIndex._to_vespa_tensor_query(self, marqo_query)
         elif isinstance(marqo_query, MarqoLexicalQuery):
-            return StructuredVespaIndex._to_vespa_lexical_query(self, marqo_query)
+            return self._to_vespa_lexical_query(marqo_query)
 
         else:
             raise InternalError(f'Unknown query type {type(marqo_query)}')
+
+    def _to_vespa_lexical_query(self, marqo_query: MarqoLexicalQuery) -> Dict[str, Any]:
+        """Override to apply _optimize_yql_query to the lexical term."""
+        query = StructuredVespaIndex._to_vespa_lexical_query(self, marqo_query)
+        # Re-build the YQL with the optimized lexical term
+        fields_to_search = self._get_lexical_fields_to_search(marqo_query)
+        if fields_to_search:
+            from marqo.core.structured_vespa_index import common as structured_common
+            lexical_term = self._get_lexical_search_term(marqo_query)
+            optimized_lexical_term = self._optimize_yql_query(lexical_term)
+            filter_term = self._get_filter_term(marqo_query)
+            if filter_term:
+                search_term = f'({optimized_lexical_term}) AND ({filter_term})'
+            else:
+                search_term = f'({optimized_lexical_term})'
+            select_attributes = self._get_select_attributes(marqo_query)
+            query['yql'] = f'select {select_attributes} from {self._marqo_index.schema_name} where {search_term}'
+        return query
 
     # --- Custom score rerank support: duplicated from structured (to be deprecated) ---
 
@@ -178,6 +196,148 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
             return f'weakAnd({", ".join(terms)})'
         else:
             raise InternalError(f'Unknown lexical operand: {lexical_operand}')
+
+    @staticmethod
+    def _combine_lexical_or_and_terms(or_terms: str, and_terms: str, use_rank: bool = True) -> str:
+        """Combine OR (optional) and AND (required) lexical terms.
+
+        When use_rank=True (default): uses rank() so optional terms contribute to BM25
+        scoring but don't affect recall. When use_rank=False (lexicalOperand='and'):
+        uses AND so all terms are required.
+        """
+        if not or_terms and not and_terms:
+            return 'false'
+        if not and_terms:
+            return or_terms
+        if not or_terms:
+            return and_terms
+
+        if use_rank:
+            # rank(required, optional_terms_blob)
+            # or_terms passed as single arg here; flattening happens in _optimize_yql_query()
+            return f'rank({and_terms}, {or_terms})'
+        else:
+            # All terms required — old AND behavior
+            return f'({or_terms}) AND ({and_terms})'
+
+    @staticmethod
+    def _optimize_yql_query(term: str) -> str:
+        """Flatten nested rank() and unwrap OR/weakAnd in non-first rank positions.
+
+        Transforms:
+            rank(rank(a, b), c)  →  rank(a, b, c)
+            rank(a, weakAnd(b, c), d)  →  rank(a, b, c, d)
+            rank(a, b OR c)  →  rank(a, b, c)
+
+        First position is preserved as-is (it controls retrieval).
+        """
+        if not term.startswith('rank('):
+            return term
+
+        cls = SemiStructuredVespaIndex
+        parts = cls._split_rank_args(term)
+        if len(parts) < 2:
+            return term
+
+        result = []
+
+        # Flatten first arg: if it's rank(), merge its children into this level
+        first = parts[0].strip()
+        if first.startswith('rank('):
+            first_nested = cls._split_rank_args(first)
+            # Recurse on the nested first arg's retrieval term
+            result.append(cls._optimize_yql_query(first_nested[0]))
+            # Rest of nested first arg's terms become scoring terms
+            result.extend(first_nested[1:])
+        else:
+            result.append(first)
+
+        for part in parts[1:]:
+            part = part.strip()
+            # Recursively flatten nested rank()
+            if part.startswith('rank('):
+                nested = cls._split_rank_args(part)
+                result.extend(nested)
+            else:
+                # Unwrap weakAnd, OR, and bare parens in non-first positions
+                unwrapped = cls._unwrap_non_retrieval_term(part)
+                result.extend(unwrapped)
+
+        return f'rank({", ".join(result)})'
+
+    @staticmethod
+    def _unwrap_non_retrieval_term(term: str) -> List[str]:
+        """Unwrap weakAnd(a, b), (a OR b), or {targetHits:N}weakAnd(a, b) into [a, b].
+
+        For terms not wrapped in these operators, returns [term].
+        """
+        stripped = term.strip()
+
+        # Strip outer parens: (something) -> something, if balanced
+        if stripped.startswith('(') and stripped.endswith(')'):
+            inner = stripped[1:-1].strip()
+            if SemiStructuredVespaIndex._parens_balanced(inner):
+                stripped = inner
+
+        # {targetHits:N}weakAnd(a, b, ...) or weakAnd(a, b, ...) -> [a, b, ...]
+        if 'weakAnd(' in stripped:
+            wa_start = stripped.index('weakAnd(')
+            inner = stripped[wa_start + len('weakAnd('):-1]
+            return SemiStructuredVespaIndex._split_top_level(inner, ',')
+
+        # a OR b OR c -> [a, b, c]
+        or_parts = SemiStructuredVespaIndex._split_top_level(stripped, ' OR ')
+        if len(or_parts) > 1:
+            return [p.strip() for p in or_parts]
+
+        return [stripped]
+
+    @staticmethod
+    def _split_rank_args(term: str) -> List[str]:
+        """Split rank(a, b, c) into [a, b, c], respecting nested parens."""
+        if not term.startswith('rank(') or not term.endswith(')'):
+            return [term]
+        inner = term[5:-1]  # strip rank( and )
+        return SemiStructuredVespaIndex._split_top_level(inner, ',')
+
+    @staticmethod
+    def _split_top_level(s: str, delimiter: str) -> List[str]:
+        """Split string by delimiter, only at the top level (not inside parens)."""
+        parts = []
+        depth = 0
+        current = []
+        i = 0
+        while i < len(s):
+            if s[i] == '(':
+                depth += 1
+                current.append(s[i])
+            elif s[i] == ')':
+                depth -= 1
+                current.append(s[i])
+            elif depth == 0 and s[i:i+len(delimiter)] == delimiter:
+                parts.append(''.join(current).strip())
+                current = []
+                i += len(delimiter)
+                continue
+            else:
+                current.append(s[i])
+            i += 1
+        if current:
+            parts.append(''.join(current).strip())
+        return parts
+
+    @staticmethod
+    def _parens_balanced(s: str) -> bool:
+        """Check if parentheses in the string are balanced."""
+        depth = 0
+        for c in s:
+            if c == '(':
+                depth += 1
+            elif c == ')':
+                depth -= 1
+            if depth < 0:
+                return False
+        return depth == 0
 
     def _generate_or_terms(
         self,
@@ -295,12 +455,17 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
                 )
                 for phrase in marqo_query.and_phrases
             ])
-            if or_terms:
-                or_terms = f'({or_terms})'
-                and_terms = f' AND ({and_terms})'
         else:
             and_terms = ''
-        return f'{or_terms}{and_terms}'
+
+        # Determine the effective lexical operand for this specific query
+        effective_operand = lexical_operand_override or (
+            marqo_query.hybrid_parameters.lexicalOperand if isinstance(marqo_query, MarqoHybridQuery) else None
+        )
+        # Use rank() unless the effective operand is explicitly AND
+        use_rank = (effective_operand != LexicalOperand.And)
+
+        return self._combine_lexical_or_and_terms(or_terms, and_terms, use_rank=use_rank)
 
     def _get_lexical_contains_term(
         self,
@@ -543,17 +708,20 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
         if getattr(marqo_query, "relevance_cutoff", None) is not None:
             if not marqo_query.relevance_cutoff.lexical_operand:
                 # If the relevance_cutoff has no lexical_operand, it uses whatever is used in the main lexical query
+                optimized_probe_lexical_term = self._optimize_yql_query(lexical_term)
                 lexical_yql_for_probe = (
-                    f'select {select_attributes} from {self._marqo_index.schema_name} where ({lexical_term}){filter_term}'
+                    f'select {select_attributes} from {self._marqo_index.schema_name} '
+                    f'where ({optimized_probe_lexical_term}){filter_term}'
                 )
 
             else:
                 probe_lexical_term = self._get_lexical_search_term(
-                    marqo_query, lexical_operand_override=marqo_query.relevance_cutoff.lexical_operand \
+                    marqo_query, lexical_operand_override=marqo_query.relevance_cutoff.lexical_operand
                 ) if fields_to_search_lexical else "False"
+                optimized_probe_lexical_term = self._optimize_yql_query(probe_lexical_term)
                 lexical_yql_for_probe = (
                     f'select {select_attributes} from {self._marqo_index.schema_name} '
-                    f'where ({probe_lexical_term}){filter_term}'
+                    f'where ({optimized_probe_lexical_term}){filter_term}'
                 )
 
         # Assign parameters to query
@@ -626,8 +794,12 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
         if applicable_custom_score_keys and marqo_query.attributes_to_retrieve is not None:
             select_for_hybrid_yql = select_attributes + ', summaryfeatures'
 
-        tensor_yql = f'select {select_for_hybrid_yql} from {self._marqo_index.schema_name} where {tensor_term}{filter_term}'
-        lexical_yql = f'select {select_for_hybrid_yql} from {self._marqo_index.schema_name} where ({lexical_term}){filter_term}'
+        # Flatten nested rank() and unwrap OR/weakAnd in non-first rank positions
+        optimized_lexical_term = self._optimize_yql_query(lexical_term)
+        optimized_tensor_term = self._optimize_yql_query(tensor_term)
+
+        tensor_yql = f'select {select_for_hybrid_yql} from {self._marqo_index.schema_name} where {optimized_tensor_term}{filter_term}'
+        lexical_yql = f'select {select_for_hybrid_yql} from {self._marqo_index.schema_name} where ({optimized_lexical_term}){filter_term}'
 
         query = {
             'searchChain': 'marqo',
@@ -860,7 +1032,8 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
             marqo_query.rerank_depth_tensor = marqo_query.hybrid_parameters.rerankDepthTensor
             tensor_term = self._get_tensor_search_term(marqo_query)
 
-        facets_lexical_term = self._get_lexical_search_term(marqo_query, is_facets_term=True)
+        raw_facets_lexical_term = self._get_lexical_search_term(marqo_query, is_facets_term=True)
+        facets_lexical_term = self._optimize_yql_query(raw_facets_lexical_term)
         base_yql = f'select {select_attributes} from {self._marqo_index.schema_name} where ({facets_lexical_term})'
         if marqo_query.hybrid_parameters.retrievalMethod == RetrievalMethod.Disjunction:
             base_yql = f'select {select_attributes} from {self._marqo_index.schema_name} where ({facets_lexical_term} OR {tensor_term})'

--- a/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_lexical_optional_terms_rank.py
+++ b/components/marqo/tests/integ_tests/core/semi_structured_vespa_index/test_lexical_optional_terms_rank.py
@@ -1,0 +1,236 @@
+"""Integration tests for lexical optional/required terms using rank().
+
+Tests that the rank() operator correctly handles mixed required (quoted) and
+optional (unquoted) terms so that:
+- Only required terms affect recall (matching)
+- Optional terms contribute to BM25 scoring
+- Various combinations with hybrid search, custom score rerank, and lexicalOperand work correctly
+"""
+
+import unittest
+from marqo.core.models.add_docs_params import AddDocsParams
+from marqo.core.models.marqo_index import Model
+from marqo.core.models.hybrid_parameters import HybridParameters, RetrievalMethod, RankingMethod
+from marqo.tensor_search import tensor_search
+from tests.integ_tests.marqo_test import MarqoTestCase
+
+
+class TestLexicalOptionalTermsWithRank(MarqoTestCase):
+    """Integration tests for the rank() operator with mixed required/optional lexical terms."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Create an unstructured index with auto-generated name (uses default random/small model)
+        index_request = cls.unstructured_marqo_index_request()
+        cls.create_indexes([index_request])
+        cls.index_name = index_request.name
+
+        # Add test documents
+        # doc1: has "required" only
+        # doc2: has "required" and "optional"
+        # doc3: has "optional" only
+        # doc4: has neither
+        docs = [
+            {"_id": "doc1", "content": "This document has the required term"},
+            {"_id": "doc2", "content": "This document has both required and optional terms"},
+            {"_id": "doc3", "content": "This document has the optional term only"},
+            {"_id": "doc4", "content": "This document has nothing relevant"},
+        ]
+
+        cls.add_documents(
+            config=cls.config,
+            add_docs_params=AddDocsParams(
+                docs=docs,
+                index_name=cls.index_name,
+                tensor_fields=["content"],
+            ),
+        )
+
+    def setUp(self):
+        # Don't clear documents between tests
+        pass
+
+    def test_basic_recall_with_mixed_terms(self):
+        """Documents with only 'required' should be returned even without 'optional'."""
+        res = tensor_search.search(
+            config=self.config,
+            index_name=self.index_name,
+            text='"required" optional',
+            search_method="LEXICAL",
+            result_count=10,
+        )
+        result_ids = {hit["_id"] for hit in res["hits"]}
+        # doc1 and doc2 have "required" - both should be returned
+        self.assertIn("doc1", result_ids, "Doc with only 'required' should be found")
+        self.assertIn("doc2", result_ids, "Doc with both terms should be found")
+        # doc3 has only "optional" - should NOT be returned (optional terms don't affect recall)
+        self.assertNotIn("doc3", result_ids,
+                         "Doc with only 'optional' should NOT be found when 'required' is quoted")
+
+    def test_bm25_scoring_optional_boosts(self):
+        """Documents matching both required+optional should score higher than required-only."""
+        res = tensor_search.search(
+            config=self.config,
+            index_name=self.index_name,
+            text='"required" optional',
+            search_method="LEXICAL",
+            result_count=10,
+        )
+        scores = {hit["_id"]: hit["_score"] for hit in res["hits"]}
+        if "doc1" in scores and "doc2" in scores:
+            self.assertGreater(
+                scores["doc2"], scores["doc1"],
+                "Doc with both 'required' and 'optional' should score higher"
+            )
+
+    def test_or_only_unchanged(self):
+        """Optional-only query should return docs matching any term (unchanged behavior)."""
+        res = tensor_search.search(
+            config=self.config,
+            index_name=self.index_name,
+            text="required optional",
+            search_method="LEXICAL",
+            result_count=10,
+        )
+        result_ids = {hit["_id"] for hit in res["hits"]}
+        # All docs with either 'required' or 'optional' should be found
+        self.assertIn("doc1", result_ids)
+        self.assertIn("doc2", result_ids)
+        self.assertIn("doc3", result_ids)
+
+    def test_and_only_unchanged(self):
+        """All-required query should require all terms (unchanged behavior)."""
+        res = tensor_search.search(
+            config=self.config,
+            index_name=self.index_name,
+            text='"required" "optional"',
+            search_method="LEXICAL",
+            result_count=10,
+        )
+        result_ids = {hit["_id"] for hit in res["hits"]}
+        # Only doc2 has both required and optional
+        self.assertIn("doc2", result_ids)
+        # doc1 has only required, doc3 has only optional
+        self.assertNotIn("doc1", result_ids)
+        self.assertNotIn("doc3", result_ids)
+
+    def test_hybrid_lexical_tensor_with_mixed_terms(self):
+        """Hybrid search with mixed terms should use rank() for lexical retrieval."""
+        res = tensor_search.search(
+            config=self.config,
+            index_name=self.index_name,
+            text='"required" optional',
+            search_method="HYBRID",
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                rankingMethod=RankingMethod.RRF,
+                alpha=0.5,
+            ),
+            result_count=10,
+        )
+        result_ids = {hit["_id"] for hit in res["hits"]}
+        # doc1 and doc2 should be returned (have "required")
+        # doc3 may or may not be found (tensor may retrieve it)
+        self.assertIn("doc1", result_ids)
+        self.assertIn("doc2", result_ids)
+
+    def test_lexical_operand_and_keeps_old_behavior(self):
+        """With lexicalOperand='and', all terms become required (old AND behavior)."""
+        res = tensor_search.search(
+            config=self.config,
+            index_name=self.index_name,
+            text='"required" optional',
+            search_method="HYBRID",
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                rankingMethod=RankingMethod.RRF,
+                alpha=0.5,
+                lexicalOperand="and",
+            ),
+            result_count=10,
+        )
+        result_ids = {hit["_id"] for hit in res["hits"]}
+        # With AND, both "required" AND "optional" are required for lexical matching
+        # doc2 has both terms
+        self.assertIn("doc2", result_ids)
+
+    def test_lexical_operand_weakand_uses_rank(self):
+        """With lexicalOperand='weakAnd', rank() is used for mixed terms."""
+        res = tensor_search.search(
+            config=self.config,
+            index_name=self.index_name,
+            text='"required" optional',
+            search_method="HYBRID",
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                rankingMethod=RankingMethod.RRF,
+                alpha=0.5,
+                lexicalOperand="weakAnd",
+            ),
+            result_count=10,
+        )
+        result_ids = {hit["_id"] for hit in res["hits"]}
+        # doc1 and doc2 should be returned (have "required")
+        self.assertIn("doc1", result_ids)
+        self.assertIn("doc2", result_ids)
+
+    def test_rerank_depth_lexical_with_mixed_terms(self):
+        """OR-only query with rerankDepthLexical still uses weakAnd with targetHits."""
+        res = tensor_search.search(
+            config=self.config,
+            index_name=self.index_name,
+            text="required optional",
+            search_method="HYBRID",
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                rankingMethod=RankingMethod.RRF,
+                alpha=0.5,
+                rerankDepthLexical=100,
+            ),
+            result_count=10,
+        )
+        # Should return results without error
+        self.assertIn("hits", res)
+
+    def test_rerank_depth_with_lexical_operand_and_raises(self):
+        """rerankDepthLexical with lexicalOperand='and' should raise validation error."""
+        with self.assertRaises(Exception):
+            tensor_search.search(
+                config=self.config,
+                index_name=self.index_name,
+                text="required optional",
+                search_method="HYBRID",
+                hybrid_parameters=HybridParameters(
+                    retrievalMethod=RetrievalMethod.Disjunction,
+                    rankingMethod=RankingMethod.RRF,
+                    alpha=0.5,
+                    rerankDepthLexical=100,
+                    lexicalOperand="and",
+                ),
+                result_count=10,
+            )
+
+    def test_track_total_hits_with_mixed_terms(self):
+        """trackTotalHits with mixed terms should work correctly."""
+        res = tensor_search.search(
+            config=self.config,
+            index_name=self.index_name,
+            text='"required" optional',
+            search_method="HYBRID",
+            hybrid_parameters=HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                rankingMethod=RankingMethod.RRF,
+                alpha=0.5,
+            ),
+            result_count=10,
+            track_total_hits=True,
+        )
+        self.assertIn("hits", res)
+        # totalHits should be present
+        self.assertIn("totalHits", res)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/components/marqo/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_semi_structured_vespa_index_to_vespa_query.py
+++ b/components/marqo/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_semi_structured_vespa_index_to_vespa_query.py
@@ -200,7 +200,7 @@ class TestSemiStructuredVespaIndexToVespaQuery(unittest.TestCase):
                     'language': 'en'
                 },
                 'expected_query': {
-                    'yql': 'select * from test_index where ((weakAnd(default contains "machine learning", default contains "artificial intelligence")) AND (default contains "deep"))',
+                    'yql': 'select * from test_index where (rank(default contains "deep", default contains "machine learning", default contains "artificial intelligence"))',
                     'model_restrict': 'test_index',
                     'hits': 20,
                     'offset': 5,
@@ -307,7 +307,7 @@ class TestSemiStructuredVespaIndexToVespaQuery(unittest.TestCase):
                     'marqo__ranking.lexical.tensor': 'hybrid_bm25_then_embedding_similarity',
                     'marqo__ranking.tensor.lexical': 'hybrid_embedding_similarity_then_bm25',
                     'marqo__ranking.tensor.tensor': 'embedding_similarity',
-                    'marqo__yql.lexical': 'select * from test_index where ((weakAnd(default contains "neural networks", default contains "deep learning")) AND (default contains "transformer"))',
+                    'marqo__yql.lexical': 'select * from test_index where (rank(default contains "transformer", default contains "neural networks", default contains "deep learning"))',
                     'marqo__yql.tensor': 'select * from test_index where (({targetHits:40, approximate:True, hnsw.exploreAdditionalHits:1960}nearestNeighbor(marqo__embeddings_title, marqo__query_embedding)) OR ({targetHits:40, approximate:True, hnsw.exploreAdditionalHits:1960}nearestNeighbor(marqo__embeddings_description, marqo__query_embedding)))',
                     'model_restrict': 'test_index',
                     'offset': 10,
@@ -442,13 +442,12 @@ class TestSemiStructuredVespaIndexToVespaQuery(unittest.TestCase):
                     "ranking.matching.weakand.adjustTarget": 0.3,
                     "ranking.matching.weakand.allowDropAll": True,
                     "ranking.matching.filterThreshold": 0.4,
-                    # Facets should still use the OR query structure
-                    'marqo__yql.facets': 'select * from test_index where ((default contains "neural networks" OR default contains "deep learning") '
-                                         'AND (default contains "transformer") OR '
+                    # Facets use rank() with OR-joined optional terms
+                    'marqo__yql.facets': 'select * from test_index where (rank(default contains "transformer", default contains "neural networks", default contains "deep learning") OR '
                                          '(({targetHits:40, approximate:True, hnsw.exploreAdditionalHits:1960}nearestNeighbor(marqo__embeddings_title, marqo__query_embedding)) '
                                          'OR ({targetHits:40, approximate:True, hnsw.exploreAdditionalHits:1960}nearestNeighbor(marqo__embeddings_description, marqo__query_embedding)))) '
                                          'limit 0 | all(group(1.1) each(output(count())))',
-                    'marqo__yql.lexical': 'select * from test_index where (({targetHits:111}weakAnd(default contains "neural networks", default contains "deep learning")) AND (default contains "transformer"))',
+                    'marqo__yql.lexical': 'select * from test_index where (rank(default contains "transformer", default contains "neural networks", default contains "deep learning"))',
                     'marqo__yql.tensor': 'select * from test_index where (({targetHits:40, approximate:True, hnsw.exploreAdditionalHits:1960}nearestNeighbor(marqo__embeddings_title, marqo__query_embedding)) OR ({targetHits:40, approximate:True, hnsw.exploreAdditionalHits:1960}nearestNeighbor(marqo__embeddings_description, marqo__query_embedding)))',
                     'model_restrict': 'test_index',
                     'offset': 10,
@@ -1596,12 +1595,12 @@ class TestSemiStructuredCustomScoreRerankToVespaQuery(unittest.TestCase):
             'select * from test_index where (weakAnd(default contains "search"))',
             vespa_query['marqo__yql.lexical'],
         )
-        # Assert tensor yql has the extra weakAnd (for bm25 sum)
+        # Assert tensor yql has the extra bm25 term (weakAnd unwrapped by _optimize_yql_query)
         self.assertEqual(
             'select * from test_index where rank((({targetHits:10, approximate:True, '
             'hnsw.exploreAdditionalHits:1990}nearestNeighbor(marqo__embeddings_title, marqo__query_embedding)) OR '
             '({targetHits:10, approximate:True, hnsw.exploreAdditionalHits:1990}nearestNeighbor('
-            'marqo__embeddings_description, marqo__query_embedding))), weakAnd(default contains "search"))',
+            'marqo__embeddings_description, marqo__query_embedding))), default contains "search")',
             vespa_query['marqo__yql.tensor'],
         )
 
@@ -2301,12 +2300,11 @@ class TestLexicalOperandSemiStructured(TestSemiStructuredVespaIndexToVespaQuery)
         result = self.vespa_index._generate_or_terms(q)
         self.assertEqual(result, 'weakAnd(default contains "search")')
 
-    def test_lexical_operand_or_with_rerank_depth(self):
-        """When lexicalOperand='or' with rerankDepthLexical, should use OR (no targetHits wrapping)."""
-        q = self._make_hybrid_query(lexical_operand='or', rerank_depth_lexical=100,
+    def test_lexical_operand_or_with_rerank_depth_raises(self):
+        """When lexicalOperand='or' with rerankDepthLexical, validation should reject this combination."""
+        with self.assertRaises(Exception):
+            self._make_hybrid_query(lexical_operand='or', rerank_depth_lexical=100,
                                     or_phrases=['term1', 'term2'])
-        result = self.vespa_index._generate_or_terms(q)
-        self.assertEqual(result, 'default contains "term1" OR default contains "term2"')
 
     def test_lexical_operand_weakand_with_rerank_depth(self):
         """When lexicalOperand='weakAnd' with rerankDepthLexical, should use weakAnd with targetHits."""
@@ -2448,8 +2446,8 @@ class TestLexicalOperandSemiStructured(TestSemiStructuredVespaIndexToVespaQuery)
 
         lexical_yql = vespa_query.get('marqo__yql.lexical', '')
         expected = ('select * from test_index where '
-                    '((default contains "hello" OR default contains "world") '
-                    'AND (default contains "exact phrase"))')
+                    '(rank(default contains "exact phrase", '
+                    'default contains "hello", default contains "world"))')
         self.assertEqual(expected, lexical_yql)
 
     def test_all_quoted_terms_with_lexical_operand_or_and_relevance_cutoff(self):
@@ -2502,7 +2500,7 @@ class TestLexicalOperandSemiStructured(TestSemiStructuredVespaIndexToVespaQuery)
 
     def test_custom_score_ranking_term_weakand_with_lexical_operand_or_full_query(self):
         """End-to-end: with lexicalOperand='or' and BM25 custom score, the main retrieval uses OR
-        but the extra rank() term must use weakAnd."""
+        and the extra rank() term's weakAnd is unwrapped by _optimize_yql_query."""
         q = self._make_hybrid_query(
             lexical_operand='or',
             or_phrases=['hello', 'world'],
@@ -2521,12 +2519,12 @@ class TestLexicalOperandSemiStructured(TestSemiStructuredVespaIndexToVespaQuery)
             'select * from test_index where '
             '(rank('
             '(marqo__lexical_description contains "hello") OR (marqo__lexical_description contains "world"), '
-            'weakAnd((marqo__lexical_title contains "hello"), (marqo__lexical_title contains "world"))))')
+            '(marqo__lexical_title contains "hello"), (marqo__lexical_title contains "world")))')
         self.assertEqual(expected_lexical, lexical_yql)
 
     def test_custom_score_ranking_term_weakand_with_lexical_operand_and_full_query(self):
         """End-to-end: with lexicalOperand='and' and BM25 custom score, the main retrieval uses AND
-        but the extra rank() term must use weakAnd."""
+        and the extra rank() term's weakAnd is unwrapped by _optimize_yql_query."""
         q = self._make_hybrid_query(
             lexical_operand='and',
             or_phrases=['hello', 'world'],
@@ -2545,12 +2543,12 @@ class TestLexicalOperandSemiStructured(TestSemiStructuredVespaIndexToVespaQuery)
             'select * from test_index where '
             '(rank('
             '(marqo__lexical_description contains "hello") AND (marqo__lexical_description contains "world"), '
-            'weakAnd((marqo__lexical_title contains "hello"), (marqo__lexical_title contains "world"))))')
+            '(marqo__lexical_title contains "hello"), (marqo__lexical_title contains "world")))')
         self.assertEqual(expected_lexical, lexical_yql)
 
     def test_custom_score_ranking_term_weakand_with_lexical_operand_weakand_full_query(self):
         """End-to-end: with lexicalOperand='weakAnd' and BM25 custom score, both the main retrieval
-        and the extra rank() term use weakAnd."""
+        and the extra rank() term use weakAnd, with non-first weakAnd unwrapped."""
         q = self._make_hybrid_query(
             lexical_operand='weakAnd',
             or_phrases=['hello', 'world'],
@@ -2569,12 +2567,12 @@ class TestLexicalOperandSemiStructured(TestSemiStructuredVespaIndexToVespaQuery)
             'select * from test_index where '
             '(rank('
             'weakAnd((marqo__lexical_description contains "hello"), (marqo__lexical_description contains "world")), '
-            'weakAnd((marqo__lexical_title contains "hello"), (marqo__lexical_title contains "world"))))')
+            '(marqo__lexical_title contains "hello"), (marqo__lexical_title contains "world")))')
         self.assertEqual(expected_lexical, lexical_yql)
 
     def test_custom_score_tensor_ranking_term_always_weakand_with_lexical_operand(self):
-        """Tensor YQL's extra BM25 ranking term must use weakAnd regardless of lexicalOperand.
-        The tensor YQL is identical across all lexicalOtest_no_lexical_fields_returns_false_regardless_of_lexical_operandperand values since it only affects lexical retrieval."""
+        """Tensor YQL's extra BM25 ranking term's weakAnd is unwrapped by _optimize_yql_query.
+        The tensor YQL is identical across all lexicalOperand values since it only affects lexical retrieval."""
         expected_tensor = (
             'select * from test_index where '
             'rank(('
@@ -2582,7 +2580,7 @@ class TestLexicalOperandSemiStructured(TestSemiStructuredVespaIndexToVespaQuery)
             'nearestNeighbor(marqo__embeddings_title, marqo__query_embedding)) OR '
             '({targetHits:10, approximate:True, hnsw.exploreAdditionalHits:1990}'
             'nearestNeighbor(marqo__embeddings_description, marqo__query_embedding))), '
-            'weakAnd((marqo__lexical_title contains "hello"), (marqo__lexical_title contains "world")))')
+            '(marqo__lexical_title contains "hello"), (marqo__lexical_title contains "world"))')
         for lexical_operand in ['or', 'and', 'weakAnd']:
             with self.subTest(lexical_operand=lexical_operand):
                 q = self._make_hybrid_query(
@@ -2618,6 +2616,374 @@ class TestLexicalOperandSemiStructured(TestSemiStructuredVespaIndexToVespaQuery)
                 vespa_query = vi_no_lex.to_vespa_query(q)
                 lexical_yql = vespa_query.get('marqo__yql.lexical', '')
                 self.assertEqual(expected, lexical_yql)
+
+
+class TestOptimizeYqlQuery(unittest.TestCase):
+    """Tests for SemiStructuredVespaIndex._optimize_yql_query."""
+
+    def test_noop_for_non_rank_term(self):
+        result = SemiStructuredVespaIndex._optimize_yql_query('weakAnd(a, b)')
+        self.assertEqual('weakAnd(a, b)', result)
+
+    def test_noop_for_simple_rank(self):
+        result = SemiStructuredVespaIndex._optimize_yql_query('rank(a, b)')
+        self.assertEqual('rank(a, b)', result)
+
+    def test_flatten_nested_rank_first_child(self):
+        result = SemiStructuredVespaIndex._optimize_yql_query('rank(rank(a, b), c)')
+        self.assertEqual('rank(a, b, c)', result)
+
+    def test_flatten_nested_rank_non_first(self):
+        result = SemiStructuredVespaIndex._optimize_yql_query('rank(a, rank(b, c))')
+        self.assertEqual('rank(a, b, c)', result)
+
+    def test_flatten_double_nested(self):
+        result = SemiStructuredVespaIndex._optimize_yql_query('rank(rank(a, b), rank(c, d))')
+        self.assertEqual('rank(a, b, c, d)', result)
+
+    def test_unwrap_weakand_in_non_first(self):
+        result = SemiStructuredVespaIndex._optimize_yql_query('rank(a, weakAnd(b, c))')
+        self.assertEqual('rank(a, b, c)', result)
+
+    def test_unwrap_target_hits_weakand(self):
+        result = SemiStructuredVespaIndex._optimize_yql_query('rank(a, {targetHits:100}weakAnd(b, c))')
+        self.assertEqual('rank(a, b, c)', result)
+
+    def test_unwrap_or_in_non_first(self):
+        result = SemiStructuredVespaIndex._optimize_yql_query('rank(a, b OR c)')
+        self.assertEqual('rank(a, b, c)', result)
+
+    def test_preserve_weakand_in_first_position(self):
+        result = SemiStructuredVespaIndex._optimize_yql_query('rank(weakAnd(a, b), c)')
+        self.assertEqual('rank(weakAnd(a, b), c)', result)
+
+    def test_complex_real_world(self):
+        result = SemiStructuredVespaIndex._optimize_yql_query(
+            'rank(rank(required AND optional_wa, tensor1), weakAnd(extra))'
+        )
+        self.assertEqual('rank(required AND optional_wa, tensor1, extra)', result)
+
+    def test_empty_trivial(self):
+        self.assertEqual('false', SemiStructuredVespaIndex._optimize_yql_query('false'))
+        self.assertEqual('true', SemiStructuredVespaIndex._optimize_yql_query('true'))
+
+    def test_nested_contains_with_parens(self):
+        result = SemiStructuredVespaIndex._optimize_yql_query(
+            'rank(a, (field1 contains "x" OR field2 contains "x"))'
+        )
+        self.assertEqual('rank(a, field1 contains "x", field2 contains "x")', result)
+
+
+class TestCombineLexicalOrAndTerms(unittest.TestCase):
+    """Tests for SemiStructuredVespaIndex._combine_lexical_or_and_terms."""
+
+    def test_both_present_use_rank_true(self):
+        result = SemiStructuredVespaIndex._combine_lexical_or_and_terms(
+            'weakAnd(a, b)', 'c AND d', True
+        )
+        self.assertEqual('rank(c AND d, weakAnd(a, b))', result)
+
+    def test_both_present_use_rank_false(self):
+        result = SemiStructuredVespaIndex._combine_lexical_or_and_terms(
+            'weakAnd(a, b)', 'c AND d', False
+        )
+        self.assertEqual('(weakAnd(a, b)) AND (c AND d)', result)
+
+    def test_only_or_terms(self):
+        result = SemiStructuredVespaIndex._combine_lexical_or_and_terms(
+            'weakAnd(a, b)', '', True
+        )
+        self.assertEqual('weakAnd(a, b)', result)
+
+    def test_only_and_terms(self):
+        result = SemiStructuredVespaIndex._combine_lexical_or_and_terms(
+            '', 'c AND d', True
+        )
+        self.assertEqual('c AND d', result)
+
+    def test_neither(self):
+        result = SemiStructuredVespaIndex._combine_lexical_or_and_terms('', '', True)
+        self.assertEqual('false', result)
+
+
+class TestSplitTopLevel(unittest.TestCase):
+    """Tests for SemiStructuredVespaIndex._split_top_level."""
+
+    def test_simple_comma_split(self):
+        result = SemiStructuredVespaIndex._split_top_level('a, b, c', ',')
+        self.assertEqual(['a', 'b', 'c'], result)
+
+    def test_nested_parens_preserved(self):
+        result = SemiStructuredVespaIndex._split_top_level('rank(a, b), c', ',')
+        self.assertEqual(['rank(a, b)', 'c'], result)
+
+    def test_or_split(self):
+        result = SemiStructuredVespaIndex._split_top_level('a OR b OR c', ' OR ')
+        self.assertEqual(['a', 'b', 'c'], result)
+
+    def test_nested_or_preserved(self):
+        result = SemiStructuredVespaIndex._split_top_level('(a OR b) AND c', ' OR ')
+        self.assertEqual(['(a OR b) AND c'], result)
+
+
+class TestLexicalRankBehavior(unittest.TestCase):
+    """Tests for the rank() behavior with mixed required/optional terms."""
+
+    _SENTINEL = object()
+
+    def setUp(self):
+        """Set up test fixtures."""
+        marqo_index = SemiStructuredMarqoIndex(
+            name='test_index',
+            schema_name='test_index',
+            model=Model(name='hf/all-MiniLM-L6-v2'),
+            normalize_embeddings=True,
+            distance_metric=DistanceMetric.Angular,
+            vector_numeric_type='float',
+            hnsw_config=HnswConfig(ef_construction=100, m=16),
+            marqo_version='2.16.0',
+            created_at=time.time(),
+            updated_at=time.time(),
+            text_preprocessing=TextPreProcessing(
+                split_length=2, split_overlap=0, split_method=TextSplitMethod.Sentence
+            ),
+            image_preprocessing=ImagePreProcessing(patch_method=None),
+            treat_urls_and_pointers_as_images=False,
+            treat_urls_and_pointers_as_media=False,
+            filter_string_max_length=50,
+            lexical_fields=[
+                Field(name='title', type=FieldType.Text,
+                      features=[FieldFeature.LexicalSearch, FieldFeature.Filter],
+                      lexical_field_name=f'{SemiStructuredVespaSchema.FIELD_INDEX_PREFIX}title',
+                      filter_field_name='title_filter'),
+                Field(name='description', type=FieldType.Text,
+                      features=[FieldFeature.LexicalSearch, FieldFeature.Filter],
+                      lexical_field_name=f'{SemiStructuredVespaSchema.FIELD_INDEX_PREFIX}description',
+                      filter_field_name='description_filter'),
+            ],
+            tensor_fields=[
+                TensorField(name='title',
+                            embeddings_field_name=f'{SemiStructuredVespaSchema.FIELD_EMBEDDING_PREFIX}title',
+                            chunk_field_name=f'{SemiStructuredVespaSchema.FIELD_CHUNKS_PREFIX}title'),
+                TensorField(name='description',
+                            embeddings_field_name=f'{SemiStructuredVespaSchema.FIELD_EMBEDDING_PREFIX}description',
+                            chunk_field_name=f'{SemiStructuredVespaSchema.FIELD_CHUNKS_PREFIX}description'),
+            ],
+        )
+        self.vespa_index = SemiStructuredVespaIndex(marqo_index)
+
+    def _make_hybrid_query(self, lexical_operand=None, rerank_depth_lexical=None,
+                           or_phrases=_SENTINEL, and_phrases=None, relevance_cutoff=None,
+                           score_modifiers=None, searchable_attributes_lexical=None,
+                           retrieval_method=RetrievalMethod.Disjunction,
+                           ranking_method=RankingMethod.RRF):
+        """Helper to create a MarqoHybridQuery."""
+        if or_phrases is self._SENTINEL:
+            or_phrases = ['search']
+        hp = HybridParameters(
+            retrievalMethod=retrieval_method,
+            rankingMethod=ranking_method,
+            lexicalOperand=lexical_operand,
+            rerankDepthLexical=rerank_depth_lexical,
+            searchableAttributesLexical=searchable_attributes_lexical,
+        )
+        return MarqoHybridQuery(
+            index_name='test_index',
+            limit=10,
+            offset=0,
+            vector_query=[0.1] * 4,
+            or_phrases=or_phrases or [],
+            and_phrases=and_phrases or [],
+            hybrid_parameters=hp,
+            approximate=True,
+            relevance_cutoff=relevance_cutoff,
+            score_modifiers=score_modifiers,
+        )
+
+    def test_or_only_query_unchanged(self):
+        """OR-only query produces weakAnd as before."""
+        q = self._make_hybrid_query(or_phrases=['a', 'b'])
+        term = self.vespa_index._get_lexical_search_term(q)
+        self.assertEqual('weakAnd(default contains "a", default contains "b")', term)
+
+    def test_and_only_query_unchanged(self):
+        """AND-only query produces AND as before."""
+        q = self._make_hybrid_query(or_phrases=[], and_phrases=['a', 'b'])
+        term = self.vespa_index._get_lexical_search_term(q)
+        self.assertEqual('default contains "a" AND default contains "b"', term)
+
+    def test_mixed_query_uses_rank(self):
+        """Mixed query uses rank(required, optional) instead of AND."""
+        q = self._make_hybrid_query(or_phrases=['opt1', 'opt2'], and_phrases=['req1'])
+        term = self.vespa_index._get_lexical_search_term(q)
+        self.assertEqual(
+            'rank(default contains "req1", weakAnd(default contains "opt1", default contains "opt2"))',
+            term
+        )
+
+    def test_mixed_query_after_optimize(self):
+        """After _optimize_yql_query, weakAnd in non-first position is unwrapped."""
+        q = self._make_hybrid_query(or_phrases=['opt1', 'opt2'], and_phrases=['req1'])
+        term = self.vespa_index._get_lexical_search_term(q)
+        optimized = SemiStructuredVespaIndex._optimize_yql_query(term)
+        self.assertEqual(
+            'rank(default contains "req1", default contains "opt1", default contains "opt2")',
+            optimized
+        )
+
+    def test_mixed_query_lexical_operand_and(self):
+        """With lexicalOperand='and', mixed terms use old AND behavior."""
+        q = self._make_hybrid_query(
+            lexical_operand='and', or_phrases=['opt1', 'opt2'], and_phrases=['req1']
+        )
+        term = self.vespa_index._get_lexical_search_term(q)
+        self.assertEqual(
+            '(default contains "opt1" AND default contains "opt2") AND (default contains "req1")',
+            term
+        )
+
+    def test_mixed_query_lexical_operand_weakand(self):
+        """With lexicalOperand='weakAnd', mixed terms use rank()."""
+        q = self._make_hybrid_query(
+            lexical_operand='weakAnd', or_phrases=['opt1', 'opt2'], and_phrases=['req1']
+        )
+        term = self.vespa_index._get_lexical_search_term(q)
+        self.assertEqual(
+            'rank(default contains "req1", weakAnd(default contains "opt1", default contains "opt2"))',
+            term
+        )
+
+    def test_mixed_query_with_rerank_depth(self):
+        """Mixed terms + rerankDepthLexical uses targetHits in weakAnd."""
+        q = self._make_hybrid_query(
+            or_phrases=['opt1', 'opt2'], and_phrases=['req1'],
+            rerank_depth_lexical=100
+        )
+        term = self.vespa_index._get_lexical_search_term(q)
+        self.assertEqual(
+            'rank(default contains "req1", {targetHits:100}weakAnd(default contains "opt1", default contains "opt2"))',
+            term
+        )
+
+    def test_mixed_query_full_vespa_query_optimized(self):
+        """Full vespa query with mixed terms produces optimized rank() in lexical YQL."""
+        q = self._make_hybrid_query(or_phrases=['opt1', 'opt2'], and_phrases=['req1'])
+        vespa_query = self.vespa_index.to_vespa_query(q)
+        lexical_yql = vespa_query.get('marqo__yql.lexical', '')
+        expected = (
+            'select * from test_index where '
+            '(rank(default contains "req1", default contains "opt1", default contains "opt2"))'
+        )
+        self.assertEqual(expected, lexical_yql)
+
+    def test_mixed_query_with_custom_score_rerank_flattened(self):
+        """Mixed terms + custom score rerank produces flattened rank()."""
+        q = self._make_hybrid_query(
+            or_phrases=['opt1', 'opt2'], and_phrases=['req1'],
+            searchable_attributes_lexical=['description'],
+            score_modifiers=[
+                ScoreModifier(
+                    field=f"{MARQO_CUSTOM_SCORE_RERANK_INPUT_PREFIX}bm25_field_title",
+                    weight=1.0,
+                    type=ScoreModifierType.Add,
+                ),
+            ],
+        )
+        vespa_query = self.vespa_index.to_vespa_query(q)
+        lexical_yql = vespa_query.get('marqo__yql.lexical', '')
+        # rank(rank(req, weakAnd(opt)), weakAnd(extra)) should be flattened
+        self.assertIn('rank(', lexical_yql)
+        # Verify it's a single level rank()
+        # The inner content after first 'rank(' should not contain another 'rank('
+        inner = lexical_yql[lexical_yql.index('rank('):]
+        self.assertEqual(1, inner.count('rank('))
+
+    def test_facets_query_with_mixed_terms(self):
+        """Facets query with mixed terms uses rank() with OR-joined facet terms."""
+        q = self._make_hybrid_query(or_phrases=['opt1', 'opt2'], and_phrases=['req1'])
+        facets_term = self.vespa_index._get_lexical_search_term(q, is_facets_term=True)
+        optimized = SemiStructuredVespaIndex._optimize_yql_query(facets_term)
+        # Facets use OR for or_terms, then rank() with and_terms
+        self.assertIn('rank(', optimized)
+
+    def test_relevance_cutoff_probe_with_and_override(self):
+        """Probe query with lexicalOperand='and' override uses AND, main query uses rank()."""
+        relevance_cutoff = RelevanceCutoffModel(
+            method=RelevanceCutoffMethod.RelativeMaxScore,
+            parameters=RelativeMaxScoreParameters(relativeScoreFactor=0.5),
+            lexicalOperand='and'
+        )
+        q = self._make_hybrid_query(
+            or_phrases=['opt1', 'opt2'], and_phrases=['req1'],
+            relevance_cutoff=relevance_cutoff
+        )
+        vespa_query = self.vespa_index.to_vespa_query(q)
+
+        # Main lexical query uses rank()
+        lexical_yql = vespa_query.get('marqo__yql.lexical', '')
+        self.assertIn('rank(', lexical_yql)
+
+        # Probe uses AND (from override)
+        probe_yql = vespa_query.get('marqo__yql.lexical.probe', '')
+        self.assertIn(' AND ', probe_yql)
+        self.assertNotIn('rank(', probe_yql)
+
+    def test_relevance_cutoff_probe_without_override(self):
+        """Probe query without override follows hybrid_parameters.lexicalOperand."""
+        relevance_cutoff = RelevanceCutoffModel(
+            method=RelevanceCutoffMethod.RelativeMaxScore,
+            parameters=RelativeMaxScoreParameters(relativeScoreFactor=0.5),
+        )
+        q = self._make_hybrid_query(
+            or_phrases=['opt1', 'opt2'], and_phrases=['req1'],
+            relevance_cutoff=relevance_cutoff
+        )
+        vespa_query = self.vespa_index.to_vespa_query(q)
+
+        # Both main and probe should use rank()
+        lexical_yql = vespa_query.get('marqo__yql.lexical', '')
+        probe_yql = vespa_query.get('marqo__yql.lexical.probe', '')
+        self.assertIn('rank(', lexical_yql)
+        self.assertIn('rank(', probe_yql)
+
+
+class TestHybridParametersLexicalOperandValidation(unittest.TestCase):
+    """Tests for the rerankDepthLexical + lexicalOperand validation."""
+
+    def test_rerank_depth_with_and_raises(self):
+        with self.assertRaises(Exception):
+            HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                rankingMethod=RankingMethod.RRF,
+                lexicalOperand='and',
+                rerankDepthLexical=100,
+            )
+
+    def test_rerank_depth_with_or_raises(self):
+        with self.assertRaises(Exception):
+            HybridParameters(
+                retrievalMethod=RetrievalMethod.Disjunction,
+                rankingMethod=RankingMethod.RRF,
+                lexicalOperand='or',
+                rerankDepthLexical=100,
+            )
+
+    def test_rerank_depth_with_weakand_ok(self):
+        hp = HybridParameters(
+            retrievalMethod=RetrievalMethod.Disjunction,
+            rankingMethod=RankingMethod.RRF,
+            lexicalOperand='weakAnd',
+            rerankDepthLexical=100,
+        )
+        self.assertEqual(100, hp.rerankDepthLexical)
+
+    def test_rerank_depth_with_none_operand_ok(self):
+        hp = HybridParameters(
+            retrievalMethod=RetrievalMethod.Disjunction,
+            rankingMethod=RankingMethod.RRF,
+            rerankDepthLexical=100,
+        )
+        self.assertEqual(100, hp.rerankDepthLexical)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Lexical queries with both quoted (required) and unquoted (optional) terms previously generated `(weakAnd(optional)) AND (required)`, making optional terms effectively required for recall. This changes the query to use Vespa's `rank()` operator: `rank(required_terms, optional_terms)`, so optional terms contribute to BM25 scoring without affecting matching.
- Adds `_optimize_yql_query()` to flatten nested `rank()` calls and unwrap `weakAnd`/`OR` in non-retrieval positions for cleaner YQL.
- Adds validation that `rerankDepthLexical` cannot be combined with `lexicalOperand` set to `and` or `or`.

## Changes
- **`semi_structured_vespa_index.py`**: Added `_combine_lexical_or_and_terms()`, `_optimize_yql_query()` and helpers. Applied optimization across hybrid, facet, relevance cutoff, and pure lexical query paths.
- **`hybrid_parameters.py`**: Added `validate_lexical_operand_with_rerank_depth` validator.
- **Unit tests**: 38 new tests covering `_optimize_yql_query`, `_combine_lexical_or_and_terms`, `_split_top_level`, rank behavior across query types, and parameter validation. Updated 13 existing tests with new expected YQL.
- **Integration tests**: 10 new tests verifying recall, BM25 scoring boost, hybrid search, `lexicalOperand` variants, `rerankDepthLexical`, and `trackTotalHits` with mixed terms against a live Vespa instance.

## Test plan
- [x] All 124 unit tests pass in `test_semi_structured_vespa_index_to_vespa_query.py`
- [x] All 10 integration tests pass in `test_lexical_optional_terms_rank.py`
- [ ] Verify no regressions in broader test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Vespa YQL generation for lexical/hybrid searches (including facets, relevance-cutoff probes, and custom-score rerank paths), which can affect recall/scoring and query correctness across multiple search modes.
> 
> **Overview**
> Fixes lexical query generation when mixing required (quoted) and optional (unquoted) terms by switching from an effective `AND` behavior to Vespa `rank(required_terms, optional_terms)` so optional terms influence BM25 scoring without restricting recall.
> 
> Adds YQL normalization via `_optimize_yql_query()` (flatten nested `rank()` and unwrap `weakAnd`/`OR` in non-retrieval positions) and applies it across lexical-only queries, hybrid subqueries (including custom-score rerank), facet queries, and relevance-cutoff probe YQL.
> 
> Tightens `HybridParameters` validation to reject `rerankDepthLexical` when `lexicalOperand` is `and`/`or`, and updates/expands unit + integration tests to assert the new YQL shapes and end-to-end scoring/recall behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 361efeef72990c007c59d717c946842e5f426d6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->