### PR TITLE
docs: fix 'recieve' typo in deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@
 
 Marqo is the an AI-native ecommerce search platform built for online brands in fashion, beauty, electronics, and home goods. Powered by best-in-class semantic search and personalization technology, the platform leverages clickstream, purchase, and event data to understand shopper intent and deliver fast, relevant, and personalized search results and product recommendations. Marqo enables commerce teams to improve search relevance, increase conversion and average order value, and reduce manual merchandising effort through automated ranking and optimization.
 
-NOTICE: Marqo's Open Source project is deprecated and will no longer recieve updates. To explore Marqo's product search and discovery platform, go to <a href="https://marqo.ai/">marqo.ai</a>
+NOTICE: Marqo's Open Source project is deprecated and will no longer receive updates. To explore Marqo's product search and discovery platform, go to <a href="https://marqo.ai/">marqo.ai</a>


### PR DESCRIPTION
## Summary
Fixes a spelling typo in the open-source deprecation notice: `recieve` → `receive`.

## Test plan
- [ ] Confirm the NOTICE sentence in the README is spelled correctly

Made with [Cursor](https://cursor.com)