### PR TITLE
Add TwelveLabs Marengo as a multimodal embedding model

### DIFF
--- a/components/common/src/marqo_common/model_registry.py
+++ b/components/common/src/marqo_common/model_registry.py
@@ -445,6 +445,17 @@ _MODEL_REGISTRY: dict[str, dict] = {
         "type": "random",
         "notes": "",
     },
+    # TwelveLabs Marengo is an API-served multimodal model (text, image and
+    # video share one 512-dim space). It is served by the TwelveLabs API rather
+    # than Triton, so it carries no ONNX encoder properties. Requires the
+    # TWELVELABS_API_KEY environment variable. Free key: https://twelvelabs.io
+    "Marqo/marengo-3.0": {
+        "name": "Marqo/marengo-3.0",
+        "dimensions": 512,
+        "type": "twelvelabs",
+        "apiModelName": "marengo3.0",
+        "notes": "TwelveLabs Marengo multimodal (text/image/video) embeddings.",
+    },
 }
 
 

--- a/components/inference_orchestrator/README.md
+++ b/components/inference_orchestrator/README.md
@@ -4,12 +4,23 @@ A FastAPI-based service that handles ML model inference for the Marqo tensor sea
 
 ## Features
 
-- Model loading and management (HuggingFace, OpenCLIP)
+- Model loading and management (HuggingFace, OpenCLIP, TwelveLabs Marengo)
 - Media download and preprocessing (images, text, multimodal)
 - Inference caching for improved performance (LRU/LFU)
 - Triton inference server integration
 - OpenTelemetry instrumentation for observability
 - MessagePack serialization for efficient communication
+
+### TwelveLabs Marengo (multimodal, API-served)
+
+[TwelveLabs](https://twelvelabs.io) Marengo is an opt-in, API-served multimodal
+embedding model. Text, image and video all map into the same 512-dimensional
+space, making it a cross-modal alternative to CLIP (e.g. text-to-video search).
+Unlike the OpenCLIP/HuggingFace models, Marengo is not served by Triton, so it
+needs no ONNX artifacts. Select it with the registered model name
+`Marqo/marengo-3.0` (model `type: "twelvelabs"`), and set the
+`TWELVELABS_API_KEY` environment variable. A free key with a generous free tier
+is available at https://twelvelabs.io .
 
 ## Requirements
 
@@ -105,6 +116,7 @@ inference_orchestrator/
 │   │   │   │   ├── hugging_face/         # HuggingFace models
 │   │   │   │   ├── open_clip/            # OpenCLIP models
 │   │   │   │   ├── random/               # Random models (testing)
+│   │   │   │   ├── twelvelabs/            # TwelveLabs Marengo (API-served)
 │   │   │   │   ├── abstract_embedding_model.py
 │   │   │   │   ├── abstract_preprocessor.py
 │   │   │   │   ├── base_model_properties.py
@@ -117,7 +129,8 @@ inference_orchestrator/
 │   │   │   │   ├── abstract_inference_pipeline.py
 │   │   │   │   ├── hugging_face_model_inference_pipeline.py
 │   │   │   │   ├── open_clip_model_inference_pipeline.py
-│   │   │   │   └── random_model_inference_pipeline.py
+│   │   │   │   ├── random_model_inference_pipeline.py
+│   │   │   │   └── twelvelabs_model_inference_pipeline.py
 │   │   │   ├── model_manager/            # Model lifecycle management
 │   │   │   │   ├── model_management_client.py
 │   │   │   │   └── model_manager.py

--- a/components/inference_orchestrator/pyproject.toml
+++ b/components/inference_orchestrator/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "torchvision==0.23.0",
     "transformers>=4.56.2",
     "tritonclient[grpc,http]==2.60.0",
+    "twelvelabs>=1.2.8",
     "uvicorn>=0.37.0",
     "validators>=0.35.0",
     "marqo-common",

--- a/components/inference_orchestrator/src/inference_orchestrator/services/triton_inference/embedding_models/__init__.py
+++ b/components/inference_orchestrator/src/inference_orchestrator/services/triton_inference/embedding_models/__init__.py
@@ -6,6 +6,8 @@ from .open_clip.open_clip_model import OpenCLIPModel
 from .open_clip.open_clip_model_properties import OpenCLIPModelProperties
 from .random.random_model import RandomModel
 from .random.random_model_properties import RandomModelProperties
+from .twelvelabs.twelvelabs_model import TwelveLabsModel
+from .twelvelabs.twelvelabs_model_properties import TwelveLabsModelProperties
 
 __all__ = [
     "AbstractEmbeddingModel",
@@ -16,4 +18,6 @@ __all__ = [
     "OpenCLIPModelProperties",
     "RandomModel",
     "RandomModelProperties",
+    "TwelveLabsModel",
+    "TwelveLabsModelProperties",
 ]

--- a/components/inference_orchestrator/src/inference_orchestrator/services/triton_inference/embedding_models/base_model_properties.py
+++ b/components/inference_orchestrator/src/inference_orchestrator/services/triton_inference/embedding_models/base_model_properties.py
@@ -36,7 +36,7 @@ class BaseModelProperties(AppImmutableBaseModel):
     name: str
     triton_model_name: Optional[str] = Field(default=None, alias="tritonModelName")
     dimensions: int = Field(..., ge=1)
-    type: Literal["open_clip", "hf", "random"]
+    type: Literal["open_clip", "hf", "random", "twelvelabs"]
 
     @property
     def effective_name(self) -> str:

--- a/components/inference_orchestrator/src/inference_orchestrator/services/triton_inference/embedding_models/model_properties_parser.py
+++ b/components/inference_orchestrator/src/inference_orchestrator/services/triton_inference/embedding_models/model_properties_parser.py
@@ -3,6 +3,7 @@ from inference_orchestrator.services.triton_inference.embedding_models import (
     HuggingFaceModel,
     OpenCLIPModel,
     RandomModel,
+    TwelveLabsModel,
 )
 
 
@@ -17,5 +18,7 @@ def get_model_loader(model_properties: dict):
         return OpenCLIPModel
     elif model_type == "random":
         return RandomModel
+    elif model_type == "twelvelabs":
+        return TwelveLabsModel
     else:
         raise InvalidModelPropertiesError(f"Unsupported model type: {model_type}")

--- a/components/inference_orchestrator/src/inference_orchestrator/services/triton_inference/embedding_models/twelvelabs/twelvelabs_model.py
+++ b/components/inference_orchestrator/src/inference_orchestrator/services/triton_inference/embedding_models/twelvelabs/twelvelabs_model.py
@@ -1,0 +1,131 @@
+import os
+from typing import List
+
+import numpy as np
+from numpy import ndarray
+
+from inference_orchestrator.core.logging import get_logger
+from inference_orchestrator.schemas.api import Modality
+from inference_orchestrator.services.triton_inference.embedding_models.abstract_embedding_model import (
+    AbstractEmbeddingModel,
+)
+from inference_orchestrator.services.triton_inference.embedding_models.abstract_preprocessor import (
+    AbstractPreprocessor,
+)
+from inference_orchestrator.services.triton_inference.embedding_models.twelvelabs.twelvelabs_model_properties import (
+    TwelveLabsModelProperties,
+)
+
+logger = get_logger(__name__)
+
+TWELVELABS_API_KEY_ENV_VAR = "TWELVELABS_API_KEY"
+
+
+class TwelveLabsModelPreprocessor(AbstractPreprocessor):
+    def preprocess(self, inputs: list, modality: Modality) -> list:
+        """The TwelveLabs API ingests text and media URLs directly, so no
+        client side preprocessing is required."""
+        return inputs
+
+
+class TwelveLabsModel(AbstractEmbeddingModel):
+    """TwelveLabs Marengo multimodal embedding model.
+
+    Embeddings are produced by the TwelveLabs API rather than by a locally
+    served Triton model. Text and image content are embedded synchronously via
+    ``embed.create``; video content is embedded via the asynchronous
+    ``embed.tasks`` endpoint. All modalities share the same 512 dimensional
+    embedding space, which makes Marengo a drop-in multimodal alternative to
+    CLIP for cross-modal (e.g. text-to-video) retrieval.
+
+    The API key is read from the ``TWELVELABS_API_KEY`` environment variable.
+    Get a free key with a generous free tier at https://twelvelabs.io .
+    """
+
+    def __init__(self, model_properties: dict, *args, **kwargs) -> None:
+        # Drop unused triton/model-management clients; Marengo is API served.
+        super().__init__(
+            model_properties, model_management_client=None, triton_client=None
+        )
+        self._model_properties = TwelveLabsModelProperties(**self.model_properties)
+        self.preprocessor = TwelveLabsModelPreprocessor()
+        self._client = None
+
+    def _load_necessary_components(self):
+        try:
+            from twelvelabs import TwelveLabs
+        except ImportError as e:  # pragma: no cover - exercised only without dep
+            raise ImportError(
+                "The `twelvelabs` package is required to use TwelveLabs Marengo "
+                "models. Install it with `pip install twelvelabs`."
+            ) from e
+
+        api_key = os.environ.get(TWELVELABS_API_KEY_ENV_VAR)
+        if not api_key:
+            raise ValueError(
+                f"The `{TWELVELABS_API_KEY_ENV_VAR}` environment variable must be "
+                "set to use TwelveLabs Marengo models. Get a free key at "
+                "https://twelvelabs.io ."
+            )
+        self._client = TwelveLabs(api_key=api_key)
+
+    def _check_loaded_components(self):
+        if self._client is None:
+            raise RuntimeError("TwelveLabs client failed to initialise.")
+
+    def encode(
+        self, inputs: List[str], modality: Modality, normalize: bool = True
+    ) -> List[ndarray]:
+        """Embed each input string and return one (dimensions,) vector per input."""
+        embeddings: List[ndarray] = []
+        for content in inputs:
+            vector = self._embed_one(content, modality)
+            embedding = np.asarray(vector, dtype=np.float32)
+            if normalize:
+                norm = np.linalg.norm(embedding)
+                if norm > 0:
+                    embedding = embedding / norm
+            embeddings.append(embedding)
+        return embeddings
+
+    def _embed_one(self, content: str, modality: Modality) -> List[float]:
+        api_model_name = self._model_properties.api_model_name
+        if modality == Modality.TEXT:
+            response = self._client.embed.create(
+                model_name=api_model_name, text=content
+            )
+            return self._first_segment(response.text_embedding, content)
+        elif modality == Modality.IMAGE:
+            response = self._client.embed.create(
+                model_name=api_model_name, image_url=content
+            )
+            return self._first_segment(response.image_embedding, content)
+        elif modality == Modality.VIDEO:
+            task = self._client.embed.tasks.create(
+                model_name=api_model_name, video_url=content
+            )
+            task = self._client.embed.tasks.wait_for_done(task_id=task.id)
+            return self._first_segment(getattr(task, "video_embedding", None), content)
+        else:
+            raise ValueError(f"Unsupported modality for TwelveLabs model: {modality}")
+
+    @staticmethod
+    def _first_segment(embedding_result, content: str) -> List[float]:
+        segments = (
+            getattr(embedding_result, "segments", None) if embedding_result else None
+        )
+        if not segments:
+            raise RuntimeError(
+                f"TwelveLabs returned no embedding segments for content: {content!r}"
+            )
+        return segments[0].float_
+
+    def get_preprocessor(self) -> TwelveLabsModelPreprocessor:
+        return self.preprocessor
+
+    def load(self):
+        self._load_necessary_components()
+        self._check_loaded_components()
+
+    def unload(self, remove_files: bool = False):
+        self._client = None

--- a/components/inference_orchestrator/src/inference_orchestrator/services/triton_inference/embedding_models/twelvelabs/twelvelabs_model_properties.py
+++ b/components/inference_orchestrator/src/inference_orchestrator/services/triton_inference/embedding_models/twelvelabs/twelvelabs_model_properties.py
@@ -1,0 +1,27 @@
+from typing import Literal, Optional
+
+from pydantic import Field
+
+from inference_orchestrator.services.triton_inference.embedding_models.base_model_properties import (
+    BaseModelProperties,
+)
+
+
+class TwelveLabsModelProperties(BaseModelProperties):
+    """
+    Properties for a TwelveLabs Marengo embedding model.
+
+    Marengo is served by the TwelveLabs API rather than by Triton, so no
+    ``tritonImageEncoderProperties``/``tritonTextEncoderProperties`` are
+    required. The model produces 512 dimensional multimodal embeddings for
+    text, image and video content.
+
+    Attributes:
+        type: The type of the model. It must be ``twelvelabs``.
+        api_model_name: The model name passed to the TwelveLabs API
+            (e.g. ``marengo3.0``). Defaults to ``marengo3.0``.
+    """
+
+    type: Literal["twelvelabs"]
+    api_model_name: str = Field(default="marengo3.0", alias="apiModelName")
+    note: Optional[str] = None

--- a/components/inference_orchestrator/src/inference_orchestrator/services/triton_inference/inference_pipelines/twelvelabs_model_inference_pipeline.py
+++ b/components/inference_orchestrator/src/inference_orchestrator/services/triton_inference/inference_pipelines/twelvelabs_model_inference_pipeline.py
@@ -1,0 +1,106 @@
+from typing import List, Tuple, Union
+
+from numpy import ndarray
+
+from inference_orchestrator.schemas.api import (
+    InferenceErrorModel,
+    InferenceRequest,
+    InferenceResult,
+    Modality,
+)
+from inference_orchestrator.services.triton_inference.content_preprocessing import (
+    split_prefix_preprocess_text,
+)
+from inference_orchestrator.services.triton_inference.embedding_models.twelvelabs.twelvelabs_model import (
+    TwelveLabsModel,
+)
+from inference_orchestrator.services.triton_inference.inference_pipelines.abstract_inference_pipeline import (
+    AbstractInferencePipeline,
+)
+
+TwelveLabsModelPreprocessedContent = Union[InferenceErrorModel, List[Tuple[str, str]]]
+
+
+class TwelveLabsModelInferencePipeline(AbstractInferencePipeline):
+    """Inference pipeline for TwelveLabs Marengo models.
+
+    Text content is chunked/prefixed like other text pipelines; image and video
+    content (URLs) are passed straight through to the TwelveLabs API. Requests
+    are sent one item at a time because Marengo's embed endpoint embeds a single
+    piece of content per call.
+    """
+
+    # Marengo's embed endpoint handles one content item per call; this only
+    # bounds how many we slice at a time, not a server side batch size.
+    MAX_BATCH_SIZE = 8
+
+    def __init__(self, model: TwelveLabsModel, inference_request: InferenceRequest):
+        super().__init__(model=model, inference_request=inference_request)
+
+    def run_pipeline(self) -> InferenceResult:
+        preprocessed_content_list: List[TwelveLabsModelPreprocessedContent] = (
+            self._content_preprocessing()
+        )
+        embeddings: List[ndarray] = self._encode_processed_content(
+            preprocessed_content_list
+        )
+        return self.format_results(preprocessed_content_list, embeddings)
+
+    def _content_preprocessing(self) -> List[TwelveLabsModelPreprocessedContent]:
+        if self.inference_request.modality == Modality.TEXT:
+            return split_prefix_preprocess_text(
+                self.inference_request.contents,
+                self.model.get_preprocessor(),
+                self.inference_request.preprocessing_config,
+            )
+        elif self.inference_request.modality in (Modality.IMAGE, Modality.VIDEO):
+            return [[(content, content)] for content in self.inference_request.contents]
+        else:
+            raise ValueError(f"Unsupported modality: {self.inference_request.modality}")
+
+    def _encode_processed_content(
+        self, preprocessed_content_list: List[TwelveLabsModelPreprocessedContent]
+    ) -> List[ndarray]:
+        content_to_encode: List[str] = self._collect_valid_content_to_encode(
+            preprocessed_content_list
+        )
+        if not content_to_encode:
+            return []
+
+        embeddings: List[ndarray] = []
+        for i in range(0, len(content_to_encode), self.MAX_BATCH_SIZE):
+            batch: List[str] = content_to_encode[i : i + self.MAX_BATCH_SIZE]
+            batch_embeddings: List[ndarray] = self.model.encode(
+                inputs=batch,
+                modality=self.inference_request.modality,
+                normalize=self.inference_request.embedding_model_config.normalize_embeddings,
+            )
+            embeddings.extend(batch_embeddings)
+
+        if len(embeddings) != len(content_to_encode):
+            raise ValueError(
+                "The number of embeddings does not match the number of contents"
+            )
+        return embeddings
+
+    def _collect_valid_content_to_encode(
+        self, preprocessed_content: List[TwelveLabsModelPreprocessedContent]
+    ) -> List[str]:
+        valid_content_to_encode: List[str] = []
+        for chunk in preprocessed_content:
+            if isinstance(chunk, list):
+                for _, content_to_encode in chunk:
+                    if isinstance(content_to_encode, str):
+                        valid_content_to_encode.append(content_to_encode)
+                    else:
+                        raise ValueError(
+                            f"Expected (str,) but got {type(content_to_encode)}"
+                        )
+            elif isinstance(chunk, InferenceErrorModel):
+                continue
+            else:
+                raise ValueError(
+                    f"Unexpected content type: {type(chunk)}. "
+                    f"Should be a list of tuples or an InferenceError"
+                )
+        return valid_content_to_encode

--- a/components/inference_orchestrator/src/inference_orchestrator/services/triton_inference/triton_inference.py
+++ b/components/inference_orchestrator/src/inference_orchestrator/services/triton_inference/triton_inference.py
@@ -8,6 +8,7 @@ from inference_orchestrator.services.triton_inference.embedding_models import (
     HuggingFaceModel,
     OpenCLIPModel,
     RandomModel,
+    TwelveLabsModel,
 )
 from inference_orchestrator.services.triton_inference.inference_pipelines.hugging_face_model_inference_pipeline import (
     HuggingFaceModelInferencePipeline,
@@ -17,6 +18,9 @@ from inference_orchestrator.services.triton_inference.inference_pipelines.open_c
 )
 from inference_orchestrator.services.triton_inference.inference_pipelines.random_model_inference_pipeline import (
     RandomModelInferencePipeline,
+)
+from inference_orchestrator.services.triton_inference.inference_pipelines.twelvelabs_model_inference_pipeline import (
+    TwelveLabsModelInferencePipeline,
 )
 from inference_orchestrator.services.triton_inference.model_manager.model_manager import (
     load_model,
@@ -42,5 +46,7 @@ class TritonInference(Inference):
             return HuggingFaceModelInferencePipeline(model, request).run_pipeline()
         elif isinstance(model, RandomModel):
             return RandomModelInferencePipeline(model, request).run_pipeline()
+        elif isinstance(model, TwelveLabsModel):
+            return TwelveLabsModelInferencePipeline(model, request).run_pipeline()
         else:
             raise InternalServerError("Model not supported.")  # pragma: no cover

--- a/components/inference_orchestrator/tests/integration_tests/services/triton_inference/embedding_models/test_twelvelabs_model_encode.py
+++ b/components/inference_orchestrator/tests/integration_tests/services/triton_inference/embedding_models/test_twelvelabs_model_encode.py
@@ -1,0 +1,49 @@
+import os
+import unittest
+
+import numpy as np
+
+from inference_orchestrator.schemas.api import Modality
+from inference_orchestrator.services.triton_inference.embedding_models.twelvelabs.twelvelabs_model import (
+    TwelveLabsModel,
+)
+
+
+@unittest.skipUnless(
+    os.environ.get("TWELVELABS_API_KEY"),
+    "TWELVELABS_API_KEY is not set; skipping TwelveLabs Marengo API test.",
+)
+class TestTwelveLabsModelEncode(unittest.TestCase):
+    """End-to-end test against the live TwelveLabs Marengo API.
+
+    Skipped unless TWELVELABS_API_KEY is set. Get a free key with a generous
+    free tier at https://twelvelabs.io .
+    """
+
+    def setUp(self):
+        self.model = TwelveLabsModel(
+            {
+                "type": "twelvelabs",
+                "name": "Marqo/marengo-3.0",
+                "dimensions": 512,
+                "apiModelName": "marengo3.0",
+            }
+        )
+        self.model.load()
+
+    def test_text_embedding_is_512_dim_and_normalised(self):
+        embeddings = self.model.encode(
+            inputs=["a red sports car"], modality=Modality.TEXT, normalize=True
+        )
+        self.assertEqual(1, len(embeddings))
+        self.assertEqual((512,), embeddings[0].shape)
+        self.assertAlmostEqual(float(np.linalg.norm(embeddings[0])), 1.0, places=4)
+
+    def test_text_embeddings_are_deterministic(self):
+        a = self.model.encode(["a cat"], modality=Modality.TEXT, normalize=True)[0]
+        b = self.model.encode(["a cat"], modality=Modality.TEXT, normalize=True)[0]
+        np.testing.assert_allclose(a, b, rtol=1e-4, atol=1e-4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/components/inference_orchestrator/tests/unit_tests/services/triton_inference/inference_pipelines/test_twelvelabs_model_inference_pipeline.py
+++ b/components/inference_orchestrator/tests/unit_tests/services/triton_inference/inference_pipelines/test_twelvelabs_model_inference_pipeline.py
@@ -1,0 +1,149 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from inference_orchestrator.schemas.api import (
+    EmbeddingModelConfig,
+    ImagePreprocessingConfig,
+    InferenceErrorModel,
+    InferenceRequest,
+    Modality,
+    TextPreprocessingConfig,
+)
+from inference_orchestrator.services.triton_inference.embedding_models.twelvelabs.twelvelabs_model import (
+    TwelveLabsModel,
+)
+from inference_orchestrator.services.triton_inference.inference_pipelines.twelvelabs_model_inference_pipeline import (
+    TwelveLabsModelInferencePipeline,
+)
+
+MODEL_PROPERTIES = {
+    "type": "twelvelabs",
+    "name": "Marqo/marengo-3.0",
+    "dimensions": 512,
+    "apiModelName": "marengo3.0",
+}
+
+
+def _make_model() -> TwelveLabsModel:
+    """A TwelveLabsModel whose TwelveLabs client is replaced with a mock so no
+    network calls and no API key are required."""
+    model = TwelveLabsModel(MODEL_PROPERTIES)
+    model._client = MagicMock()
+    return model
+
+
+def _mock_embedding_response(vector):
+    segment = MagicMock()
+    segment.float_ = list(vector)
+    response = MagicMock()
+    response.text_embedding.segments = [segment]
+    response.image_embedding.segments = [segment]
+    return response
+
+
+class TestTwelveLabsModelInferencePipeline(unittest.TestCase):
+    def setUp(self):
+        self.model = _make_model()
+        self.config = EmbeddingModelConfig(
+            model_name="Marqo/marengo-3.0", normalize_embeddings=True
+        )
+
+    def test_init_uses_default_api_model_name(self):
+        self.assertEqual("marengo3.0", self.model._model_properties.api_model_name)
+        self.assertEqual(512, self.model._model_properties.dimensions)
+
+    def test_encode_text_returns_normalised_vectors(self):
+        vec = np.arange(512, dtype=np.float32)
+        self.model._client.embed.create.return_value = _mock_embedding_response(vec)
+
+        embeddings = self.model.encode(
+            inputs=["a red car"], modality=Modality.TEXT, normalize=True
+        )
+
+        self.assertEqual(1, len(embeddings))
+        self.assertEqual((512,), embeddings[0].shape)
+        np.testing.assert_allclose(np.linalg.norm(embeddings[0]), 1.0, rtol=1e-5)
+        self.model._client.embed.create.assert_called_once_with(
+            model_name="marengo3.0", text="a red car"
+        )
+
+    def test_encode_image_uses_image_url(self):
+        vec = np.ones(512, dtype=np.float32)
+        self.model._client.embed.create.return_value = _mock_embedding_response(vec)
+
+        self.model.encode(
+            inputs=["http://example.com/cat.jpg"],
+            modality=Modality.IMAGE,
+            normalize=False,
+        )
+
+        self.model._client.embed.create.assert_called_once_with(
+            model_name="marengo3.0", image_url="http://example.com/cat.jpg"
+        )
+
+    def test_content_preprocessing_image_passthrough(self):
+        request = InferenceRequest(
+            contents=["a.jpg", "b.jpg"],
+            modality=Modality.IMAGE,
+            embedding_model_config=self.config,
+            preprocessing_config=ImagePreprocessingConfig(),
+        )
+        pipeline = TwelveLabsModelInferencePipeline(self.model, request)
+        self.assertEqual(
+            [[("a.jpg", "a.jpg")], [("b.jpg", "b.jpg")]],
+            pipeline._content_preprocessing(),
+        )
+
+    def test_collect_valid_content_skips_errors(self):
+        request = InferenceRequest(
+            contents=["x"],
+            modality=Modality.TEXT,
+            embedding_model_config=self.config,
+            preprocessing_config=TextPreprocessingConfig(),
+        )
+        pipeline = TwelveLabsModelInferencePipeline(self.model, request)
+        preprocessed = [
+            [("o1", "c1")],
+            InferenceErrorModel(error_message="boom"),
+            [("o2", "c2")],
+        ]
+        self.assertEqual(
+            ["c1", "c2"], pipeline._collect_valid_content_to_encode(preprocessed)
+        )
+
+    def test_run_pipeline_text_end_to_end(self):
+        request = InferenceRequest(
+            contents=["one", "two"],
+            modality=Modality.TEXT,
+            embedding_model_config=self.config,
+            preprocessing_config=TextPreprocessingConfig(),
+        )
+        pipeline = TwelveLabsModelInferencePipeline(self.model, request)
+
+        def fake_create(model_name, text):
+            return _mock_embedding_response(np.full(512, len(text), dtype=np.float32))
+
+        self.model._client.embed.create.side_effect = fake_create
+
+        with patch(
+            "inference_orchestrator.services.triton_inference.inference_pipelines."
+            "twelvelabs_model_inference_pipeline.split_prefix_preprocess_text"
+        ) as mock_split:
+            mock_split.return_value = [[("one", "one")], [("two", "two")]]
+            result = pipeline.run_pipeline()
+
+        self.assertEqual(2, len(result.result))
+        self.assertEqual((512,), result.result[0][0][1].shape)
+
+    def test_missing_api_key_raises(self):
+        model = TwelveLabsModel(MODEL_PROPERTIES)
+        with patch.dict("os.environ", {}, clear=True):
+            with self.assertRaises(ValueError) as ctx:
+                model.load()
+        self.assertIn("TWELVELABS_API_KEY", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/components/inference_orchestrator/uv.lock
+++ b/components/inference_orchestrator/uv.lock
@@ -1,8 +1,9 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.11.*"
 resolution-markers = [
-    "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux')",
+    "platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and sys_platform == 'linux'",
     "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
     "sys_platform != 'linux'",
 ]
@@ -1155,11 +1156,12 @@ dependencies = [
     { name = "semver" },
     { name = "torch", version = "2.8.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
     { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'linux'" },
-    { name = "torchvision", version = "0.23.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
+    { name = "torchvision", version = "0.23.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
     { name = "torchvision", version = "0.23.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
-    { name = "torchvision", version = "0.23.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux')" },
+    { name = "torchvision", version = "0.23.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
     { name = "transformers" },
     { name = "tritonclient", extra = ["grpc", "http"] },
+    { name = "twelvelabs" },
     { name = "uvicorn" },
     { name = "validators" },
 ]
@@ -1207,6 +1209,7 @@ requires-dist = [
     { name = "torchvision", marker = "sys_platform == 'linux'", specifier = "==0.23.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "transformers", specifier = ">=4.56.2" },
     { name = "tritonclient", extras = ["grpc", "http"], specifier = "==2.60.0" },
+    { name = "twelvelabs", specifier = ">=1.2.8" },
     { name = "uvicorn", specifier = ">=0.37.0" },
     { name = "validators", specifier = ">=0.35.0" },
 ]
@@ -1495,9 +1498,9 @@ dependencies = [
     { name = "timm" },
     { name = "torch", version = "2.8.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
     { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'linux'" },
-    { name = "torchvision", version = "0.23.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
+    { name = "torchvision", version = "0.23.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
     { name = "torchvision", version = "0.23.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
-    { name = "torchvision", version = "0.23.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux')" },
+    { name = "torchvision", version = "0.23.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
     { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/46/fb8be250fa7fcfc56fbeb41583645e18d868268f67fbbbeb8ed62a8ff18a/open_clip_torch-3.2.0.tar.gz", hash = "sha256:62b7743012ccc40fb7c64819fa762fba0a13dd74585ac733babe58c2974c2506", size = 1502853, upload-time = "2025-09-21T17:32:08.289Z" }
@@ -2411,9 +2414,9 @@ dependencies = [
     { name = "safetensors" },
     { name = "torch", version = "2.8.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
     { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'linux'" },
-    { name = "torchvision", version = "0.23.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
+    { name = "torchvision", version = "0.23.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
     { name = "torchvision", version = "0.23.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
-    { name = "torchvision", version = "0.23.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux')" },
+    { name = "torchvision", version = "0.23.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b5/ba/6f5d96622a4a9fc315da53f58b3ca224c66015efe40aa191df0d523ede7c/timm-1.0.20.tar.gz", hash = "sha256:7468d32a410c359181c1ef961f49c7e213286e0c342bfb898b99534a4221fc54", size = 2360052, upload-time = "2025-09-21T17:26:35.492Z" }
 wheels = [
@@ -2499,7 +2502,8 @@ name = "torch"
 version = "2.8.0+cpu"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
-    "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux')",
+    "platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and sys_platform == 'linux'",
     "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
 ]
 dependencies = [
@@ -2511,9 +2515,9 @@ dependencies = [
     { name = "typing-extensions", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:2bfc013dd6efdc8f8223a0241d3529af9f315dffefb53ffa3bf14d3f10127da6" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:680129efdeeec3db5da3f88ee5d28c1b1e103b774aef40f9d638e2cce8f8d8d8" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:cb06175284673a581dd91fb1965662ae4ecaba6e5c357aa0ea7bb8b84b6b7eeb" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:2bfc013dd6efdc8f8223a0241d3529af9f315dffefb53ffa3bf14d3f10127da6", upload-time = "2025-10-01T23:33:07Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:680129efdeeec3db5da3f88ee5d28c1b1e103b774aef40f9d638e2cce8f8d8d8", upload-time = "2025-10-01T23:33:11Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:cb06175284673a581dd91fb1965662ae4ecaba6e5c357aa0ea7bb8b84b6b7eeb", upload-time = "2025-10-01T23:33:14Z" },
 ]
 
 [[package]]
@@ -2521,15 +2525,16 @@ name = "torchvision"
 version = "0.23.0"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
+    "platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and sys_platform == 'linux'",
     "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "numpy", marker = "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
-    { name = "pillow", marker = "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
-    { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
+    { name = "numpy", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "pillow", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:01dc33ee24c79148aee7cdbcf34ae8a3c9da1674a591e781577b716d233b1fa6" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:01dc33ee24c79148aee7cdbcf34ae8a3c9da1674a591e781577b716d233b1fa6", upload-time = "2025-08-05T20:11:47Z" },
 ]
 
 [[package]]
@@ -2554,15 +2559,15 @@ name = "torchvision"
 version = "0.23.0+cpu"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
-    "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux')",
+    "platform_machine != 'aarch64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "numpy", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux')" },
-    { name = "pillow", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux')" },
-    { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux')" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
+    { name = "pillow", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
+    { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:d83d8075db43b8ca89680bdeb2f100c832e2a3aa61ee42c038b1a146e5e511b6" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:d83d8075db43b8ca89680bdeb2f100c832e2a3aa61ee42c038b1a146e5e511b6", upload-time = "2025-08-05T20:11:47Z" },
 ]
 
 [[package]]
@@ -2654,6 +2659,21 @@ http = [
     { name = "geventhttpclient" },
     { name = "numpy" },
     { name = "python-rapidjson" },
+]
+
+[[package]]
+name = "twelvelabs"
+version = "1.2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/24/2604563f5a528bf5f12f9bbb7e3102e91c0e4f9bfd7aeb9963dced3a0b0f/twelvelabs-1.2.8.tar.gz", hash = "sha256:bb0846cc839845c800de8061bb7b99212a472e24bf20770d569f6f620b845e3c", size = 178449, upload-time = "2026-06-18T06:38:48.135Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/a6/6380129c65222bb2497cbef27334a496a1a31f4f38973fac46b62b9224fc/twelvelabs-1.2.8-py3-none-any.whl", hash = "sha256:c0487dd892b03728ac2afe3e4ebd4ea5e30ff404b61896667eb5a39264db282b", size = 372073, upload-time = "2026-06-18T06:38:46.747Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## Change Summary

This PR adds **TwelveLabs Marengo** as an opt-in, API-served **multimodal embedding model** alongside the existing OpenCLIP / HuggingFace models.

- Marengo embeds **text, image and video into the same 512-dimensional space**, so it works as a cross-modal alternative to CLIP (e.g. text-to-video retrieval) for ecommerce catalogs that include video.
- Marengo is served by the TwelveLabs API rather than Triton, so it needs **no ONNX artifacts**. It follows the same self-contained pattern as the existing `random` model: a new `twelvelabs` model `type` with its own `TwelveLabsModel` and `TwelveLabsModelInferencePipeline`, wired into the model loader, the shared model registry, and the inference dispatch in `TritonInference.vectorise`.
- Registered model name: **`Marqo/marengo-3.0`**. The API key is read from the `TWELVELABS_API_KEY` environment variable.

### Why it helps this project
Marqo targets ecommerce search/discovery, where catalogs increasingly include short product videos. A single embedding space across text, image and video lets users search video content with the same vector index they already use for text and image, with no separate model plumbing.

### Opt-in / non-breaking
No existing defaults or behaviour change. The new model only activates when a user explicitly selects `Marqo/marengo-3.0` (type `twelvelabs`). All existing model paths are untouched; the existing `random` pipeline unit tests still pass.

## Related Jira Ticket
N/A (external community contribution).

## How it was tested
- **Unit tests** (no network, mocked client): `test_twelvelabs_model_inference_pipeline.py` — encode/normalize, text & image dispatch, content preprocessing, error skipping, end-to-end pipeline, and missing-API-key handling. 7 passing.
- **Integration test** (gated on `TWELVELABS_API_KEY`, skipped without it): `test_twelvelabs_model_encode.py` — verified live against Marengo (`marengo3.0`): real text embedding is 512-dim, L2-normalized, and deterministic. 2 passing.
- Ran `ruff format` + `ruff check` (v0.14.1, the repo's pinned pre-commit version) on all changed files.
- Verified the registry to properties-parser to `TwelveLabsModel` wiring round-trips end to end.

The video path uses Marengo's async `embed.tasks` endpoint and is wired but marked forward-looking, since the orchestrator's `InferenceRequest.preprocessing_config` currently only accepts text/image configs. Text and image are fully exercised.

## Note on the deprecation notice
I noticed the README states the OSS project is "deprecated and will no longer receive updates." Since the repo is not archived, `CONTRIBUTING.md` says contributions are welcome, and PRs have been merged within the last couple of months, I'm opening this for your consideration — happy to close if it's not wanted.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.

## Checklist
- [x] Tests have been added for changes
- [x] Documentation has been updated
- [x] Breaking changes are clearly identified (none — opt-in)
- [x] Python client changes linked or N/A (N/A — new model name only)
