### PR TITLE
fix: correct typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@
 
 ## Marqo 
 
-Marqo is the an AI-native ecommerce search platform built for online brands in fashion, beauty, electronics, and home goods. Powered by best-in-class semantic search and personalization technology, the platform leverages clickstream, purchase, and event data to understand shopper intent and deliver fast, relevant, and personalized search results and product recommendations. Marqo enables commerce teams to improve search relevance, increase conversion and average order value, and reduce manual merchandising effort through automated ranking and optimization.
+Marqo is an AI-native ecommerce search platform built for online brands in fashion, beauty, electronics, and home goods. Powered by best-in-class semantic search and personalization technology, the platform leverages clickstream, purchase, and event data to understand shopper intent and deliver fast, relevant, and personalized search results and product recommendations. Marqo enables commerce teams to improve search relevance, increase conversion and average order value, and reduce manual merchandising effort through automated ranking and optimization.
 
-NOTICE: Marqo's Open Source project is deprecated and will no longer recieve updates. To explore Marqo's product search and discovery platform, go to <a href="https://marqo.ai/">marqo.ai</a>
+NOTICE: Marqo's Open Source project is deprecated and will no longer receive updates. To explore Marqo's product search and discovery platform, go to <a href="https://marqo.ai/">marqo.ai</a>


### PR DESCRIPTION
This PR corrects two typos in the README.md file:

1. **"recieve" → "receive"** — common spelling error in the deprecation notice
2. **"is the an" → "is an"** — extra article "the" in the description

These are straightforward documentation fixes that improve readability.