### PR TITLE
Fix tensorTargetHits not being reduced when overrideLimitPlusOffset is true with both RC and sortBy enabled

### DIFF
--- a/components/common/src/marqo_common/version.py
+++ b/components/common/src/marqo_common/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.26.1"
+__version__ = "2.26.2"
 
 
 def get_version() -> str:

--- a/components/marqo/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
+++ b/components/marqo/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
@@ -815,7 +815,11 @@ public class HybridSearcher extends Searcher {
             // check is required
             newHits = Math.max(relevantCandidates, sortByMinSortCandidates);
             if (currentTensorTargetHits != null) {
-                newTensorTargetHits = Math.max(newHits, currentTensorTargetHits);
+                if (overrideLimitPlusOffset) {
+                    newTensorTargetHits = newHits;
+                } else {
+                    newTensorTargetHits = Math.max(newHits, currentTensorTargetHits);
+                }
             }
         } else if (isRelevanceCutoffEnabled) {
             if (overrideLimitPlusOffset) {

--- a/components/marqo/vespa/src/test/java/ai/marqo/search/SortByTest.java
+++ b/components/marqo/vespa/src/test/java/ai/marqo/search/SortByTest.java
@@ -928,6 +928,55 @@ class SortByTest {
         }
 
         @Test
+        void shouldSetTensorTargetHitsToNewHitsWhenBothFeaturesEnabledAndOverrideEnabled() {
+            HybridSearcher searcher = new HybridSearcher();
+            Query query = new Query("?q=test&hits=10&offset=0");
+            query.properties()
+                    .set(
+                            "marqo__yql.tensor",
+                            "select * from sources * where ({targetHits: 20,"
+                                    + " hnsw.exploreAdditionalHits: 1980}nearestNeighbor(f, q))");
+
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, 30, 25, true, true, false, true, false);
+
+            // newHits = Math.max(relevantCandidates=30, sortByMinSortCandidates=25) = 30
+            // overrideLimitPlusOffset=true: newTensorTargetHits = newHits = 30 (not max with 20)
+            assertThat(result.getHits()).isEqualTo(30);
+            String updatedYql = result.properties().getString("marqo__yql.tensor");
+            assertThat(updatedYql)
+                    .isEqualTo(
+                            "select * from sources * where ({targetHits: 30,"
+                                    + " hnsw.exploreAdditionalHits: 1970}nearestNeighbor(f, q))");
+        }
+
+        @Test
+        void shouldReduceTensorTargetHitsWhenBothFeaturesEnabledAndOverrideEnabled() {
+            HybridSearcher searcher = new HybridSearcher();
+            Query query = new Query("?q=test&hits=10&offset=0");
+            query.properties()
+                    .set(
+                            "marqo__yql.tensor",
+                            "select * from sources * where ({targetHits: 500,"
+                                    + " hnsw.exploreAdditionalHits: 1500}nearestNeighbor(f, q))");
+
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, 30, 25, true, true, false, true, false);
+
+            // newHits = Math.max(relevantCandidates=30, sortByMinSortCandidates=25) = 30
+            // overrideLimitPlusOffset=true: newTensorTargetHits = newHits = 30
+            // (NOT Math.max(30, 500) = 500, which would be the old behaviour)
+            assertThat(result.getHits()).isEqualTo(30);
+            String updatedYql = result.properties().getString("marqo__yql.tensor");
+            assertThat(updatedYql)
+                    .isEqualTo(
+                            "select * from sources * where ({targetHits: 30,"
+                                    + " hnsw.exploreAdditionalHits: 1970}nearestNeighbor(f, q))");
+        }
+
+        @Test
         void shouldThrowExceptionWhenTensorTargetHitsLowerThanLimitOffset() {
             HybridSearcher searcher = new HybridSearcher();
             Query query = new Query("?q=test&hits=10&offset=5");


### PR DESCRIPTION
## Summary

- When both relevance cutoff and sort-by are enabled, `overrideLimitPlusOffset=true` now correctly sets `newTensorTargetHits = newHits` instead of `Math.max(newHits, currentTensorTargetHits)`, preventing a stale larger `targetHits` from persisting in the tensor query
- Adds two unit tests in `SortByTest` covering the new behaviour (expansion and reduction cases)

## Test plan

- [ ] Run `SortByTest` — all tests pass
- [ ] Run full Java test suite (`mvn test`) in `vespa/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)