### PR TITLE
fix: [BUG] Outdated reference for documentation in error message when indexin...

### DIFF
--- a/components/marqo/src/marqo/marqo_docs.py
+++ b/components/marqo/src/marqo/marqo_docs.py
@@ -76,6 +76,10 @@ def search_api_score_modifiers_parameter():
     return _build_url('reference/api/search/#score-modifiers')
 
 
+def search_api_boost_parameter():
+    return _build_url('reference/api/search/')
+
+
 # TODO: Update URL when a bring-your-own-model page is available in the new docs
 def hugging_face_trust_remote_code():
     return _build_url('reference/')

--- a/components/marqo/src/marqo/tensor_search/validation.py
+++ b/components/marqo/src/marqo/tensor_search/validation.py
@@ -194,8 +194,8 @@ def validate_context(context: Optional[SearchContext], search_method: SearchMeth
 
 def validate_boost(boost: Dict, search_method: Union[str, SearchMethod]):
     if boost is not None:
-        further_info_message = ("\nRead about boost usage here: "
-                                "https://docs.marqo.ai/0.0.13/API-Reference/search/#boost")
+        further_info_message = (f"\nRead about boost usage here: "
+                                f"{marqo_docs.search_api_boost_parameter()}")
         for boost_attr in boost:
             try:
                 validate_field_name(boost_attr)

--- a/components/marqo/tests/unit_tests/marqo/tensor_search/test_validation.py
+++ b/components/marqo/tests/unit_tests/marqo/tensor_search/test_validation.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import patch, MagicMock
 
+from marqo import marqo_docs
 from marqo.api.exceptions import InvalidArgError, InvalidFieldNameError
 from marqo.core.models import marqo_index
 from marqo.tensor_search import validation
@@ -328,6 +329,27 @@ class TestValidateMappingsObject(unittest.TestCase):
                     with self.assertRaises(InvalidArgError) as cm:
                         validation.validate_mappings_object(case["mapping"], mock_index)
                     self.assertIn(case["expected_error"], str(cm.exception))
+
+
+class TestValidateBoost(unittest.TestCase):
+    """Unit tests for the validate_boost function."""
+
+    def test_boost_error_messages_reference_current_docs(self):
+        """Boost validation errors must link to the current docs rather than a pinned old version."""
+        expected_url = marqo_docs.search_api_boost_parameter()
+        test_cases = [
+            ("invalid field name", {'': [1.2]}, SearchMethod.TENSOR),
+            ("unsupported search method", {'fine': [1.2]}, SearchMethod.LEXICAL),
+            ("invalid boost value", {'bad': [1, 2, 3]}, SearchMethod.TENSOR),
+        ]
+
+        for description, boost, search_method in test_cases:
+            with self.subTest(description=description):
+                with self.assertRaises((InvalidArgError, InvalidFieldNameError)) as cm:
+                    validation.validate_boost(boost=boost, search_method=search_method)
+                message = str(cm.exception)
+                self.assertIn(expected_url, message)
+                self.assertNotRegex(message, r'docs\.marqo\.ai/\d+\.\d+')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #501

## Root cause

Hardcoded outdated docs URL in boost validation error message

## Changes

- Replaced the hardcoded versioned docs link in validation.validate_boost with a new marqo_docs.search_api_boost_parameter() helper so the message resolves through the centralized (unversioned) docs URL builder, and added a unit test asserting boost validation messages reference the current docs and contain no version-pinned docs path.