### PR TITLE
Fix: Return 400 instead of 500 on backend errors

### DIFF
--- a/components/marqo/src/marqo/api/exceptions.py
+++ b/components/marqo/src/marqo/api/exceptions.py
@@ -235,7 +235,7 @@ class ServiceUnavailableError(MarqoWebError):
 class BackendCommunicationError(InternalError):
     """Error when connecting to Vespa"""
     code = "backend_communication_error"
-    status_code = HTTPStatus.INTERNAL_SERVER_ERROR
+    status_code = HTTPStatus.BAD_REQUEST
 
 
 class BackendDataParsingError(InternalError):


### PR DESCRIPTION
Fixes #533. Adjusted the HTTP status code for BackendCommunicationError from 500 to 400.