### PR TITLE
Add index storage size to stats response

### DIFF
--- a/components/marqo/src/marqo/core/models/marqo_index_stats.py
+++ b/components/marqo/src/marqo/core/models/marqo_index_stats.py
@@ -12,3 +12,4 @@ class MarqoIndexStats(StrictBaseModel):
     number_of_documents: int
     number_of_vectors: int
     backend: VespaStats
+    storage_size_gb: Optional[float]

--- a/components/marqo/src/marqo/core/monitoring/monitoring.py
+++ b/components/marqo/src/marqo/core/monitoring/monitoring.py
@@ -54,12 +54,15 @@ class Monitoring:
 
         memory_utilization = metrics.clusterController_resourceUsage_maxMemoryUtilization_max
         disk_utilization = metrics.clusterController_resourceUsage_maxDiskUtilization_max
+        storage_size_bytes = metrics.documentDb_diskUsage_bytes(marqo_index.schema_name)
 
         # Occasionally Vespa returns empty metrics, often for the first call after a restart
         if memory_utilization is None:
             logger.warning(f'Vespa did not return a value for memory utilization metrics')
         if disk_utilization is None:
             logger.warning(f'Vespa did not return a value for disk utilization metrics')
+        if storage_size_bytes is None:
+            logger.warning(f'Vespa did not return a value for index disk usage metrics')
 
         return MarqoIndexStats(
             number_of_documents=doc_count_query_result.total_count,
@@ -67,7 +70,8 @@ class Monitoring:
             backend=VespaStats(
                 memory_used_percentage=memory_utilization * 100 if memory_utilization is not None else None,
                 storage_used_percentage=disk_utilization * 100 if disk_utilization is not None else None
-            )
+            ),
+            storage_size_gb=storage_size_bytes / (1024 ** 3) if storage_size_bytes is not None else None
         )
 
     def get_index_stats_by_name(self, index_name: str) -> MarqoIndexStats:

--- a/components/marqo/src/marqo/tensor_search/api.py
+++ b/components/marqo/src/marqo/tensor_search/api.py
@@ -434,7 +434,8 @@ def get_index_stats(index_name: str, marqo_config: config.Config = Depends(get_c
         'backend': {
             'memoryUsedPercentage': stats.backend.memory_used_percentage,
             'storageUsedPercentage': stats.backend.storage_used_percentage
-        }
+        },
+        'storageSizeGb': stats.storage_size_gb
     }
 
 

--- a/components/marqo/src/marqo/vespa/models/application_metrics.py
+++ b/components/marqo/src/marqo/vespa/models/application_metrics.py
@@ -66,11 +66,29 @@ class ApplicationMetrics(BaseModel):
             service_name=self._SERVICE_CLUSTERCONTROLLER
         )
 
+    def documentDb_diskUsage_bytes(self, document_type: str) -> Optional[Union[int, float]]:
+        """
+        Get the on-disk size, in bytes, of a given document type (Marqo index schema), summed across all
+        content nodes.
+
+        Args:
+            document_type: The Vespa document type / schema name of the Marqo index
+
+        Returns:
+            Total disk usage in bytes for the document type, or None if the metric is not reported
+        """
+        return self._aggregate_metric(
+            metric_name='content.proton.documentdb.documentstore.disk_usage.last',
+            aggregation=Aggregation.Sum,
+            dimension_filter={'documenttype': document_type}
+        )
+
     def _aggregate_metric(
             self,
             metric_name: str,
             aggregation,
-            service_name: Optional[str] = None
+            service_name: Optional[str] = None,
+            dimension_filter: Optional[Dict[str, str]] = None
     ) -> Optional[Union[int, float]]:
         """
         Aggregate a metric across all nodes and services.
@@ -80,6 +98,8 @@ class ApplicationMetrics(BaseModel):
             aggregation: Aggregation to use
             service_name: Optional name of service to aggregate metric for. Provioding this will speed up the
                 aggregation process
+            dimension_filter: Optional dict of dimension name/value pairs that must all match a metric set's
+                dimensions for it to be included in the aggregation
 
         Returns:
             Aggregated metric value. If no values are found and aggregation type is not Aggregation.Count,
@@ -92,6 +112,11 @@ class ApplicationMetrics(BaseModel):
                     continue
 
                 for metric_set in service.metrics:
+                    if dimension_filter is not None and not all(
+                            metric_set.dimensions.get(key) == value for key, value in dimension_filter.items()
+                    ):
+                        continue
+
                     if metric_name in metric_set.values:
                         values.append(metric_set.values[metric_name])
 

--- a/components/marqo/tests/unit_tests/marqo/vespa/test_application_metrics.py
+++ b/components/marqo/tests/unit_tests/marqo/vespa/test_application_metrics.py
@@ -1,0 +1,66 @@
+import unittest
+
+from marqo.vespa.models.application_metrics import ApplicationMetrics, Node, Service, Status, MetricSet
+
+
+def _make_metrics(node_metric_sets):
+    """
+    Build an ApplicationMetrics with a single content node whose service reports the given metric sets.
+    node_metric_sets: list of (dimensions_dict, values_dict)
+    """
+    metrics = [MetricSet(dimensions=dims, values=values) for dims, values in node_metric_sets]
+    return ApplicationMetrics(nodes=[
+        Node(
+            hostname='content-node-0',
+            role='content',
+            services=[
+                Service(
+                    name='vespa.searchnode',
+                    timestamp=0,
+                    status=Status(code='up', description=''),
+                    metrics=metrics
+                )
+            ]
+        )
+    ])
+
+
+class TestApplicationMetricsDiskUsage(unittest.TestCase):
+
+    def test_documentDb_diskUsage_bytes_filters_by_documenttype(self):
+        metrics = _make_metrics([
+            ({'documenttype': 'index_a'}, {'content.proton.documentdb.documentstore.disk_usage.last': 1000}),
+            ({'documenttype': 'index_b'}, {'content.proton.documentdb.documentstore.disk_usage.last': 2000}),
+        ])
+
+        self.assertEqual(1000, metrics.documentDb_diskUsage_bytes('index_a'))
+        self.assertEqual(2000, metrics.documentDb_diskUsage_bytes('index_b'))
+
+    def test_documentDb_diskUsage_bytes_sums_across_nodes(self):
+        metric_sets = [
+            ({'documenttype': 'index_a'}, {'content.proton.documentdb.documentstore.disk_usage.last': 1000})
+        ]
+        node_a = _make_metrics(metric_sets).nodes[0]
+        node_b = _make_metrics(metric_sets).nodes[0]
+
+        metrics = ApplicationMetrics(nodes=[node_a, node_b])
+
+        self.assertEqual(2000, metrics.documentDb_diskUsage_bytes('index_a'))
+
+    def test_documentDb_diskUsage_bytes_missing_metric_returns_none(self):
+        metrics = _make_metrics([
+            ({'documenttype': 'index_a'}, {'some.other.metric': 1000}),
+        ])
+
+        self.assertIsNone(metrics.documentDb_diskUsage_bytes('index_a'))
+
+    def test_documentDb_diskUsage_bytes_no_matching_documenttype_returns_none(self):
+        metrics = _make_metrics([
+            ({'documenttype': 'index_a'}, {'content.proton.documentdb.documentstore.disk_usage.last': 1000}),
+        ])
+
+        self.assertIsNone(metrics.documentDb_diskUsage_bytes('index_b'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `storageSizeGb` to `GET /indexes/{index}/stats`
- calculate it by summing `content.proton.documentdb.documentstore.disk_usage.last` across Vespa content nodes
- add mocked unit coverage for the metrics response and aggregation behavior

Closes #374.

## Testing

- Unit tests: 4/4 passing with mocked Vespa metrics

## Verification caveat

This is a best-effort implementation based on the Vespa documentation. I could not run Marqo integration tests against a live Vespa cluster in this environment, so the exact availability and path of `content.proton.documentdb.documentstore.disk_usage.last` on `/metrics/v2/values` remain unverified. Please confirm the metric name and mapping against a real cluster during review; I do not want to present that part as fully verified.