### PR TITLE
fix: accept imageDownloadHeaders camelCase field name in search()

### DIFF
--- a/components/marqo/src/marqo/tensor_search/models/api_models.py
+++ b/components/marqo/src/marqo/tensor_search/models/api_models.py
@@ -27,6 +27,11 @@ from marqo.tensor_search.models.collapse_model import CollapseModel
 class BaseMarqoModel(BaseModel):
     class Config:
         extra: str = "forbid"
+        # imageDownloadHeaders (SearchQuery) is aliased to the deprecated
+        # image_download_headers for backwards compatibility. Without this,
+        # pydantic only accepts the alias as input, so the documented
+        # camelCase field name would be rejected outright by extra="forbid".
+        allow_population_by_field_name = True
 
     pass
 

--- a/components/marqo/tests/unit_tests/marqo/tensor_search/models/test_api_models.py
+++ b/components/marqo/tests/unit_tests/marqo/tensor_search/models/test_api_models.py
@@ -218,6 +218,17 @@ class TestSearchQuery(unittest.TestCase):
         )
         self.assertEqual(search_query.mediaDownloadHeaders, {"header1": "value1"})
 
+    def test_image_download_headers_accepts_camel_case_field_name(self):
+        """imageDownloadHeaders is the documented field name; the snake_case
+        image_download_headers is only a deprecated alias kept for backwards
+        compatibility. Both must be accepted as input."""
+        search_query = SearchQuery(
+            q="test",
+            imageDownloadHeaders={"header1": "value1"}
+        )
+        self.assertEqual(search_query.imageDownloadHeaders, {"header1": "value1"})
+        self.assertEqual(search_query.mediaDownloadHeaders, {"header1": "value1"})
+
     def test_search_query_with_invalid_search_method_fails(self):
         """Test that invalid search method raises validation error"""
         with self.assertRaises(ValidationError) as cm:


### PR DESCRIPTION
## Summary
`SearchQuery.imageDownloadHeaders` (`components/marqo/src/marqo/tensor_search/models/api_models.py`) is declared with `alias="image_download_headers"`, and the docstring/validator comments make clear the intent is: `imageDownloadHeaders` is the current field name, `image_download_headers` is kept only as a deprecated alias for backwards compatibility.

But `BaseMarqoModel.Config` never sets `allow_population_by_field_name`. In pydantic v1, when a field has an `alias`, only the alias is accepted as input unless that flag is set — and combined with `extra = "forbid"`, a request actually using the documented camelCase `imageDownloadHeaders` is rejected outright as an unrecognized field:

```
pydantic.v1.error_wrappers.ValidationError: 1 validation error for SearchQuery
imageDownloadHeaders
  extra fields not permitted (type=value_error.extra)
```

So today only the deprecated snake_case name works, which is backwards from the documented behavior.

## Fix
Set `allow_population_by_field_name = True` on `BaseMarqoModel.Config`. This is the same pattern already used elsewhere in the codebase for exactly this kind of alias (`base_model.py`, `recency_parameters.py`), so it's consistent with existing convention. `SearchQuery` and `BulkSearchQuery` are the only classes built on `BaseMarqoModel`, and `RecommendQuery` (also built on it) declares no aliased fields, so this is scoped to the one place that needed it.

Fixes #401

## Test plan
- [x] Added `test_image_download_headers_accepts_camel_case_field_name`, asserting `SearchQuery(imageDownloadHeaders=...)` is accepted and correctly copied into `mediaDownloadHeaders`
- [x] Verified the new test fails with exactly the reported `extra fields not permitted` error when the fix is reverted, and passes with it applied
- [x] Full `tests/unit_tests/marqo/tensor_search/models/test_api_models.py` — 71 passed, 45 subtests passed (Python 3.11, per `pyproject.toml`'s `requires-python`)