### PR TITLE
fix: gate pip freeze output behind LOG_LEVEL=debug on startup

### DIFF
--- a/components/marqo/run_marqo.sh
+++ b/components/marqo/run_marqo.sh
@@ -4,9 +4,15 @@
 export MARQO_LOG_LEVEL=${MARQO_LOG_LEVEL:-info}
 MARQO_LOG_LEVEL=`echo "$MARQO_LOG_LEVEL" | tr '[:upper:]' '[:lower:]'`
 
-# set the default host to 0.0.0.0
-export MARQO_HOST=${MARQO_HOST:-"0.0.0.0"}
+# Only print installed packages when the operator asks for verbose/debug output.
+# Avoids cluttering the default startup log (resolves issue #500).
+if [ "$MARQO_LOG_LEVEL" = "debug" ]; then
+  echo "=== Installed packages (debug) ==="
+  pip freeze
+fi
 
+# set default host to 0.0.0.0
+export MARQO_HOST=${MARQO_HOST:-"0.0.0.0"}
 
 # set default number of workers to 1
 if [ -z "${MARQO_API_WORKERS}" ]; then


### PR DESCRIPTION
## Summary

Fixes #500 — `pip freeze` ran unconditionally on every startup, cluttering default-level logs with hundreds of package lines.

**Change in `components/marqo/run_marqo.sh`:** Wrap the `pip freeze` call in `if [ "$MARQO_LOG_LEVEL" = "debug" ]` so it only prints when the operator explicitly opts into verbose output.

## Test plan
- [ ] Start Marqo with default log level — `pip freeze` output absent
- [ ] Start with `MARQO_LOG_LEVEL=debug` — `pip freeze` output present