### PR TITLE
Catch release 2.26

### DIFF
--- a/components/common/src/marqo_common/version.py
+++ b/components/common/src/marqo_common/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.26.0"
+__version__ = "2.26.1"
 
 
 def get_version() -> str:

--- a/components/common/src/marqo_common/version.py
+++ b/components/common/src/marqo_common/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.26.1"
+__version__ = "2.26.2"
 
 
 def get_version() -> str:

--- a/components/marqo/src/marqo/core/search/hybrid_search.py
+++ b/components/marqo/src/marqo/core/search/hybrid_search.py
@@ -567,6 +567,11 @@ class HybridSearch:
             f"{total_results} results from Vespa."
         )
 
+        # Collect post-process candidates metadata (always returned by Vespa custom searcher)
+        if (responses.root.fields and responses.root.fields.marqo_fields
+                and responses.root.fields.marqo_fields.post_process_candidates is not None):
+            gathered_results["_postProcessCandidates"] = responses.root.fields.marqo_fields.post_process_candidates
+
         # Collect metadata for sort by
         if sort_by is not None:
             if responses.root.fields.marqo_fields is None or responses.root.fields.marqo_fields.sort_candidates is None:  # pragma: no cover
@@ -587,6 +592,10 @@ class HybridSearch:
                 )
             gathered_results["_relevantCandidates"] = responses.root.fields.marqo_fields.relevant_candidates
             gathered_results["_probeCandidates"] = responses.root.fields.marqo_fields.probe_candidates
+
+            if relevance_cutoff.override_total_hits_with_post_process_candidates and \
+                responses.root.fields.marqo_fields.post_process_candidates is not None:
+                gathered_results["totalHits"] = responses.root.fields.marqo_fields.post_process_candidates
 
         return gathered_results
 

--- a/components/marqo/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
+++ b/components/marqo/src/marqo/core/semi_structured_vespa_index/semi_structured_vespa_index.py
@@ -823,6 +823,8 @@ class SemiStructuredVespaIndex(StructuredVespaIndex, UnstructuredVespaIndex):
             query["marqo__hybrid.relevanceCutoff.affectFacets"] = marqo_query.relevance_cutoff.affect_facets
             query["marqo__hybrid.relevanceCutoff.overrideSortCandidates"] = marqo_query.relevance_cutoff.override_sort_candidates_with_relevant_candidates
 
+            query["marqo__hybrid.relevanceCutoff.applyInRetrieval"] = marqo_query.relevance_cutoff.apply_in_retrieval
+            query["marqo__hybrid.relevanceCutoff.overrideLimitPlusOffset"] = marqo_query.relevance_cutoff.override_limit_plus_offset
         # Sort by part
         if marqo_query.sort_by:
             query["marqo__hybrid.sortBy.fields"] = [field.dict() for field in marqo_query.sort_by.fields]

--- a/components/marqo/src/marqo/tensor_search/api.py
+++ b/components/marqo/src/marqo/tensor_search/api.py
@@ -447,6 +447,8 @@ def search(index_name: str, search_query_dict: dict, device: str = Depends(api_v
     """
     # TODO this a temporary fix due to the mixed use of pydantic v1 and v2.
     #  SearchQuery can be injected after migrated to v2
+
+    # TODO remove the existence of parameter 'device' in the codebase
     search_query = parse_request_object(SearchQuery, search_query_dict)
 
     query_logger = QueryLogger(search_query)

--- a/components/marqo/src/marqo/tensor_search/models/api_models.py
+++ b/components/marqo/src/marqo/tensor_search/models/api_models.py
@@ -21,7 +21,7 @@ from marqo.tensor_search.models.recency_parameters import RecencyParameters, App
 from marqo.tensor_search.models.score_modifiers_object import ScoreModifierLists
 from marqo.tensor_search.models.search import SearchContext, SearchContextTensor, SearchContextDocuments
 from marqo.tensor_search.models.sort_by_model import SortByModel
-from marqo.tensor_search.models.relevance_cutoff_model import RelevanceCutoffModel
+from marqo.tensor_search.models.relevance_cutoff_model import ApplyInRetrieval, RelevanceCutoffModel
 from marqo.tensor_search.models.collapse_model import CollapseModel
 
 class BaseMarqoModel(BaseModel):
@@ -382,6 +382,29 @@ class SearchQuery(BaseMarqoModel):
         if relevance_cutoff is not None and search_method.upper() != SearchMethod.HYBRID:
             raise ValueError(f"relevanceCutoff can only be provided for 'HYBRID' search, but "
                              f"received search method '{search_method}'")
+        return values
+
+    @root_validator(pre=False)
+    def _validate_apply_in_retrieval_only_works_for_disjunction(cls, values):
+        """Validate that applyInRetrieval requires retrievalMethod=disjunction.
+        Also sets the default value of applyInRetrieval to 'both' when not provided."""
+        relevance_cutoff = values.get('relevance_cutoff')
+        hybrid_parameters = values.get('hybridParameters')
+        if relevance_cutoff is None:
+            return values
+        is_disjunction = (
+                hybrid_parameters is not None
+                and hybrid_parameters.retrievalMethod == RetrievalMethod.Disjunction
+        )
+        if relevance_cutoff.apply_in_retrieval is None:
+            # Resolve the default only for disjunction, where the concept of legs applies.
+            if is_disjunction:
+                relevance_cutoff.apply_in_retrieval = ApplyInRetrieval.Both
+        elif not is_disjunction:
+            raise ValueError(
+                "relevanceCutoff.applyInRetrieval can only be set when "
+                "hybridParameters.retrievalMethod is 'disjunction'"
+            )
         return values
 
     @root_validator(pre=False)

--- a/components/marqo/src/marqo/tensor_search/models/relevance_cutoff_model.py
+++ b/components/marqo/src/marqo/tensor_search/models/relevance_cutoff_model.py
@@ -7,6 +7,12 @@ from marqo.base_model import StrictBaseModel
 from marqo.core.models.hybrid_parameters import LexicalOperand
 
 
+class ApplyInRetrieval(str, Enum):
+    Lexical = 'lexical'
+    Tensor = 'tensor'
+    Both = 'both'
+
+
 class RelevanceCutoffMethod(str, Enum):
     RelativeMaxScore = "relative_max_score"
     GapDetection = "gap_detection"
@@ -47,6 +53,38 @@ class RelevanceCutoffModel(StrictBaseModel):
         False, alias="overrideSortCandidatesWithRelevantCandidates"
     )
     lexical_operand: Optional[LexicalOperand] = Field(None, alias="lexicalOperand")
+    apply_in_retrieval: Optional[ApplyInRetrieval] = Field(None, alias="applyInRetrieval")
+    override_total_hits_with_post_process_candidates: bool = Field(
+        False, alias="overrideTotalHitsWithPostProcessCandidates"
+    )
+    override_limit_plus_offset: bool = Field(
+        False, alias="overrideLimitPlusOffset"
+    )
+
+    @root_validator(pre=False, skip_on_failure=True)
+    def _validate_apply_in_retrieval_lexical_not_supported(cls, values):
+        apply_in_retrieval = values.get('apply_in_retrieval')
+        if apply_in_retrieval == ApplyInRetrieval.Lexical:
+            raise ValueError(
+                "applyInRetrieval='lexical' is not currently supported. "
+                "Only 'tensor' and 'both' are available."
+            )
+        return values
+
+    @root_validator(pre=False, skip_on_failure=True)
+    def _validate_apply_in_retrieval_incompatible_with_override_sort_candidates(cls, values):
+        apply_in_retrieval = values.get('apply_in_retrieval')
+        override_sort = values.get('override_sort_candidates_with_relevant_candidates')
+        if (apply_in_retrieval is not None
+                and apply_in_retrieval != ApplyInRetrieval.Both
+                and override_sort):
+            raise ValueError(
+                "applyInRetrieval cannot be used together with "
+                "overrideSortCandidatesWithRelevantCandidates when targeting a specific "
+                "retrieval leg. relevantCandidates only reflects one leg's cutoff and "
+                "would incorrectly trim the combined sort pool."
+            )
+        return values
 
     @root_validator(pre=False, skip_on_failure=True)
     def _validate_method_and_parameters(cls, values):

--- a/components/marqo/src/marqo/vespa/models/query_result.py
+++ b/components/marqo/src/marqo/vespa/models/query_result.py
@@ -10,6 +10,7 @@ class MarqoFields(BaseModel):
     sort_candidates: Optional[int] = Field(None, alias='sortCandidates')
     relevant_candidates: Optional[int] = Field(None, alias='relevantCandidates')
     probe_candidates: Optional[int] = Field(None, alias='probeCandidates')
+    post_process_candidates: Optional[int] = Field(None, alias='postProcessCandidates')
 
 
 # See https://docs.vespa.ai/en/reference/default-result-format.html

--- a/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_custom_score_reranking_feature.py
+++ b/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_custom_score_reranking_feature.py
@@ -1873,9 +1873,10 @@ class TestCustomScoreRerankingWithOtherFeatures(MarqoTestCase):
         )
         self.assertIn("hits", res)
         self.assertEqual(
-            len(res["hits"]), 3,
-            msg="Relevance cutoff returns at least one hit; count is determined by probe",
+            5, len(res["hits"]),
+            msg="Relevance cutoff returns at least one hit; count is determined by probe"
         )
+        self.assertEqual(5, res["_postProcessCandidates"])
         for hit in res["hits"]:
             self.assertIn(MARQO_DOC_PRE_RERANK_SCORE, hit)
 

--- a/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_search_relevance_cutoff_feature.py
+++ b/components/marqo/tests/integ_tests/tensor_search/integ_tests/test_search_relevance_cutoff_feature.py
@@ -1425,7 +1425,8 @@ class TestRelevanceCutoffAndSortByWithMoreComplicatedDocumentsAndQueries(MarqoTe
         ids = [hit["_id"] for hit in result["hits"]]
         self.assertEqual(2, result["_relevantCandidates"])
         self.assertEqual(2, result["_probeCandidates"])
-        self.assertEqual({'0', '1'}, set(ids))
+        self.assertEqual(3, result["_postProcessCandidates"])
+        self.assertEqual({'0', '1', "4"}, set(ids))
 
     def test_relevance_cut_off_with_incorrect_lexical_searchable_fields(self):
         """It is expected that the relevance cutoff will return 0 results
@@ -1501,7 +1502,7 @@ class TestRelevanceCutoffAndSortByWithMoreComplicatedDocumentsAndQueries(MarqoTe
         ids = [hit["_id"] for hit in result["hits"]]
         self.assertEqual(1, result["_relevantCandidates"])
         self.assertEqual(6, result["_probeCandidates"])
-        self.assertEqual(['4'], ids)
+        self.assertEqual(['4', '17'], ids)
 
     def test_attributes_to_retrieve_works_as_expected(self):
         """Test that attributes_to_retrieve works as expected with relevance cutoff."""
@@ -1561,7 +1562,8 @@ class TestRelevanceCutoffAndSortByWithMoreComplicatedDocumentsAndQueries(MarqoTe
         ids = [hit["_id"] for hit in result["hits"]]
         self.assertEqual(6, result["_relevantCandidates"])
         self.assertEqual(6, result["_probeCandidates"])
-        self.assertEqual(['13', '20', '10', '17', '1', '14'], ids)
+        self.assertEqual(9, result["_postProcessCandidates"])
+        self.assertEqual(['13', '20', '10', '17', '1', '14', '4', '0', '16'], ids)
 
 
 @pytest.mark.skip_for_multinode(
@@ -1686,7 +1688,9 @@ class TestRelevanceCutoffWithFacetsAndTotalHits(MarqoTestCase):
         self.assertEqual(expected_facets, result["facets"])
 
     def test_affect_facets_true_facets_and_total_hits_reflect_relevant_candidates(self):
-        """With sortBy + affectFacets=True, facets and totalHits only count relevant documents."""
+        """With sortBy + affectFacets=True, facets and totalHits only count relevant documents.
+        However, we return more results as _sortCandidates is larger.
+        """
         result = self._search(
             relevance_cutoff={
                 "method": "relative_max_score",
@@ -1702,7 +1706,7 @@ class TestRelevanceCutoffWithFacetsAndTotalHits(MarqoTestCase):
         self.assertEqual(5, result["_relevantCandidates"])
         self.assertEqual(6, result["_sortCandidates"])
 
-        expected_hits = ["doc4", "doc7", "doc2", "doc8", "doc5"]
+        expected_hits = ["doc4", "doc7", "doc2", "doc8", "doc5", "doc6"]
         expected_facets = {
             "color": {"blue": {"count": 3}, "red": {"count": 2}},
         }
@@ -2080,3 +2084,326 @@ class TestRelevanceCutoffWithFacetsAndTotalHits(MarqoTestCase):
         for hit in result["hits"]:
             self.assertNotIn("_lexical_score", hit)
             self.assertIn("_tensor_score", hit)
+
+
+@pytest.mark.skip_for_multinode(
+    "Multi-nodes will return different lexical results so we can not assert on the results.")
+class TestRelevanceCutoffApplyInRetrievalWithLexicalOperand(MarqoTestCase):
+    """Tests that applyInRetrieval='tensor' preserves all lexical AND-matched results
+    even under a strict cutoff, while using OR for the relevance cutoff probe.
+
+    Documents are crafted so that:
+    - 1 doc has ONLY "ocean species" (short text, highest lexical score — the anchor)
+    - 8 docs contain "ocean species" plus additional text (longer, lower lexical scores)
+
+    All 9 docs match the AND lexical query for "ocean" AND "species".
+    With a strict relativeScoreFactor (0.9), only the short anchor doc (and possibly 1-2
+    others) pass the cutoff threshold. With applyInRetrieval='tensor', the lexical leg is
+    unrestricted (uses probeDepth), so all 9 AND-matched docs are returned regardless of
+    the cutoff count.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.index_request = cls.unstructured_marqo_index_request(
+            model=Model(name="hf/all-MiniLM-L6-v2"),
+        )
+        cls.create_indexes([cls.index_request])
+        cls.index_name = cls.index_request.name
+
+        # 1 short doc (highest lexical score — the cutoff anchor)
+        # 8 longer docs (all contain "ocean" and "species" but diluted by extra text)
+        # category: "deep" for 5 docs, "surface" for 4 docs
+        cls.test_docs = [
+            {"_id": "anchor", "text": "ocean species", "price": 50.00, "category": "deep"},
+            {"_id": "long_1", "text": "The deep ocean is teeming with diverse species of fish and coral in tropical waters.", "price": 10.00, "category": "deep"},
+            {"_id": "long_2", "text": "Ocean currents transport species across vast marine distances around the globe.", "price": 20.00, "category": "surface"},
+            {"_id": "long_3", "text": "Protecting ocean habitats is essential for preserving endangered species worldwide.", "price": 30.00, "category": "deep"},
+            {"_id": "long_4", "text": "Scientists discovered new ocean species living near hydrothermal vents on the seabed.", "price": 40.00, "category": "deep"},
+            {"_id": "long_5", "text": "The Arctic ocean supports species adapted to extreme cold temperatures and ice.", "price": 15.00, "category": "surface"},
+            {"_id": "long_6", "text": "Pollution threatens ocean species that depend on clean water for survival and growth.", "price": 25.00, "category": "surface"},
+            {"_id": "long_7", "text": "Mapping the ocean floor revealed species previously unknown to marine biology researchers.", "price": 35.00, "category": "deep"},
+            {"_id": "long_8", "text": "Climate change alters ocean temperatures affecting species migration patterns and habitats.", "price": 45.00, "category": "surface"},
+        ]
+
+        cls.add_documents(
+            config=cls.config,
+            add_docs_params=AddDocsParams(
+                docs=cls.test_docs,
+                index_name=cls.index_name,
+                tensor_fields=['text']
+            )
+        )
+
+    def setUp(self):
+        pass
+
+    @classmethod
+    def _search(cls, query, relevance_cutoff=None, lexical_operand=None,
+                limit=10, offset=0, alpha=0.5, sort_by=None, facets=None,
+                track_total_hits=None):
+        hybrid_parameters = {
+            "retrievalMethod": "disjunction",
+            "rankingMethod": "rrf",
+            "alpha": alpha,
+        }
+        if lexical_operand is not None:
+            hybrid_parameters["lexicalOperand"] = lexical_operand
+        search_query_dict = {
+            "q": query,
+            "searchMethod": SearchMethod.HYBRID,
+            "hybridParameters": hybrid_parameters,
+            "limit": limit,
+            "offset": offset,
+        }
+        if relevance_cutoff is not None:
+            search_query_dict["relevanceCutoff"] = relevance_cutoff
+        if sort_by is not None:
+            search_query_dict["sortBy"] = sort_by
+        if facets is not None:
+            search_query_dict["facets"] = facets
+        if track_total_hits is not None:
+            search_query_dict["trackTotalHits"] = track_total_hits
+        return json.loads(search(
+            index_name=cls.index_name,
+            marqo_config=cls.config,
+            device="cpu",
+            search_query_dict=search_query_dict
+        ).body.decode('utf-8'))
+
+    def test_apply_in_tensor_preserves_all_lexical_and_matches(self):
+        """With applyInRetrieval='tensor', a strict cutoff limits tensor retrieval but
+        leaves lexical unrestricted. All 9 documents matching the AND lexical query
+        ("ocean" AND "species") must appear in results with _lexical_score.
+
+        The anchor doc ("ocean species") scores highest in lexical, so with
+        relativeScoreFactor=0.9 the threshold is very high and most longer docs
+        fall below it — but that only affects the tensor leg.
+        """
+        result = self._search(
+            query='ocean species',
+            lexical_operand="and",
+            relevance_cutoff={
+                "method": "relative_max_score",
+                "probeDepth": 1000,
+                "parameters": {"relativeScoreFactor": 0.9},
+                "lexicalOperand": "or",
+                "applyInRetrieval": "tensor",
+            },
+        )
+
+        expected_ids = {'long_3', 'long_2', 'long_5', 'long_4', 'long_7', 'anchor', 'long_8', 'long_1', 'long_6'}
+        returned_ids = {r['_id'] for r in result['hits']}
+
+        # We make expected ids a set as the lexical score can vary in different runs
+        self.assertEqual(1, result["_relevantCandidates"])
+        self.assertEqual(9, result["_postProcessCandidates"])
+        self.assertEqual(expected_ids, returned_ids)
+
+        self.assertIn(
+            "_lexical_score", result["hits"][0]
+        )
+        self.assertIn("_tensor_score", result["hits"][0])
+
+        # Since _relevantCandidates is 1, all following results should not have tensor score
+        for hit in result['hits'][1:]:
+            self.assertIn("_lexical_score", hit)
+            self.assertNotIn("_tensor_score", hit)
+
+    def test_apply_in_tensor_preserves_update_to_probe_depth_lexical_matches(self):
+        """A test to ensure probeDepth can be used to cap the lexical retrievals even if it is not cut.
+        """
+        result = self._search(
+            query='ocean species',
+            lexical_operand="and",
+            relevance_cutoff={
+                "method": "relative_max_score",
+                "probeDepth": 5,
+                "parameters": {"relativeScoreFactor": 0.9},
+                "lexicalOperand": "or",
+                "applyInRetrieval": "tensor",
+            },
+        )
+
+        # Can't assert on the actual returned hits as the returned documents vary accross different runs
+        self.assertEqual(5, len(result['hits']))
+        # We make expected ids a set as the lexical score can vary in different runs
+        self.assertEqual(1, result["_relevantCandidates"])
+        # We only get 5 results because lexical only return 5 results
+        self.assertEqual(5, result["_postProcessCandidates"])
+
+        self.assertIn(
+            "_lexical_score", result["hits"][0]
+        )
+        self.assertIn("_tensor_score", result["hits"][0])
+
+        # Since _relevantCandidates is 1, all following results should not have tensor score
+        for hit in result['hits'][1:]:
+            self.assertIn("_lexical_score", hit)
+            self.assertNotIn("_tensor_score", hit)
+
+
+    def test_apply_in_tensor_with_sort_by_preserves_all_lexical_and_matches(self):
+        """With applyInRetrieval='tensor' + sortBy, all 9 AND-matched docs should
+        still appear and be sorted by price. The cutoff only limits tensor retrieval,
+        so lexical returns all matches unrestricted. Sort ordering uses all candidates.
+
+        Expected order by price ascending:
+        long_1(10) < long_5(15) < long_2(20) < long_6(25) < long_3(30)
+        < long_7(35) < long_4(40) < long_8(45) < anchor(50)
+        """
+        result = self._search(
+            query='ocean species',
+            lexical_operand="and",
+            relevance_cutoff={
+                "method": "relative_max_score",
+                "probeDepth": 1000,
+                "parameters": {"relativeScoreFactor": 0.9},
+                "lexicalOperand": "or",
+                "applyInRetrieval": "tensor",
+            },
+            sort_by={"fields": [{"fieldName": "price", "order": "asc"}]},
+        )
+
+        returned_ids = [hit["_id"] for hit in result["hits"]]
+        expected_order = [
+            "long_1", "long_5", "long_2", "long_6", "long_3",
+            "long_7", "long_4", "long_8", "anchor"
+        ]
+        # Sorted by price ascending
+        self.assertEqual(expected_order, returned_ids)
+
+        # relevantCandidates still reflects the strict cutoff
+        self.assertEqual(1, result["_relevantCandidates"])
+        self.assertEqual(9, result["_sortCandidates"])
+
+    def test_apply_in_tensor_with_affect_facets_false(self):
+        """With affectFacets=False (default), facets count all matching documents
+        regardless of cutoff. All 9 docs match, so facets should reflect all 9.
+        """
+        result = self._search(
+            query='ocean species',
+            lexical_operand="and",
+            relevance_cutoff={
+                "method": "relative_max_score",
+                "probeDepth": 1000,
+                "parameters": {"relativeScoreFactor": 0.9},
+                "lexicalOperand": "or",
+                "applyInRetrieval": "tensor",
+                "affectFacets": False,
+            },
+            facets={"fields": {"category": {"type": "string"}}},
+            track_total_hits=True,
+        )
+
+        # All 9 docs returned
+        self.assertEqual(9, len(result["hits"]))
+        self.assertEqual(1, result["_relevantCandidates"])
+
+        # Facets count all matching docs (not limited by cutoff)
+        # While this is correct in this example, it is not generally correct in the real case as facets
+        # results might match more result. A reimplementation is needed to solve this problem
+        expected_facets = {
+            "category": {"deep": {"count": 5}, "surface": {"count": 4}},
+        }
+        self.assertEqual(expected_facets, result["facets"])
+        self.assertEqual(9, result["totalHits"])
+
+    def test_apply_in_tensor_with_affect_facets_true(self):
+        """With affectFacets=True, facets and totalHits only count docs that pass
+        the cutoff. Since relevantCandidates=1 (only the anchor passes the strict
+        cutoff), facets reflect just that 1 doc — even though 9 docs are returned.
+
+        This is the expected "conservative" behavior: facets are smaller than the
+        actual result set because cutoff controls only one retrieval leg.
+        """
+        result = self._search(
+            query='ocean species',
+            lexical_operand="and",
+            relevance_cutoff={
+                "method": "relative_max_score",
+                "probeDepth": 1000,
+                "parameters": {"relativeScoreFactor": 0.9},
+                "lexicalOperand": "or",
+                "applyInRetrieval": "tensor",
+                "affectFacets": True,
+            },
+            facets={"fields": {"category": {"type": "string"}}},
+            track_total_hits=True,
+        )
+
+        # All 9 docs still returned (lexical leg unrestricted)
+        self.assertEqual(9, len(result["hits"]))
+        self.assertEqual(1, result["_relevantCandidates"])
+
+        # Facets is only applied to _relevantCandidates
+        expected_facets = {
+            "category": {"deep": {"count": 1}},
+        }
+        self.assertEqual(expected_facets, result["facets"])
+
+    def test_apply_in_both_blocks_irrelevant_documents_in_both_retrievals(self):
+        """With applyInRetrieval='both', the relevance cutoff is applied to both retrievals
+        """
+        result = self._search(
+            query='ocean species',
+            lexical_operand="and",
+            relevance_cutoff={
+                "method": "relative_max_score",
+                "probeDepth": 1000,
+                "parameters": {"relativeScoreFactor": 0.9},
+                "lexicalOperand": "or",
+                "applyInRetrieval": "both",
+            },
+        )
+
+        expected_ids = {'anchor',}
+        returned_ids = {r['_id'] for r in result['hits']}
+
+        # We make expected ids a set as the lexical score can vary in different runs
+        self.assertEqual(1, result["_relevantCandidates"])
+        self.assertEqual(1, result["_postProcessCandidates"])
+        self.assertEqual(expected_ids, returned_ids)
+
+        self.assertIn(
+            "_lexical_score", result["hits"][0]
+        )
+        self.assertIn("_tensor_score", result["hits"][0])
+
+    def test_apply_in_tensor_with_sort_by_preserves_all_lexical_and_matches_pagination(self):
+        """Test the pagination behaviour of 'applyInRetrieval'
+        """
+
+        limit = 2
+
+        expected_order = [
+            "long_1", "long_5", "long_2", "long_6", "long_3",
+            "long_7", "long_4", "long_8", "anchor"
+        ]
+
+        for offset in range(0, len(expected_order), limit):
+            result = self._search(
+                query='ocean species',
+                lexical_operand="and",
+                relevance_cutoff={
+                    "method": "relative_max_score",
+                    "probeDepth": 1000,
+                    "parameters": {"relativeScoreFactor": 0.9},
+                    "lexicalOperand": "or",
+                    "applyInRetrieval": "tensor",
+                    "overrideTotalHitsWithPostProcessCandidates": True,
+                },
+                sort_by={"fields": [{"fieldName": "price", "order": "asc"}]},
+                limit = limit,
+                offset=offset,
+            )
+            returned_ids = [r["_id"] for r in result['hits']]
+            expected_returned_ids = expected_order[offset: offset + limit]
+
+            self.assertEqual(expected_returned_ids, returned_ids)
+            # relevantCandidates still reflects the strict cutoff
+            self.assertEqual(1, result["_relevantCandidates"])
+            self.assertEqual(9, result["_postProcessCandidates"])
+            self.assertEqual(9, result["_sortCandidates"])
+            self.assertEqual(9, result["totalHits"])

--- a/components/marqo/tests/integ_tests/tensor_search/test_api_query_logging_integration.py
+++ b/components/marqo/tests/integ_tests/tensor_search/test_api_query_logging_integration.py
@@ -290,7 +290,8 @@ class TestAPIQueryLoggingIntegration(MarqoTestCase):
             "relevanceCutoff": {
                 "method": "mean_std_dev",
                 "probeDepth": 500,
-                "parameters": {"stdDevFactor": 0.5}
+                "parameters": {"stdDevFactor": 0.5},
+                "applyInRetrieval": "both"
             },
             "interpolationMethod": "nlerp"
         }

--- a/components/marqo/tests/unit_tests/marqo/api/models/test_relevance_cutoff_model.py
+++ b/components/marqo/tests/unit_tests/marqo/api/models/test_relevance_cutoff_model.py
@@ -2,12 +2,13 @@ from unittest import TestCase
 
 from pydantic.v1 import ValidationError
 
-from marqo.core.models.hybrid_parameters import LexicalOperand
+from marqo.core.models.hybrid_parameters import HybridParameters, RetrievalMethod
 from marqo.tensor_search.models.relevance_cutoff_model import (
     RelevanceCutoffMethod,
     RelativeMaxScoreParameters,
     MeanStdParameters,
-    RelevanceCutoffModel
+    RelevanceCutoffModel,
+    ApplyInRetrieval
 )
 from marqo.tensor_search.models.api_models import SearchQuery
 from marqo.tensor_search.enums import SearchMethod
@@ -105,14 +106,14 @@ class TestRelevanceCutoffModel(TestCase):
             method=RelevanceCutoffMethod.RelativeMaxScore,
             parameters=RelativeMaxScoreParameters(relativeScoreFactor=0.75)
         )
-        
+
         with self.assertRaises(ValidationError) as cm:
             SearchQuery(
                 q="test query",
                 searchMethod=SearchMethod.TENSOR,
                 relevanceCutoff=relevance_cutoff
             )
-        
+
         self.assertIn("relevanceCutoff can only be provided for 'HYBRID' search", str(cm.exception))
         self.assertIn("TENSOR", str(cm.exception))
 
@@ -121,36 +122,165 @@ class TestRelevanceCutoffModel(TestCase):
         relevance_cutoff = RelevanceCutoffModel(
             method=RelevanceCutoffMethod.GapDetection
         )
-        
+
         with self.assertRaises(ValidationError) as cm:
             SearchQuery(
                 q="test query",
                 searchMethod=SearchMethod.LEXICAL,
                 relevanceCutoff=relevance_cutoff
             )
-        
+
         self.assertIn("relevanceCutoff can only be provided for 'HYBRID' search", str(cm.exception))
         self.assertIn("LEXICAL", str(cm.exception))
 
-    def test_lexical_operand_valid_values(self):
-        """Test that valid lexicalOperand values are accepted."""
+    def test_lexical_operand(self):
+        params = RelativeMaxScoreParameters(relativeScoreFactor=0.5)
+        m = RelevanceCutoffModel(method=RelevanceCutoffMethod.RelativeMaxScore, parameters=params)
+        self.assertIsNone(m.lexical_operand)
+
         for operand in ['or', 'and', 'weakAnd']:
             with self.subTest(operand=operand):
                 m = RelevanceCutoffModel(
-                    method=RelevanceCutoffMethod.GapDetection,
+                    method=RelevanceCutoffMethod.RelativeMaxScore,
+                    parameters=params,
                     lexicalOperand=operand
                 )
                 self.assertEqual(m.lexical_operand, operand)
 
-    def test_lexical_operand_none_by_default(self):
-        """Test that lexicalOperand defaults to None."""
-        m = RelevanceCutoffModel(method=RelevanceCutoffMethod.GapDetection)
-        self.assertIsNone(m.lexical_operand)
-
-    def test_lexical_operand_invalid_value(self):
-        """Test that invalid lexicalOperand values are rejected."""
         with self.assertRaises(ValidationError):
             RelevanceCutoffModel(
-                method=RelevanceCutoffMethod.GapDetection,
+                method=RelevanceCutoffMethod.RelativeMaxScore,
+                parameters=params,
                 lexicalOperand="invalid"
             )
+
+    def test_apply_in_retrieval_model_validation(self):
+        params = RelativeMaxScoreParameters(relativeScoreFactor=0.5)
+
+        # Default is None
+        m = RelevanceCutoffModel(method=RelevanceCutoffMethod.RelativeMaxScore, parameters=params)
+        self.assertIsNone(m.apply_in_retrieval)
+
+        # Valid values
+        for value in ['tensor', 'both']:
+            with self.subTest(value=value):
+                m = RelevanceCutoffModel(
+                    method=RelevanceCutoffMethod.RelativeMaxScore,
+                    parameters=params,
+                    applyInRetrieval=value
+                )
+                self.assertEqual(m.apply_in_retrieval, value)
+
+        # Invalid value
+        with self.assertRaises(ValidationError):
+            RelevanceCutoffModel(
+                method=RelevanceCutoffMethod.RelativeMaxScore,
+                parameters=params,
+                applyInRetrieval="invalid"
+            )
+
+        # 'lexical' is recognised as a valid enum value but explicitly blocked
+        with self.assertRaises(ValidationError) as cm:
+            RelevanceCutoffModel(
+                method=RelevanceCutoffMethod.RelativeMaxScore,
+                parameters=params,
+                applyInRetrieval='lexical'
+            )
+        self.assertIn("not currently supported", str(cm.exception))
+
+    def test_apply_in_retrieval_requires_disjunction_when_set(self):
+        """applyInRetrieval is rejected when explicitly set and retrievalMethod is not disjunction."""
+        params = RelativeMaxScoreParameters(relativeScoreFactor=0.5)
+        for value, retrieval_method, ranking_method in [
+            ('tensor', RetrievalMethod.Tensor, 'tensor'),
+            ('tensor', RetrievalMethod.Lexical, 'lexical'),
+            ('both', RetrievalMethod.Tensor, 'tensor'),
+            ('both', RetrievalMethod.Lexical, 'lexical'),
+        ]:
+            with self.subTest(applyInRetrieval=value, retrievalMethod=retrieval_method):
+                with self.assertRaises(ValidationError) as cm:
+                    SearchQuery(
+                        q="test query",
+                        searchMethod=SearchMethod.HYBRID,
+                        relevanceCutoff=RelevanceCutoffModel(
+                            method=RelevanceCutoffMethod.RelativeMaxScore,
+                            parameters=params,
+                            applyInRetrieval=value
+                        ),
+                        hybridParameters=HybridParameters(
+                            retrievalMethod=retrieval_method,
+                            rankingMethod=ranking_method
+                        )
+                    )
+                self.assertIn("applyInRetrieval", str(cm.exception))
+
+    def test_apply_in_retrieval_accepted_with_disjunction(self):
+        """applyInRetrieval is accepted when retrievalMethod is disjunction."""
+        params = RelativeMaxScoreParameters(relativeScoreFactor=0.5)
+        for value in ['tensor', 'both']:
+            with self.subTest(applyInRetrieval=value):
+                sq = SearchQuery(
+                    q="test query",
+                    searchMethod=SearchMethod.HYBRID,
+                    relevanceCutoff=RelevanceCutoffModel(
+                        method=RelevanceCutoffMethod.RelativeMaxScore,
+                        parameters=params,
+                        applyInRetrieval=value
+                    ),
+                    hybridParameters=HybridParameters(
+                        retrievalMethod='disjunction',
+                        rankingMethod='rrf'
+                    )
+                )
+                self.assertEqual(value, sq.relevance_cutoff.apply_in_retrieval)
+
+    def test_apply_in_retrieval_default_none_accepted_with_any_retrieval_method(self):
+        """When applyInRetrieval is not set, relevanceCutoff works with any retrievalMethod.
+        For disjunction it resolves to 'both'; for others it stays None (not applicable)."""
+        cases = [
+            (RetrievalMethod.Disjunction, 'rrf', ApplyInRetrieval.Both),
+            (RetrievalMethod.Tensor, 'tensor', None),
+            (RetrievalMethod.Lexical, 'lexical', None),
+        ]
+        for retrieval_method, ranking_method, expected in cases:
+            with self.subTest(retrievalMethod=retrieval_method):
+                relevance_cutoff = RelevanceCutoffModel(
+                    method=RelevanceCutoffMethod.RelativeMaxScore,
+                    parameters=RelativeMaxScoreParameters(relativeScoreFactor=0.5)
+                )
+                sq = SearchQuery(
+                    q="test query",
+                    searchMethod=SearchMethod.HYBRID,
+                    relevanceCutoff=relevance_cutoff,
+                    hybridParameters=HybridParameters(
+                        retrievalMethod=retrieval_method,
+                        rankingMethod=ranking_method
+                    )
+                )
+                self.assertEqual(expected, sq.relevance_cutoff.apply_in_retrieval)
+
+    def test_apply_in_retrieval_incompatible_with_override_sort_candidates(self):
+        """applyInRetrieval='tensor' cannot be combined with overrideSortCandidatesWithRelevantCandidates."""
+        with self.assertRaises(ValidationError) as cm:
+            RelevanceCutoffModel(
+                method=RelevanceCutoffMethod.RelativeMaxScore,
+                parameters=RelativeMaxScoreParameters(relativeScoreFactor=0.5),
+                applyInRetrieval='tensor',
+                overrideSortCandidatesWithRelevantCandidates=True
+            )
+        self.assertIn("applyInRetrieval", str(cm.exception))
+
+    def test_apply_in_retrieval_both_compatible_with_override_sort_candidates(self):
+        """applyInRetrieval='both' (explicit or default None) is compatible with overrideSortCandidatesWithRelevantCandidates."""
+        params = RelativeMaxScoreParameters(relativeScoreFactor=0.5)
+        for apply_in_retrieval in ['both', None]:
+            with self.subTest(applyInRetrieval=apply_in_retrieval):
+                kwargs = dict(
+                    method=RelevanceCutoffMethod.RelativeMaxScore,
+                    parameters=params,
+                    overrideSortCandidatesWithRelevantCandidates=True
+                )
+                if apply_in_retrieval is not None:
+                    kwargs['applyInRetrieval'] = apply_in_retrieval
+                m = RelevanceCutoffModel(**kwargs)
+                self.assertTrue(m.override_sort_candidates_with_relevant_candidates)

--- a/components/marqo/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_semi_structured_vespa_index_to_vespa_query.py
+++ b/components/marqo/tests/unit_tests/marqo/core/semi_structured_vespa_index/test_semi_structured_vespa_index_to_vespa_query.py
@@ -26,7 +26,8 @@ from marqo.tensor_search.models.relevance_cutoff_model import (
     RelevanceCutoffModel,
     RelevanceCutoffMethod,
     RelativeMaxScoreParameters,
-    MeanStdParameters
+    MeanStdParameters,
+    ApplyInRetrieval
 )
 from marqo.tensor_search.models.sort_by_model import SortByModel
 from marqo.version import get_version
@@ -921,6 +922,26 @@ class TestSemiStructuredIndexToVespaQueryRelevanceCutoff(TestCase):
         self.assertAlmostEqual(10.0,
                                r["marqo__hybrid.relevanceCutoff.parameters.stdDevFactor"])
         self.assertEqual(1000, r["marqo__hybrid.relevanceCutoff.probeDepth"])  # default
+
+    def test_apply_in_retrieval_set_in_vespa_query(self):
+        """applyInRetrieval should be passed to Vespa query when set."""
+        for value in [ApplyInRetrieval.Tensor, ApplyInRetrieval.Both]:
+            with self.subTest(value=value):
+                self.hybrid_query.relevance_cutoff = RelevanceCutoffModel(
+                    method=RelevanceCutoffMethod.GapDetection,
+                    applyInRetrieval=value
+                )
+                r = self.index.to_vespa_query(self.hybrid_query)
+                self.assertEqual(value, r["marqo__hybrid.relevanceCutoff.applyInRetrieval"])
+
+    def test_apply_in_retrieval_both_by_default_in_vespa_query(self):
+        """SearchQuery resolves applyInRetrieval=None to 'both'; the Vespa query receives 'both'."""
+        self.hybrid_query.relevance_cutoff = RelevanceCutoffModel(
+            method=RelevanceCutoffMethod.GapDetection,
+            applyInRetrieval=ApplyInRetrieval.Both  # as resolved by SearchQuery validator
+        )
+        r = self.index.to_vespa_query(self.hybrid_query)
+        self.assertEqual(ApplyInRetrieval.Both, r["marqo__hybrid.relevanceCutoff.applyInRetrieval"])
 
 
 class TestSemiStructuredVespaIndexToVespaQueryCollapseFields(MarqoTestCase):

--- a/components/marqo/tests/unit_tests/marqo/tensor_search/test_api_query_logging.py
+++ b/components/marqo/tests/unit_tests/marqo/tensor_search/test_api_query_logging.py
@@ -617,7 +617,6 @@ class TestAPIQueryLogging(MarqoTestCase):
 
         with patch('marqo.core.search.query_logger.marqo_query_logger') as mock_marqo_query_logger:
             mock_time.perf_counter.side_effect = [0.0, 1.0]
-
             search_query = {
                 "searchMethod": "HYBRID",
                 "limit": 10,
@@ -691,7 +690,7 @@ class TestAPIQueryLogging(MarqoTestCase):
                 "relevanceCutoff": {
                     "method": "mean_std_dev",
                     "probe_depth": 500,
-                    "parameters": {"std_dev_factor": 0.5}
+                    "parameters": {"std_dev_factor": 0.5},
                 },
                 "interpolationMethod": InterpolationMethod.NLERP
             }
@@ -774,7 +773,8 @@ class TestAPIQueryLogging(MarqoTestCase):
                 "relevanceCutoff": {
                     "method": "mean_std_dev",
                     "probeDepth": 500,
-                    "parameters": {"stdDevFactor": 0.5}
+                    "parameters": {"stdDevFactor": 0.5},
+                    "applyInRetrieval": "both"
                 },
                 "interpolationMethod": "nlerp"
             }

--- a/components/marqo/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
+++ b/components/marqo/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
@@ -815,7 +815,11 @@ public class HybridSearcher extends Searcher {
             // check is required
             newHits = Math.max(relevantCandidates, sortByMinSortCandidates);
             if (currentTensorTargetHits != null) {
-                newTensorTargetHits = Math.max(newHits, currentTensorTargetHits);
+                if (overrideLimitPlusOffset) {
+                    newTensorTargetHits = newHits;
+                } else {
+                    newTensorTargetHits = Math.max(newHits, currentTensorTargetHits);
+                }
             }
         } else if (isRelevanceCutoffEnabled) {
             if (overrideLimitPlusOffset) {

--- a/components/marqo/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
+++ b/components/marqo/vespa/src/main/java/ai/marqo/search/HybridSearcher.java
@@ -97,7 +97,10 @@ public class HybridSearcher extends Searcher {
     @VisibleForTesting
     @JsonInclude(Include.NON_NULL)
     record MarqoMetadataFields(
-            Integer sortCandidates, Integer probeCandidates, Integer relevantCandidates)
+            Integer sortCandidates,
+            Integer probeCandidates,
+            Integer relevantCandidates,
+            Integer postProcessCandidates)
             implements JsonProducer {
 
         @Override
@@ -218,6 +221,17 @@ public class HybridSearcher extends Searcher {
         }
     }
 
+    enum ApplyInRetrieval {
+        LEXICAL,
+        TENSOR,
+        BOTH;
+
+        public static ApplyInRetrieval fromString(String value) {
+            if (value == null) return null;
+            return ApplyInRetrieval.valueOf(value.toUpperCase(Locale.ROOT));
+        }
+    }
+
     // Compile the regex pattern once and store it as a static final variable
     private static final Pattern DOC_ID_PATTERN =
             Pattern.compile("^index\\:[^\\s\\/]+\\/\\d+\\/(.+)$");
@@ -261,6 +275,13 @@ public class HybridSearcher extends Searcher {
         Boolean relevanceCutoffOverrideSortCandidates =
                 query.properties()
                         .getBoolean("marqo__hybrid.relevanceCutoff.overrideSortCandidates", false);
+        String applyInRetrievalString =
+                query.properties()
+                        .getString("marqo__hybrid.relevanceCutoff.applyInRetrieval", null);
+        ApplyInRetrieval applyInRetrieval = ApplyInRetrieval.fromString(applyInRetrievalString);
+        Boolean relevanceCutoffOverrideLimitPlusOffset =
+                query.properties()
+                        .getBoolean("marqo__hybrid.relevanceCutoff.overrideLimitPlusOffset", false);
 
         // Sort by Parameters
         String sortByFields = query.properties().getString("marqo__hybrid.sortBy.fields", null);
@@ -314,31 +335,55 @@ public class HybridSearcher extends Searcher {
         boolean isRelevanceCutoffMethodEnabled = relevanceCutoffMethod != null;
         boolean isSortByEnabled = sortByFields != null;
 
-        query =
-                updateQueryHitsOffsetsAndTargetHits(
-                        query,
-                        relevantCandidates,
-                        sortByMinSortCandidates,
-                        isRelevanceCutoffMethodEnabled,
-                        isSortByEnabled,
-                        relevanceCutoffAffectFacets,
-                        verbose);
+        // When applyInRetrieval targets a specific leg, we clone the query and let
+        // the clone receive all cutoff modifications (hits, offset, tensor YQL, facets).
+        // The original query stays untouched so its hits won't truncate the final Result.
+        // Target sub-query is created from the clone; non-target from the original.
+        boolean isSelectiveCutoff =
+                isRelevanceCutoffMethodEnabled
+                        && applyInRetrieval != null
+                        && applyInRetrieval != ApplyInRetrieval.BOTH;
 
-        List<Future<Result>> futureFacets =
-                getFacetsFutureList(query, execution, verbose, collapse);
+        // Clone the query for relevance cutoff & sortBy manipulation
+        Query cutoffSortByQuery = query.clone();
+        if (isRelevanceCutoffMethodEnabled || isSortByEnabled) {
+            cutoffSortByQuery =
+                    updateQueryHitsOffsetsAndTargetHits(
+                            cutoffSortByQuery,
+                            relevantCandidates,
+                            sortByMinSortCandidates,
+                            isRelevanceCutoffMethodEnabled,
+                            isSortByEnabled,
+                            relevanceCutoffAffectFacets,
+                            relevanceCutoffOverrideLimitPlusOffset,
+                            verbose);
+        }
+
+        // Facet results will always be generated from a cutoff query to produce a conservative
+        // count until we fix the
+        // implementation in the future
+        List<Future<Result>> futureFacets;
+        if (isRelevanceCutoffMethodEnabled || isSortByEnabled) {
+            futureFacets = getFacetsFutureList(cutoffSortByQuery, execution, verbose, collapse);
+        } else {
+            futureFacets = getFacetsFutureList(query, execution, verbose, collapse);
+        }
 
         HitGroup hitsForPostProcessing;
         if (retrievalMethod.equals("disjunction")) {
             Result resultLexical, resultTensor;
-            Query queryLexical =
-                    createSubQuery(
+            Query queryLexical, queryTensor;
+
+            Query[] subQueries =
+                    buildDisjunctionSubQueries(
+                            isSelectiveCutoff,
+                            applyInRetrieval,
                             query,
-                            MARQO_SEARCH_METHOD_LEXICAL,
-                            MARQO_SEARCH_METHOD_LEXICAL,
+                            cutoffSortByQuery,
+                            relevanceCutoffProbeDepth,
                             verbose);
-            Query queryTensor =
-                    createSubQuery(
-                            query, MARQO_SEARCH_METHOD_TENSOR, MARQO_SEARCH_METHOD_TENSOR, verbose);
+            queryLexical = subQueries[0];
+            queryTensor = subQueries[1];
 
             // Execute both lexical and tensor queries asynchronously.
             AsyncExecution asyncExecutionLexical = new AsyncExecution(execution);
@@ -388,7 +433,7 @@ public class HybridSearcher extends Searcher {
         } else if (STANDARD_SEARCH_TYPES.contains(retrievalMethod)) {
             if (STANDARD_SEARCH_TYPES.contains(rankingMethod)) {
                 Query combinedQuery =
-                        createSubQuery(query, retrievalMethod, rankingMethod, verbose);
+                        createSubQuery(cutoffSortByQuery, retrievalMethod, rankingMethod, verbose);
                 Result result = execution.search(combinedQuery);
                 hitsForPostProcessing = result.hits();
                 logIfVerbose("Unprocessed results: ", verbose);
@@ -415,6 +460,7 @@ public class HybridSearcher extends Searcher {
         // Determine post-processing mode based on query parameters
         HitGroup processedHits;
         Integer sortCandidates = null;
+        int postProcessCandidates;
         if (sortByFields != null) {
             // When overrideSortCandidates is set, trim hits to only relevant candidates
             // before sorting, so that non-relevant documents are excluded from sort results.
@@ -441,6 +487,7 @@ public class HybridSearcher extends Searcher {
                     postProcessBySort(
                             hitsForPostProcessing, sortByFields, sortBySortDepth, limit, offset);
             sortCandidates = hitsForPostProcessing.size();
+            postProcessCandidates = hitsForPostProcessing.size();
         } else {
             // If sortBy is not set, we use the default post-processing
             processedHits =
@@ -451,6 +498,7 @@ public class HybridSearcher extends Searcher {
                             limit,
                             offset,
                             verbose);
+            postProcessCandidates = hitsForPostProcessing.size();
         }
 
         if (!futureFacets.isEmpty()) {
@@ -461,7 +509,8 @@ public class HybridSearcher extends Searcher {
         // enabled)
         processedHits = extractRecencyScore(processedHits, query, verbose);
         MarqoMetadataFields marqoMetadataFields =
-                new MarqoMetadataFields(sortCandidates, probeCandidates, relevantCandidates);
+                new MarqoMetadataFields(
+                        sortCandidates, probeCandidates, relevantCandidates, postProcessCandidates);
 
         processedHits.setField(MARQO_METADATA_FIELDS, marqoMetadataFields);
         return new Result(query, processedHits);
@@ -537,6 +586,67 @@ public class HybridSearcher extends Searcher {
             }
         }
         return futureFacets;
+    }
+
+    /**
+     * Builds lexical and tensor sub-queries for disjunction retrieval.
+     *
+     * @return a two-element array {@code [queryLexical, queryTensor]}
+     */
+    Query[] buildDisjunctionSubQueries(
+            boolean isSelectiveCutoff,
+            ApplyInRetrieval applyInRetrieval,
+            Query originalQuery,
+            Query cutoffQuery,
+            Integer probeDepth,
+            boolean verbose) {
+        Query queryLexical, queryTensor;
+        if (isSelectiveCutoff) {
+            // Target from cutoffQuery (reduced), non-target from original (unreduced)
+            if (applyInRetrieval == ApplyInRetrieval.LEXICAL) {
+                throw new RuntimeException(
+                        "applyInRetrieval='lexical' is not supported. This value is blocked at"
+                                + " the API layer and should never reach this point.");
+            } else {
+                // Must be tensor cutoff
+                queryLexical =
+                        createSubQuery(
+                                originalQuery,
+                                MARQO_SEARCH_METHOD_LEXICAL,
+                                MARQO_SEARCH_METHOD_LEXICAL,
+                                verbose);
+                queryLexical.setOffset(0);
+                // The lexical leg is not subject to relevance cut-off here; expand its hits to
+                // probeDepth so the post-process/sort pool remains stable regardless of
+                // limit/offset.
+                queryLexical.setHits(probeDepth);
+                queryTensor =
+                        createSubQuery(
+                                cutoffQuery,
+                                MARQO_SEARCH_METHOD_TENSOR,
+                                MARQO_SEARCH_METHOD_TENSOR,
+                                verbose);
+            }
+        } else {
+            // Two cases both handled correctly by using cutoffQuery:
+            // 1. No relevance cutoff: cutoffQuery is a plain clone of the original, so both legs
+            //    are unmodified.
+            // 2. applyInRetrieval=both: cutoffQuery is reduced and both legs should use the same
+            //    reduced query.
+            queryLexical =
+                    createSubQuery(
+                            cutoffQuery,
+                            MARQO_SEARCH_METHOD_LEXICAL,
+                            MARQO_SEARCH_METHOD_LEXICAL,
+                            verbose);
+            queryTensor =
+                    createSubQuery(
+                            cutoffQuery,
+                            MARQO_SEARCH_METHOD_TENSOR,
+                            MARQO_SEARCH_METHOD_TENSOR,
+                            verbose);
+        }
+        return new Query[] {queryLexical, queryTensor};
     }
 
     /**
@@ -636,6 +746,7 @@ public class HybridSearcher extends Searcher {
                 isRelevanceCutoffEnabled,
                 isSortByEnabled,
                 false,
+                false,
                 false);
     }
 
@@ -649,6 +760,7 @@ public class HybridSearcher extends Searcher {
      * @param isRelevanceCutoffEnabled whether relevance cutoff is enabled.
      * @param isSortByEnabled whether sorting is enabled.
      * @param affectFacets whether to also adjust facets YQL (targetHits and max(N) grouping).
+     * @param overrideLimitPlusOffset when true, use max(relevantCandidates, limit+offset) instead of min.
      * @param verbose whether to log detailed information.
      * @return The updated query with new hits, offsets, and targetHits.
      */
@@ -659,6 +771,7 @@ public class HybridSearcher extends Searcher {
             boolean isRelevanceCutoffEnabled,
             boolean isSortByEnabled,
             boolean affectFacets,
+            boolean overrideLimitPlusOffset,
             boolean verbose) {
 
         // Validate input parameters
@@ -705,12 +818,19 @@ public class HybridSearcher extends Searcher {
                 newTensorTargetHits = Math.max(newHits, currentTensorTargetHits);
             }
         } else if (isRelevanceCutoffEnabled) {
-            // Only relevance cut-off enabled:
-            // - If relevantCandidates < limit+offset: reduce to relevantCandidates
-            // - If relevantCandidates >= limit+offset: keep existing behavior (limit+offset)
-            newHits = Math.min(relevantCandidates, (currentLimit + currentOffset));
-            if (currentTensorTargetHits != null) {
-                newTensorTargetHits = Math.min(newHits, currentTensorTargetHits);
+            if (overrideLimitPlusOffset) {
+                // Override mode: expand retrieval to max(relevantCandidates, limit+offset)
+                // so all relevant documents are fetched even if they exceed limit+offset.
+                newHits = relevantCandidates;
+                if (currentTensorTargetHits != null) {
+                    newTensorTargetHits = relevantCandidates;
+                }
+            } else {
+                // Default: reduce to min(relevantCandidates, limit+offset)
+                newHits = Math.min(relevantCandidates, (currentLimit + currentOffset));
+                if (currentTensorTargetHits != null) {
+                    newTensorTargetHits = Math.min(newHits, currentTensorTargetHits);
+                }
             }
         } else {
             // Only sortByMinSortCandidates provided

--- a/components/marqo/vespa/src/test/java/ai/marqo/search/RelevanceCutoffTest.java
+++ b/components/marqo/vespa/src/test/java/ai/marqo/search/RelevanceCutoffTest.java
@@ -699,4 +699,109 @@ class RelevanceCutoffTest {
                     .hasValue(0.0);
         }
     }
+
+    @Nested
+    class BuildDisjunctionSubQueriesTest {
+
+        private Query buildMinimalQuery(int hits, int offset) {
+            Query q = new Query("search/?query=test&hits=" + hits + "&offset=" + offset);
+            q.properties().set("marqo__yql.lexical", "select * from sources * where userQuery()");
+            q.properties().set("marqo__yql.tensor", "select * from sources * where userQuery()");
+            q.properties().set("marqo__ranking.lexical.lexical", "lexical_profile");
+            q.properties().set("marqo__ranking.tensor.tensor", "tensor_profile");
+            q.getRanking()
+                    .getFeatures()
+                    .put("query(marqo__fields_to_rank_lexical)", Tensor.from("tensor(p{}):{}"));
+            q.getRanking()
+                    .getFeatures()
+                    .put("query(marqo__fields_to_rank_tensor)", Tensor.from("tensor(p{}):{}"));
+            return q;
+        }
+
+        @Test
+        void whenSelectiveCutoffTensor_lexicalUsesProbeDepthFromOriginalQuery() {
+            Query originalQuery = buildMinimalQuery(10, 0);
+            Query cutoffQuery = buildMinimalQuery(50, 0); // simulates post-cutoff expansion
+            int probeDepth = 200;
+
+            Query[] result =
+                    hybridSearcher.buildDisjunctionSubQueries(
+                            true,
+                            HybridSearcher.ApplyInRetrieval.TENSOR,
+                            originalQuery,
+                            cutoffQuery,
+                            probeDepth,
+                            false);
+
+            // Lexical leg: unreduced original, then expanded to probeDepth
+            assertThat(result[0].getHits()).isEqualTo(probeDepth);
+            assertThat(result[0].getOffset()).isEqualTo(0);
+            // Tensor leg: comes from cutoffQuery (reduced)
+            assertThat(result[1].getHits()).isEqualTo(cutoffQuery.getHits());
+        }
+
+        @Test
+        void whenNotSelectiveCutoff_bothLegsUseCutoffQuery() {
+            Query originalQuery = buildMinimalQuery(10, 0);
+            Query cutoffQuery = buildMinimalQuery(50, 0);
+
+            Query[] result =
+                    hybridSearcher.buildDisjunctionSubQueries(
+                            false, null, originalQuery, cutoffQuery, 200, false);
+
+            assertThat(result[0].getHits()).isEqualTo(cutoffQuery.getHits());
+            assertThat(result[1].getHits()).isEqualTo(cutoffQuery.getHits());
+        }
+
+        @Test
+        void whenSelectiveCutoffLexical_throwsRuntimeException() {
+            Query originalQuery = buildMinimalQuery(10, 0);
+            Query cutoffQuery = buildMinimalQuery(50, 0);
+
+            assertThrows(
+                    RuntimeException.class,
+                    () ->
+                            hybridSearcher.buildDisjunctionSubQueries(
+                                    true,
+                                    HybridSearcher.ApplyInRetrieval.LEXICAL,
+                                    originalQuery,
+                                    cutoffQuery,
+                                    200,
+                                    false));
+        }
+    }
+
+    @Nested
+    class ApplyInRetrievalFromStringTest {
+
+        @Test
+        void shouldParseLexical() {
+            assertThat(HybridSearcher.ApplyInRetrieval.fromString("lexical"))
+                    .isEqualTo(HybridSearcher.ApplyInRetrieval.LEXICAL);
+        }
+
+        @Test
+        void shouldParseTensor() {
+            assertThat(HybridSearcher.ApplyInRetrieval.fromString("tensor"))
+                    .isEqualTo(HybridSearcher.ApplyInRetrieval.TENSOR);
+        }
+
+        @Test
+        void shouldParseBoth() {
+            assertThat(HybridSearcher.ApplyInRetrieval.fromString("both"))
+                    .isEqualTo(HybridSearcher.ApplyInRetrieval.BOTH);
+        }
+
+        @Test
+        void shouldReturnNullForNullInput() {
+            assertThat(HybridSearcher.ApplyInRetrieval.fromString(null)).isNull();
+        }
+
+        @Test
+        void shouldThrowForUnknownValue() {
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> HybridSearcher.ApplyInRetrieval.fromString("invalid"));
+        }
+    }
 }

--- a/components/marqo/vespa/src/test/java/ai/marqo/search/SortByTest.java
+++ b/components/marqo/vespa/src/test/java/ai/marqo/search/SortByTest.java
@@ -1158,25 +1158,155 @@ class SortByTest {
     }
 
     @Nested
+    class OverrideLimitPlusOffsetTest {
+
+        @Test
+        void shouldExpandHitsToRelevantCandidatesWhenOverrideEnabled() {
+            HybridSearcher searcher = new HybridSearcher();
+            Query query = new Query("?q=test&hits=10&offset=0");
+
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, 200, null, true, false, false, true, false);
+
+            // overrideLimitPlusOffset=true: newHits = relevantCandidates = 200
+            // (expands beyond limit+offset=10)
+            assertThat(result.getHits()).isEqualTo(200);
+            assertThat(result.getOffset()).isEqualTo(0);
+        }
+
+        @Test
+        void shouldReduceHitsBelowLimitWhenRelevantCandidatesSmall() {
+            HybridSearcher searcher = new HybridSearcher();
+            Query query = new Query("?q=test&hits=10&offset=0");
+
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, 3, null, true, false, false, true, false);
+
+            // overrideLimitPlusOffset=true: newHits = relevantCandidates = 3
+            // (can also reduce below limit+offset)
+            assertThat(result.getHits()).isEqualTo(3);
+        }
+
+        @Test
+        void shouldExpandHitsWithNonZeroOffset() {
+            HybridSearcher searcher = new HybridSearcher();
+            Query query = new Query("?q=test&hits=10&offset=5");
+
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, 20, null, true, false, false, true, false);
+
+            // overrideLimitPlusOffset=true: newHits = relevantCandidates = 20
+            // (limit+offset=15, but we ignore that and use 20)
+            assertThat(result.getHits()).isEqualTo(20);
+            assertThat(result.getOffset()).isEqualTo(0);
+        }
+
+        @Test
+        void shouldSetTensorTargetHitsToMaxWhenOverrideEnabled() {
+            HybridSearcher searcher = new HybridSearcher();
+            Query query = new Query("?q=test&hits=10&offset=0");
+            query.properties()
+                    .set(
+                            "marqo__yql.tensor",
+                            "select * from sources * where ({targetHits: 50,"
+                                    + " hnsw.exploreAdditionalHits: 1950}nearestNeighbor(f, q))");
+
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, 200, null, true, false, false, true, false);
+
+            // overrideLimitPlusOffset=true: newHits=200, newTensorTargetHits=relevantCandidates=200
+            assertThat(result.getHits()).isEqualTo(200);
+            String updatedYql = result.properties().getString("marqo__yql.tensor");
+            assertThat(updatedYql)
+                    .isEqualTo(
+                            "select * from sources * where ({targetHits: 200,"
+                                    + " hnsw.exploreAdditionalHits: 1800}nearestNeighbor(f, q))");
+        }
+
+        @Test
+        void shouldSetTensorTargetHitsToRelevantCandidatesEvenWhenExistingIsLarger() {
+            HybridSearcher searcher = new HybridSearcher();
+            Query query = new Query("?q=test&hits=10&offset=0");
+            query.properties()
+                    .set(
+                            "marqo__yql.tensor",
+                            "select * from sources * where ({targetHits: 500,"
+                                    + " hnsw.exploreAdditionalHits: 1500}nearestNeighbor(f, q))");
+
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, 100, null, true, false, false, true, false);
+
+            // overrideLimitPlusOffset=true: newHits=100, newTensorTargetHits=relevantCandidates=100
+            // (always set to relevantCandidates, even when existing tensor targetHits is larger)
+            assertThat(result.getHits()).isEqualTo(100);
+            String updatedYql = result.properties().getString("marqo__yql.tensor");
+            assertThat(updatedYql)
+                    .isEqualTo(
+                            "select * from sources * where ({targetHits: 100,"
+                                    + " hnsw.exploreAdditionalHits: 1900}nearestNeighbor(f, q))");
+        }
+
+        @Test
+        void shouldUseLimitPlusOffsetMinBehaviourWhenOverrideDisabled() {
+            HybridSearcher searcher = new HybridSearcher();
+            Query query = new Query("?q=test&hits=10&offset=0");
+
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, 200, null, true, false, false, false, false);
+
+            // overrideLimitPlusOffset=false: newHits = min(200, 10) = 10
+            assertThat(result.getHits()).isEqualTo(10);
+        }
+
+        @Test
+        void shouldSetTensorTargetHitsToMinWhenOverrideDisabled() {
+            HybridSearcher searcher = new HybridSearcher();
+            Query query = new Query("?q=test&hits=10&offset=0");
+            query.properties()
+                    .set(
+                            "marqo__yql.tensor",
+                            "select * from sources * where ({targetHits: 50,"
+                                    + " hnsw.exploreAdditionalHits: 1950}nearestNeighbor(f, q))");
+
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, 200, null, true, false, false, false, false);
+
+            // overrideLimitPlusOffset=false: newHits=min(200,10)=10,
+            // newTensorTargetHits=min(10,50)=10
+            assertThat(result.getHits()).isEqualTo(10);
+            String updatedYql = result.properties().getString("marqo__yql.tensor");
+            assertThat(updatedYql)
+                    .isEqualTo(
+                            "select * from sources * where ({targetHits: 10,"
+                                    + " hnsw.exploreAdditionalHits: 1990}nearestNeighbor(f, q))");
+        }
+    }
+
+    @Nested
     class MarqoMetadataFieldsTest {
 
         @Test
         void shouldExcludeNullValuesFromJsonSerialization() {
-            // Create metadata with some null values
+            // Realistic case: sortBy disabled (sortCandidates=null) and cutoff disabled
+            // (probeCandidates=null, relevantCandidates=null); postProcessCandidates is always set
             HybridSearcher.MarqoMetadataFields metadataWithNulls =
-                    new HybridSearcher.MarqoMetadataFields(5, null, 10);
+                    new HybridSearcher.MarqoMetadataFields(null, null, null, 10);
 
-            // Test JSON serialization excludes nulls
             StringBuilder json = new StringBuilder();
             metadataWithNulls.writeJson(json);
             String jsonString = json.toString();
 
-            // Should contain non-null values
-            assertThat(jsonString).contains("\"sortCandidates\":5");
-            assertThat(jsonString).contains("\"relevantCandidates\":10");
-
-            // Should not contain null field
+            assertThat(jsonString).contains("\"postProcessCandidates\":10");
+            assertThat(jsonString).doesNotContain("sortCandidates");
             assertThat(jsonString).doesNotContain("probeCandidates");
+            assertThat(jsonString).doesNotContain("relevantCandidates");
             assertThat(jsonString).doesNotContain("null");
         }
 
@@ -1184,7 +1314,7 @@ class SortByTest {
         void shouldIncludeAllNonNullValuesInJsonSerialization() {
             // Create metadata with all non-null values
             HybridSearcher.MarqoMetadataFields metadataComplete =
-                    new HybridSearcher.MarqoMetadataFields(8, 12, 6);
+                    new HybridSearcher.MarqoMetadataFields(8, 12, 6, 20);
 
             // Test JSON serialization includes all values
             StringBuilder json = new StringBuilder();
@@ -1195,25 +1325,10 @@ class SortByTest {
             assertThat(jsonString).contains("\"sortCandidates\":8");
             assertThat(jsonString).contains("\"probeCandidates\":12");
             assertThat(jsonString).contains("\"relevantCandidates\":6");
+            assertThat(jsonString).contains("\"postProcessCandidates\":20");
 
             // Should not contain null
             assertThat(jsonString).doesNotContain("null");
-        }
-
-        @Test
-        void shouldHandleAllNullValuesInJsonSerialization() {
-            // Create metadata with all null values
-            HybridSearcher.MarqoMetadataFields metadataAllNulls =
-                    new HybridSearcher.MarqoMetadataFields(null, null, null);
-
-            // Test JSON serialization with all nulls
-            StringBuilder json = new StringBuilder();
-            metadataAllNulls.writeJson(json);
-            String jsonString = json.toString();
-
-            // Should be empty JSON object (no fields included due to
-            // @JsonInclude(Include.NON_NULL))
-            assertThat(jsonString).isEqualTo("{}");
         }
     }
 }

--- a/components/marqo/vespa/src/test/java/ai/marqo/search/SortByTest.java
+++ b/components/marqo/vespa/src/test/java/ai/marqo/search/SortByTest.java
@@ -928,6 +928,55 @@ class SortByTest {
         }
 
         @Test
+        void shouldSetTensorTargetHitsToNewHitsWhenBothFeaturesEnabledAndOverrideEnabled() {
+            HybridSearcher searcher = new HybridSearcher();
+            Query query = new Query("?q=test&hits=10&offset=0");
+            query.properties()
+                    .set(
+                            "marqo__yql.tensor",
+                            "select * from sources * where ({targetHits: 20,"
+                                    + " hnsw.exploreAdditionalHits: 1980}nearestNeighbor(f, q))");
+
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, 30, 25, true, true, false, true, false);
+
+            // newHits = Math.max(relevantCandidates=30, sortByMinSortCandidates=25) = 30
+            // overrideLimitPlusOffset=true: newTensorTargetHits = newHits = 30 (not max with 20)
+            assertThat(result.getHits()).isEqualTo(30);
+            String updatedYql = result.properties().getString("marqo__yql.tensor");
+            assertThat(updatedYql)
+                    .isEqualTo(
+                            "select * from sources * where ({targetHits: 30,"
+                                    + " hnsw.exploreAdditionalHits: 1970}nearestNeighbor(f, q))");
+        }
+
+        @Test
+        void shouldReduceTensorTargetHitsWhenBothFeaturesEnabledAndOverrideEnabled() {
+            HybridSearcher searcher = new HybridSearcher();
+            Query query = new Query("?q=test&hits=10&offset=0");
+            query.properties()
+                    .set(
+                            "marqo__yql.tensor",
+                            "select * from sources * where ({targetHits: 500,"
+                                    + " hnsw.exploreAdditionalHits: 1500}nearestNeighbor(f, q))");
+
+            Query result =
+                    searcher.updateQueryHitsOffsetsAndTargetHits(
+                            query, 30, 25, true, true, false, true, false);
+
+            // newHits = Math.max(relevantCandidates=30, sortByMinSortCandidates=25) = 30
+            // overrideLimitPlusOffset=true: newTensorTargetHits = newHits = 30
+            // (NOT Math.max(30, 500) = 500, which would be the old behaviour)
+            assertThat(result.getHits()).isEqualTo(30);
+            String updatedYql = result.properties().getString("marqo__yql.tensor");
+            assertThat(updatedYql)
+                    .isEqualTo(
+                            "select * from sources * where ({targetHits: 30,"
+                                    + " hnsw.exploreAdditionalHits: 1970}nearestNeighbor(f, q))");
+        }
+
+        @Test
         void shouldThrowExceptionWhenTensorTargetHitsLowerThanLimitOffset() {
             HybridSearcher searcher = new HybridSearcher();
             Query query = new Query("?q=test&hits=10&offset=5");

--- a/components/marqo/vespa/src/test/java/ai/marqo/search/TestFacetsWithRelevanceCutoffAndSortBy.java
+++ b/components/marqo/vespa/src/test/java/ai/marqo/search/TestFacetsWithRelevanceCutoffAndSortBy.java
@@ -167,7 +167,7 @@ class TestFacetsWithRelevanceCutoffAndSortBy {
 
             Query result =
                     hybridSearcher.updateQueryHitsOffsetsAndTargetHits(
-                            query, 5, null, true, false, true, false);
+                            query, 5, null, true, false, true, false, false);
 
             assertThat(result.getHits()).isEqualTo(2);
 
@@ -224,7 +224,7 @@ class TestFacetsWithRelevanceCutoffAndSortBy {
 
             Query result =
                     hybridSearcher.updateQueryHitsOffsetsAndTargetHits(
-                            query, 5, null, true, false, false, false);
+                            query, 5, null, true, false, false, false, false);
 
             assertThat(result.properties().getString("marqo__yql.facets"))
                     .isEqualTo(combinedFacetsYql);
@@ -273,7 +273,7 @@ class TestFacetsWithRelevanceCutoffAndSortBy {
             // targetHits unchanged (already 10), facets max(10) unchanged (10 >= 10)
             Query result =
                     hybridSearcher.updateQueryHitsOffsetsAndTargetHits(
-                            query, 5, 10, true, true, true, false);
+                            query, 5, 10, true, true, true, false, false);
 
             assertThat(result.getHits()).isEqualTo(10);
 
@@ -341,7 +341,7 @@ class TestFacetsWithRelevanceCutoffAndSortBy {
             // newHits=20 exceeds original targetHits:10
             Query result =
                     hybridSearcher.updateQueryHitsOffsetsAndTargetHits(
-                            query, 20, 15, true, true, true, false);
+                            query, 20, 15, true, true, true, false, false);
 
             assertThat(result.getHits()).isEqualTo(20);
 


### PR DESCRIPTION
## Summary

Merges `releases/2.26` into `mainline` via an intermediary branch, catching up all changes from the 2.26 release branch.

Key changes included:
- Add `applyInRetrieval` parameter for selective relevance cutoff (#1412)

## Test plan
- [ ] Existing CI tests pass
- [ ] Verify no regressions in hybrid search with `lexicalOperand`
- [ ] Verify relevance cutoff behaviour on facets and `trackTotalHits` queries