### PR TITLE
fix: validate splitOverlap < splitLength at index-creation time

### DIFF
--- a/components/marqo/src/marqo/core/models/marqo_index.py
+++ b/components/marqo/src/marqo/core/models/marqo_index.py
@@ -141,20 +141,40 @@ class HnswConfig(ImmutableBaseModel):
     m: int = pydantic.Field(gt=0)
 
 
+def _validate_split_overlap_less_than_split_length(cls, values: dict) -> dict:
+    """A splitOverlap >= splitLength leaves the chunker with a zero or negative
+    stride, which fails deep inside the text/video/audio splitters at
+    add_documents time instead of at index-creation time (see #605).
+    """
+    split_length = values.get('split_length')
+    split_overlap = values.get('split_overlap')
+    if split_length is not None and split_overlap is not None and split_overlap >= split_length:
+        raise ValueError(
+            f'splitOverlap ({split_overlap}) must be less than splitLength ({split_length})'
+        )
+    return values
+
+
 class TextPreProcessing(ImmutableBaseModel):
     split_length: int = pydantic.Field(gt=0, alias='splitLength')
     split_overlap: int = pydantic.Field(ge=0, alias='splitOverlap')
     split_method: TextSplitMethod = pydantic.Field(alias='splitMethod')
+
+    _validate_split_overlap = root_validator(allow_reuse=True)(_validate_split_overlap_less_than_split_length)
 
 
 class VideoPreProcessing(ImmutableBaseModel):
     split_length: int = pydantic.Field(gt=0, alias='splitLength')
     split_overlap: int = pydantic.Field(ge=0, alias='splitOverlap')
 
+    _validate_split_overlap = root_validator(allow_reuse=True)(_validate_split_overlap_less_than_split_length)
+
 
 class AudioPreProcessing(ImmutableBaseModel):
     split_length: int = pydantic.Field(gt=0, alias='splitLength')
     split_overlap: int = pydantic.Field(ge=0, alias='splitOverlap')
+
+    _validate_split_overlap = root_validator(allow_reuse=True)(_validate_split_overlap_less_than_split_length)
 
 
 class ImagePreProcessing(ImmutableBaseModel):

--- a/components/marqo/tests/unit_tests/marqo/core/models/test_marqo_index.py
+++ b/components/marqo/tests/unit_tests/marqo/core/models/test_marqo_index.py
@@ -684,6 +684,38 @@ class TestForwardCompatibility(unittest.TestCase):
         self.assertEqual(image_preprocessing.patch_method, PatchMethod.Simple)
 
 
+class TestPreProcessingSplitOverlapValidation(unittest.TestCase):
+    """splitOverlap >= splitLength used to pass model construction and only fail deep in
+    the chunker at add_documents time with an unhelpful 500 (more_itertools.windowed
+    raises 'step must be >= 1' because step = split_length - split_overlap). See #605.
+    """
+
+    def test_text_preprocessing_rejects_overlap_equal_to_length(self):
+        with self.assertRaises(ValidationError):
+            TextPreProcessing(splitLength=2, splitOverlap=2, splitMethod=TextSplitMethod.Word)
+
+    def test_text_preprocessing_rejects_overlap_greater_than_length(self):
+        with self.assertRaises(ValidationError):
+            TextPreProcessing(splitLength=2, splitOverlap=5, splitMethod=TextSplitMethod.Word)
+
+    def test_text_preprocessing_accepts_overlap_less_than_length(self):
+        text_preprocessing = TextPreProcessing(splitLength=2, splitOverlap=1, splitMethod=TextSplitMethod.Word)
+        self.assertEqual(text_preprocessing.split_length, 2)
+        self.assertEqual(text_preprocessing.split_overlap, 1)
+
+    def test_text_preprocessing_accepts_zero_overlap(self):
+        text_preprocessing = TextPreProcessing(splitLength=2, splitOverlap=0, splitMethod=TextSplitMethod.Word)
+        self.assertEqual(text_preprocessing.split_overlap, 0)
+
+    def test_video_preprocessing_rejects_overlap_greater_than_or_equal_to_length(self):
+        with self.assertRaises(ValidationError):
+            VideoPreProcessing(splitLength=30, splitOverlap=30)
+
+    def test_audio_preprocessing_rejects_overlap_greater_than_or_equal_to_length(self):
+        with self.assertRaises(ValidationError):
+            AudioPreProcessing(splitLength=60, splitOverlap=60)
+
+
 class TestMarqoIndexSchemaVersion(MarqoTestCase):
     """Unit tests for MarqoIndex schema_template_version functionality."""
 


### PR DESCRIPTION
## Change Summary

`TextPreProcessing`, `VideoPreProcessing`, and `AudioPreProcessing` accepted any non-negative `splitOverlap` regardless of `splitLength`. When `splitOverlap >= splitLength`, index creation succeeded, and the failure only surfaced later, at `add_documents` time, as an unhelpful 500: `more_itertools.windowed` raises `ValueError: step must be >= 1` because the chunker computes `step = splitLength - splitOverlap`.

Added a pydantic root validator to all three pre-processing models that rejects `splitOverlap >= splitLength` at index-creation time, with a clear message, instead of letting it reach the chunker. This routes through the existing pydantic `ValidationError` -> `InvalidArgError` handler in `api.py`, so callers now get a 400 with a readable message instead of a 500.

Reproduced the exact values from the issue (`splitLength=2, splitOverlap=5`) directly against the fix and confirmed it now raises at construction time with the message `splitOverlap (5) must be less than splitLength (2)`.

## Related Jira Ticket

Fixes #605

## Checklist
- [x] Tests have been added for changes
- [ ] Documentation has been updated
- [x] Breaking changes are clearly identified (none: this only rejects previously-broken configurations that always failed anyway, just later and with a worse error)
- [ ] Python client changes linked or N/A (N/A, no client-facing schema change)
